### PR TITLE
REG-387: Fix test hangs by using cleanupAllTestDatabases in after() hooks

### DIFF
--- a/_tasks/REG-387/001-user-request.md
+++ b/_tasks/REG-387/001-user-request.md
@@ -1,0 +1,15 @@
+# REG-387: Fix FetchAnalyzer unit tests hang (RFDB test server lifecycle)
+
+## Goal
+
+Make `FetchAnalyzer` unit tests exit cleanly without hangs or EPIPE errors.
+
+## Acceptance Criteria
+
+* Running `node --import tsx --test test/unit/plugins/analysis/FetchAnalyzer.test.ts` exits on its own.
+* No EPIPE errors from RFDB client/server during test teardown.
+* Cleanup is explicit and localized to test setup (no global side effects).
+
+## Context
+
+During REG-384, `FetchAnalyzer.test.ts` passed assertions but the Node test runner hung due to open handles. A follow-up attempt with shared cleanup caused EPIPE (RFDB connection closed while async activity still ongoing). This appears to be a test server lifecycle / cleanup ordering issue.

--- a/_tasks/REG-387/002-implementation.md
+++ b/_tasks/REG-387/002-implementation.md
@@ -1,0 +1,44 @@
+# REG-387: Implementation Report
+
+## Root Cause
+
+`FetchAnalyzer.test.ts` (and 14 other `.ts` test files) used `db.cleanup()` in their `after()` hooks. This method only closes the individual test database client connection, but leaves the **shared RFDB server connection** (`sharedServerInstance.client`) alive with a ref'd socket, preventing Node.js from exiting.
+
+The established pattern in all `.js` test files is to use `cleanupAllTestDatabases()` which:
+1. Gracefully closes all test database connections
+2. Forcefully silences all sockets (removes listeners, destroys sockets)
+3. Kills the shared server process if owned by this process
+4. Clears the `sharedServerInstance` singleton
+
+## Fix
+
+For all 15 affected `.ts` test files:
+1. Added `cleanupAllTestDatabases` to the import from `TestRFDB.js`
+2. Replaced `after(async () => { if (db) await db.cleanup(); })` with `after(cleanupAllTestDatabases)`
+
+The `beforeEach` hooks that call `db.cleanup()` before re-creating were left unchanged — that's correct cleanup-before-recreate behavior.
+
+## Files Changed
+
+- `test/unit/plugins/analysis/FetchAnalyzer.test.ts`
+- `test/unit/plugins/analysis/ExpressResponseAnalyzer.test.ts`
+- `test/unit/plugins/analysis/ExpressResponseAnalyzer.linking.test.ts`
+- `test/unit/plugins/analysis/ast/property-access.test.ts`
+- `test/unit/plugins/analysis/ast/meta-property.test.ts`
+- `test/unit/plugins/analysis/ast/loop-nodes.test.ts`
+- `test/unit/plugins/analysis/ast/method-call-uses-edges.test.ts`
+- `test/unit/plugins/analysis/ast/object-property-edges.test.ts`
+- `test/unit/plugins/analysis/ast/switch-statement.test.ts`
+- `test/unit/plugins/analysis/ast/ternary-branch.test.ts`
+- `test/unit/plugins/analysis/ast/try-catch-nodes.test.ts`
+- `test/unit/plugins/analysis/ast/function-metadata.test.ts`
+- `test/unit/plugins/analysis/ast/if-statement-nodes.test.ts`
+- `test/unit/analysis/async-error-tracking.test.ts`
+- `test/unit/GuaranteeAPI.test.ts`
+
+## Verification
+
+- `FetchAnalyzer.test.ts`: 14/14 pass, exits cleanly (was hanging)
+- `property-access.test.ts`: 35/35 pass, exits cleanly
+- `GuaranteeAPI.test.ts`: 30/30 pass, exits cleanly
+- Existing `.js` tests: no regression

--- a/test/unit/GuaranteeAPI.test.ts
+++ b/test/unit/GuaranteeAPI.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, it, after, beforeEach } from 'node:test';
 import assert from 'node:assert';
-import { createTestDatabase } from '../helpers/TestRFDB.js';
+import { createTestDatabase, cleanupAllTestDatabases } from '../helpers/TestRFDB.js';
 import { GuaranteeAPI, type GuaranteeGraphBackend, GuaranteeNode } from '@grafema/core';
 
 describe('GuaranteeAPI', () => {
@@ -27,9 +27,7 @@ describe('GuaranteeAPI', () => {
     api = new GuaranteeAPI(backend as unknown as GuaranteeGraphBackend);
   });
 
-  after(async () => {
-    if (db) await db.cleanup();
-  });
+  after(cleanupAllTestDatabases);
 
   describe('createGuarantee()', () => {
     it('should create a guarantee:queue node', async () => {

--- a/test/unit/analysis/async-error-tracking.test.ts
+++ b/test/unit/analysis/async-error-tracking.test.ts
@@ -19,7 +19,7 @@ import { join } from 'path';
 import { writeFileSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 
-import { createTestDatabase } from '../../helpers/TestRFDB.js';
+import { createTestDatabase, cleanupAllTestDatabases } from '../../helpers/TestRFDB.js';
 import { createTestOrchestrator } from '../../helpers/createTestOrchestrator.js';
 import type { NodeRecord, EdgeRecord } from '@grafema/types';
 
@@ -143,9 +143,7 @@ describe('Basic Rejection Patterns (REG-311)', () => {
     db = await createTestDatabase();
   });
 
-  after(async () => {
-    if (db) await db.cleanup();
-  });
+  after(cleanupAllTestDatabases);
 
   // ---------------------------------------------------------------------------
   // 1.1 Promise.reject(new Error())
@@ -390,9 +388,7 @@ describe('Variable Rejection Micro-Trace (REG-311)', () => {
     db = await createTestDatabase();
   });
 
-  after(async () => {
-    if (db) await db.cleanup();
-  });
+  after(cleanupAllTestDatabases);
 
   // ---------------------------------------------------------------------------
   // 2.1 const err = new Error(); reject(err)
@@ -612,9 +608,7 @@ describe('isAwaited and isInsideTry on CALL nodes (REG-311)', () => {
     db = await createTestDatabase();
   });
 
-  after(async () => {
-    if (db) await db.cleanup();
-  });
+  after(cleanupAllTestDatabases);
 
   // ---------------------------------------------------------------------------
   // 3.1 isAwaited detection
@@ -830,9 +824,7 @@ describe('CATCHES_FROM edges (REG-311)', () => {
     db = await createTestDatabase();
   });
 
-  after(async () => {
-    if (db) await db.cleanup();
-  });
+  after(cleanupAllTestDatabases);
 
   // ---------------------------------------------------------------------------
   // 4.1 Catch block linked to awaited calls in try
@@ -1082,9 +1074,7 @@ describe('RejectionPropagationEnricher (REG-311)', () => {
     db = await createTestDatabase();
   });
 
-  after(async () => {
-    if (db) await db.cleanup();
-  });
+  after(cleanupAllTestDatabases);
 
   // ---------------------------------------------------------------------------
   // 5.1 Transitive propagation through await
@@ -1298,9 +1288,7 @@ describe('Async Error Tracking Integration (REG-311)', () => {
     db = await createTestDatabase();
   });
 
-  after(async () => {
-    if (db) await db.cleanup();
-  });
+  after(cleanupAllTestDatabases);
 
   describe('Complex real-world patterns', () => {
     it('should handle async function with multiple error paths', async () => {
@@ -1428,9 +1416,7 @@ describe('Sync Throw Patterns and THROWS Edges (REG-286)', () => {
     db = await createTestDatabase();
   });
 
-  after(async () => {
-    if (db) await db.cleanup();
-  });
+  after(cleanupAllTestDatabases);
 
   // ---------------------------------------------------------------------------
   // 7.1 THROWS edge creation for sync functions

--- a/test/unit/plugins/analysis/ExpressResponseAnalyzer.linking.test.ts
+++ b/test/unit/plugins/analysis/ExpressResponseAnalyzer.linking.test.ts
@@ -17,7 +17,7 @@ import { join } from 'path';
 import { writeFileSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 
-import { createTestDatabase } from '../../../helpers/TestRFDB.js';
+import { createTestDatabase, cleanupAllTestDatabases } from '../../../helpers/TestRFDB.js';
 import { createTestOrchestrator } from '../../../helpers/createTestOrchestrator.js';
 import { ExpressRouteAnalyzer, ExpressResponseAnalyzer } from '@grafema/core';
 import type { NodeRecord, EdgeRecord } from '@grafema/types';
@@ -146,9 +146,7 @@ describe('ExpressResponseAnalyzer Variable Linking (REG-326)', () => {
     backend = await createTestDatabase(); backend = db.backend;
   });
 
-  after(async () => {
-    if (db) await db.cleanup();
-  });
+  after(cleanupAllTestDatabases);
 
   // ===========================================================================
   // TEST 1: res.json(localVar) links to existing VARIABLE

--- a/test/unit/plugins/analysis/ExpressResponseAnalyzer.test.ts
+++ b/test/unit/plugins/analysis/ExpressResponseAnalyzer.test.ts
@@ -18,7 +18,7 @@ import { join } from 'path';
 import { writeFileSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 
-import { createTestDatabase } from '../../../helpers/TestRFDB.js';
+import { createTestDatabase, cleanupAllTestDatabases } from '../../../helpers/TestRFDB.js';
 import { createTestOrchestrator } from '../../../helpers/createTestOrchestrator.js';
 import { ExpressRouteAnalyzer, ExpressResponseAnalyzer } from '@grafema/core';
 import type { NodeRecord, EdgeRecord } from '@grafema/types';
@@ -136,9 +136,7 @@ describe('ExpressResponseAnalyzer (REG-252 Phase A)', () => {
     backend = await createTestDatabase(); backend = db.backend;
   });
 
-  after(async () => {
-    if (db) await db.cleanup();
-  });
+  after(cleanupAllTestDatabases);
 
   // ===========================================================================
   // TEST 1: res.json(object) creates RESPONDS_WITH edge

--- a/test/unit/plugins/analysis/FetchAnalyzer.test.ts
+++ b/test/unit/plugins/analysis/FetchAnalyzer.test.ts
@@ -18,7 +18,7 @@ import { join } from 'path';
 import { writeFileSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 
-import { createTestDatabase } from '../../../helpers/TestRFDB.js';
+import { createTestDatabase, cleanupAllTestDatabases } from '../../../helpers/TestRFDB.js';
 import { createTestOrchestrator } from '../../../helpers/createTestOrchestrator.js';
 import type { NodeRecord, EdgeRecord } from '@grafema/types';
 
@@ -125,9 +125,7 @@ describe('FetchAnalyzer responseDataNode tracking (REG-252 Phase B)', () => {
     backend = db.backend;
   });
 
-  after(async () => {
-    if (db) await db.cleanup();
-  });
+  after(cleanupAllTestDatabases);
 
   // ===========================================================================
   // TEST 1: Basic responseDataNode with await fetch() and response.json()

--- a/test/unit/plugins/analysis/ast/function-metadata.test.ts
+++ b/test/unit/plugins/analysis/ast/function-metadata.test.ts
@@ -23,7 +23,7 @@ import { join } from 'path';
 import { writeFileSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 
-import { createTestDatabase } from '../../../../helpers/TestRFDB.js';
+import { createTestDatabase, cleanupAllTestDatabases } from '../../../../helpers/TestRFDB.js';
 import { createTestOrchestrator } from '../../../../helpers/createTestOrchestrator.js';
 import type { NodeRecord } from '@grafema/types';
 
@@ -124,9 +124,7 @@ describe('Function Control Flow Metadata (REG-267 Phase 6)', () => {
     backend = await createTestDatabase(); backend = db.backend;
   });
 
-  after(async () => {
-    if (db) await db.cleanup();
-  });
+  after(cleanupAllTestDatabases);
 
   // ===========================================================================
   // GROUP 1: Basic metadata presence

--- a/test/unit/plugins/analysis/ast/if-statement-nodes.test.ts
+++ b/test/unit/plugins/analysis/ast/if-statement-nodes.test.ts
@@ -26,7 +26,7 @@ import { join } from 'path';
 import { writeFileSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 
-import { createTestDatabase } from '../../../../helpers/TestRFDB.js';
+import { createTestDatabase, cleanupAllTestDatabases } from '../../../../helpers/TestRFDB.js';
 import { createTestOrchestrator } from '../../../../helpers/createTestOrchestrator.js';
 import type { NodeRecord, EdgeRecord } from '@grafema/types';
 
@@ -125,9 +125,7 @@ describe('If Statement Nodes Analysis (REG-267 Phase 3)', () => {
     backend = await createTestDatabase(); backend = db.backend;
   });
 
-  after(async () => {
-    if (db) await db.cleanup();
-  });
+  after(cleanupAllTestDatabases);
 
   // ===========================================================================
   // GROUP 1: Basic if statement creates BRANCH node

--- a/test/unit/plugins/analysis/ast/loop-nodes.test.ts
+++ b/test/unit/plugins/analysis/ast/loop-nodes.test.ts
@@ -24,7 +24,7 @@ import { join } from 'path';
 import { writeFileSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 
-import { createTestDatabase } from '../../../../helpers/TestRFDB.js';
+import { createTestDatabase, cleanupAllTestDatabases } from '../../../../helpers/TestRFDB.js';
 import { createTestOrchestrator } from '../../../../helpers/createTestOrchestrator.js';
 import type { NodeRecord, EdgeRecord } from '@grafema/types';
 
@@ -123,9 +123,7 @@ describe('Loop Nodes Analysis (REG-267 Phase 2)', () => {
     backend = await createTestDatabase(); backend = db.backend;
   });
 
-  after(async () => {
-    if (db) await db.cleanup();
-  });
+  after(cleanupAllTestDatabases);
 
   // ===========================================================================
   // GROUP 1: Basic for-loop

--- a/test/unit/plugins/analysis/ast/meta-property.test.ts
+++ b/test/unit/plugins/analysis/ast/meta-property.test.ts
@@ -16,7 +16,7 @@ import { join } from 'path';
 import { writeFileSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 
-import { createTestDatabase } from '../../../../helpers/TestRFDB.js';
+import { createTestDatabase, cleanupAllTestDatabases } from '../../../../helpers/TestRFDB.js';
 import { createTestOrchestrator } from '../../../../helpers/createTestOrchestrator.js';
 import type { NodeRecord, EdgeRecord } from '@grafema/types';
 
@@ -99,9 +99,7 @@ describe('MetaProperty: new.target (REG-301)', () => {
     backend = db.backend;
   });
 
-  after(async () => {
-    if (db) await db.cleanup();
-  });
+  after(cleanupAllTestDatabases);
 
   // ===========================================================================
   // Basic new.target tracking

--- a/test/unit/plugins/analysis/ast/method-call-uses-edges.test.ts
+++ b/test/unit/plugins/analysis/ast/method-call-uses-edges.test.ts
@@ -23,7 +23,7 @@ import { join } from 'path';
 import { writeFileSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 
-import { createTestDatabase } from '../../../../helpers/TestRFDB.js';
+import { createTestDatabase, cleanupAllTestDatabases } from '../../../../helpers/TestRFDB.js';
 import { createTestOrchestrator } from '../../../../helpers/createTestOrchestrator.js';
 import type { NodeRecord, EdgeRecord } from '@grafema/types';
 
@@ -146,9 +146,7 @@ describe('Method Call USES Edges (REG-262)', () => {
     backend = await createTestDatabase(); backend = db.backend;
   });
 
-  after(async () => {
-    if (db) await db.cleanup();
-  });
+  after(cleanupAllTestDatabases);
 
   // ===========================================================================
   // TEST 1: Basic method call creates USES edge

--- a/test/unit/plugins/analysis/ast/object-property-edges.test.ts
+++ b/test/unit/plugins/analysis/ast/object-property-edges.test.ts
@@ -29,7 +29,7 @@ import { join } from 'path';
 import { writeFileSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 
-import { createTestDatabase } from '../../../../helpers/TestRFDB.js';
+import { createTestDatabase, cleanupAllTestDatabases } from '../../../../helpers/TestRFDB.js';
 import { createTestOrchestrator } from '../../../../helpers/createTestOrchestrator.js';
 import type { NodeRecord, EdgeRecord } from '@grafema/types';
 
@@ -112,9 +112,7 @@ describe('Object Property Edges (REG-228)', () => {
     backend = await createTestDatabase(); backend = db.backend;
   });
 
-  after(async () => {
-    if (db) await db.cleanup();
-  });
+  after(cleanupAllTestDatabases);
 
   // ===========================================================================
   // TESTS: Basic HAS_PROPERTY edge creation

--- a/test/unit/plugins/analysis/ast/property-access.test.ts
+++ b/test/unit/plugins/analysis/ast/property-access.test.ts
@@ -34,7 +34,7 @@ import { join } from 'path';
 import { writeFileSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 
-import { createTestDatabase } from '../../../../helpers/TestRFDB.js';
+import { createTestDatabase, cleanupAllTestDatabases } from '../../../../helpers/TestRFDB.js';
 import { createTestOrchestrator } from '../../../../helpers/createTestOrchestrator.js';
 import type { NodeRecord, EdgeRecord } from '@grafema/types';
 
@@ -160,9 +160,7 @@ describe('PROPERTY_ACCESS Nodes (REG-395)', () => {
     backend = db.backend;
   });
 
-  after(async () => {
-    if (db) await db.cleanup();
-  });
+  after(cleanupAllTestDatabases);
 
   // ===========================================================================
   // TEST 1: Simple property access

--- a/test/unit/plugins/analysis/ast/switch-statement.test.ts
+++ b/test/unit/plugins/analysis/ast/switch-statement.test.ts
@@ -24,7 +24,7 @@ import { join } from 'path';
 import { writeFileSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 
-import { createTestDatabase } from '../../../../helpers/TestRFDB.js';
+import { createTestDatabase, cleanupAllTestDatabases } from '../../../../helpers/TestRFDB.js';
 import { createTestOrchestrator } from '../../../../helpers/createTestOrchestrator.js';
 import type { NodeRecord, EdgeRecord } from '@grafema/types';
 
@@ -123,9 +123,7 @@ describe('Switch Statement Analysis (REG-275)', () => {
     backend = await createTestDatabase(); backend = db.backend;
   });
 
-  after(async () => {
-    if (db) await db.cleanup();
-  });
+  after(cleanupAllTestDatabases);
 
   // ===========================================================================
   // GROUP 1: Basic BRANCH node creation

--- a/test/unit/plugins/analysis/ast/ternary-branch.test.ts
+++ b/test/unit/plugins/analysis/ast/ternary-branch.test.ts
@@ -24,7 +24,7 @@ import { join } from 'path';
 import { writeFileSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 
-import { createTestDatabase } from '../../../../helpers/TestRFDB.js';
+import { createTestDatabase, cleanupAllTestDatabases } from '../../../../helpers/TestRFDB.js';
 import { createTestOrchestrator } from '../../../../helpers/createTestOrchestrator.js';
 import type { NodeRecord } from '@grafema/types';
 
@@ -125,9 +125,7 @@ describe('Ternary Branch Nodes Analysis (REG-287)', () => {
     backend = await createTestDatabase(); backend = db.backend;
   });
 
-  after(async () => {
-    if (db) await db.cleanup();
-  });
+  after(cleanupAllTestDatabases);
 
   // ===========================================================================
   // GROUP 1: Basic ternary creates BRANCH node

--- a/test/unit/plugins/analysis/ast/try-catch-nodes.test.ts
+++ b/test/unit/plugins/analysis/ast/try-catch-nodes.test.ts
@@ -29,7 +29,7 @@ import { join } from 'path';
 import { writeFileSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 
-import { createTestDatabase } from '../../../../helpers/TestRFDB.js';
+import { createTestDatabase, cleanupAllTestDatabases } from '../../../../helpers/TestRFDB.js';
 import { createTestOrchestrator } from '../../../../helpers/createTestOrchestrator.js';
 import type { NodeRecord, EdgeRecord } from '@grafema/types';
 
@@ -128,9 +128,7 @@ describe('Try/Catch/Finally Nodes Analysis (REG-267 Phase 4)', () => {
     backend = await createTestDatabase(); backend = db.backend;
   });
 
-  after(async () => {
-    if (db) await db.cleanup();
-  });
+  after(cleanupAllTestDatabases);
 
   // ===========================================================================
   // GROUP 1: Try-catch creates TRY_BLOCK and CATCH_BLOCK


### PR DESCRIPTION
## Summary

- Fixed 15 `.ts` test files that hung after tests passed due to shared RFDB server connection not being closed
- Root cause: `db.cleanup()` only closes the individual test client, not the shared server singleton
- Fix: replaced with `cleanupAllTestDatabases()` — the established pattern used by all `.js` tests

## Test plan

- [x] `FetchAnalyzer.test.ts`: 14/14 pass, exits cleanly (was hanging)
- [x] `property-access.test.ts`: 35/35 pass, exits cleanly
- [x] `GuaranteeAPI.test.ts`: 30/30 pass, exits cleanly  
- [x] Existing `.js` tests: no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)