### PR TITLE
feat(ast): track type parameter constraints (REG-303)

### DIFF
--- a/_tasks/REG-303/001-user-request.md
+++ b/_tasks/REG-303/001-user-request.md
@@ -1,0 +1,16 @@
+# REG-303: AST: Track type parameter constraints
+
+## Issue
+
+**Gap:** Generic constraints not tracked.
+
+**Example:**
+
+```typescript
+function process<T extends Serializable>(item: T): string { }
+```
+
+## Acceptance Criteria
+
+- [ ] TYPE_PARAMETER node with constraint reference
+- [ ] EXTENDS edge to constraint type

--- a/_tasks/REG-303/002-don-plan.md
+++ b/_tasks/REG-303/002-don-plan.md
@@ -1,0 +1,220 @@
+# REG-303: AST — Track Type Parameter Constraints
+
+## Don Melton — Tech Lead Plan
+
+---
+
+## 1. Current State Analysis
+
+### What exists
+
+**Node types:**
+- `TYPE` node exists (`TypeNode.ts`) -- represents type alias declarations (`type Foo = ...`)
+- `INTERFACE` node exists (`InterfaceNode.ts`) -- has `extends` and `properties` fields
+- `PARAMETER` node exists -- represents function parameters (value params, not type params)
+- **No `TYPE_PARAMETER` node exists anywhere in the codebase**
+
+**Edge types:**
+- `EXTENDS` edge exists in `EDGE_TYPE` (edges.ts line 41) -- currently used for:
+  - Interface extends interface (`bufferInterfaceNodes` in GraphBuilder)
+  - Class extends class uses `DERIVES_FROM` instead (interesting divergence)
+- `IMPLEMENTS` edge exists -- class implements interface
+
+**Current type handling in visitors:**
+- `TypeScriptVisitor.ts` handles: `TSInterfaceDeclaration`, `TSTypeAliasDeclaration`, `TSEnumDeclaration`
+- `FunctionVisitor.ts` extracts `paramTypes` and `returnType` as **strings** (via `typeNodeToString()`)
+- `typeNodeToString()` converts type AST nodes to string representations but **completely ignores type parameters** -- e.g., `Promise<string>` becomes just `Promise`, `Array<T>` becomes just `Array`
+- `InterfaceSchemaExtractor.ts` has a `typeParameters?: string[]` field on its internal `InterfaceNodeRecord`, suggesting some awareness of type params exists in the schema layer, but the data is never populated from the analyzer
+
+**What's NOT tracked:**
+- Type parameters on functions: `function foo<T>(x: T): T {}`
+- Type parameters on classes: `class Box<T> {}`
+- Type parameters on interfaces: `interface Container<T> {}`
+- Type parameters on type aliases: `type Pair<A, B> = [A, B]`
+- Constraints: `<T extends Serializable>`
+- Defaults: `<T = string>`
+
+### Babel AST representation
+
+Per [Babel docs](https://babeljs.io/docs/babel-types) and [Babel types source](https://github.com/babel/babel/issues/10317):
+
+```
+TSTypeParameterDeclaration {
+  params: TSTypeParameter[]
+}
+
+TSTypeParameter {
+  name: string          // (Babel 7: string, Babel 8: Identifier)
+  constraint?: TSType   // e.g., TSTypeReference for "extends Serializable"
+  default?: TSType      // e.g., TSStringKeyword for "= string"
+  in?: boolean          // variance: `in T`
+  out?: boolean         // variance: `out T`
+}
+```
+
+Where `TSTypeParameterDeclaration` appears on:
+- `FunctionDeclaration.typeParameters`
+- `ArrowFunctionExpression.typeParameters`
+- `ClassDeclaration.typeParameters`
+- `TSInterfaceDeclaration.typeParameters`
+- `TSTypeAliasDeclaration.typeParameters`
+- `ClassMethod.typeParameters`
+
+---
+
+## 2. What Needs to Be Added/Changed
+
+### New node type: `TYPE_PARAMETER`
+
+A new base node type representing a generic type parameter.
+
+```
+TYPE_PARAMETER {
+  name: string           // "T", "K", "V"
+  constraint?: string    // String representation of constraint type: "Serializable", "string"
+  default?: string       // String representation of default type: "string", "unknown"
+  variance?: 'in' | 'out' | 'in out'  // TypeScript variance annotations
+}
+```
+
+**ID format:** `{parentId}:TYPE_PARAMETER:{name}` -- scoped to parent (function, class, interface, type alias).
+
+### New edge: `EXTENDS` (reuse existing)
+
+The `EXTENDS` edge type already exists. We reuse it for:
+- `TYPE_PARAMETER --EXTENDS--> constraint type node` (when constraint is a known INTERFACE/CLASS/TYPE in the graph)
+
+### New edge: `HAS_TYPE_PARAMETER` (new)
+
+Need a containment edge to connect owner to its type parameters:
+- `FUNCTION --HAS_TYPE_PARAMETER--> TYPE_PARAMETER`
+- `CLASS --HAS_TYPE_PARAMETER--> TYPE_PARAMETER`
+- `INTERFACE --HAS_TYPE_PARAMETER--> TYPE_PARAMETER`
+- `TYPE --HAS_TYPE_PARAMETER--> TYPE_PARAMETER`
+
+Could also use `CONTAINS` but `HAS_TYPE_PARAMETER` is more semantic and queryable.
+
+### Collection type: `TypeParameterInfo`
+
+```typescript
+interface TypeParameterInfo {
+  name: string;              // "T"
+  constraintType?: string;   // "Serializable" (string repr)
+  defaultType?: string;      // "string" (string repr)
+  variance?: 'in' | 'out' | 'in out';
+  parentId: string;          // ID of owning function/class/interface/type
+  parentType: 'FUNCTION' | 'CLASS' | 'INTERFACE' | 'TYPE';
+  file: string;
+  line: number;
+  column: number;
+}
+```
+
+---
+
+## 3. Files That Need Modification
+
+| File | Change |
+|------|--------|
+| `packages/types/src/nodes.ts` | Add `TYPE_PARAMETER` to `NODE_TYPE` const |
+| `packages/types/src/edges.ts` | Add `HAS_TYPE_PARAMETER` to `EDGE_TYPE` const |
+| `packages/core/src/core/nodes/NodeKind.ts` | Add `TYPE_PARAMETER` to `NODE_TYPE` |
+| `packages/core/src/plugins/analysis/ast/types.ts` | Add `TypeParameterInfo` interface, add `typeParameters?: TypeParameterInfo[]` to `ASTCollections` |
+| `packages/core/src/plugins/analysis/ast/visitors/TypeScriptVisitor.ts` | Extract type params from `TSInterfaceDeclaration` and `TSTypeAliasDeclaration` |
+| `packages/core/src/plugins/analysis/ast/visitors/FunctionVisitor.ts` | Extract type params from `FunctionDeclaration` and `ArrowFunctionExpression` |
+| `packages/core/src/plugins/analysis/ast/visitors/ClassVisitor.ts` | Extract type params from `ClassDeclaration` and `ClassMethod` |
+| `packages/core/src/plugins/analysis/ast/GraphBuilder.ts` | New `bufferTypeParameterNodes()` method; call it from `build()` |
+| **New file:** `packages/core/src/core/nodes/TypeParameterNode.ts` | Node contract for TYPE_PARAMETER |
+| `packages/core/src/core/nodes/index.ts` | Export TypeParameterNode |
+| `packages/core/src/core/NodeFactory.ts` | Add `createTypeParameter()` factory method |
+| `packages/core/src/plugins/analysis/JSASTAnalyzer.ts` | Add `HAS_TYPE_PARAMETER` to plugin metadata edge list |
+
+---
+
+## 4. Risks and Edge Cases
+
+### Multiple constraints: `T extends A & B`
+
+Babel represents `<T extends A & B>` as:
+```
+TSTypeParameter.constraint = TSIntersectionType {
+  types: [TSTypeReference(A), TSTypeReference(B)]
+}
+```
+
+**Approach:** Store constraint as string `"A & B"` in `TYPE_PARAMETER.constraint` metadata (using existing `typeNodeToString()`). Create EXTENDS edges to **each** type that resolves to a known node. This is the pattern the codebase already uses for interface extends.
+
+### Default type params: `T = string`
+
+Babel represents `<T = string>` as:
+```
+TSTypeParameter.default = TSStringKeyword
+```
+
+**Approach:** Store in `TYPE_PARAMETER.default` as string via `typeNodeToString()`. No edge needed -- this is metadata, not a graph relationship.
+
+### Nested generics: `T extends Map<string, V>`
+
+The constraint type itself may have type arguments. `typeNodeToString()` currently turns `TSTypeReference` into just the type name (e.g., `"Map"`, dropping `<string, V>`).
+
+**Risk level:** LOW for MVP. The constraint string will be incomplete (`"Map"` instead of `"Map<string, V>"`) but the EXTENDS edge to `Map` is still correct. Improving `typeNodeToString()` to handle `TSTypeReference.typeParameters` is a separate enhancement (not needed for this task).
+
+### Variance annotations: `in T`, `out T`
+
+TypeScript 4.7+ supports variance annotations on type parameters. Babel exposes these as `TSTypeParameter.in` and `TSTypeParameter.out` booleans.
+
+**Approach:** Store as `variance` field on TYPE_PARAMETER node. Low priority -- most codebases don't use variance annotations.
+
+### Type parameters on methods
+
+Class methods can have their own type parameters: `class Foo { bar<U>(x: U): U {} }`. The `ClassMethod` AST node has `typeParameters`. This needs to be handled in ClassVisitor alongside function-level type parameters.
+
+### Type parameter ID uniqueness
+
+Using `{parentId}:TYPE_PARAMETER:{name}` ensures uniqueness since type parameter names are unique within their declaration scope (you can't have `<T, T>`).
+
+### Cross-file constraint resolution
+
+When `<T extends Serializable>` refers to an interface defined in another file, we won't be able to create the EXTENDS edge during single-file analysis. This matches existing behavior for interface extends and class implements -- dangling edges are expected and resolved during enrichment.
+
+---
+
+## 5. Recommended Approach
+
+### Strategy: Extend existing visitor + GraphBuilder pattern
+
+This follows the established pattern exactly:
+1. **Visitors** extract data into collection arrays (like `InterfaceDeclarationInfo[]`)
+2. **GraphBuilder** converts collections into nodes + edges (like `bufferInterfaceNodes()`)
+
+### Implementation order
+
+1. **Types first** -- Add `TYPE_PARAMETER` node type, `HAS_TYPE_PARAMETER` edge type, `TypeParameterInfo` interface
+2. **Node contract** -- Create `TypeParameterNode.ts` following exact pattern of `TypeNode.ts`/`InterfaceNode.ts`
+3. **Extraction** -- Add type parameter extraction to TypeScriptVisitor, FunctionVisitor, ClassVisitor
+4. **Graph building** -- Add `bufferTypeParameterNodes()` to GraphBuilder
+5. **Tests** -- Test all declaration contexts (function, arrow, class, interface, type alias, method)
+
+### What we're NOT doing (scope boundaries)
+
+- NOT enhancing `typeNodeToString()` to include generic arguments (separate task)
+- NOT tracking type parameter usage sites (where T is used as a type annotation in params/returns)
+- NOT tracking type argument instantiation (`foo<string>()` -- that's a different feature)
+- NOT changing the existing `paramTypes`/`returnType` string representation
+
+### Complexity assessment
+
+This is a **local addition** -- no architectural changes, no iteration space concerns:
+- Visitors already traverse the exact AST nodes we need
+- We're adding extraction of `.typeParameters` property that's already accessible
+- GraphBuilder pattern is copy-paste from `bufferInterfaceNodes()`/`bufferTypeAliasNodes()`
+- O(k) per declaration where k = number of type params (typically 1-3)
+
+**Estimated effort:** Small task. Single agent (Rob) sufficient.
+
+---
+
+## Sources
+
+- [Babel Types documentation](https://babeljs.io/docs/babel-types)
+- [Babel TSTypeParameter issue #10317](https://github.com/babel/babel/issues/10317)

--- a/_tasks/REG-303/003-joel-tech-plan.md
+++ b/_tasks/REG-303/003-joel-tech-plan.md
@@ -1,0 +1,914 @@
+# REG-303: AST -- Track Type Parameter Constraints
+
+## Joel Spolsky -- Detailed Technical Specification
+
+---
+
+## 1. Summary
+
+Add `TYPE_PARAMETER` node type and `HAS_TYPE_PARAMETER` edge type to represent generic type parameters (`<T extends Serializable = string>`) on functions, classes, interfaces, and type aliases. Follows the existing visitor -> collection -> GraphBuilder pattern exactly.
+
+---
+
+## 2. Implementation Steps (Ordered)
+
+### Step 1: Add type constants (`packages/types/src/nodes.ts`, `packages/types/src/edges.ts`)
+
+### Step 2: Add `TYPE_PARAMETER` to `NodeKind.ts` (`packages/core`)
+
+### Step 3: Add `TypeParameterInfo` interface to `types.ts` and `typeParameters` to `ASTCollections`
+
+### Step 4: Create `TypeParameterNode.ts` contract (new file)
+
+### Step 5: Export from `nodes/index.ts`
+
+### Step 6: Add `createTypeParameter()` to `NodeFactory.ts`
+
+### Step 7: Add `TypeParameterNode` to `NodeFactory.validate()`
+
+### Step 8: Add type param extraction helper to `TypeScriptVisitor.ts`
+
+### Step 9: Extract type params in `TypeScriptVisitor` (interfaces + type aliases)
+
+### Step 10: Extract type params in `FunctionVisitor` (function declarations + arrow functions)
+
+### Step 11: Extract type params in `ClassVisitor` (class declarations + class methods)
+
+### Step 12: Add `bufferTypeParameterNodes()` to `GraphBuilder.ts` and call it from `build()`
+
+### Step 13: Update plugin metadata in `JSASTAnalyzer.ts`
+
+### Step 14: Export `TypeParameterNode` from `@grafema/core` index
+
+### Step 15: Write tests
+
+---
+
+## 3. Exact Code Changes Per File
+
+### 3.1 `packages/types/src/nodes.ts` (line 47)
+
+Add `TYPE_PARAMETER` to `NODE_TYPE` const, after `EXPRESSION`:
+
+```typescript
+// Current (line 15-16):
+  EXPRESSION: 'EXPRESSION',
+
+// After EXPRESSION, before the closing }, add:
+  TYPE_PARAMETER: 'TYPE_PARAMETER',
+```
+
+Also add `TypeParameterNodeRecord` interface after `PluginNodeRecord` (around line 309):
+
+```typescript
+// Type parameter node (generic type param: <T extends Constraint = Default>)
+export interface TypeParameterNodeRecord extends BaseNodeRecord {
+  type: 'TYPE_PARAMETER';
+  column: number;
+  constraint?: string;    // String repr of constraint: "Serializable", "A & B"
+  defaultType?: string;   // String repr of default: "string", "unknown"
+  variance?: 'in' | 'out' | 'in out';
+}
+```
+
+Add `TypeParameterNodeRecord` to the `NodeRecord` union type (around line 334).
+
+### 3.2 `packages/types/src/edges.ts` (line 103)
+
+Add `HAS_TYPE_PARAMETER` to `EDGE_TYPE` const. Insert in the **Inheritance** section after `INSTANCE_OF` (line 43):
+
+```typescript
+  // Inheritance
+  EXTENDS: 'EXTENDS',
+  IMPLEMENTS: 'IMPLEMENTS',
+  INSTANCE_OF: 'INSTANCE_OF',
+  HAS_TYPE_PARAMETER: 'HAS_TYPE_PARAMETER',
+```
+
+### 3.3 `packages/core/src/core/nodes/NodeKind.ts` (line 27)
+
+Add `TYPE_PARAMETER` to the `NODE_TYPE` const. After `EXPRESSION` (line 27):
+
+```typescript
+  EXPRESSION: 'EXPRESSION',  // Generic expression node for data flow tracking
+  TYPE_PARAMETER: 'TYPE_PARAMETER',
+```
+
+### 3.4 `packages/core/src/plugins/analysis/ast/types.ts`
+
+**A. Add `TypeParameterInfo` interface** (after `EnumMemberInfo`, around line 404):
+
+```typescript
+// === TYPE PARAMETER INFO ===
+export interface TypeParameterInfo {
+  name: string;              // "T", "K", "V"
+  constraintType?: string;   // "Serializable" (string repr via typeNodeToString)
+  defaultType?: string;      // "string" (string repr via typeNodeToString)
+  variance?: 'in' | 'out' | 'in out';
+  parentId: string;          // ID of owning function/class/interface/type
+  parentType: 'FUNCTION' | 'CLASS' | 'INTERFACE' | 'TYPE';
+  file: string;
+  line: number;
+  column: number;
+}
+```
+
+**B. Add `typeParameters` to `ASTCollections` interface** (after `decorators`, around line 1123):
+
+```typescript
+  decorators?: DecoratorInfo[];
+  // Type parameter tracking for generics (REG-303)
+  typeParameters?: TypeParameterInfo[];
+```
+
+### 3.5 `packages/core/src/core/nodes/TypeParameterNode.ts` (NEW FILE)
+
+Follow exact pattern of `TypeNode.ts`:
+
+```typescript
+/**
+ * TypeParameterNode - contract for TYPE_PARAMETER node
+ *
+ * Represents a generic type parameter on a function, class, interface, or type alias.
+ *
+ * ID format: {parentId}:TYPE_PARAMETER:{name}
+ * Example: /src/types.ts:INTERFACE:Container:5:TYPE_PARAMETER:T
+ *
+ * Type parameter names are unique within their declaration scope
+ * (TypeScript does not allow `<T, T>`), so {parentId}:{name} is sufficient.
+ */
+
+import type { BaseNodeRecord } from '@grafema/types';
+
+interface TypeParameterNodeRecord extends BaseNodeRecord {
+  type: 'TYPE_PARAMETER';
+  column: number;
+  constraint?: string;
+  defaultType?: string;
+  variance?: 'in' | 'out' | 'in out';
+}
+
+interface TypeParameterNodeOptions {
+  constraint?: string;
+  defaultType?: string;
+  variance?: 'in' | 'out' | 'in out';
+}
+
+export class TypeParameterNode {
+  static readonly TYPE = 'TYPE_PARAMETER' as const;
+
+  static readonly REQUIRED = ['name', 'file', 'line', 'column'] as const;
+  static readonly OPTIONAL = ['constraint', 'defaultType', 'variance'] as const;
+
+  /**
+   * Create TYPE_PARAMETER node
+   *
+   * @param name - Type parameter name (e.g., "T", "K")
+   * @param parentId - ID of the owning declaration (function, class, interface, type)
+   * @param file - File path
+   * @param line - Line number
+   * @param column - Column position
+   * @param options - Optional constraint, defaultType, variance
+   * @returns TypeParameterNodeRecord
+   */
+  static create(
+    name: string,
+    parentId: string,
+    file: string,
+    line: number,
+    column: number,
+    options: TypeParameterNodeOptions = {}
+  ): TypeParameterNodeRecord {
+    if (!name) throw new Error('TypeParameterNode.create: name is required');
+    if (!parentId) throw new Error('TypeParameterNode.create: parentId is required');
+    if (!file) throw new Error('TypeParameterNode.create: file is required');
+    if (!line) throw new Error('TypeParameterNode.create: line is required');
+    if (column === undefined) throw new Error('TypeParameterNode.create: column is required');
+
+    return {
+      id: `${parentId}:TYPE_PARAMETER:${name}`,
+      type: this.TYPE,
+      name,
+      file,
+      line,
+      column,
+      ...(options.constraint !== undefined && { constraint: options.constraint }),
+      ...(options.defaultType !== undefined && { defaultType: options.defaultType }),
+      ...(options.variance !== undefined && { variance: options.variance }),
+    };
+  }
+
+  static validate(node: TypeParameterNodeRecord): string[] {
+    const errors: string[] = [];
+
+    if (node.type !== this.TYPE) {
+      errors.push(`Expected type ${this.TYPE}, got ${node.type}`);
+    }
+
+    const nodeRecord = node as unknown as Record<string, unknown>;
+    for (const field of this.REQUIRED) {
+      if (nodeRecord[field] === undefined || nodeRecord[field] === null) {
+        errors.push(`Missing required field: ${field}`);
+      }
+    }
+
+    return errors;
+  }
+}
+
+export type { TypeParameterNodeRecord, TypeParameterNodeOptions };
+```
+
+### 3.6 `packages/core/src/core/nodes/index.ts` (line 36)
+
+After the TypeNode export:
+
+```typescript
+export { TypeNode, type TypeNodeRecord } from './TypeNode.js';
+export { TypeParameterNode, type TypeParameterNodeRecord, type TypeParameterNodeOptions } from './TypeParameterNode.js';
+```
+
+### 3.7 `packages/core/src/core/NodeFactory.ts`
+
+**A. Add import** (line 41, after TypeNode import):
+
+```typescript
+  TypeNode,
+  TypeParameterNode,
+  EnumNode,
+```
+
+**B. Add `TypeParameterOptions` interface** (after `TypeOptions`, around line 202):
+
+```typescript
+interface TypeParameterOptions {
+  constraint?: string;
+  defaultType?: string;
+  variance?: 'in' | 'out' | 'in out';
+}
+```
+
+**C. Add `createTypeParameter()` factory method** (after `createType`, around line 530):
+
+```typescript
+  /**
+   * Create TYPE_PARAMETER node
+   *
+   * Represents a generic type parameter (<T extends Constraint = Default>).
+   *
+   * @param name - Type parameter name ("T", "K", "V")
+   * @param parentId - ID of the owning declaration (function/class/interface/type)
+   * @param file - File path
+   * @param line - Line number
+   * @param column - Column position
+   * @param options - Optional constraint, defaultType, variance
+   */
+  static createTypeParameter(
+    name: string,
+    parentId: string,
+    file: string,
+    line: number,
+    column: number,
+    options: TypeParameterOptions = {}
+  ) {
+    return brandNode(TypeParameterNode.create(name, parentId, file, line, column, options));
+  }
+```
+
+**D. Add to `validate()` map** (around line 726, after `'TYPE': TypeNode`):
+
+```typescript
+      'TYPE': TypeNode,
+      'TYPE_PARAMETER': TypeParameterNode,
+      'ENUM': EnumNode,
+```
+
+### 3.8 `packages/core/src/plugins/analysis/ast/visitors/TypeScriptVisitor.ts`
+
+**A. Add import** for `TypeParameterInfo` (line 27):
+
+```typescript
+import type {
+  InterfaceDeclarationInfo,
+  InterfacePropertyInfo,
+  TypeAliasInfo,
+  EnumDeclarationInfo,
+  EnumMemberInfo,
+  TypeParameterInfo
+} from '../types.js';
+```
+
+**B. Add helper function `extractTypeParameters()`** (after `typeNodeToString`, around line 99):
+
+```typescript
+/**
+ * Extracts type parameter info from a TSTypeParameterDeclaration node.
+ *
+ * Handles:
+ * - Simple: <T>
+ * - Constrained: <T extends Serializable>
+ * - Defaulted: <T = string>
+ * - Variance: <in T>, <out T>, <in out T>
+ * - Intersection constraints: <T extends A & B>
+ *
+ * @param typeParameters - Babel TSTypeParameterDeclaration node (or undefined)
+ * @param parentId - ID of the owning declaration
+ * @param parentType - 'FUNCTION' | 'CLASS' | 'INTERFACE' | 'TYPE'
+ * @param file - File path
+ * @param line - Line of the declaration
+ * @param column - Column of the declaration
+ * @returns Array of TypeParameterInfo (empty if no type params)
+ */
+export function extractTypeParameters(
+  typeParameters: unknown,
+  parentId: string,
+  parentType: 'FUNCTION' | 'CLASS' | 'INTERFACE' | 'TYPE',
+  file: string,
+  line: number,
+  column: number
+): TypeParameterInfo[] {
+  if (!typeParameters || typeof typeParameters !== 'object') return [];
+
+  const tpDecl = typeParameters as { type?: string; params?: unknown[] };
+  if (tpDecl.type !== 'TSTypeParameterDeclaration' || !Array.isArray(tpDecl.params)) return [];
+
+  const result: TypeParameterInfo[] = [];
+
+  for (const param of tpDecl.params) {
+    const tsParam = param as {
+      type?: string;
+      name?: string;
+      constraint?: unknown;
+      default?: unknown;
+      in?: boolean;
+      out?: boolean;
+      loc?: { start?: { line?: number; column?: number } };
+    };
+
+    if (tsParam.type !== 'TSTypeParameter') continue;
+
+    const paramName = tsParam.name;
+    if (!paramName) continue;
+
+    // Extract constraint via typeNodeToString
+    const constraintType = tsParam.constraint ? typeNodeToString(tsParam.constraint) : undefined;
+
+    // Extract default via typeNodeToString
+    const defaultType = tsParam.default ? typeNodeToString(tsParam.default) : undefined;
+
+    // Extract variance
+    let variance: 'in' | 'out' | 'in out' | undefined;
+    if (tsParam.in && tsParam.out) {
+      variance = 'in out';
+    } else if (tsParam.in) {
+      variance = 'in';
+    } else if (tsParam.out) {
+      variance = 'out';
+    }
+
+    // Use param's own location if available, otherwise fall back to declaration location
+    const paramLine = tsParam.loc?.start?.line ?? line;
+    const paramColumn = tsParam.loc?.start?.column ?? column;
+
+    result.push({
+      name: paramName,
+      constraintType: constraintType !== 'unknown' ? constraintType : undefined,
+      defaultType: defaultType !== 'unknown' ? defaultType : undefined,
+      variance,
+      parentId,
+      parentType,
+      file,
+      line: paramLine,
+      column: paramColumn,
+    });
+  }
+
+  return result;
+}
+```
+
+**C. Destructure `typeParameters` from collections** (inside `getHandlers()`, line 117):
+
+```typescript
+    const {
+      interfaces,
+      typeAliases,
+      enums,
+      typeParameters
+    } = this.collections;
+```
+
+Note: `VisitorCollections` has `[key: string]: unknown` so accessing `typeParameters` is type-safe.
+
+**D. Add type param extraction to `TSInterfaceDeclaration` handler** (after `properties` extraction, before the push to `interfaces`, around line 174):
+
+The parentId for interfaces is generated by InterfaceNode.create() in GraphBuilder, which uses format `{file}:INTERFACE:{name}:{line}`. We must use the same ID format here for consistency:
+
+```typescript
+        // Extract type parameters (REG-303)
+        if (typeParameters && node.typeParameters) {
+          const interfaceId = `${module.file}:INTERFACE:${interfaceName}:${getLine(node)}`;
+          const typeParamInfos = extractTypeParameters(
+            node.typeParameters,
+            interfaceId,
+            'INTERFACE',
+            module.file,
+            getLine(node),
+            getColumn(node)
+          );
+          for (const tp of typeParamInfos) {
+            (typeParameters as TypeParameterInfo[]).push(tp);
+          }
+        }
+```
+
+Insert this right before the `(interfaces as InterfaceDeclarationInfo[]).push({` line (line 174).
+
+**E. Add type param extraction to `TSTypeAliasDeclaration` handler** (after `aliasOf` extraction, before the push, around line 201):
+
+```typescript
+        // Extract type parameters (REG-303)
+        if (typeParameters && node.typeParameters) {
+          const typeId = `${module.file}:TYPE:${typeName}:${getLine(node)}`;
+          const typeParamInfos = extractTypeParameters(
+            node.typeParameters,
+            typeId,
+            'TYPE',
+            module.file,
+            getLine(node),
+            getColumn(node)
+          );
+          for (const tp of typeParamInfos) {
+            (typeParameters as TypeParameterInfo[]).push(tp);
+          }
+        }
+```
+
+Insert right before the `(typeAliases as TypeAliasInfo[]).push({` line (line 201).
+
+### 3.9 `packages/core/src/plugins/analysis/ast/visitors/FunctionVisitor.ts`
+
+**A. Add import** (line 30):
+
+```typescript
+import type { ParameterInfo, PromiseExecutorContext, TypeParameterInfo } from '../types.js';
+```
+
+Also add `extractTypeParameters` import (after `typeNodeToString` import, line 25):
+
+```typescript
+import { typeNodeToString, extractTypeParameters } from './TypeScriptVisitor.js';
+```
+
+**B. Add type param extraction to `FunctionDeclaration` handler** (after `start: node.start ?? undefined` push, before `scopeTracker.enterScope`, around line 245):
+
+```typescript
+        // Extract type parameters (REG-303)
+        const typeParametersCollection = collections.typeParameters;
+        if (typeParametersCollection && (node as any).typeParameters) {
+          const typeParamInfos = extractTypeParameters(
+            (node as any).typeParameters,
+            functionId,
+            'FUNCTION',
+            module.file,
+            line,
+            getColumn(node)
+          );
+          for (const tp of typeParamInfos) {
+            (typeParametersCollection as TypeParameterInfo[]).push(tp);
+          }
+        }
+```
+
+Insert between the `(functions as FunctionInfo[]).push({...})` block and the `scopeTracker.enterScope(...)` call.
+
+**C. Add type param extraction to `ArrowFunctionExpression` handler** (after the push to `functions`, before `scopeTracker.enterScope`, around line 320):
+
+```typescript
+        // Extract type parameters (REG-303)
+        const arrowTypeParamsCollection = collections.typeParameters;
+        if (arrowTypeParamsCollection && (node as any).typeParameters) {
+          const typeParamInfos = extractTypeParameters(
+            (node as any).typeParameters,
+            functionId,
+            'FUNCTION',
+            module.file,
+            line,
+            column
+          );
+          for (const tp of typeParamInfos) {
+            (arrowTypeParamsCollection as TypeParameterInfo[]).push(tp);
+          }
+        }
+```
+
+### 3.10 `packages/core/src/plugins/analysis/ast/visitors/ClassVisitor.ts`
+
+**A. Add imports** (line 29):
+
+```typescript
+import type { DecoratorInfo, ParameterInfo, VariableDeclarationInfo, TypeParameterInfo } from '../types.js';
+```
+
+And add `extractTypeParameters` (after existing imports, no `typeNodeToString` is imported yet in ClassVisitor -- add it):
+
+```typescript
+import { extractTypeParameters } from './TypeScriptVisitor.js';
+```
+
+**B. Add type param extraction to `ClassDeclaration` handler** (after implements extraction and before `(classDeclarations as ClassInfo[]).push(...)`, around line 208):
+
+The parentId for classes is generated by `ClassNode.createWithContext()` which returns `classRecord.id`. So:
+
+```typescript
+        // Extract type parameters (REG-303)
+        if (collections.typeParameters && (classNode as any).typeParameters) {
+          const typeParamInfos = extractTypeParameters(
+            (classNode as any).typeParameters,
+            classRecord.id,
+            'CLASS',
+            module.file,
+            classLine,
+            classColumn
+          );
+          for (const tp of typeParamInfos) {
+            (collections.typeParameters as TypeParameterInfo[]).push(tp);
+          }
+        }
+```
+
+Insert between the `implementsNames` extraction block and the `(classDeclarations as ClassInfo[]).push({...})` block.
+
+**C. Add type param extraction to `ClassMethod` handler** (after `funcData` push, before decorator extraction, around line 356):
+
+ClassMethod type parameters are on the method node itself. The parentId is the `functionId` (semantic ID):
+
+```typescript
+            // Extract type parameters for methods (REG-303)
+            if (collections.typeParameters && (methodNode as any).typeParameters) {
+              const typeParamInfos = extractTypeParameters(
+                (methodNode as any).typeParameters,
+                functionId,
+                'FUNCTION',
+                module.file,
+                methodLine,
+                methodColumn
+              );
+              for (const tp of typeParamInfos) {
+                (collections.typeParameters as TypeParameterInfo[]).push(tp);
+              }
+            }
+```
+
+### 3.11 `packages/core/src/plugins/analysis/ast/GraphBuilder.ts`
+
+**A. Add import for TypeParameterInfo** (in the import block from `./types.js`, around line 38):
+
+```typescript
+  TypeParameterInfo,
+```
+
+Add import for `TypeParameterNode`:
+
+```typescript
+import { TypeParameterNode } from '../../../core/nodes/TypeParameterNode.js';
+```
+
+**B. Add destructuring in `build()`** (after `decorators = []`, line 164):
+
+```typescript
+      decorators = [],
+      // Type parameter tracking for generics (REG-303)
+      typeParameters = [],
+```
+
+**C. Add call to `bufferTypeParameterNodes()`** (after `bufferDecoratorNodes` call, around line 382):
+
+```typescript
+    // 24.5. Buffer TYPE_PARAMETER nodes and HAS_TYPE_PARAMETER edges (REG-303)
+    this.bufferTypeParameterNodes(typeParameters);
+```
+
+**D. Add `bufferTypeParameterNodes()` private method** (after `bufferDecoratorNodes`, around line 2100):
+
+```typescript
+  /**
+   * Buffer TYPE_PARAMETER nodes, HAS_TYPE_PARAMETER edges, and EXTENDS edges for constraints.
+   *
+   * For each type parameter:
+   * 1. Creates TYPE_PARAMETER node with constraint/default/variance metadata
+   * 2. Creates HAS_TYPE_PARAMETER edge: parent -> TYPE_PARAMETER
+   * 3. If constraint is a known type name, creates EXTENDS edge:
+   *    TYPE_PARAMETER -> constraint target (dangling edge, resolved during enrichment)
+   */
+  private bufferTypeParameterNodes(typeParameters: TypeParameterInfo[]): void {
+    for (const tp of typeParameters) {
+      // Create TYPE_PARAMETER node
+      const tpNode = TypeParameterNode.create(
+        tp.name,
+        tp.parentId,
+        tp.file,
+        tp.line,
+        tp.column,
+        {
+          constraint: tp.constraintType,
+          defaultType: tp.defaultType,
+          variance: tp.variance,
+        }
+      );
+      this._bufferNode(tpNode as unknown as GraphNode);
+
+      // HAS_TYPE_PARAMETER edge: parent -> TYPE_PARAMETER
+      this._bufferEdge({
+        type: 'HAS_TYPE_PARAMETER',
+        src: tp.parentId,
+        dst: tpNode.id
+      });
+
+      // EXTENDS edge for constraint (if constraint looks like a type reference, not a primitive)
+      // Primitives (string, number, boolean, etc.) don't need EXTENDS edges
+      if (tp.constraintType && !isPrimitiveType(tp.constraintType)) {
+        // For intersection types ("A & B"), create EXTENDS edge for each part
+        const constraintParts = tp.constraintType.includes(' & ')
+          ? tp.constraintType.split(' & ').map(s => s.trim())
+          : [tp.constraintType];
+
+        for (const part of constraintParts) {
+          // Skip primitives and complex types
+          if (isPrimitiveType(part) || part === 'unknown') continue;
+          // Skip union types, array types, etc.
+          if (part.includes(' | ') || part.includes('[]') || part.includes('[')) continue;
+
+          // Create a dangling EXTENDS edge -- will be resolved during enrichment
+          // The dst is a TYPE_PARAMETER -> constraint name mapping
+          // We use the constraint name as-is; cross-file resolution happens during enrichment
+          this._bufferEdge({
+            type: 'EXTENDS',
+            src: tpNode.id,
+            dst: part,  // Dangling reference to constraint type name
+            metadata: { constraintRef: true }
+          });
+        }
+      }
+    }
+  }
+```
+
+**E. Add `isPrimitiveType()` helper** (right before or after `bufferTypeParameterNodes`, as a module-level function or private method):
+
+```typescript
+/**
+ * Check if a type string represents a TypeScript primitive (no EXTENDS edge needed)
+ */
+function isPrimitiveType(typeName: string): boolean {
+  const PRIMITIVES = new Set([
+    'string', 'number', 'boolean', 'void', 'null', 'undefined',
+    'never', 'any', 'unknown', 'object', 'symbol', 'bigint', 'function'
+  ]);
+  return PRIMITIVES.has(typeName);
+}
+```
+
+### 3.12 `packages/core/src/plugins/analysis/JSASTAnalyzer.ts`
+
+**A. Add `TypeParameterInfo` to import** (wherever the other types are imported from `./ast/types.js`):
+
+```typescript
+  TypeParameterInfo,
+```
+
+**B. Add `typeParameters` to `Collections` interface** (after `decorators`, line 154):
+
+```typescript
+  decorators: DecoratorInfo[];
+  // Type parameter tracking for generics (REG-303)
+  typeParameters: TypeParameterInfo[];
+```
+
+**C. Add initialization in `analyzeModule()`** (after `const decorators`, around line 1460):
+
+```typescript
+      const decorators: DecoratorInfo[] = [];
+      // Type parameter tracking for generics (REG-303)
+      const typeParameters: TypeParameterInfo[] = [];
+```
+
+**D. Add to `allCollections`** (after `decorators` in the allCollections object, around line 1547):
+
+```typescript
+        interfaces, typeAliases, enums, decorators,
+        // Type parameter tracking for generics (REG-303)
+        typeParameters,
+```
+
+**E. Update plugin metadata** (in `get metadata()`, around line 270):
+
+Add `'TYPE_PARAMETER'` to nodes:
+
+```typescript
+          // TypeScript-specific nodes
+          'INTERFACE', 'TYPE', 'ENUM', 'DECORATOR', 'TYPE_PARAMETER'
+```
+
+Add `'HAS_TYPE_PARAMETER'` to edges:
+
+```typescript
+          // TypeScript-specific edges
+          'IMPLEMENTS', 'EXTENDS', 'DECORATED_BY', 'HAS_TYPE_PARAMETER',
+```
+
+### 3.13 `packages/core/src/index.ts`
+
+Add export after `TypeNode` (around line 196):
+
+```typescript
+export { TypeNode } from './core/nodes/TypeNode.js';
+export { TypeParameterNode, type TypeParameterNodeRecord, type TypeParameterNodeOptions } from './core/nodes/TypeParameterNode.js';
+```
+
+---
+
+## 4. Test Plan
+
+### Test file: `test/unit/TypeParameterTracking.test.js`
+
+Follow the pattern from `InterfaceNodeMigration.test.js`:
+- Use `createTestDatabase()` + `createTestOrchestrator()` for integration tests
+- Use direct node creation for unit tests
+
+### 4.1 Unit Tests (TypeParameterNode contract)
+
+```
+describe('TypeParameterNode.create()')
+  it('should generate ID with format {parentId}:TYPE_PARAMETER:{name}')
+  it('should set type to TYPE_PARAMETER')
+  it('should include constraint when provided')
+  it('should include defaultType when provided')
+  it('should include variance when provided')
+  it('should omit optional fields when not provided')
+  it('should throw when name is missing')
+  it('should throw when parentId is missing')
+  it('should create unique IDs for different type params on same parent')
+  it('should create same ID for same parameters (idempotent)')
+
+describe('TypeParameterNode.validate()')
+  it('should pass for valid TYPE_PARAMETER node')
+  it('should fail for wrong type')
+  it('should fail for missing required fields')
+
+describe('NodeFactory.createTypeParameter()')
+  it('should delegate to TypeParameterNode.create()')
+  it('should pass NodeFactory.validate()')
+```
+
+### 4.2 extractTypeParameters() Unit Tests
+
+```
+describe('extractTypeParameters()')
+  it('should return empty array for null/undefined')
+  it('should return empty array for non-TSTypeParameterDeclaration')
+  it('should extract single type parameter')
+  it('should extract constraint via typeNodeToString')
+  it('should extract defaultType via typeNodeToString')
+  it('should extract variance annotations (in, out, in out)')
+  it('should handle intersection constraints ("A & B")')
+  it('should handle multiple type parameters')
+```
+
+### 4.3 Integration Tests (full pipeline analysis)
+
+```
+describe('Type parameter tracking - Functions')
+  it('should create TYPE_PARAMETER node for function with single type param')
+    // function identity<T>(x: T): T { return x; }
+  it('should create TYPE_PARAMETER with constraint')
+    // function serialize<T extends Serializable>(obj: T): string { ... }
+  it('should create TYPE_PARAMETER with default')
+    // function create<T = string>(): T { ... }
+  it('should handle multiple type params')
+    // function map<K, V>(key: K, value: V): Map<K, V> { ... }
+  it('should create HAS_TYPE_PARAMETER edge from function to type param')
+  it('should create EXTENDS edge for constraint type')
+
+describe('Type parameter tracking - Arrow functions')
+  it('should extract type params from arrow function')
+    // const identity = <T>(x: T): T => x;
+
+describe('Type parameter tracking - Classes')
+  it('should create TYPE_PARAMETER for class declaration')
+    // class Container<T> { value: T; }
+  it('should create TYPE_PARAMETER with constraint on class')
+    // class Repository<T extends Entity> { ... }
+  it('should create TYPE_PARAMETER for class methods')
+    // class Mapper { map<U>(fn: (t: T) => U): U { ... } }
+
+describe('Type parameter tracking - Interfaces')
+  it('should create TYPE_PARAMETER for interface')
+    // interface Collection<T> { items: T[]; }
+  it('should create TYPE_PARAMETER with constraint on interface')
+    // interface Comparable<T extends Comparable<T>> { ... }
+
+describe('Type parameter tracking - Type aliases')
+  it('should create TYPE_PARAMETER for type alias')
+    // type Pair<A, B> = [A, B];
+  it('should create TYPE_PARAMETER with intersection constraint')
+    // type Merged<T extends A & B> = T;
+
+describe('Type parameter tracking - Edge cases')
+  it('should handle variance annotation: in T')
+    // interface Consumer<in T> { consume(value: T): void; }
+  it('should handle variance annotation: out T')
+    // interface Producer<out T> { produce(): T; }
+  it('should not create EXTENDS edge for primitive constraints')
+    // function parse<T extends string>(input: T): T
+  it('should handle constraint with default combined')
+    // function create<T extends object = Record<string, unknown>>(): T
+```
+
+---
+
+## 5. Complexity Analysis
+
+| Operation | Complexity | Notes |
+|-----------|-----------|-------|
+| `extractTypeParameters()` | O(k) per declaration | k = number of type params (typically 1-3) |
+| `bufferTypeParameterNodes()` | O(n * k) | n = total declarations with type params, k = avg type params per declaration |
+| `typeNodeToString()` for constraints | O(1) per constraint | Already exists, no recursion for simple types |
+| Intersection constraint splitting | O(c) | c = parts in intersection (typically 2-3) |
+| `isPrimitiveType()` | O(1) | Set lookup |
+
+**Overall impact:** Negligible. Type parameters are extracted from AST nodes the visitors ALREADY traverse (no extra iteration over the AST). The number of type-parameterized declarations in a typical file is small (0-20). This is strictly O(k) per declaration where k is type params count, piggy-backing on existing traversal.
+
+**Memory:** One `TypeParameterInfo` object per type parameter encountered. Typical file has 0-20 type params. Not a concern.
+
+---
+
+## 6. Decisions and Rationale
+
+### Why `{parentId}:TYPE_PARAMETER:{name}` for ID format?
+
+- Matches the hierarchical pattern: parent contains type param
+- Type param names are unique within declaration scope (TS enforces this)
+- No need for line/column disambiguation since name is unique within parent
+
+### Why reuse `EXTENDS` for constraints?
+
+- `EXTENDS` already semantically means "is constrained to" or "is a subtype of"
+- Used for interface extends, which is the same relationship
+- Avoids creating a new edge type for something that IS an extends relationship
+- Edge metadata `{ constraintRef: true }` distinguishes from regular EXTENDS if needed
+
+### Why dangling EXTENDS edges?
+
+- Matches existing pattern for interface extends (see `bufferInterfaceNodes`)
+- Cross-file resolution happens during enrichment phase
+- Same file resolution could be added later as optimization
+
+### Why string representation for constraint/default?
+
+- Matches existing pattern (`TypeNode.aliasOf`, `FunctionNodeRecord.returnType`, etc.)
+- `typeNodeToString()` already exists and handles all TSType variants
+- Graph nodes store string metadata -- consistent with codebase
+- Full AST representation of constraints is not needed for querying
+
+### Why extract in visitors, not in GraphBuilder?
+
+- Follows the established pattern: visitors extract -> GraphBuilder creates nodes
+- Visitors already have access to the Babel AST; GraphBuilder only sees collections
+- Keeps GraphBuilder focused on graph construction, not AST parsing
+
+---
+
+## 7. Files Changed Summary
+
+| # | File | Change Type | Lines Changed (est.) |
+|---|------|------------|---------------------|
+| 1 | `packages/types/src/nodes.ts` | Add TYPE_PARAMETER const + record | +15 |
+| 2 | `packages/types/src/edges.ts` | Add HAS_TYPE_PARAMETER const | +1 |
+| 3 | `packages/core/src/core/nodes/NodeKind.ts` | Add TYPE_PARAMETER const | +1 |
+| 4 | `packages/core/src/plugins/analysis/ast/types.ts` | Add TypeParameterInfo + collection field | +18 |
+| 5 | `packages/core/src/core/nodes/TypeParameterNode.ts` | NEW: node contract | ~90 |
+| 6 | `packages/core/src/core/nodes/index.ts` | Export TypeParameterNode | +1 |
+| 7 | `packages/core/src/core/NodeFactory.ts` | Add createTypeParameter + validate entry | +25 |
+| 8 | `packages/core/src/plugins/analysis/ast/visitors/TypeScriptVisitor.ts` | Add extractTypeParameters helper + calls | +80 |
+| 9 | `packages/core/src/plugins/analysis/ast/visitors/FunctionVisitor.ts` | Add type param extraction | +25 |
+| 10 | `packages/core/src/plugins/analysis/ast/visitors/ClassVisitor.ts` | Add type param extraction | +30 |
+| 11 | `packages/core/src/plugins/analysis/ast/GraphBuilder.ts` | Add bufferTypeParameterNodes + isPrimitiveType | +60 |
+| 12 | `packages/core/src/plugins/analysis/JSASTAnalyzer.ts` | Add collection + metadata | +10 |
+| 13 | `packages/core/src/index.ts` | Export TypeParameterNode | +1 |
+| 14 | `test/unit/TypeParameterTracking.test.js` | NEW: tests | ~400 |
+| | **Total** | | **~757 lines** |
+
+---
+
+## 8. Implementation Order for Kent and Rob
+
+1. **Kent writes unit tests** for TypeParameterNode contract (Step 15, first group)
+2. **Rob implements** Steps 1-7 (types, node contract, factory) -- make Kent's unit tests pass
+3. **Kent writes unit tests** for `extractTypeParameters()` helper (Step 15, second group)
+4. **Rob implements** Steps 8-11 (visitors + GraphBuilder)
+5. **Kent writes integration tests** (Step 15, third group)
+6. **Rob implements** Steps 12-14 (JSASTAnalyzer metadata, exports) -- make integration tests pass
+7. **Run full test suite** to ensure no regressions
+
+Each step is atomic: the codebase compiles and all existing tests pass after each step.

--- a/_tasks/REG-303/004-steve-review.md
+++ b/_tasks/REG-303/004-steve-review.md
@@ -1,0 +1,170 @@
+# REG-303: Steve Jobs Review
+
+## Verdict: APPROVE (with required fixes)
+
+---
+
+## 1. Vision Alignment
+
+**PASS.** This is exactly the kind of feature Grafema needs. Generic type parameters are fundamental to understanding TypeScript code structure. Without them, an agent querying "what constraints does this generic function have?" gets nothing -- it has to read the source. Adding `TYPE_PARAMETER` nodes with `constraint` metadata and `EXTENDS` edges to constraint types moves us directly toward "query the graph, not read code."
+
+The scope is well-bounded: we track the declaration of type parameters, not their usage sites or instantiation. That is correct for a first pass.
+
+---
+
+## 2. Corner-Cutting Check
+
+**PASS with one concern.**
+
+The plan correctly identifies that `typeNodeToString()` drops generic arguments from `TSTypeReference` (`Map<string, V>` becomes `Map`). This is acknowledged as a known limitation, and the EXTENDS edge to `Map` is still semantically correct. Acceptable for this task -- it is a pre-existing limitation of `typeNodeToString`, not something introduced here.
+
+The plan does NOT cut corners on:
+- Intersection constraints (`T extends A & B`) -- handled correctly, splitting into multiple EXTENDS edges
+- Variance annotations -- included
+- Default types -- included
+- All declaration contexts (function, arrow, class, method, interface, type alias) -- covered
+
+---
+
+## 3. Architecture Gaps
+
+**One issue to fix (non-blocking).**
+
+### 3a. Dangling EXTENDS edges -- WRONG PATTERN
+
+The plan proposes (Joel's spec, section 3.11.D):
+```typescript
+this._bufferEdge({
+  type: 'EXTENDS',
+  src: tpNode.id,
+  dst: part,  // Dangling reference to constraint type name
+  metadata: { constraintRef: true }
+});
+```
+
+Don's plan says: "dangling edges are expected and resolved during enrichment" and claims this "matches existing behavior for interface extends."
+
+**This is incorrect.** I verified the actual `bufferInterfaceNodes` implementation (GraphBuilder.ts lines 1985-2018). When an interface extends another interface not found in the same file, it does NOT create a dangling edge with a raw name string as `dst`. Instead, it creates an **external interface node** with `isExternal: true` and links the EXTENDS edge to that node's ID:
+
+```typescript
+// External interface - create a reference node
+const externalInterface = NodeFactory.createInterface(
+  parentName, iface.file, iface.line, 0,
+  { isExternal: true }
+);
+this._bufferNode(externalInterface as unknown as GraphNode);
+this._bufferEdge({
+  type: 'EXTENDS',
+  src: srcNode.id,
+  dst: externalInterface.id  // <-- actual node ID, not raw name
+});
+```
+
+**Required fix:** The `bufferTypeParameterNodes` method must follow the same pattern. When a constraint type is not resolvable in the same file, create an external reference node (e.g., an external INTERFACE or TYPE node with `isExternal: true`) and point the EXTENDS edge to that node's ID. Using raw type names as edge destinations is a different pattern that will create inconsistency in how graph queries work.
+
+This is not a blocking architectural gap -- the fix is straightforward and stays within the same method. But it MUST be done during implementation, not deferred.
+
+### 3b. `TypeParameterNodeRecord` in `packages/types/src/nodes.ts` -- INCONSISTENT PATTERN
+
+The plan (Joel section 3.1) proposes adding `TypeParameterNodeRecord` to `packages/types/src/nodes.ts` and to the `NodeRecord` union type. However, I verified that `InterfaceNodeRecord`, `TypeNodeRecord`, `EnumNodeRecord`, and `DecoratorNodeRecord` are NOT in `packages/types/src/nodes.ts`. They exist only in their respective files under `packages/core/src/core/nodes/`.
+
+Similarly, the plan proposes adding `TYPE_PARAMETER` to the `NODE_TYPE` const in `packages/types/src/nodes.ts`, but INTERFACE, TYPE, ENUM, and DECORATOR are not there either.
+
+**Required fix:** Do NOT add `TypeParameterNodeRecord` to `packages/types/src/nodes.ts` or to the `NodeRecord` union. Do NOT add `TYPE_PARAMETER` to `packages/types/src/nodes.ts` `NODE_TYPE`. Follow the same pattern as INTERFACE/TYPE/ENUM/DECORATOR: the record type lives only in `packages/core/src/core/nodes/TypeParameterNode.ts`. The string `'TYPE_PARAMETER'` is used directly where needed.
+
+Whether to add to `packages/core/src/core/nodes/NodeKind.ts` is also questionable since INTERFACE/TYPE/ENUM/DECORATOR are not there. But NodeKind.ts and packages/types/src/nodes.ts appear to be identical copies (same content), so the same reasoning applies -- skip both, or add to both. Given the existing pattern, skip both.
+
+---
+
+## 4. Complexity Check (MANDATORY)
+
+**PASS.** No red flags.
+
+- Type parameter extraction: O(k) per declaration where k = number of type params (1-3 typically). Piggybacks on existing AST traversal -- no extra iteration.
+- `bufferTypeParameterNodes`: O(n * k) where n = number of declarations with type params in a file (0-20 typically) and k = avg type params per declaration (1-3). This is negligible.
+- No iteration over ALL nodes/edges.
+- No backward pattern scanning.
+- Memory: one `TypeParameterInfo` per type parameter. Trivial.
+
+---
+
+## 5. Plugin Architecture
+
+**PASS.** This is textbook forward registration:
+
+1. **Visitors** extract type parameter data from AST nodes they already traverse (no extra traversal)
+2. Data is collected into `TypeParameterInfo[]` collection
+3. **GraphBuilder** converts collections into nodes + edges
+
+This matches the existing pattern for interfaces, type aliases, enums, and decorators exactly. No backward scanning, no global iteration.
+
+---
+
+## 6. Extensibility
+
+**PASS.** The `extractTypeParameters()` helper is generic and works with any AST node that has a `typeParameters` field. Adding support for new declaration types (e.g., future TypeScript constructs) means calling this one function from the appropriate visitor handler. Clean.
+
+The parent type parameter (`parentType: 'FUNCTION' | 'CLASS' | 'INTERFACE' | 'TYPE'`) is extensible if new parent types are added later.
+
+---
+
+## 7. "MVP Limitations"
+
+**PASS.** The limitations are genuine scope boundaries, not feature-defeating holes:
+
+- NOT tracking type parameter usage sites -- separate feature, not needed to answer "what type params does X have?"
+- NOT tracking type argument instantiation (`foo<string>()`) -- separate feature
+- NOT enhancing `typeNodeToString()` for generic arguments -- pre-existing limitation
+- `typeNodeToString` returning `'unknown'` for complex types -- edge case, constraint string still stored
+
+None of these defeat the core purpose: "track type parameter constraints on declarations."
+
+---
+
+## 8. EXTENDS Edge Reuse
+
+**PASS with nuance.** Reusing `EXTENDS` for type parameter constraints is semantically correct. `T extends Serializable` IS an extends relationship -- it declares that T is a subtype of Serializable. This is the same semantic relationship as `interface Foo extends Bar`.
+
+The `{ constraintRef: true }` metadata distinguishes constraint-EXTENDS from inheritance-EXTENDS when needed for queries. An agent can query:
+- "What does this type parameter extend?" (follow EXTENDS from TYPE_PARAMETER)
+- "What interfaces extend this interface?" (follow EXTENDS from INTERFACE)
+
+These are naturally distinguished by the source node type (TYPE_PARAMETER vs INTERFACE), so the metadata is a nice-to-have, not strictly necessary. No confusion risk.
+
+---
+
+## 9. Dangling Edges
+
+**FAIL -- see section 3a above.**
+
+The plan claims to follow the existing pattern but does not. The existing pattern creates external reference nodes, not truly dangling edges. This must be fixed.
+
+However, since `skip_validation=true` is used for edge flushing, truly dangling edges would not crash anything -- they would just create inconsistency in query patterns (some EXTENDS edges point to node IDs, some point to raw names). This inconsistency is what must be avoided.
+
+---
+
+## 10. Test Coverage
+
+**PASS.** The test plan is comprehensive:
+
+- Unit tests for `TypeParameterNode.create()` and `validate()` -- contract tests
+- Unit tests for `extractTypeParameters()` helper -- all edge cases (null, variance, intersection, multiple params)
+- Integration tests for all declaration contexts (function, arrow, class, method, interface, type alias)
+- Edge case tests (variance, primitives, combined constraint+default)
+- Tests verify both nodes AND edges (HAS_TYPE_PARAMETER, EXTENDS)
+
+The plan references following `InterfaceNodeMigration.test.js` pattern with `createTestDatabase()` + `createTestOrchestrator()`. I did not find `InterfaceNodeMigration.test.js` in the test directory (only `EnumNodeMigration.test.js` and `DecoratorNodeMigration.test.js`), but the approach is the same.
+
+---
+
+## Summary of Required Fixes
+
+1. **Do NOT create truly dangling EXTENDS edges.** Follow the `bufferInterfaceNodes` pattern: create external reference nodes for constraint types not found in the same file.
+
+2. **Do NOT add `TypeParameterNodeRecord` or `TYPE_PARAMETER` to `packages/types/src/nodes.ts`.** Follow the same pattern as INTERFACE/TYPE/ENUM/DECORATOR. Similarly, reconsider adding to `NodeKind.ts` since other TS-specific node types are not there.
+
+These are implementation-level fixes. The overall architecture, approach, and scope are correct. The plan can proceed to implementation with these adjustments.
+
+---
+
+**Decision: APPROVE** -- proceed to implementation with the two required fixes above. These do not require re-planning, just adjustment during Rob's implementation.

--- a/_tasks/REG-303/005-steve-implementation-review.md
+++ b/_tasks/REG-303/005-steve-implementation-review.md
@@ -1,0 +1,195 @@
+# REG-303: Steve Jobs Implementation Review
+
+## Verdict: APPROVE
+
+---
+
+## 1. Required Fix Verification
+
+### Fix #1: External Reference Nodes for EXTENDS edges -- APPLIED CORRECTLY
+
+My earlier review (004) required: "Do NOT create dangling EXTENDS edges. Follow the `bufferInterfaceNodes` pattern: create external reference nodes for constraint types not found in the same file."
+
+**Verified.** The `bufferTypeParameterNodes()` method in GraphBuilder.ts (lines 2129-2200) follows the exact pattern from `bufferInterfaceNodes()`:
+
+```typescript
+// Same-file interface -- use its real ID
+const sameFileId = interfaceIdsByName.get(part);
+if (sameFileId) {
+  this._bufferEdge({
+    type: 'EXTENDS',
+    src: tpNode.id,
+    dst: sameFileId
+  });
+} else {
+  // External type -- create an external reference node
+  const externalInterface = NodeFactory.createInterface(
+    part, tp.file, tp.line, 0,
+    { isExternal: true }
+  );
+  this._bufferNode(externalInterface as unknown as GraphNode);
+  this._bufferEdge({
+    type: 'EXTENDS',
+    src: tpNode.id,
+    dst: externalInterface.id
+  });
+}
+```
+
+This is structurally identical to `bufferInterfaceNodes()` lines 2018-2032. No dangling edges. EXTENDS edges always point to real node IDs. Same-file resolution via `interfaceIdsByName` lookup. External constraint types get proper `isExternal: true` reference nodes.
+
+Additionally, the implementation correctly handles intersection constraints (`T extends A & B`) by splitting on ` & ` and creating separate EXTENDS edges for each part, while filtering out primitives, union types, array types, and complex types. This is thorough.
+
+### Fix #2: No changes to `packages/types/src/nodes.ts` -- APPLIED CORRECTLY
+
+My earlier review required: "Do NOT add `TypeParameterNodeRecord` or `TYPE_PARAMETER` to `packages/types/src/nodes.ts`."
+
+**Verified.** `packages/types/src/nodes.ts` has no mention of `TYPE_PARAMETER` or `TypeParameterNodeRecord`. The record type lives exclusively in `packages/core/src/core/nodes/TypeParameterNode.ts`, exactly matching the INTERFACE/TYPE/ENUM/DECORATOR pattern.
+
+**Minor note:** `TYPE_PARAMETER` was added to `NodeKind.ts` (line 28) even though INTERFACE, TYPE, ENUM, and DECORATOR are not there. This is a minor inconsistency but not a blocking issue -- `NodeKind.ts` represents "base types" (FUNCTION, CLASS, VARIABLE, etc.) and TYPE_PARAMETER is arguably a "core code entity" that belongs alongside PARAMETER and EXPRESSION. The key constraint was `packages/types/src/nodes.ts`, and that is clean.
+
+---
+
+## 2. Code Quality Assessment
+
+### TypeParameterNode.ts -- CLEAN
+
+Follows the TypeNode.ts / InterfaceNode.ts pattern exactly:
+
+- `static readonly TYPE = 'TYPE_PARAMETER' as const`
+- `static readonly REQUIRED` / `OPTIONAL` arrays
+- `create()` with validation, spreading optional fields only when defined
+- `validate()` using the standard pattern
+- ID format `{parentId}:TYPE_PARAMETER:{name}` is clean and deterministic
+- TypeScript's `<T, T>` prohibition guarantees uniqueness within scope
+
+The conditional spreading pattern (`...(options.constraint !== undefined && { constraint: options.constraint })`) ensures the node object has no `undefined` values for absent optional fields. The tests verify this explicitly (lines 148-154 check `!('constraint' in node)`). Good discipline.
+
+### NodeFactory.ts -- CLEAN
+
+`createTypeParameter()` at line 551 follows the exact pattern of `createInterface()`, `createType()`, `createEnum()`, `createDecorator()`. The `TypeParameterOptions` interface is defined alongside the others. The validator map includes `'TYPE_PARAMETER': TypeParameterNode`. Everything is consistent.
+
+### extractTypeParameters() -- CLEAN
+
+In TypeScriptVisitor.ts (lines 120-185). Well-structured helper:
+
+- Handles null/undefined input gracefully (returns `[]`)
+- Validates `TSTypeParameterDeclaration` type before processing
+- Extracts constraint via existing `typeNodeToString()` -- correct reuse
+- Filters `constraintType !== 'unknown'` to undefined -- prevents noise
+- Variance extraction handles all three cases (`in`, `out`, `in out`)
+- Uses param's own location when available, falls back to declaration location
+
+One subtle correctness detail: the `typeNodeToString()` returns `'unknown'` for types it cannot parse, and `extractTypeParameters()` maps `'unknown'` back to `undefined`. This means if a constraint is literally `T extends unknown`, it will be stored as `undefined` rather than `'unknown'`. This is acceptable because `unknown` as a constraint is semantically meaningless (all types extend `unknown`), so omitting it is correct behavior.
+
+### Visitor Integration -- CLEAN
+
+All four declaration contexts are handled:
+
+1. **FunctionDeclaration** (FunctionVisitor.ts, line 247-261) -- extracts from `(node as any).typeParameters` using the shared helper
+2. **ArrowFunctionExpression** (FunctionVisitor.ts, line 338-352) -- same pattern
+3. **ClassDeclaration** (ClassVisitor.ts, line 209-221) -- same pattern, uses `classRecord.id` as parentId
+4. **ClassMethod** (ClassVisitor.ts, line 374-387) -- extracts method-level type params, correctly using `functionId` (the method's semantic ID) as parentId
+5. **TSInterfaceDeclaration** (TypeScriptVisitor.ts, line 261-275) -- uses computed interface ID as parentId
+6. **TSTypeAliasDeclaration** (TypeScriptVisitor.ts, line 304-318) -- uses computed type ID as parentId
+
+All six contexts use the same `extractTypeParameters()` helper and push to the shared `collections.typeParameters` array. Consistent and DRY.
+
+### JSASTAnalyzer.ts -- CLEAN
+
+The `typeParameters` collection is:
+- Declared in the `PerModuleAnalysisData` interface (line 157)
+- Initialized as empty array in `analyzeModule()` (line 1465)
+- Passed through the collections object to visitors (line 1554)
+- Forwarded to `GraphBuilder.buildGraph()` (line 1943)
+
+Complete data flow pipeline from AST visitors through to graph construction.
+
+### GraphBuilder.ts bufferTypeParameterNodes() -- CLEAN
+
+The method (lines 2129-2200) is well-structured:
+
+1. Builds interface name-to-ID lookup for same-file resolution
+2. Creates TYPE_PARAMETER nodes via `TypeParameterNode.create()`
+3. Creates HAS_TYPE_PARAMETER edges from parent to type parameter
+4. For non-primitive constraints, handles intersection types by splitting on ` & `
+5. For each constraint part, checks same-file interfaces first, then creates external reference nodes
+6. Filters out primitives, union types, array types via `isPrimitiveType()` and string checks
+
+The `isPrimitiveType()` helper (line 84) is a clean module-level function covering all TS primitives including `function`. The additional filters for `' | '`, `'[]'`, `'['` in the constraint loop prevent EXTENDS edges for complex types that cannot be resolved to a single named type. This is correct -- you cannot create a meaningful EXTENDS edge to a union or array type.
+
+---
+
+## 3. Test Quality Assessment
+
+### Unit Tests (Sections 1-3, 9) -- STRONG
+
+- `TypeParameterNode.create()` contract: ID format, type field, optional fields, validation
+- Validation: detects wrong type, missing required fields
+- NodeFactory compatibility: produces same result, passes through validator
+- ID uniqueness: different parents produce different IDs, different names produce different IDs, same inputs produce same IDs
+
+These are proper contract tests. They test the public API surface without testing implementation details.
+
+### Integration Tests (Sections 4-8) -- STRONG
+
+These test the FULL PIPELINE: write TypeScript source -> analyze via orchestrator -> query graph database -> verify nodes and edges.
+
+Coverage:
+- Simple type parameter on function (`identity<T>`)
+- Constrained type parameter with EXTENDS edge (`process<T extends Serializable>`)
+- Multiple type parameters (`pair<A, B>`)
+- Default type (`create<T = string>`)
+- Arrow function type parameters
+- Class type parameters with HAS_TYPE_PARAMETER edge
+- Class with constrained type parameter and EXTENDS edge
+- Class method type parameters
+- Interface type parameters
+- Type alias type parameters
+- Intersection constraints (`T extends HasName & HasAge`) -- verifies TWO EXTENDS edges
+
+### Edge Case Tests (Section 10) -- STRONG
+
+- Primitive constraint (`T extends string`) -- verifies NO EXTENDS edge
+- Variance annotations: `out`, `in`, `in out` -- all three variants tested
+
+### What the tests verify for "AI should query the graph":
+
+An agent can now query:
+- "What type parameters does function X have?" -- Follow HAS_TYPE_PARAMETER edges from FUNCTION node
+- "What are the constraints on type parameter T?" -- Read `constraint` metadata on TYPE_PARAMETER node
+- "What type does T extend?" -- Follow EXTENDS edge from TYPE_PARAMETER node to target type
+- "What is the default type for T?" -- Read `defaultType` metadata on TYPE_PARAMETER node
+- "Is T covariant or contravariant?" -- Read `variance` metadata on TYPE_PARAMETER node
+
+All of these queries are tested in the integration tests. The graph IS the superior way to answer these questions.
+
+---
+
+## 4. Vision Check
+
+**PASS.** This implementation directly serves "AI should query the graph, not read code."
+
+Before REG-303: An agent asking "what constraints does this generic function have?" must read the source code. There is nothing in the graph.
+
+After REG-303: The agent follows `FUNCTION --HAS_TYPE_PARAMETER--> TYPE_PARAMETER` edges and reads `constraint`, `defaultType`, `variance` metadata. For non-primitive constraints, it can follow `TYPE_PARAMETER --EXTENDS--> INTERFACE/TYPE` edges to understand the constraint hierarchy. No source reading needed.
+
+The implementation is clean, follows established patterns, and the tests verify the full pipeline. Both required fixes from my plan review have been applied correctly.
+
+---
+
+## 5. Potential Issues (non-blocking)
+
+1. **NodeKind.ts inconsistency**: `TYPE_PARAMETER` was added to `NodeKind.ts` but INTERFACE/TYPE/ENUM/DECORATOR are not there. This is cosmetic -- it does not affect functionality. The pattern in NodeKind.ts seems to track "abstract base types" (FUNCTION, CLASS, VARIABLE, etc.) vs TypeScript-specific types (INTERFACE, ENUM). TYPE_PARAMETER could be argued either way. Not worth blocking.
+
+2. **No `TypeNode` lookup for constraints**: The `bufferTypeParameterNodes()` builds a lookup for interfaces but not for type aliases. So `T extends MyTypeAlias` where `MyTypeAlias` is in the same file will create an external reference node rather than linking to the actual TYPE node. This is a minor gap -- the EXTENDS edge still points to a node named `MyTypeAlias`, which can be resolved by enrichment later. Creating a type alias lookup would be a small enhancement but is NOT needed for the core feature to work.
+
+3. **Class property arrow functions**: ClassVisitor does NOT extract type parameters from class property arrow functions (e.g., `process = <T>(x: T): T => x`). However, this is an edge case -- class property arrow functions with their own type parameters are rare. The six primary declaration contexts are all covered. If needed, this can be added later as a follow-up.
+
+None of these are blocking. The core feature is complete and correct.
+
+---
+
+## Decision: APPROVE
+
+Ship it. The implementation is clean, correct, follows established patterns, the required fixes are applied, and the tests are comprehensive. This moves Grafema closer to "AI should query the graph, not read code" for generic TypeScript code.

--- a/packages/core/src/core/NodeFactory.ts
+++ b/packages/core/src/core/NodeFactory.ts
@@ -39,6 +39,7 @@ import {
   ExternalModuleNode,
   InterfaceNode,
   TypeNode,
+  TypeParameterNode,
   EnumNode,
   DecoratorNode,
   ExpressionNode,
@@ -199,6 +200,12 @@ interface InterfaceOptions {
 
 interface TypeOptions {
   aliasOf?: string;
+}
+
+interface TypeParameterOptions {
+  constraint?: string;
+  defaultType?: string;
+  variance?: 'in' | 'out' | 'in out';
 }
 
 interface EnumOptions {
@@ -530,6 +537,29 @@ export class NodeFactory {
   }
 
   /**
+   * Create TYPE_PARAMETER node
+   *
+   * Represents a generic type parameter (<T extends Constraint = Default>).
+   *
+   * @param name - Type parameter name ("T", "K", "V")
+   * @param parentId - ID of the owning declaration (function/class/interface/type)
+   * @param file - File path
+   * @param line - Line number
+   * @param column - Column position
+   * @param options - Optional constraint, defaultType, variance
+   */
+  static createTypeParameter(
+    name: string,
+    parentId: string,
+    file: string,
+    line: number,
+    column: number,
+    options: TypeParameterOptions = {}
+  ) {
+    return brandNode(TypeParameterNode.create(name, parentId, file, line, column, options));
+  }
+
+  /**
    * Create ENUM node
    */
   static createEnum(
@@ -722,6 +752,7 @@ export class NodeFactory {
       'EXTERNAL_MODULE': ExternalModuleNode,
       'INTERFACE': InterfaceNode,
       'TYPE': TypeNode,
+      'TYPE_PARAMETER': TypeParameterNode,
       'ENUM': EnumNode,
       'DECORATOR': DecoratorNode,
       'EXPRESSION': ExpressionNode

--- a/packages/core/src/core/nodes/NodeKind.ts
+++ b/packages/core/src/core/nodes/NodeKind.ts
@@ -25,6 +25,7 @@ export const NODE_TYPE = {
   CONSTANT: 'CONSTANT',
   LITERAL: 'LITERAL',
   EXPRESSION: 'EXPRESSION',  // Generic expression node for data flow tracking
+  TYPE_PARAMETER: 'TYPE_PARAMETER',
 
   // Module system
   MODULE: 'MODULE',

--- a/packages/core/src/core/nodes/TypeParameterNode.ts
+++ b/packages/core/src/core/nodes/TypeParameterNode.ts
@@ -1,0 +1,91 @@
+/**
+ * TypeParameterNode - contract for TYPE_PARAMETER node
+ *
+ * Represents a generic type parameter on a function, class, interface, or type alias.
+ *
+ * ID format: {parentId}:TYPE_PARAMETER:{name}
+ * Example: /src/types.ts:INTERFACE:Container:5:TYPE_PARAMETER:T
+ *
+ * Type parameter names are unique within their declaration scope
+ * (TypeScript does not allow `<T, T>`), so {parentId}:{name} is sufficient.
+ */
+
+import type { BaseNodeRecord } from '@grafema/types';
+
+interface TypeParameterNodeRecord extends BaseNodeRecord {
+  type: 'TYPE_PARAMETER';
+  column: number;
+  constraint?: string;
+  defaultType?: string;
+  variance?: 'in' | 'out' | 'in out';
+}
+
+interface TypeParameterNodeOptions {
+  constraint?: string;
+  defaultType?: string;
+  variance?: 'in' | 'out' | 'in out';
+}
+
+export class TypeParameterNode {
+  static readonly TYPE = 'TYPE_PARAMETER' as const;
+
+  static readonly REQUIRED = ['name', 'file', 'line', 'column'] as const;
+  static readonly OPTIONAL = ['constraint', 'defaultType', 'variance'] as const;
+
+  /**
+   * Create TYPE_PARAMETER node
+   *
+   * @param name - Type parameter name (e.g., "T", "K")
+   * @param parentId - ID of the owning declaration (function, class, interface, type)
+   * @param file - File path
+   * @param line - Line number
+   * @param column - Column position
+   * @param options - Optional constraint, defaultType, variance
+   * @returns TypeParameterNodeRecord
+   */
+  static create(
+    name: string,
+    parentId: string,
+    file: string,
+    line: number,
+    column: number,
+    options: TypeParameterNodeOptions = {}
+  ): TypeParameterNodeRecord {
+    if (!name) throw new Error('TypeParameterNode.create: name is required');
+    if (!parentId) throw new Error('TypeParameterNode.create: parentId is required');
+    if (!file) throw new Error('TypeParameterNode.create: file is required');
+    if (!line) throw new Error('TypeParameterNode.create: line is required');
+    if (column === undefined) throw new Error('TypeParameterNode.create: column is required');
+
+    return {
+      id: `${parentId}:TYPE_PARAMETER:${name}`,
+      type: this.TYPE,
+      name,
+      file,
+      line,
+      column,
+      ...(options.constraint !== undefined && { constraint: options.constraint }),
+      ...(options.defaultType !== undefined && { defaultType: options.defaultType }),
+      ...(options.variance !== undefined && { variance: options.variance }),
+    };
+  }
+
+  static validate(node: TypeParameterNodeRecord): string[] {
+    const errors: string[] = [];
+
+    if (node.type !== this.TYPE) {
+      errors.push(`Expected type ${this.TYPE}, got ${node.type}`);
+    }
+
+    const nodeRecord = node as unknown as Record<string, unknown>;
+    for (const field of this.REQUIRED) {
+      if (nodeRecord[field] === undefined || nodeRecord[field] === null) {
+        errors.push(`Missing required field: ${field}`);
+      }
+    }
+
+    return errors;
+  }
+}
+
+export type { TypeParameterNodeRecord, TypeParameterNodeOptions };

--- a/packages/core/src/core/nodes/index.ts
+++ b/packages/core/src/core/nodes/index.ts
@@ -32,6 +32,7 @@ export { ExternalModuleNode, type ExternalModuleNodeRecord } from './ExternalMod
 // TypeScript declaration nodes
 export { InterfaceNode, type InterfaceNodeRecord, type InterfacePropertyRecord } from './InterfaceNode.js';
 export { TypeNode, type TypeNodeRecord } from './TypeNode.js';
+export { TypeParameterNode, type TypeParameterNodeRecord, type TypeParameterNodeOptions } from './TypeParameterNode.js';
 export { EnumNode, type EnumNodeRecord, type EnumMemberRecord } from './EnumNode.js';
 export { DecoratorNode, type DecoratorNodeRecord, type DecoratorTargetType } from './DecoratorNode.js';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -194,6 +194,7 @@ export { ExternalModuleNode } from './core/nodes/ExternalModuleNode.js';
 export { NetworkRequestNode } from './core/nodes/NetworkRequestNode.js';
 export { InterfaceNode, type InterfacePropertyRecord } from './core/nodes/InterfaceNode.js';
 export { TypeNode } from './core/nodes/TypeNode.js';
+export { TypeParameterNode, type TypeParameterNodeRecord, type TypeParameterNodeOptions } from './core/nodes/TypeParameterNode.js';
 export { EnumNode, type EnumMemberRecord } from './core/nodes/EnumNode.js';
 export { DecoratorNode, type DecoratorTargetType } from './core/nodes/DecoratorNode.js';
 export { ExpressionNode, type ExpressionNodeOptions } from './core/nodes/ExpressionNode.js';

--- a/packages/core/src/plugins/analysis/JSASTAnalyzer.ts
+++ b/packages/core/src/plugins/analysis/JSASTAnalyzer.ts
@@ -106,6 +106,7 @@ import type {
   RejectionPatternInfo,
   CatchesFromInfo,
   PropertyAccessInfo,
+  TypeParameterInfo,
   CounterRef,
   ProcessedNodes,
   ASTCollections,
@@ -152,6 +153,8 @@ interface Collections {
   typeAliases: TypeAliasInfo[];
   enums: EnumDeclarationInfo[];
   decorators: DecoratorInfo[];
+  // Type parameter tracking for generics (REG-303)
+  typeParameters: TypeParameterInfo[];
   // Object/Array literal tracking
   objectLiterals: ObjectLiteralInfo[];
   objectProperties: ObjectPropertyInfo[];
@@ -267,14 +270,14 @@ export class JSASTAnalyzer extends Plugin {
           'CALL', 'IMPORT', 'EXPORT', 'LITERAL', 'EXTERNAL_MODULE',
           'net:stdio', 'net:request', 'event:listener', 'http:request',
           // TypeScript-specific nodes
-          'INTERFACE', 'TYPE', 'ENUM', 'DECORATOR'
+          'INTERFACE', 'TYPE', 'ENUM', 'DECORATOR', 'TYPE_PARAMETER'
         ],
         edges: [
           'CONTAINS', 'DECLARES', 'CALLS', 'HAS_SCOPE', 'CAPTURES', 'MODIFIES',
           'WRITES_TO', 'IMPORTS', 'INSTANCE_OF', 'HANDLED_BY', 'HAS_CALLBACK',
           'PASSES_ARGUMENT', 'MAKES_REQUEST', 'IMPORTS_FROM', 'EXPORTS_TO', 'ASSIGNED_FROM',
           // TypeScript-specific edges
-          'IMPLEMENTS', 'EXTENDS', 'DECORATED_BY',
+          'IMPLEMENTS', 'EXTENDS', 'DECORATED_BY', 'HAS_TYPE_PARAMETER',
           // Promise data flow
           'RESOLVES_TO'
         ]
@@ -1458,6 +1461,8 @@ export class JSASTAnalyzer extends Plugin {
       const typeAliases: TypeAliasInfo[] = [];
       const enums: EnumDeclarationInfo[] = [];
       const decorators: DecoratorInfo[] = [];
+      // Type parameter tracking for generics (REG-303)
+      const typeParameters: TypeParameterInfo[] = [];
       // Object/Array literal tracking for data flow
       const objectLiterals: ObjectLiteralInfo[] = [];
       const objectProperties: ObjectPropertyInfo[] = [];
@@ -1545,6 +1550,8 @@ export class JSASTAnalyzer extends Plugin {
         httpRequests, literals, variableAssignments,
         // TypeScript-specific collections
         interfaces, typeAliases, enums, decorators,
+        // Type parameter tracking for generics (REG-303)
+        typeParameters,
         // Object/Array literal tracking
         objectLiterals, objectProperties, arrayLiterals, arrayElements,
         // Array mutation tracking
@@ -1932,6 +1939,8 @@ export class JSASTAnalyzer extends Plugin {
         typeAliases,
         enums,
         decorators,
+        // Type parameter tracking for generics (REG-303)
+        typeParameters,
         // Array mutation tracking
         arrayMutations,
         // Object mutation tracking

--- a/packages/core/src/plugins/analysis/ast/types.ts
+++ b/packages/core/src/plugins/analysis/ast/types.ts
@@ -417,6 +417,19 @@ export interface DecoratorInfo {
   targetType: 'CLASS' | 'METHOD' | 'PROPERTY' | 'PARAMETER';
 }
 
+// === TYPE PARAMETER INFO ===
+export interface TypeParameterInfo {
+  name: string;              // "T", "K", "V"
+  constraintType?: string;   // "Serializable" (string repr via typeNodeToString)
+  defaultType?: string;      // "string" (string repr via typeNodeToString)
+  variance?: 'in' | 'out' | 'in out';
+  parentId: string;          // ID of owning function/class/interface/type
+  parentType: 'FUNCTION' | 'CLASS' | 'INTERFACE' | 'TYPE';
+  file: string;
+  line: number;
+  column: number;
+}
+
 // === METHOD CALLBACK INFO ===
 export interface MethodCallbackInfo {
   methodCallId: string;
@@ -1120,6 +1133,8 @@ export interface ASTCollections {
   typeAliases?: TypeAliasInfo[];
   enums?: EnumDeclarationInfo[];
   decorators?: DecoratorInfo[];
+  // Type parameter tracking for generics (REG-303)
+  typeParameters?: TypeParameterInfo[];
   // Counter refs (used internally during collection)
   ifScopeCounterRef?: CounterRef;
   scopeCounterRef?: CounterRef;

--- a/packages/core/src/plugins/analysis/ast/visitors/TypeScriptVisitor.ts
+++ b/packages/core/src/plugins/analysis/ast/visitors/TypeScriptVisitor.ts
@@ -23,7 +23,8 @@ import type {
   InterfacePropertyInfo,
   TypeAliasInfo,
   EnumDeclarationInfo,
-  EnumMemberInfo
+  EnumMemberInfo,
+  TypeParameterInfo
 } from '../types.js';
 import type { ScopeTracker } from '../../../../core/ScopeTracker.js';
 import { computeSemanticId } from '../../../../core/SemanticId.js';
@@ -98,6 +99,91 @@ export function typeNodeToString(node: unknown): string {
   }
 }
 
+/**
+ * Extracts type parameter info from a TSTypeParameterDeclaration node.
+ *
+ * Handles:
+ * - Simple: <T>
+ * - Constrained: <T extends Serializable>
+ * - Defaulted: <T = string>
+ * - Variance: <in T>, <out T>, <in out T>
+ * - Intersection constraints: <T extends A & B>
+ *
+ * @param typeParameters - Babel TSTypeParameterDeclaration node (or undefined)
+ * @param parentId - ID of the owning declaration
+ * @param parentType - 'FUNCTION' | 'CLASS' | 'INTERFACE' | 'TYPE'
+ * @param file - File path
+ * @param line - Line of the declaration
+ * @param column - Column of the declaration
+ * @returns Array of TypeParameterInfo (empty if no type params)
+ */
+export function extractTypeParameters(
+  typeParameters: unknown,
+  parentId: string,
+  parentType: 'FUNCTION' | 'CLASS' | 'INTERFACE' | 'TYPE',
+  file: string,
+  line: number,
+  column: number
+): TypeParameterInfo[] {
+  if (!typeParameters || typeof typeParameters !== 'object') return [];
+
+  const tpDecl = typeParameters as { type?: string; params?: unknown[] };
+  if (tpDecl.type !== 'TSTypeParameterDeclaration' || !Array.isArray(tpDecl.params)) return [];
+
+  const result: TypeParameterInfo[] = [];
+
+  for (const param of tpDecl.params) {
+    const tsParam = param as {
+      type?: string;
+      name?: string;
+      constraint?: unknown;
+      default?: unknown;
+      in?: boolean;
+      out?: boolean;
+      loc?: { start?: { line?: number; column?: number } };
+    };
+
+    if (tsParam.type !== 'TSTypeParameter') continue;
+
+    const paramName = tsParam.name;
+    if (!paramName) continue;
+
+    // Extract constraint via typeNodeToString
+    const constraintType = tsParam.constraint ? typeNodeToString(tsParam.constraint) : undefined;
+
+    // Extract default via typeNodeToString
+    const defaultType = tsParam.default ? typeNodeToString(tsParam.default) : undefined;
+
+    // Extract variance
+    let variance: 'in' | 'out' | 'in out' | undefined;
+    if (tsParam.in && tsParam.out) {
+      variance = 'in out';
+    } else if (tsParam.in) {
+      variance = 'in';
+    } else if (tsParam.out) {
+      variance = 'out';
+    }
+
+    // Use param's own location if available, otherwise fall back to declaration location
+    const paramLine = tsParam.loc?.start?.line ?? line;
+    const paramColumn = tsParam.loc?.start?.column ?? column;
+
+    result.push({
+      name: paramName,
+      constraintType: constraintType !== 'unknown' ? constraintType : undefined,
+      defaultType: defaultType !== 'unknown' ? defaultType : undefined,
+      variance,
+      parentId,
+      parentType,
+      file,
+      line: paramLine,
+      column: paramColumn,
+    });
+  }
+
+  return result;
+}
+
 export class TypeScriptVisitor extends ASTVisitor {
   private scopeTracker?: ScopeTracker;
 
@@ -116,7 +202,8 @@ export class TypeScriptVisitor extends ASTVisitor {
     const {
       interfaces,
       typeAliases,
-      enums
+      enums,
+      typeParameters
     } = this.collections;
     const scopeTracker = this.scopeTracker;
 
@@ -171,6 +258,22 @@ export class TypeScriptVisitor extends ASTVisitor {
           }
         }
 
+        // Extract type parameters (REG-303)
+        if (typeParameters && node.typeParameters) {
+          const interfaceId = `${module.file}:INTERFACE:${interfaceName}:${getLine(node)}`;
+          const typeParamInfos = extractTypeParameters(
+            node.typeParameters,
+            interfaceId,
+            'INTERFACE',
+            module.file,
+            getLine(node),
+            getColumn(node)
+          );
+          for (const tp of typeParamInfos) {
+            (typeParameters as TypeParameterInfo[]).push(tp);
+          }
+        }
+
         (interfaces as InterfaceDeclarationInfo[]).push({
           semanticId: interfaceSemanticId,
           type: 'INTERFACE',
@@ -197,6 +300,22 @@ export class TypeScriptVisitor extends ASTVisitor {
 
         // Extract the type being aliased
         const aliasOf = typeNodeToString(node.typeAnnotation);
+
+        // Extract type parameters (REG-303)
+        if (typeParameters && node.typeParameters) {
+          const typeId = `${module.file}:TYPE:${typeName}:${getLine(node)}`;
+          const typeParamInfos = extractTypeParameters(
+            node.typeParameters,
+            typeId,
+            'TYPE',
+            module.file,
+            getLine(node),
+            getColumn(node)
+          );
+          for (const tp of typeParamInfos) {
+            (typeParameters as TypeParameterInfo[]).push(tp);
+          }
+        }
 
         (typeAliases as TypeAliasInfo[]).push({
           semanticId: typeSemanticId,

--- a/test/unit/TypeParameterTracking.test.js
+++ b/test/unit/TypeParameterTracking.test.js
@@ -1,0 +1,905 @@
+/**
+ * Type Parameter Tracking Tests (REG-303)
+ *
+ * TDD tests for TYPE_PARAMETER node creation, HAS_TYPE_PARAMETER edges,
+ * and EXTENDS edges for constrained type parameters.
+ *
+ * Verifies:
+ * 1. TypeParameterNode.create() generates correct ID format: {parentId}:TYPE_PARAMETER:{name}
+ * 2. TypeParameterNode validation works for required/optional fields
+ * 3. Full pipeline integration: functions, arrow functions, classes, methods,
+ *    interfaces, type aliases all produce correct TYPE_PARAMETER nodes and edges
+ * 4. Edge cases: primitive constraints (no EXTENDS edge), variance annotations, defaults
+ *
+ * TDD: Tests written first per Kent Beck's methodology.
+ */
+
+import { describe, it, after, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { join } from 'path';
+import { writeFileSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+
+import { TypeParameterNode, NodeFactory } from '@grafema/core';
+import { createTestDatabase, cleanupAllTestDatabases } from '../helpers/TestRFDB.js';
+import { createTestOrchestrator } from '../helpers/createTestOrchestrator.js';
+
+// Cleanup all test databases after all tests complete
+after(cleanupAllTestDatabases);
+
+let testCounter = 0;
+
+/**
+ * Helper to create a test project with given files and analyze it.
+ * Files must be discoverable through the dependency tree.
+ * We use index.ts as entry point.
+ */
+async function setupTest(backend, files) {
+  const testDir = join(tmpdir(), `grafema-test-typeparam-${Date.now()}-${testCounter++}`);
+  mkdirSync(testDir, { recursive: true });
+
+  writeFileSync(
+    join(testDir, 'package.json'),
+    JSON.stringify({
+      name: `test-typeparam-${testCounter}`,
+      type: 'module',
+      main: 'index.ts'
+    })
+  );
+
+  for (const [filename, content] of Object.entries(files)) {
+    writeFileSync(join(testDir, filename), content);
+  }
+
+  const orchestrator = createTestOrchestrator(backend, { forceAnalysis: true });
+  await orchestrator.run(testDir);
+
+  return { testDir };
+}
+
+// ============================================================================
+// 1. TypeParameterNode contract (unit tests)
+// ============================================================================
+
+describe('Type Parameter Tracking (REG-303)', () => {
+  describe('TypeParameterNode.create() contract', () => {
+    it('creates node with correct ID format: {parentId}:TYPE_PARAMETER:{name}', () => {
+      const node = TypeParameterNode.create(
+        'T',
+        '/src/types.ts:INTERFACE:Container:5',
+        '/src/types.ts',
+        5,
+        20
+      );
+
+      assert.strictEqual(
+        node.id,
+        '/src/types.ts:INTERFACE:Container:5:TYPE_PARAMETER:T',
+        'ID should be {parentId}:TYPE_PARAMETER:{name}'
+      );
+    });
+
+    it('sets type to TYPE_PARAMETER', () => {
+      const node = TypeParameterNode.create(
+        'T',
+        '/src/fn.ts:FUNCTION:identity:3',
+        '/src/fn.ts',
+        3,
+        20
+      );
+
+      assert.strictEqual(node.type, 'TYPE_PARAMETER');
+    });
+
+    it('includes constraint when provided', () => {
+      const node = TypeParameterNode.create(
+        'T',
+        '/src/fn.ts:FUNCTION:process:10',
+        '/src/fn.ts',
+        10,
+        25,
+        { constraint: 'Serializable' }
+      );
+
+      assert.strictEqual(node.constraint, 'Serializable');
+    });
+
+    it('includes defaultType when provided', () => {
+      const node = TypeParameterNode.create(
+        'T',
+        '/src/fn.ts:FUNCTION:create:15',
+        '/src/fn.ts',
+        15,
+        20,
+        { defaultType: 'string' }
+      );
+
+      assert.strictEqual(node.defaultType, 'string');
+    });
+
+    it('includes variance when provided', () => {
+      const node = TypeParameterNode.create(
+        'T',
+        '/src/types.ts:INTERFACE:Producer:5',
+        '/src/types.ts',
+        5,
+        22,
+        { variance: 'out' }
+      );
+
+      assert.strictEqual(node.variance, 'out');
+    });
+
+    it('omits optional fields when not provided', () => {
+      const node = TypeParameterNode.create(
+        'T',
+        '/src/fn.ts:FUNCTION:identity:1',
+        '/src/fn.ts',
+        1,
+        10
+      );
+
+      assert.strictEqual(node.constraint, undefined,
+        'constraint should be absent when not provided');
+      assert.strictEqual(node.defaultType, undefined,
+        'defaultType should be absent when not provided');
+      assert.strictEqual(node.variance, undefined,
+        'variance should be absent when not provided');
+      // Verify the keys are not present (not just undefined values)
+      assert.ok(!('constraint' in node),
+        'constraint key should not be present');
+      assert.ok(!('defaultType' in node),
+        'defaultType key should not be present');
+      assert.ok(!('variance' in node),
+        'variance key should not be present');
+    });
+
+    it('throws when name is missing', () => {
+      assert.throws(
+        () => TypeParameterNode.create(
+          '',
+          '/src/fn.ts:FUNCTION:identity:1',
+          '/src/fn.ts',
+          1,
+          0
+        ),
+        /name is required/,
+        'Should throw when name is empty'
+      );
+    });
+
+    it('throws when parentId is missing', () => {
+      assert.throws(
+        () => TypeParameterNode.create(
+          'T',
+          '',
+          '/src/fn.ts',
+          1,
+          0
+        ),
+        /parentId is required/,
+        'Should throw when parentId is empty'
+      );
+    });
+  });
+
+  // ============================================================================
+  // 2. TypeParameterNode validation
+  // ============================================================================
+
+  describe('TypeParameterNode validation', () => {
+    it('returns empty errors for valid node', () => {
+      const node = TypeParameterNode.create(
+        'T',
+        '/src/fn.ts:FUNCTION:identity:3',
+        '/src/fn.ts',
+        3,
+        20
+      );
+
+      const errors = TypeParameterNode.validate(node);
+      assert.strictEqual(errors.length, 0,
+        `Expected no validation errors, got: ${JSON.stringify(errors)}`);
+    });
+
+    it('detects invalid type', () => {
+      const node = {
+        id: '/src/fn.ts:FUNCTION:identity:3:TYPE_PARAMETER:T',
+        type: 'WRONG_TYPE',
+        name: 'T',
+        file: '/src/fn.ts',
+        line: 3,
+        column: 20,
+      };
+
+      const errors = TypeParameterNode.validate(node);
+      assert.ok(errors.length > 0, 'Should have validation errors');
+      assert.ok(
+        errors.some(e => e.includes('TYPE_PARAMETER')),
+        `Should report type mismatch: ${JSON.stringify(errors)}`
+      );
+    });
+
+    it('detects missing required fields', () => {
+      const node = {
+        id: '/src/fn.ts:FUNCTION:identity:3:TYPE_PARAMETER:T',
+        type: 'TYPE_PARAMETER',
+        name: 'T',
+        // missing: file, line, column
+      };
+
+      const errors = TypeParameterNode.validate(node);
+      assert.ok(errors.length > 0, 'Should have validation errors for missing fields');
+    });
+  });
+
+  // ============================================================================
+  // 3. NodeFactory.createTypeParameter compatibility
+  // ============================================================================
+
+  describe('NodeFactory.createTypeParameter compatibility', () => {
+    it('produces same result as TypeParameterNode.create', () => {
+      const viaFactory = NodeFactory.createTypeParameter(
+        'T',
+        '/src/fn.ts:FUNCTION:identity:3',
+        '/src/fn.ts',
+        3,
+        20,
+        { constraint: 'Serializable' }
+      );
+
+      const viaDirect = TypeParameterNode.create(
+        'T',
+        '/src/fn.ts:FUNCTION:identity:3',
+        '/src/fn.ts',
+        3,
+        20,
+        { constraint: 'Serializable' }
+      );
+
+      // NodeFactory wraps with brandNode but the shape should match
+      assert.strictEqual(viaFactory.id, viaDirect.id,
+        'IDs should match');
+      assert.strictEqual(viaFactory.type, viaDirect.type);
+      assert.strictEqual(viaFactory.name, viaDirect.name);
+      assert.strictEqual(viaFactory.constraint, viaDirect.constraint);
+    });
+
+    it('passes validation through NodeFactory', () => {
+      const node = NodeFactory.createTypeParameter(
+        'K',
+        '/src/types.ts:TYPE:Pair:10',
+        '/src/types.ts',
+        10,
+        15,
+        { defaultType: 'string' }
+      );
+
+      const errors = NodeFactory.validate(node);
+      assert.strictEqual(errors.length, 0,
+        `Expected no validation errors, got: ${JSON.stringify(errors)}`);
+    });
+  });
+
+  // ============================================================================
+  // 4. Integration tests - Functions
+  // ============================================================================
+
+  describe('Type parameter tracking - Functions', () => {
+    let db;
+    let backend;
+
+    beforeEach(async () => {
+      if (db) await db.cleanup();
+      db = await createTestDatabase();
+      backend = db.backend;
+    });
+
+    after(async () => {
+      if (db) await db.cleanup();
+    });
+
+    it('tracks simple type parameter on function', async () => {
+      await setupTest(backend, {
+        'index.ts': `
+export function identity<T>(x: T): T { return x; }
+        `
+      });
+
+      const allNodes = await backend.getAllNodes();
+      const allEdges = await backend.getAllEdges();
+
+      // Find TYPE_PARAMETER node
+      const tpNode = allNodes.find(n =>
+        n.type === 'TYPE_PARAMETER' && n.name === 'T'
+      );
+      assert.ok(tpNode, 'TYPE_PARAMETER node T should exist');
+
+      // Verify no constraint
+      assert.strictEqual(tpNode.constraint, undefined,
+        'Simple type parameter should have no constraint');
+
+      // Find parent function
+      const fnNode = allNodes.find(n =>
+        n.type === 'FUNCTION' && n.name === 'identity'
+      );
+      assert.ok(fnNode, 'FUNCTION node identity should exist');
+
+      // HAS_TYPE_PARAMETER edge from function to type parameter
+      const hasTPEdge = allEdges.find(e =>
+        e.type === 'HAS_TYPE_PARAMETER' &&
+        e.src === fnNode.id &&
+        e.dst === tpNode.id
+      );
+      assert.ok(hasTPEdge,
+        `HAS_TYPE_PARAMETER edge from ${fnNode.id} to ${tpNode.id} should exist`);
+    });
+
+    it('tracks type parameter with constraint', async () => {
+      await setupTest(backend, {
+        'index.ts': `
+export interface Serializable { serialize(): string; }
+export function process<T extends Serializable>(item: T): string { return item.serialize(); }
+        `
+      });
+
+      const allNodes = await backend.getAllNodes();
+      const allEdges = await backend.getAllEdges();
+
+      // TYPE_PARAMETER node
+      const tpNode = allNodes.find(n =>
+        n.type === 'TYPE_PARAMETER' && n.name === 'T'
+      );
+      assert.ok(tpNode, 'TYPE_PARAMETER node T should exist');
+      assert.strictEqual(tpNode.constraint, 'Serializable',
+        'Constraint should be Serializable');
+
+      // EXTENDS edge from TYPE_PARAMETER to constraint type
+      const extendsEdge = allEdges.find(e =>
+        e.type === 'EXTENDS' && e.src === tpNode.id
+      );
+      assert.ok(extendsEdge,
+        `EXTENDS edge from TYPE_PARAMETER T should exist`);
+
+      // EXTENDS dst should point to Serializable interface (or external ref)
+      const dstNode = allNodes.find(n => n.id === extendsEdge.dst);
+      assert.ok(dstNode, 'EXTENDS target node should exist');
+      assert.strictEqual(dstNode.name, 'Serializable',
+        'EXTENDS target should be Serializable');
+    });
+
+    it('tracks multiple type parameters', async () => {
+      await setupTest(backend, {
+        'index.ts': `
+export function pair<A, B>(a: A, b: B): [A, B] { return [a, b]; }
+        `
+      });
+
+      const allNodes = await backend.getAllNodes();
+      const allEdges = await backend.getAllEdges();
+
+      const fnNode = allNodes.find(n =>
+        n.type === 'FUNCTION' && n.name === 'pair'
+      );
+      assert.ok(fnNode, 'FUNCTION node pair should exist');
+
+      // Two TYPE_PARAMETER nodes
+      const tpA = allNodes.find(n =>
+        n.type === 'TYPE_PARAMETER' && n.name === 'A'
+      );
+      const tpB = allNodes.find(n =>
+        n.type === 'TYPE_PARAMETER' && n.name === 'B'
+      );
+      assert.ok(tpA, 'TYPE_PARAMETER node A should exist');
+      assert.ok(tpB, 'TYPE_PARAMETER node B should exist');
+
+      // Both should have unique IDs
+      assert.notStrictEqual(tpA.id, tpB.id,
+        'A and B should have different IDs');
+
+      // Two HAS_TYPE_PARAMETER edges
+      const hasTPEdges = allEdges.filter(e =>
+        e.type === 'HAS_TYPE_PARAMETER' && e.src === fnNode.id
+      );
+      assert.strictEqual(hasTPEdges.length, 2,
+        `Should have 2 HAS_TYPE_PARAMETER edges from pair, found: ${hasTPEdges.length}`);
+    });
+
+    it('tracks type parameter with default', async () => {
+      await setupTest(backend, {
+        'index.ts': `
+export function create<T = string>(): T { return '' as unknown as T; }
+        `
+      });
+
+      const allNodes = await backend.getAllNodes();
+
+      const tpNode = allNodes.find(n =>
+        n.type === 'TYPE_PARAMETER' && n.name === 'T'
+      );
+      assert.ok(tpNode, 'TYPE_PARAMETER node T should exist');
+      assert.strictEqual(tpNode.defaultType, 'string',
+        'defaultType should be string');
+    });
+  });
+
+  // ============================================================================
+  // 5. Integration tests - Arrow functions
+  // ============================================================================
+
+  describe('Type parameter tracking - Arrow functions', () => {
+    let db;
+    let backend;
+
+    beforeEach(async () => {
+      if (db) await db.cleanup();
+      db = await createTestDatabase();
+      backend = db.backend;
+    });
+
+    after(async () => {
+      if (db) await db.cleanup();
+    });
+
+    it('tracks type params on arrow function', async () => {
+      await setupTest(backend, {
+        'index.ts': `
+export const identity = <T>(x: T): T => x;
+        `
+      });
+
+      const allNodes = await backend.getAllNodes();
+      const allEdges = await backend.getAllEdges();
+
+      const tpNode = allNodes.find(n =>
+        n.type === 'TYPE_PARAMETER' && n.name === 'T'
+      );
+      assert.ok(tpNode, 'TYPE_PARAMETER node T should exist on arrow function');
+
+      // Should have HAS_TYPE_PARAMETER edge from parent
+      const hasTPEdge = allEdges.find(e =>
+        e.type === 'HAS_TYPE_PARAMETER' && e.dst === tpNode.id
+      );
+      assert.ok(hasTPEdge,
+        'HAS_TYPE_PARAMETER edge should exist pointing to T');
+    });
+  });
+
+  // ============================================================================
+  // 6. Integration tests - Classes
+  // ============================================================================
+
+  describe('Type parameter tracking - Classes', () => {
+    let db;
+    let backend;
+
+    beforeEach(async () => {
+      if (db) await db.cleanup();
+      db = await createTestDatabase();
+      backend = db.backend;
+    });
+
+    after(async () => {
+      if (db) await db.cleanup();
+    });
+
+    it('tracks type params on class', async () => {
+      await setupTest(backend, {
+        'index.ts': `
+export class Container<T> {
+  value: T;
+  constructor(v: T) { this.value = v; }
+}
+        `
+      });
+
+      const allNodes = await backend.getAllNodes();
+      const allEdges = await backend.getAllEdges();
+
+      const classNode = allNodes.find(n =>
+        n.type === 'CLASS' && n.name === 'Container'
+      );
+      assert.ok(classNode, 'CLASS node Container should exist');
+
+      const tpNode = allNodes.find(n =>
+        n.type === 'TYPE_PARAMETER' && n.name === 'T'
+      );
+      assert.ok(tpNode, 'TYPE_PARAMETER node T should exist');
+
+      const hasTPEdge = allEdges.find(e =>
+        e.type === 'HAS_TYPE_PARAMETER' &&
+        e.src === classNode.id &&
+        e.dst === tpNode.id
+      );
+      assert.ok(hasTPEdge,
+        `HAS_TYPE_PARAMETER edge from Container to T should exist`);
+    });
+
+    it('tracks type params with constraint on class', async () => {
+      await setupTest(backend, {
+        'index.ts': `
+export interface Entity { id: string; }
+export class Repository<T extends Entity> {
+  items: T[] = [];
+}
+        `
+      });
+
+      const allNodes = await backend.getAllNodes();
+      const allEdges = await backend.getAllEdges();
+
+      const tpNode = allNodes.find(n =>
+        n.type === 'TYPE_PARAMETER' && n.name === 'T'
+      );
+      assert.ok(tpNode, 'TYPE_PARAMETER node T should exist');
+      assert.strictEqual(tpNode.constraint, 'Entity',
+        'Constraint should be Entity');
+
+      // EXTENDS edge from TYPE_PARAMETER to Entity
+      const extendsEdge = allEdges.find(e =>
+        e.type === 'EXTENDS' && e.src === tpNode.id
+      );
+      assert.ok(extendsEdge,
+        'EXTENDS edge from TYPE_PARAMETER T should exist');
+
+      const entityNode = allNodes.find(n => n.id === extendsEdge.dst);
+      assert.ok(entityNode, 'EXTENDS target should exist');
+      assert.strictEqual(entityNode.name, 'Entity',
+        'EXTENDS target should be Entity');
+    });
+
+    it('tracks type params on class methods', async () => {
+      await setupTest(backend, {
+        'index.ts': `
+export class Mapper {
+  map<U>(fn: (x: number) => U): U { return fn(0); }
+}
+        `
+      });
+
+      const allNodes = await backend.getAllNodes();
+      const allEdges = await backend.getAllEdges();
+
+      const tpNode = allNodes.find(n =>
+        n.type === 'TYPE_PARAMETER' && n.name === 'U'
+      );
+      assert.ok(tpNode, 'TYPE_PARAMETER node U should exist on method');
+
+      // HAS_TYPE_PARAMETER should come from the method function node
+      const hasTPEdge = allEdges.find(e =>
+        e.type === 'HAS_TYPE_PARAMETER' && e.dst === tpNode.id
+      );
+      assert.ok(hasTPEdge,
+        'HAS_TYPE_PARAMETER edge to U should exist');
+
+      // The source should be a function node (the method)
+      const parentNode = allNodes.find(n => n.id === hasTPEdge.src);
+      assert.ok(parentNode, 'Parent node of TYPE_PARAMETER should exist');
+      assert.strictEqual(parentNode.type, 'FUNCTION',
+        'Parent should be a FUNCTION node (class method)');
+    });
+  });
+
+  // ============================================================================
+  // 7. Integration tests - Interfaces
+  // ============================================================================
+
+  describe('Type parameter tracking - Interfaces', () => {
+    let db;
+    let backend;
+
+    beforeEach(async () => {
+      if (db) await db.cleanup();
+      db = await createTestDatabase();
+      backend = db.backend;
+    });
+
+    after(async () => {
+      if (db) await db.cleanup();
+    });
+
+    it('tracks type params on interface', async () => {
+      await setupTest(backend, {
+        'index.ts': `
+export interface Collection<T> {
+  items: T[];
+  add(item: T): void;
+}
+        `
+      });
+
+      const allNodes = await backend.getAllNodes();
+      const allEdges = await backend.getAllEdges();
+
+      const ifaceNode = allNodes.find(n =>
+        n.type === 'INTERFACE' && n.name === 'Collection'
+      );
+      assert.ok(ifaceNode, 'INTERFACE node Collection should exist');
+
+      const tpNode = allNodes.find(n =>
+        n.type === 'TYPE_PARAMETER' && n.name === 'T'
+      );
+      assert.ok(tpNode, 'TYPE_PARAMETER node T should exist');
+
+      const hasTPEdge = allEdges.find(e =>
+        e.type === 'HAS_TYPE_PARAMETER' &&
+        e.src === ifaceNode.id &&
+        e.dst === tpNode.id
+      );
+      assert.ok(hasTPEdge,
+        `HAS_TYPE_PARAMETER edge from Collection to T should exist`);
+    });
+
+    it('tracks type params with constraint on interface', async () => {
+      await setupTest(backend, {
+        'index.ts': `
+export interface Comparable<T> {
+  compareTo(other: T): number;
+}
+        `
+      });
+
+      const allNodes = await backend.getAllNodes();
+
+      const tpNode = allNodes.find(n =>
+        n.type === 'TYPE_PARAMETER' && n.name === 'T'
+      );
+      assert.ok(tpNode, 'TYPE_PARAMETER node T should exist');
+      // Comparable<T> has no constraint, so no EXTENDS edge expected
+      assert.strictEqual(tpNode.constraint, undefined,
+        'Unconstrained type parameter should have no constraint');
+    });
+  });
+
+  // ============================================================================
+  // 8. Integration tests - Type aliases
+  // ============================================================================
+
+  describe('Type parameter tracking - Type aliases', () => {
+    let db;
+    let backend;
+
+    beforeEach(async () => {
+      if (db) await db.cleanup();
+      db = await createTestDatabase();
+      backend = db.backend;
+    });
+
+    after(async () => {
+      if (db) await db.cleanup();
+    });
+
+    it('tracks type params on type alias', async () => {
+      await setupTest(backend, {
+        'index.ts': `
+export type Pair<A, B> = { first: A; second: B; };
+        `
+      });
+
+      const allNodes = await backend.getAllNodes();
+      const allEdges = await backend.getAllEdges();
+
+      const typeNode = allNodes.find(n =>
+        n.type === 'TYPE' && n.name === 'Pair'
+      );
+      assert.ok(typeNode, 'TYPE node Pair should exist');
+
+      const tpA = allNodes.find(n =>
+        n.type === 'TYPE_PARAMETER' && n.name === 'A'
+      );
+      const tpB = allNodes.find(n =>
+        n.type === 'TYPE_PARAMETER' && n.name === 'B'
+      );
+      assert.ok(tpA, 'TYPE_PARAMETER node A should exist');
+      assert.ok(tpB, 'TYPE_PARAMETER node B should exist');
+
+      // HAS_TYPE_PARAMETER edges from Pair to A and B
+      const hasTPEdges = allEdges.filter(e =>
+        e.type === 'HAS_TYPE_PARAMETER' && e.src === typeNode.id
+      );
+      assert.strictEqual(hasTPEdges.length, 2,
+        `Should have 2 HAS_TYPE_PARAMETER edges from Pair, found: ${hasTPEdges.length}`);
+    });
+
+    it('tracks intersection constraint', async () => {
+      await setupTest(backend, {
+        'index.ts': `
+export interface HasName { name: string; }
+export interface HasAge { age: number; }
+export type Named<T extends HasName & HasAge> = T;
+        `
+      });
+
+      const allNodes = await backend.getAllNodes();
+      const allEdges = await backend.getAllEdges();
+
+      const tpNode = allNodes.find(n =>
+        n.type === 'TYPE_PARAMETER' && n.name === 'T'
+      );
+      assert.ok(tpNode, 'TYPE_PARAMETER node T should exist');
+
+      // Constraint should capture the full intersection type
+      assert.ok(
+        tpNode.constraint && tpNode.constraint.includes('HasName'),
+        `Constraint should include HasName: ${tpNode.constraint}`
+      );
+      assert.ok(
+        tpNode.constraint && tpNode.constraint.includes('HasAge'),
+        `Constraint should include HasAge: ${tpNode.constraint}`
+      );
+
+      // EXTENDS edges to both HasName and HasAge
+      const extendsEdges = allEdges.filter(e =>
+        e.type === 'EXTENDS' && e.src === tpNode.id
+      );
+      assert.strictEqual(extendsEdges.length, 2,
+        `Should have 2 EXTENDS edges (one to HasName, one to HasAge), found: ${extendsEdges.length}`);
+
+      const extendsTargetNames = extendsEdges.map(e => {
+        const target = allNodes.find(n => n.id === e.dst);
+        return target ? target.name : 'UNKNOWN';
+      });
+      assert.ok(extendsTargetNames.includes('HasName'),
+        'Should have EXTENDS edge to HasName');
+      assert.ok(extendsTargetNames.includes('HasAge'),
+        'Should have EXTENDS edge to HasAge');
+    });
+  });
+
+  // ============================================================================
+  // 9. Edge cases - ID uniqueness (unit tests, no DB needed)
+  // ============================================================================
+
+  describe('Type parameter tracking - ID edge cases', () => {
+    it('ID format is unique per parent and name', () => {
+      const node1 = TypeParameterNode.create(
+        'T',
+        '/src/a.ts:FUNCTION:foo:1',
+        '/src/a.ts',
+        1,
+        10
+      );
+      const node2 = TypeParameterNode.create(
+        'T',
+        '/src/a.ts:FUNCTION:bar:5',
+        '/src/a.ts',
+        5,
+        10
+      );
+      const node3 = TypeParameterNode.create(
+        'U',
+        '/src/a.ts:FUNCTION:foo:1',
+        '/src/a.ts',
+        1,
+        15
+      );
+
+      assert.notStrictEqual(node1.id, node2.id,
+        'Same name but different parents should have different IDs');
+      assert.notStrictEqual(node1.id, node3.id,
+        'Same parent but different names should have different IDs');
+    });
+
+    it('creates consistent IDs for same parameters', () => {
+      const node1 = TypeParameterNode.create(
+        'T',
+        '/src/fn.ts:FUNCTION:identity:3',
+        '/src/fn.ts',
+        3,
+        20
+      );
+      const node2 = TypeParameterNode.create(
+        'T',
+        '/src/fn.ts:FUNCTION:identity:3',
+        '/src/fn.ts',
+        3,
+        20
+      );
+
+      assert.strictEqual(node1.id, node2.id,
+        'Same parameters should produce same ID');
+    });
+  });
+
+  // ============================================================================
+  // 10. Edge cases - Integration (primitive constraints, variance)
+  // ============================================================================
+
+  describe('Type parameter tracking - Edge cases (integration)', () => {
+    let db;
+    let backend;
+
+    beforeEach(async () => {
+      if (db) await db.cleanup();
+      db = await createTestDatabase();
+      backend = db.backend;
+    });
+
+    after(async () => {
+      if (db) await db.cleanup();
+    });
+
+    it('does not create EXTENDS for primitive constraints', async () => {
+      await setupTest(backend, {
+        'index.ts': `
+export function parse<T extends string>(input: T): T { return input; }
+        `
+      });
+
+      const allNodes = await backend.getAllNodes();
+      const allEdges = await backend.getAllEdges();
+
+      const tpNode = allNodes.find(n =>
+        n.type === 'TYPE_PARAMETER' && n.name === 'T'
+      );
+      assert.ok(tpNode, 'TYPE_PARAMETER node T should exist');
+      assert.strictEqual(tpNode.constraint, 'string',
+        'Constraint should be string');
+
+      // No EXTENDS edge for primitive constraint
+      const extendsEdge = allEdges.find(e =>
+        e.type === 'EXTENDS' && e.src === tpNode.id
+      );
+      assert.ok(!extendsEdge,
+        'Should NOT create EXTENDS edge for primitive constraint "string"');
+    });
+
+    it('tracks variance annotation: out', async () => {
+      await setupTest(backend, {
+        'index.ts': `
+export interface Producer<out T> {
+  produce(): T;
+}
+        `
+      });
+
+      const allNodes = await backend.getAllNodes();
+
+      const tpNode = allNodes.find(n =>
+        n.type === 'TYPE_PARAMETER' && n.name === 'T'
+      );
+      assert.ok(tpNode, 'TYPE_PARAMETER node T should exist');
+      assert.strictEqual(tpNode.variance, 'out',
+        'Variance should be "out"');
+    });
+
+    it('tracks variance annotation: in', async () => {
+      await setupTest(backend, {
+        'index.ts': `
+export interface Consumer<in T> {
+  consume(item: T): void;
+}
+        `
+      });
+
+      const allNodes = await backend.getAllNodes();
+
+      const tpNode = allNodes.find(n =>
+        n.type === 'TYPE_PARAMETER' && n.name === 'T'
+      );
+      assert.ok(tpNode, 'TYPE_PARAMETER node T should exist');
+      assert.strictEqual(tpNode.variance, 'in',
+        'Variance should be "in"');
+    });
+
+    it('tracks variance annotation: in out', async () => {
+      await setupTest(backend, {
+        'index.ts': `
+export interface Mutable<in out T> {
+  get(): T;
+  set(value: T): void;
+}
+        `
+      });
+
+      const allNodes = await backend.getAllNodes();
+
+      const tpNode = allNodes.find(n =>
+        n.type === 'TYPE_PARAMETER' && n.name === 'T'
+      );
+      assert.ok(tpNode, 'TYPE_PARAMETER node T should exist');
+      assert.strictEqual(tpNode.variance, 'in out',
+        'Variance should be "in out"');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `TYPE_PARAMETER` node type for generic type parameters (`<T extends Serializable = string>`)
- Add `HAS_TYPE_PARAMETER` edge (parent declaration → type parameter)
- Add `EXTENDS` edge from type parameter to constraint type (with external reference nodes for cross-file resolution)
- Extract type params from all 6 declaration contexts: functions, arrow functions, classes, class methods, interfaces, type aliases
- Track constraint, default type, and variance annotations (`in`/`out`)

## Test plan

- [x] 31 tests in `TypeParameterTracking.test.js` (all passing)
- [x] Unit tests for TypeParameterNode contract and NodeFactory
- [x] Integration tests for all declaration contexts
- [x] Edge cases: primitive constraints, intersection constraints, variance annotations
- [x] Full test suite: no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)