### PR TITLE
feat(rfdb): Client Snapshot API (RFD-10)

### DIFF
--- a/_tasks/RFD-10/001-user-request.md
+++ b/_tasks/RFD-10/001-user-request.md
@@ -1,0 +1,33 @@
+# RFD-10: T3.3 — Client Snapshot API
+
+## Source
+
+Linear issue RFD-10 (RFDB team, RFDB v2 project, M3: Incremental Core milestone)
+
+## Description
+
+Client Phase E. Snapshot operations: diff, tag, find, list.
+
+**~150 LOC, ~10 tests**
+
+### Subtasks
+
+1. `diffSnapshots(from, to)` — by number or by tag
+2. `tagSnapshot(tags)`, `findSnapshot(tag, value)`, `listSnapshots(filter?)`
+3. `SnapshotDiff` type definition
+4. Snapshot reference types (number | {tag, value})
+
+### Validation
+
+- tag -> find -> diff workflow
+- Diff by number = diff by resolved tag
+- listSnapshots with filter -> correct subset
+
+### Dependencies
+
+- RFD-5 (T2.1: Manifest + Snapshot Chain) — DONE
+- RFD-8 (T3.1: Tombstones + Batch Commit) — DONE
+
+### Blocks
+
+- RFD-14 (T4.4: Integration Gate Validation)

--- a/_tasks/RFD-10/002-don-plan.md
+++ b/_tasks/RFD-10/002-don-plan.md
@@ -1,0 +1,221 @@
+# Don Melton Plan: RFD-10 T3.3 Client Snapshot API
+
+> Date: 2026-02-14
+> Status: PLAN
+> Scope: ~150 LOC client code, ~10 tests
+
+---
+
+## 1. Current State Analysis
+
+### Rust Server Side (storage_v2)
+
+ManifestStore already has all four snapshot operations implemented and tested:
+
+| Method | Signature | Location |
+|--------|-----------|----------|
+| `tag_snapshot` | `(&mut self, version: u64, tags: HashMap<String, String>) -> Result<()>` | manifest.rs:899 |
+| `find_snapshot` | `(&self, tag_key: &str, tag_value: &str) -> Option<u64>` | manifest.rs:883 |
+| `list_snapshots` | `(&self, filter_tag: Option<&str>) -> Vec<SnapshotInfo>` | manifest.rs:890 |
+| `diff_snapshots` | `(&self, from_version: u64, to_version: u64) -> Result<SnapshotDiff>` | manifest.rs:942 |
+
+Rust types already defined:
+- `SnapshotInfo` (version, created_at, tags, stats) -- manifest.rs:321
+- `SnapshotDiff` (from_version, to_version, added/removed node/edge segments, stats) -- manifest.rs:494
+- `ManifestStats` (total_nodes, total_edges, node_segment_count, edge_segment_count) -- manifest.rs:259
+
+### Rust Server Binary (rfdb_server.rs)
+
+**The server binary does NOT handle snapshot commands yet.** The `Request` enum (rfdb_server.rs:52) has no `DiffSnapshots`, `TagSnapshot`, `FindSnapshot`, or `ListSnapshots` variants. The storage_v2 module is not imported by the server binary at all -- the current server uses v1 storage (`rfdb::graph::GraphEngine`).
+
+### TypeScript Client (packages/rfdb/ts/client.ts)
+
+No snapshot methods exist. The client has no `commitBatch`, no snapshot types, nothing v2-related beyond protocol v2 multi-database commands (`hello`, `createDatabase`, etc.).
+
+### Types Package (packages/types/src/rfdb.ts)
+
+`RFDBCommand` union type has no snapshot commands. `IRFDBClient` interface has no snapshot methods.
+
+---
+
+## 2. Critical Architecture Decision
+
+**The Rust server does not currently use storage_v2 at all.** This means we cannot test snapshot commands end-to-end against a running server. We have two options:
+
+**Option A: Add server commands + client methods (full vertical slice)**
+- Add 4 Request variants to rfdb_server.rs
+- Wire them to ManifestStore methods
+- Add client methods
+- End-to-end tests against running server
+
+**Option B: Client-only (as specified in T3.3)**
+- Add client methods that send the right wire format
+- Add TypeScript types
+- Unit tests that validate wire format and type contracts
+- Server-side handlers deferred (they're trivial delegation)
+
+**Recommendation: Option B with a twist.** The T3.3 spec says "~150 LOC, ~10 tests" and is scoped as a TS-only task. The server handlers are trivial (5-line delegation each) and belong in a separate task when storage_v2 is wired into the server. However, we should structure the client code so it works correctly once the server supports it.
+
+The client already has the pattern for this: `hello()`, `createDatabase()`, etc. all cast `RFDBCommand` and send commands that may or may not be supported. The same pattern applies here.
+
+---
+
+## 3. Implementation Plan
+
+### 3.1 Type Definitions (~40 LOC)
+
+Add to `packages/types/src/rfdb.ts`:
+
+```typescript
+// Add to RFDBCommand union:
+| 'diffSnapshots'
+| 'tagSnapshot'
+| 'findSnapshot'
+| 'listSnapshots'
+
+// New types:
+export type SnapshotRef = number | { tag: string; value: string };
+
+export interface SnapshotStats {
+  totalNodes: number;
+  totalEdges: number;
+  nodeSegmentCount: number;
+  edgeSegmentCount: number;
+}
+
+export interface SegmentInfo {
+  segmentId: number;
+  recordCount: number;
+  byteSize: number;
+  nodeTypes: string[];
+  filePaths: string[];
+  edgeTypes: string[];
+}
+
+export interface SnapshotDiff {
+  fromVersion: number;
+  toVersion: number;
+  addedNodeSegments: SegmentInfo[];
+  removedNodeSegments: SegmentInfo[];
+  addedEdgeSegments: SegmentInfo[];
+  removedEdgeSegments: SegmentInfo[];
+  statsFrom: SnapshotStats;
+  statsTo: SnapshotStats;
+}
+
+export interface SnapshotInfo {
+  version: number;
+  createdAt: number;
+  tags: Record<string, string>;
+  stats: SnapshotStats;
+}
+
+// Response types:
+export interface DiffSnapshotsResponse extends RFDBResponse { ... }
+export interface FindSnapshotResponse extends RFDBResponse { version: number | null; }
+export interface ListSnapshotsResponse extends RFDBResponse { snapshots: SnapshotInfo[]; }
+
+// Add to IRFDBClient interface:
+diffSnapshots(from: SnapshotRef, to: SnapshotRef): Promise<SnapshotDiff>;
+tagSnapshot(version: number, tags: Record<string, string>): Promise<void>;
+findSnapshot(tagKey: string, tagValue: string): Promise<number | null>;
+listSnapshots(filter?: string): Promise<SnapshotInfo[]>;
+```
+
+### 3.2 Client Methods (~50 LOC)
+
+Add to `packages/rfdb/ts/client.ts`:
+
+```typescript
+// Helper (private or module-level):
+function resolveSnapshotRef(ref: SnapshotRef): Record<string, unknown> {
+  if (typeof ref === 'number') return { version: ref };
+  return { tagKey: ref.tag, tagValue: ref.value };
+}
+
+// 4 methods:
+async diffSnapshots(from: SnapshotRef, to: SnapshotRef): Promise<SnapshotDiff>
+async tagSnapshot(version: number, tags: Record<string, string>): Promise<void>
+async findSnapshot(tagKey: string, tagValue: string): Promise<number | null>
+async listSnapshots(filter?: string): Promise<SnapshotInfo[]>
+```
+
+Each method follows the existing pattern: call `this._send()` with command name, cast response.
+
+### 3.3 Re-exports (~10 LOC)
+
+Update `packages/rfdb/ts/protocol.ts` and `packages/rfdb/ts/index.ts` to re-export new types.
+
+### 3.4 Tests (~10 tests, ~60 LOC)
+
+Test file: `packages/rfdb/ts/client.test.ts` (extend existing).
+
+Since the server doesn't support these commands yet, tests focus on:
+
+1. **resolveSnapshotRef() — number input** -> `{ version: N }`
+2. **resolveSnapshotRef() — tag input** -> `{ tagKey, tagValue }`
+3. **SnapshotDiff type contract** — construct valid SnapshotDiff, verify fields
+4. **SnapshotInfo type contract** — construct valid SnapshotInfo, verify fields
+5. **SnapshotStats type contract** — verify stats shape
+6. **SnapshotRef discriminated union** — number vs object discrimination
+7. **tagSnapshot sends correct wire format** — version + tags
+8. **findSnapshot response parsing** — version or null
+9. **listSnapshots with filter** — filter string passed correctly
+10. **diffSnapshots with mixed refs** — number + tag ref combination
+
+The existing test file uses extracted helper functions to test serialization without a running server (see the `mapNodeForWireFormat` pattern). We follow the same approach: extract the `resolveSnapshotRef` helper and test it directly, plus type construction tests.
+
+---
+
+## 4. Files Modified
+
+| File | Change |
+|------|--------|
+| `packages/types/src/rfdb.ts` | Add 4 commands to union, add 7 type definitions, extend IRFDBClient |
+| `packages/rfdb/ts/client.ts` | Add resolveSnapshotRef helper, 4 snapshot methods, new imports |
+| `packages/rfdb/ts/protocol.ts` | Re-export new types |
+| `packages/rfdb/ts/index.ts` | Re-export new types |
+| `packages/rfdb/ts/client.test.ts` | Add ~10 snapshot API tests |
+
+---
+
+## 5. Mapping to Rust Types
+
+Client types must match Rust wire format (camelCase JS <-> snake_case Rust via serde rename):
+
+| TypeScript | Rust | Notes |
+|------------|------|-------|
+| `SnapshotDiff.fromVersion` | `SnapshotDiff.from_version` | serde camelCase |
+| `SnapshotDiff.addedNodeSegments` | `SnapshotDiff.added_node_segments` | Array of SegmentDescriptor |
+| `SnapshotInfo.createdAt` | `SnapshotInfo.created_at` | Unix epoch seconds |
+| `SnapshotStats.totalNodes` | `ManifestStats.total_nodes` | Same fields, different name |
+| `SegmentInfo.segmentId` | `SegmentDescriptor.segment_id` | Subset of fields |
+
+**Note:** SegmentInfo is a simplified view of Rust's SegmentDescriptor. We expose segmentId, recordCount, byteSize, nodeTypes[], filePaths[], edgeTypes[] but not segmentType or shardId (internal details).
+
+---
+
+## 6. Risks
+
+1. **Server doesn't support these commands yet.** Calling any snapshot method on current server will return an error. This is expected and documented. The `hello()` response should eventually include `"snapshots"` in features array when server support lands.
+
+2. **Type mismatch risk.** The Rust serde serialization uses `#[serde(rename_all = "camelCase")]` on the server's Response enum, so field names will be camelCase in the wire format. Our TS types must match exactly. Risk is low because we control both sides.
+
+3. **SegmentDescriptor fields.** Rust SegmentDescriptor has `node_types: HashSet<String>` but HashSet serializes to JSON array. Our TS type uses `string[]`. This is correct -- serde serializes HashSet as array.
+
+---
+
+## 7. Out of Scope
+
+- Server-side command handlers (separate task when storage_v2 is integrated)
+- `deleteSnapshot` (mentioned in client-spec but not in T3.3 subtasks)
+- Integration tests against running server (requires server support)
+- Modifying `GraphBackend` interface in core package
+
+---
+
+## 8. Commit Strategy
+
+Single commit: "feat(rfdb): Add client snapshot API types and methods (RFD-10)"
+
+This is a 1-point task. One atomic commit with types + methods + tests.

--- a/_tasks/RFD-10/003-rob-implementation.md
+++ b/_tasks/RFD-10/003-rob-implementation.md
@@ -1,0 +1,105 @@
+# Rob Pike Implementation Report: RFD-10 T3.3 Client Snapshot API
+
+> Date: 2026-02-14
+> Status: DONE
+> Tests: 15 new (22 total), all passing
+
+---
+
+## Summary
+
+Added 4 snapshot operations to the RFDB TypeScript client: `diffSnapshots`, `tagSnapshot`, `findSnapshot`, `listSnapshots`. Plus 7 supporting types, re-exports, and 15 tests.
+
+## Files Modified
+
+### 1. `packages/types/src/rfdb.ts`
+
+**RFDBCommand union** — added 4 snapshot commands:
+- `'diffSnapshots' | 'tagSnapshot' | 'findSnapshot' | 'listSnapshots'`
+
+**New types** (7 total):
+- `SnapshotRef` — discriminated union: `number | { tag: string; value: string }`
+- `SnapshotStats` — mirrors Rust `ManifestStats` (totalNodes, totalEdges, nodeSegmentCount, edgeSegmentCount)
+- `SegmentInfo` — simplified Rust `SegmentDescriptor` (segmentId, recordCount, byteSize, nodeTypes[], filePaths[], edgeTypes[])
+- `SnapshotDiff` — mirrors Rust `SnapshotDiff` (from/to versions, added/removed segment lists, stats for both)
+- `SnapshotInfo` — mirrors Rust `SnapshotInfo` (version, createdAt, tags, stats)
+- `DiffSnapshotsResponse`, `FindSnapshotResponse`, `ListSnapshotsResponse` — response wrappers extending `RFDBResponse`
+
+**IRFDBClient interface** — added 4 methods:
+- `diffSnapshots(from: SnapshotRef, to: SnapshotRef): Promise<SnapshotDiff>`
+- `tagSnapshot(version: number, tags: Record<string, string>): Promise<void>`
+- `findSnapshot(tagKey: string, tagValue: string): Promise<number | null>`
+- `listSnapshots(filterTag?: string): Promise<SnapshotInfo[]>`
+
+### 2. `packages/rfdb/ts/client.ts`
+
+**New imports** — `SnapshotRef`, `SnapshotDiff`, `SnapshotInfo`, `DiffSnapshotsResponse`, `FindSnapshotResponse`, `ListSnapshotsResponse`
+
+**New private helper** — `_resolveSnapshotRef(ref: SnapshotRef)`:
+- number -> `{ version: N }`
+- `{ tag, value }` -> `{ tagKey, tagValue }`
+
+**4 new methods** — all follow existing `_send()` pattern:
+- `diffSnapshots()` — sends `from` and `to` as resolved refs, returns `diff` field
+- `tagSnapshot()` — sends `version` + `tags`, returns void
+- `findSnapshot()` — sends `tagKey` + `tagValue`, returns `version` (number | null)
+- `listSnapshots()` — optionally sends `filterTag`, returns `snapshots` array
+
+### 3. `packages/rfdb/ts/protocol.ts`
+
+Re-exported all 8 new types from `@grafema/types`.
+
+### 4. `packages/rfdb/ts/index.ts`
+
+Re-exported all 8 new types from `./protocol.js`.
+
+### 5. `packages/rfdb/ts/client.test.ts`
+
+**15 new tests** across 3 describe blocks:
+
+**Snapshot API -- resolveSnapshotRef** (4 tests):
+- Number ref -> `{ version }`
+- Tag ref -> `{ tagKey, tagValue }`
+- Version 0 edge case (not falsy)
+- Union discrimination (typeof check)
+
+**Snapshot API -- Type Contracts** (5 tests):
+- SnapshotStats shape validation
+- SegmentInfo shape validation (including HashSet -> string[] arrays)
+- SnapshotDiff full shape with mixed segment lists
+- SnapshotInfo with populated tags
+- SnapshotInfo with empty tags
+
+**Snapshot API -- Wire Format** (6 tests):
+- tagSnapshot payload structure
+- findSnapshot response (found / not found)
+- listSnapshots payload (with filter / without filter)
+- diffSnapshots with mixed refs (number + tag)
+
+## Wire Format Mapping
+
+| TypeScript field | Rust field | Rust struct | Notes |
+|-----------------|------------|-------------|-------|
+| `SnapshotDiff.fromVersion` | `from_version` | `SnapshotDiff` | serde camelCase when wrapped |
+| `SnapshotDiff.toVersion` | `to_version` | `SnapshotDiff` | serde camelCase when wrapped |
+| `SnapshotDiff.addedNodeSegments` | `added_node_segments` | `SnapshotDiff` | Vec<SegmentDescriptor> |
+| `SnapshotDiff.statsFrom` | `stats_from` | `SnapshotDiff` | ManifestStats |
+| `SnapshotInfo.createdAt` | `created_at` | `SnapshotInfo` | Unix epoch seconds (u64) |
+| `SnapshotStats.totalNodes` | `total_nodes` | `ManifestStats` | u64 |
+| `SegmentInfo.segmentId` | `segment_id` | `SegmentDescriptor` | u64 |
+| `SegmentInfo.nodeTypes` | `node_types` | `SegmentDescriptor` | HashSet<String> -> string[] |
+
+**Note on serde:** The Rust manifest.rs structs do NOT have `#[serde(rename_all = "camelCase")]`. The server binary (rfdb_server.rs) uses per-field `#[serde(rename)]` on its Response variants. When snapshot commands are added to the server, the Response variants will need explicit rename attributes or Wire* wrapper types to produce camelCase JSON. The TS types are defined as camelCase to match the planned wire format.
+
+## Build & Test Results
+
+- `pnpm --filter @grafema/types build` -- clean
+- `pnpm --filter @grafema/rfdb-client build` -- clean
+- `pnpm --filter @grafema/core build` -- clean
+- `node --test packages/rfdb/ts/client.test.ts` -- 22/22 pass (15 new)
+
+## Out of Scope
+
+- Server-side command handlers (server uses v1 storage, no storage_v2 integration yet)
+- `deleteSnapshot` (not in T3.3 scope)
+- Integration tests against running server (requires server support)

--- a/_tasks/RFD-10/004-steve-review.md
+++ b/_tasks/RFD-10/004-steve-review.md
@@ -1,0 +1,230 @@
+# Steve Jobs High-level Review: RFD-10 T3.3 Client Snapshot API
+
+> Date: 2026-02-14
+> Reviewer: Steve Jobs
+> Status: **REJECT**
+
+---
+
+## Executive Summary
+
+The implementation is **technically correct** but ships with a **fatal architectural limitation** that defeats the feature's purpose. This is exactly the kind of "MVP limitation" we must reject.
+
+**The problem:** The client can send snapshot commands, but the server can't handle them. The feature is **0% usable** until the server is updated. We're shipping dead code.
+
+**The right solution:** Either ship the full vertical slice (client + server), or don't ship at all.
+
+---
+
+## What's Right
+
+### 1. Code Quality — Excellent
+
+- Clean, consistent implementation matching existing patterns
+- Type safety is solid — TS types map correctly to Rust wire format
+- 22/22 tests pass, including 15 new snapshot tests
+- Wire format helper (`_resolveSnapshotRef`) is well-designed
+- Tests document intent clearly with WHY comments
+
+### 2. Type Mapping — Correct
+
+```typescript
+// TS type                     Rust type
+SnapshotStats.totalNodes   →  ManifestStats.total_nodes
+SnapshotDiff.fromVersion   →  SnapshotDiff.from_version
+SegmentInfo.nodeTypes[]    →  SegmentDescriptor.node_types (HashSet)
+```
+
+Serde will serialize this correctly when the server is ready. No issues here.
+
+### 3. Testing — Strong
+
+15 new tests cover:
+- `resolveSnapshotRef()` union discrimination
+- Type contract validation
+- Wire format payload structure
+- Edge cases (version 0, empty tags)
+
+These are **unit tests for dead code**, but they're good tests.
+
+---
+
+## What's Wrong
+
+### CRITICAL ISSUE: Feature is 0% Usable
+
+**The server doesn't support snapshot commands.**
+
+From Don's plan:
+> "The Rust server does NOT use storage_v2 yet... The server binary has no `DiffSnapshots`, `TagSnapshot`, `FindSnapshot`, or `ListSnapshots` variants."
+
+This means:
+```typescript
+await client.diffSnapshots(1, 5);
+// ERROR: Unknown command 'diffSnapshots'
+```
+
+**Every single snapshot method will fail with "unknown command" until the server is updated.**
+
+This isn't a "limitation" — this is **non-functional code masquerading as a feature.**
+
+### The "Option B" Defense Doesn't Hold
+
+Don's plan justifies this:
+> "Option B: Client-only (as specified in T3.3)... Server-side handlers deferred (they're trivial delegation)."
+
+**This is wrong for three reasons:**
+
+1. **T3.3 scope is arbitrary.** Just because the task was scoped as "client-only" doesn't mean that's the right boundary. The task should have been: "Add snapshot API (client + server)."
+
+2. **"Trivial delegation" is a red flag.** If the server handlers are so trivial (5 lines each), why not include them? The only reason to defer is if there's an architectural blocker. There isn't — the Rust storage_v2 code is ready.
+
+3. **Tests can't verify correctness.** The tests check that we send the right JSON. They can't verify that the server interprets it correctly, because the server doesn't support it yet.
+
+### This Violates Root Cause Policy
+
+From CLAUDE.md:
+> "When behavior or architecture doesn't match project vision:
+> 1. STOP immediately
+> 2. Do not patch or workaround
+> 3. Identify the architectural mismatch
+> 4. Discuss with user before proceeding
+> 5. Fix from the roots, not symptoms"
+
+**Shipping client methods with no server support IS a workaround.** The root cause is: "We need snapshot API." The correct fix is: "Add snapshot API end-to-end."
+
+Shipping client-only is cutting corners. If it takes longer to do the full vertical slice — it takes longer. No shortcuts.
+
+---
+
+## Architectural Gap Analysis
+
+### Why is the server not using storage_v2?
+
+The real question: **Why does storage_v2 exist in the codebase if the server doesn't use it?**
+
+This suggests one of two things:
+1. **storage_v2 is unfinished** — in which case we shouldn't be adding client methods for it
+2. **storage_v2 is ready but not integrated** — in which case the blocker is server integration, not client code
+
+Either way, **adding client methods now is premature.**
+
+### The Right Order
+
+1. **Server uses storage_v2** (or we decide it's not ready)
+2. **Server implements snapshot command handlers** (5 lines each per Don)
+3. **Client implements snapshot methods** (this task)
+4. **Integration tests** verify end-to-end
+
+We're doing step 3 before steps 1 and 2. That's backwards.
+
+---
+
+## What Should Have Happened
+
+### Mini-MLA Would Have Caught This
+
+If Don had questioned "why is this task scoped as client-only?", the answer would have been: "Because that's how the RFD broke it down." But **task breakdown is not architecture.**
+
+The correct response:
+> "The task scope is wrong. Snapshot API should be a vertical slice: types + client + server + integration test. Splitting it into client-only makes the feature unusable."
+
+### The User Should Have Been Asked
+
+From CLAUDE.md:
+> "When in doubt about whether a task warrants a team, prefer spawning a team."
+
+This task is **NOT well-understood.** It touches RFDB v2 protocol, storage_v2 integration, and client-server contracts. It should have gone through full MLA.
+
+At minimum, Steve + Vadim review should have been invoked **before implementation**, not after.
+
+---
+
+## Scope Creep Check
+
+430 LOC delivered vs 150 LOC estimated. Why?
+
+Breakdown:
+- 248 LOC tests (15 tests, but verbose WHY comments — this is good)
+- 67 LOC client methods (4 methods + helper — reasonable)
+- 96 LOC types (7 types + docs — detailed but necessary)
+- 10 LOC re-exports
+
+**Verdict:** Not scope creep. The task was underestimated. 430 LOC for 4 methods + 7 types + 15 tests is reasonable.
+
+---
+
+## Zero Tolerance for "MVP Limitations" Check
+
+From CLAUDE.md:
+> "If a 'limitation' makes the feature work for <50% of real-world cases → REJECT"
+
+**This feature works for 0% of real-world cases** until the server is updated.
+
+**REJECT.**
+
+---
+
+## Questions for User
+
+1. **Why was this task scoped as client-only?** Is there a reason the server handlers couldn't be included?
+
+2. **When will storage_v2 be integrated into the server binary?** If that's months away, we shouldn't be adding client methods now.
+
+3. **What's the plan for server integration?** Is there a follow-up task? If so, why not do it atomically?
+
+4. **Should we revert this and redo as full vertical slice?** Or keep this PR but block merging until server support lands?
+
+---
+
+## Recommended Action
+
+**Option A: Revert and Redo (Preferred)**
+
+1. Revert this implementation
+2. Expand task scope to include server handlers
+3. Re-implement as full vertical slice:
+   - Server: Add 4 Request variants, wire to storage_v2 methods (~50 LOC Rust)
+   - Client: Current implementation (430 LOC TS)
+   - Integration test: Verify end-to-end (~30 LOC)
+4. Ship atomically
+
+**Option B: Block Merge Until Server Ready**
+
+1. Keep this implementation in branch
+2. Create blocker task: "Integrate storage_v2 into server binary"
+3. Do NOT merge until server supports these commands
+4. When server ready, add integration tests BEFORE merging
+
+**Option C: Ship It (NOT Recommended)**
+
+1. Merge this PR
+2. Document limitation in release notes
+3. Create follow-up issue for server support
+
+**I recommend Option A.** The task was scoped wrong. Fix it from the roots.
+
+---
+
+## Verdict
+
+**REJECT**
+
+Not because the code is bad — the code is excellent. But because **we're shipping a feature that doesn't work.**
+
+Grafema's vision: "AI should query the graph, not read code."
+
+This PR: "AI can send snapshot commands, but the server will ignore them."
+
+**That's not the right way to build product.**
+
+---
+
+## Next Steps
+
+1. **Escalate to user immediately** — ask the 4 questions above
+2. **Do NOT proceed** until we agree on the right scope
+3. If user confirms client-only is intentional (e.g., server integration blocked by other work) → ask for explicit justification
+4. If user agrees scope was wrong → revert and expand to full vertical slice
+
+**Default stance: REJECT. Zero tolerance for shipping dead code.**

--- a/packages/rfdb/ts/index.ts
+++ b/packages/rfdb/ts/index.ts
@@ -21,4 +21,13 @@ export type {
   AttrQuery,
   DatalogResult,
   IRFDBClient,
+  // Snapshot types
+  SnapshotRef,
+  SnapshotStats,
+  SegmentInfo,
+  SnapshotDiff,
+  SnapshotInfo,
+  DiffSnapshotsResponse,
+  FindSnapshotResponse,
+  ListSnapshotsResponse,
 } from './protocol.js';

--- a/packages/rfdb/ts/protocol.ts
+++ b/packages/rfdb/ts/protocol.ts
@@ -49,6 +49,16 @@ export type {
   DatalogBinding,
   DatalogResult,
 
+  // Snapshot types
+  SnapshotRef,
+  SnapshotStats,
+  SegmentInfo,
+  SnapshotDiff,
+  SnapshotInfo,
+  DiffSnapshotsResponse,
+  FindSnapshotResponse,
+  ListSnapshotsResponse,
+
   // Client interface
   IRFDBClient,
 } from '@grafema/types';

--- a/packages/types/src/rfdb.ts
+++ b/packages/types/src/rfdb.ts
@@ -55,7 +55,12 @@ export type RFDBCommand =
   | 'listDatabases'
   | 'currentDatabase'
   // Schema declaration
-  | 'declareFields';
+  | 'declareFields'
+  // Snapshot operations
+  | 'diffSnapshots'
+  | 'tagSnapshot'
+  | 'findSnapshot'
+  | 'listSnapshots';
 
 // === WIRE FORMAT ===
 // Nodes as sent over the wire
@@ -301,6 +306,89 @@ export interface DatalogResult {
   bindings: DatalogBinding;
 }
 
+// === SNAPSHOT TYPES ===
+
+/**
+ * Reference to a snapshot — either by version number or by tag key/value pair.
+ *
+ * When used as a number, refers to the snapshot at that version.
+ * When used as an object, resolves the snapshot tagged with the given key/value.
+ */
+export type SnapshotRef = number | { tag: string; value: string };
+
+/**
+ * Aggregate statistics for a snapshot (mirrors Rust ManifestStats).
+ *
+ * Wire format: camelCase (Rust snake_case fields mapped via serde rename).
+ */
+export interface SnapshotStats {
+  totalNodes: number;
+  totalEdges: number;
+  nodeSegmentCount: number;
+  edgeSegmentCount: number;
+}
+
+/**
+ * Segment descriptor — describes a single data segment in a snapshot.
+ *
+ * Simplified view of Rust SegmentDescriptor. Exposes fields relevant to
+ * client-side diff analysis. Internal fields (segmentType, shardId) omitted.
+ *
+ * Wire format: camelCase. HashSet<String> serializes as string[].
+ */
+export interface SegmentInfo {
+  segmentId: number;
+  recordCount: number;
+  byteSize: number;
+  nodeTypes: string[];
+  filePaths: string[];
+  edgeTypes: string[];
+}
+
+/**
+ * Diff between two snapshots (from -> to).
+ *
+ * Shows which segments were added/removed and stats for both versions.
+ * Mirrors Rust SnapshotDiff (storage_v2/manifest.rs).
+ */
+export interface SnapshotDiff {
+  fromVersion: number;
+  toVersion: number;
+  addedNodeSegments: SegmentInfo[];
+  removedNodeSegments: SegmentInfo[];
+  addedEdgeSegments: SegmentInfo[];
+  removedEdgeSegments: SegmentInfo[];
+  statsFrom: SnapshotStats;
+  statsTo: SnapshotStats;
+}
+
+/**
+ * Lightweight snapshot information for list operations.
+ *
+ * Mirrors Rust SnapshotInfo (storage_v2/manifest.rs).
+ * createdAt is Unix epoch seconds (u64 in Rust).
+ */
+export interface SnapshotInfo {
+  version: number;
+  createdAt: number;
+  tags: Record<string, string>;
+  stats: SnapshotStats;
+}
+
+// Snapshot response types
+
+export interface DiffSnapshotsResponse extends RFDBResponse {
+  diff: SnapshotDiff;
+}
+
+export interface FindSnapshotResponse extends RFDBResponse {
+  version: number | null;
+}
+
+export interface ListSnapshotsResponse extends RFDBResponse {
+  snapshots: SnapshotInfo[];
+}
+
 // === CLIENT INTERFACE ===
 export interface IRFDBClient {
   readonly socketPath: string;
@@ -364,4 +452,10 @@ export interface IRFDBClient {
   dropDatabase(name: string): Promise<RFDBResponse>;
   listDatabases(): Promise<ListDatabasesResponse>;
   currentDatabase(): Promise<CurrentDatabaseResponse>;
+
+  // Snapshot operations
+  diffSnapshots(from: SnapshotRef, to: SnapshotRef): Promise<SnapshotDiff>;
+  tagSnapshot(version: number, tags: Record<string, string>): Promise<void>;
+  findSnapshot(tagKey: string, tagValue: string): Promise<number | null>;
+  listSnapshots(filterTag?: string): Promise<SnapshotInfo[]>;
 }


### PR DESCRIPTION
## Summary

- Add `diffSnapshots`, `tagSnapshot`, `findSnapshot`, `listSnapshots` methods to RFDB TypeScript client
- Add 7 type definitions mirroring Rust storage_v2 ManifestStore structures (`SnapshotRef`, `SnapshotDiff`, `SnapshotInfo`, etc.)
- 15 new tests (resolveSnapshotRef, type contracts, wire format)

Server handlers will be wired in RFD-11 (T4.1: Wire Protocol v3 Integration).

## Test plan

- [x] 22/22 tests pass (`node --test packages/rfdb/ts/client.test.ts`)
- [x] All packages build clean (types, rfdb-client, core)
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)