### PR TITLE
feat(ast): track top-level await on MODULE nodes (REG-297)

### DIFF
--- a/_tasks/REG-297/001-user-request.md
+++ b/_tasks/REG-297/001-user-request.md
@@ -1,0 +1,17 @@
+# REG-297: AST: Track top-level await
+
+## Gap
+Top-level await not marked.
+
+## Example
+
+```javascript
+// module.js
+const data = await fetchData();
+export { data };
+```
+
+## Acceptance Criteria
+
+- [ ] MODULE node with hasTopLevelAwait: true
+- [ ] Track which top-level expressions await

--- a/_tasks/REG-297/002-don-plan.md
+++ b/_tasks/REG-297/002-don-plan.md
@@ -1,0 +1,53 @@
+# Don Melton — High-Level Plan for REG-297: Track Top-Level Await
+
+## Analysis Summary
+
+MODULE nodes are created by JSModuleIndexer during INDEXING phase. Additional metadata is added during ANALYSIS phase using the upsert pattern (see REG-300's `updateModuleImportMetaMetadata`).
+
+This follows the **metadata-on-MODULE-node** pattern (like REG-300), not a data-flow-edge pattern (like REG-270/yield).
+
+## Approach
+
+Two deliverables:
+1. **`hasTopLevelAwait: true`** — Boolean flag on MODULE node
+2. **`topLevelAwaits`** — Array of `{ line, column, expressionType }` for each top-level await expression
+
+### Detection Strategy
+
+Add a traverse pass in `analyzeModule()` that:
+- Visits `AwaitExpression` nodes where `getFunctionParent()` returns null (top-level)
+- Also visits `ForOfStatement` with `await: true` where `getFunctionParent()` is null (`for await...of`)
+- Collects location + expression type info
+
+### GraphBuilder Update
+
+Following REG-300 pattern exactly:
+- New `updateModuleTopLevelAwaitMetadata()` method
+- Called after existing `updateModuleImportMetaMetadata` in `build()`
+- Uses upsert pattern to add metadata to MODULE node
+
+## Files to Change
+
+1. **`JSASTAnalyzer.ts`** — Add top-level await detection in `analyzeModule()`
+2. **`ast/types.ts`** — Add `topLevelAwaits` to `ASTCollections`
+3. **`GraphBuilder.ts`** — Add `updateModuleTopLevelAwaitMetadata()`, call from `build()`
+4. **`ModuleNode.ts`** — Add optional fields to `ModuleNodeRecord`
+5. **New test** — `test/unit/TopLevelAwait.test.js`
+
+## Test Cases
+
+1. Module with `const data = await fetchData();` → hasTopLevelAwait: true
+2. Module with `await import('./module.js');` → Detected
+3. Module with `for await (const item of stream) {}` → Detected (ForOfStatement.await)
+4. Module with await inside function only → No hasTopLevelAwait
+5. Module with multiple top-level awaits → All captured
+6. Module with no await → No hasTopLevelAwait property
+
+## Risks
+
+1. **`for await...of`** uses `ForOfStatement.await: true`, not `AwaitExpression` — needs separate check
+2. **Parallel path (ASTWorkerPool)** — must include `topLevelAwaits` in worker collections
+
+## Scope
+
+**Small.** ~50-80 lines production code, ~150-200 lines tests. Follows REG-300 pattern exactly.

--- a/_tasks/REG-297/003-steve-review.md
+++ b/_tasks/REG-297/003-steve-review.md
@@ -1,0 +1,14 @@
+# Steve Jobs Review: REG-297 — REJECT
+
+## Key Concerns
+
+1. **Data model justification** — Why `Array<{ line, column, expressionType }>` vs just boolean?
+2. **Use case clarity** — "Track which top-level expressions await" is ambiguous
+3. **Test coverage** — Needs explicit tests for conditional/try-catch/template literal awaits
+4. **Verify `getFunctionParent() === null`** works for all top-level contexts (if/try/for blocks)
+
+## Recommendation
+
+Clarify use case before implementing. Every metadata field must serve a query.
+
+See full review in conversation.

--- a/_tasks/REG-297/005-steve-review-v2.md
+++ b/_tasks/REG-297/005-steve-review-v2.md
@@ -1,0 +1,12 @@
+# Steve Jobs Review v2: REG-297 — APPROVE
+
+## Key Points
+
+1. **Fixes pre-existing gap** — module-level calls missing `isAwaited` from REG-311
+2. **No redundant metadata** — info lives on existing CALL/IMPORT/LOOP nodes
+3. **Clear use case** — dependency ordering analysis, concrete query examples
+4. **Forward registration** — detects during analysis, stores on CALL node
+5. **O(m) complexity** — no new traversal passes, piggybacks on existing visitors
+6. **10 test cases** — comprehensive real-world coverage
+
+## Verdict: APPROVE → Proceed to implementation

--- a/_tasks/REG-297/006-steve-implementation-review.md
+++ b/_tasks/REG-297/006-steve-implementation-review.md
@@ -1,0 +1,15 @@
+# Steve Jobs Implementation Review: REG-297 — APPROVE
+
+## Summary
+
+Clean implementation. 6 files changed, 14 tests, 0 regressions (1835/1835 pass).
+
+## Key Points
+
+1. **Forward registration** — isAwaited set during analysis, not backward scanning
+2. **O(m) complexity** — early stop on first top-level await found
+3. **Reuses existing patterns** — REG-300 upsert, CallExpressionVisitor, ASTWorker parity
+4. **Tests validate both MODULE metadata AND CALL node properties**
+5. **No hacks, no TODOs, no MVP limitations**
+
+## Verdict: APPROVE → Escalating to Вадим

--- a/packages/core/src/plugins/analysis/JSASTAnalyzer.ts
+++ b/packages/core/src/plugins/analysis/JSASTAnalyzer.ts
@@ -1763,6 +1763,26 @@ export class JSASTAnalyzer extends Plugin {
       traverse(ast, callExpressionVisitor.getHandlers());
       this.profiler.end('traverse_calls');
 
+      // REG-297: Detect top-level await expressions
+      this.profiler.start('traverse_top_level_await');
+      let hasTopLevelAwait = false;
+      traverse(ast, {
+        AwaitExpression(awaitPath: NodePath<t.AwaitExpression>) {
+          if (!awaitPath.getFunctionParent()) {
+            hasTopLevelAwait = true;
+            awaitPath.stop();
+          }
+        },
+        // for-await-of uses ForOfStatement.await, not AwaitExpression
+        ForOfStatement(forOfPath: NodePath<t.ForOfStatement>) {
+          if (forOfPath.node.await && !forOfPath.getFunctionParent()) {
+            hasTopLevelAwait = true;
+            forOfPath.stop();
+          }
+        }
+      });
+      this.profiler.end('traverse_top_level_await');
+
       // Property access expressions (REG-395)
       this.profiler.start('traverse_property_access');
       const propertyAccessVisitor = new PropertyAccessVisitor(module, allCollections, scopeTracker);
@@ -1958,7 +1978,9 @@ export class JSASTAnalyzer extends Plugin {
           ? allCollections.catchesFromInfos as CatchesFromInfo[]
           : catchesFromInfos,
         // Property access tracking (REG-395)
-        propertyAccesses: allCollections.propertyAccesses || propertyAccesses
+        propertyAccesses: allCollections.propertyAccesses || propertyAccesses,
+        // REG-297: Top-level await tracking
+        hasTopLevelAwait
       });
       this.profiler.end('graph_build');
 

--- a/packages/core/src/plugins/analysis/ast/types.ts
+++ b/packages/core/src/plugins/analysis/ast/types.ts
@@ -1127,6 +1127,8 @@ export interface ASTCollections {
   catchesFromInfos?: CatchesFromInfo[];
   // Property access tracking for PROPERTY_ACCESS nodes (REG-395)
   propertyAccesses?: PropertyAccessInfo[];
+  // REG-297: Top-level await tracking
+  hasTopLevelAwait?: boolean;
   // TypeScript-specific collections
   interfaces?: InterfaceDeclarationInfo[];
   typeAliases?: TypeAliasInfo[];

--- a/packages/types/src/nodes.ts
+++ b/packages/types/src/nodes.ts
@@ -146,6 +146,8 @@ export interface ModuleNodeRecord extends BaseNodeRecord {
   relativePath: string;
   contentHash: string;
   language?: string;
+  /** REG-297: true if module uses top-level await */
+  hasTopLevelAwait?: boolean;
 }
 
 // Import node

--- a/test/unit/TopLevelAwait.test.js
+++ b/test/unit/TopLevelAwait.test.js
@@ -1,0 +1,385 @@
+/**
+ * Top-Level Await Tracking Tests (REG-297)
+ *
+ * Tests for:
+ * 1. hasTopLevelAwait: true on MODULE node when module uses top-level await
+ * 2. isAwaited: true on CALL nodes at module level when wrapped in await
+ *
+ * Query examples this enables:
+ * - "Does this module block on initialization?" → MODULE { hasTopLevelAwait: true }
+ * - "What does this module await at startup?" → MODULE --CONTAINS--> CALL { isAwaited: true }
+ *
+ * Test cases:
+ * 1. Basic await call: `const data = await fetchData();` → MODULE.hasTopLevelAwait + CALL.isAwaited
+ * 2. Method call: `await db.connect();` → CALL.isAwaited on method call
+ * 3. for await...of: `for await (const x of stream) {}` → MODULE.hasTopLevelAwait
+ * 4. Await inside function only → NO hasTopLevelAwait
+ * 5. Multiple top-level awaits → all CALL nodes marked
+ * 6. No await → no hasTopLevelAwait
+ * 7. Await variable (no call): `const x = await promise;` → MODULE.hasTopLevelAwait
+ * 8. Conditional await: `if (x) { await foo(); }` → MODULE.hasTopLevelAwait + CALL.isAwaited
+ * 9. Try/catch await: `try { await foo(); } catch (e) {}` → MODULE.hasTopLevelAwait + CALL.isAwaited
+ * 10. Mixed: top-level await + function-level await → only MODULE gets hasTopLevelAwait
+ */
+
+import { describe, it, after, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { join } from 'path';
+import { writeFileSync, mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+
+import { createTestDatabase, cleanupAllTestDatabases } from '../helpers/TestRFDB.js';
+
+// Cleanup all test databases after all tests complete
+after(cleanupAllTestDatabases);
+import { createTestOrchestrator } from '../helpers/createTestOrchestrator.js';
+
+describe('Top-Level Await Tracking (REG-297)', () => {
+  let db;
+  let backend;
+  let testDir;
+  let testCounter = 0;
+
+  /**
+   * Create a temporary test directory with specified files
+   */
+  async function setupTest(files) {
+    testDir = join(tmpdir(), `grafema-test-tla-${Date.now()}-${testCounter++}`);
+    mkdirSync(testDir, { recursive: true });
+
+    // Create package.json to make it a valid project (type: module for top-level await)
+    writeFileSync(
+      join(testDir, 'package.json'),
+      JSON.stringify({ name: `test-tla-${testCounter}`, type: 'module' })
+    );
+
+    // Write test files
+    for (const [filename, content] of Object.entries(files)) {
+      writeFileSync(join(testDir, filename), content);
+    }
+
+    return testDir;
+  }
+
+  /**
+   * Clean up test directory
+   */
+  function cleanupTestDir() {
+    if (testDir) {
+      try {
+        rmSync(testDir, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+      testDir = null;
+    }
+  }
+
+  beforeEach(async () => {
+    if (db) await db.cleanup();
+    cleanupTestDir();
+    db = await createTestDatabase();
+    backend = db.backend;
+  });
+
+  after(async () => {
+    if (db) await db.cleanup();
+    cleanupTestDir();
+  });
+
+  describe('hasTopLevelAwait on MODULE node', () => {
+    it('should set hasTopLevelAwait when module has awaited function call', async () => {
+      const projectPath = await setupTest({
+        'index.js': `
+const data = await fetchData();
+export { data };
+        `.trim()
+      });
+
+      const orchestrator = createTestOrchestrator(backend);
+      await orchestrator.run(projectPath);
+
+      const allNodes = await backend.getAllNodes();
+
+      const moduleNode = allNodes.find(n => n.type === 'MODULE' && n.name === 'index.js');
+      assert.ok(moduleNode, 'MODULE node should exist');
+      assert.strictEqual(moduleNode.hasTopLevelAwait, true, 'MODULE should have hasTopLevelAwait: true');
+    });
+
+    it('should NOT set hasTopLevelAwait when await is only inside functions', async () => {
+      const projectPath = await setupTest({
+        'index.js': `
+async function loadData() {
+  const data = await fetchData();
+  return data;
+}
+export { loadData };
+        `.trim()
+      });
+
+      const orchestrator = createTestOrchestrator(backend);
+      await orchestrator.run(projectPath);
+
+      const allNodes = await backend.getAllNodes();
+
+      const moduleNode = allNodes.find(n => n.type === 'MODULE' && n.name === 'index.js');
+      assert.ok(moduleNode, 'MODULE node should exist');
+      assert.ok(!moduleNode.hasTopLevelAwait, 'MODULE should NOT have hasTopLevelAwait');
+    });
+
+    it('should NOT set hasTopLevelAwait when module has no await', async () => {
+      const projectPath = await setupTest({
+        'index.js': `
+const x = 42;
+export { x };
+        `.trim()
+      });
+
+      const orchestrator = createTestOrchestrator(backend);
+      await orchestrator.run(projectPath);
+
+      const allNodes = await backend.getAllNodes();
+
+      const moduleNode = allNodes.find(n => n.type === 'MODULE' && n.name === 'index.js');
+      assert.ok(moduleNode, 'MODULE node should exist');
+      assert.ok(!moduleNode.hasTopLevelAwait, 'MODULE should NOT have hasTopLevelAwait');
+    });
+
+    it('should set hasTopLevelAwait for awaited method call', async () => {
+      const projectPath = await setupTest({
+        'index.js': `
+const db = {};
+await db.connect();
+        `.trim()
+      });
+
+      const orchestrator = createTestOrchestrator(backend);
+      await orchestrator.run(projectPath);
+
+      const allNodes = await backend.getAllNodes();
+
+      const moduleNode = allNodes.find(n => n.type === 'MODULE' && n.name === 'index.js');
+      assert.ok(moduleNode, 'MODULE node should exist');
+      assert.strictEqual(moduleNode.hasTopLevelAwait, true, 'MODULE should have hasTopLevelAwait: true');
+    });
+
+    it('should set hasTopLevelAwait for for-await-of', async () => {
+      const projectPath = await setupTest({
+        'index.js': `
+const stream = [];
+for await (const item of stream) {
+  console.log(item);
+}
+        `.trim()
+      });
+
+      const orchestrator = createTestOrchestrator(backend);
+      await orchestrator.run(projectPath);
+
+      const allNodes = await backend.getAllNodes();
+
+      const moduleNode = allNodes.find(n => n.type === 'MODULE' && n.name === 'index.js');
+      assert.ok(moduleNode, 'MODULE node should exist');
+      assert.strictEqual(moduleNode.hasTopLevelAwait, true, 'MODULE should have hasTopLevelAwait: true for for-await-of');
+    });
+
+    it('should set hasTopLevelAwait for await on variable (no call)', async () => {
+      const projectPath = await setupTest({
+        'index.js': `
+const promise = Promise.resolve(42);
+const result = await promise;
+export { result };
+        `.trim()
+      });
+
+      const orchestrator = createTestOrchestrator(backend);
+      await orchestrator.run(projectPath);
+
+      const allNodes = await backend.getAllNodes();
+
+      const moduleNode = allNodes.find(n => n.type === 'MODULE' && n.name === 'index.js');
+      assert.ok(moduleNode, 'MODULE node should exist');
+      assert.strictEqual(moduleNode.hasTopLevelAwait, true, 'MODULE should have hasTopLevelAwait even when awaiting a variable');
+    });
+
+    it('should set hasTopLevelAwait for multiple top-level awaits', async () => {
+      const projectPath = await setupTest({
+        'index.js': `
+const config = await loadConfig();
+const db = await connectDB();
+const server = await startServer();
+        `.trim()
+      });
+
+      const orchestrator = createTestOrchestrator(backend);
+      await orchestrator.run(projectPath);
+
+      const allNodes = await backend.getAllNodes();
+
+      const moduleNode = allNodes.find(n => n.type === 'MODULE' && n.name === 'index.js');
+      assert.ok(moduleNode, 'MODULE node should exist');
+      assert.strictEqual(moduleNode.hasTopLevelAwait, true, 'MODULE should have hasTopLevelAwait: true');
+    });
+  });
+
+  describe('isAwaited on CALL nodes at module level', () => {
+    it('should mark module-level call as isAwaited when wrapped in await', async () => {
+      const projectPath = await setupTest({
+        'index.js': `
+const data = await fetchData();
+        `.trim()
+      });
+
+      const orchestrator = createTestOrchestrator(backend);
+      await orchestrator.run(projectPath);
+
+      const allNodes = await backend.getAllNodes();
+
+      const callNode = allNodes.find(n => n.type === 'CALL' && n.name === 'fetchData');
+      assert.ok(callNode, 'CALL node for fetchData should exist');
+      assert.strictEqual(callNode.isAwaited, true, 'CALL node should have isAwaited: true');
+    });
+
+    it('should mark module-level method call as isAwaited when wrapped in await', async () => {
+      const projectPath = await setupTest({
+        'index.js': `
+const db = {};
+await db.connect();
+        `.trim()
+      });
+
+      const orchestrator = createTestOrchestrator(backend);
+      await orchestrator.run(projectPath);
+
+      const allNodes = await backend.getAllNodes();
+
+      const callNode = allNodes.find(n => n.type === 'CALL' && n.name === 'db.connect');
+      assert.ok(callNode, 'CALL node for db.connect should exist');
+      assert.strictEqual(callNode.isAwaited, true, 'CALL node should have isAwaited: true');
+    });
+
+    it('should NOT mark module-level call as isAwaited when not wrapped in await', async () => {
+      const projectPath = await setupTest({
+        'index.js': `
+const data = fetchData();
+        `.trim()
+      });
+
+      const orchestrator = createTestOrchestrator(backend);
+      await orchestrator.run(projectPath);
+
+      const allNodes = await backend.getAllNodes();
+
+      const callNode = allNodes.find(n => n.type === 'CALL' && n.name === 'fetchData');
+      assert.ok(callNode, 'CALL node for fetchData should exist');
+      assert.ok(!callNode.isAwaited, 'CALL node should NOT have isAwaited');
+    });
+
+    it('should mark all awaited calls in module with multiple awaits', async () => {
+      const projectPath = await setupTest({
+        'index.js': `
+const config = await loadConfig();
+const db = await connectDB();
+const sync = fetchSync();
+        `.trim()
+      });
+
+      const orchestrator = createTestOrchestrator(backend);
+      await orchestrator.run(projectPath);
+
+      const allNodes = await backend.getAllNodes();
+
+      const loadConfigCall = allNodes.find(n => n.type === 'CALL' && n.name === 'loadConfig');
+      assert.ok(loadConfigCall, 'CALL node for loadConfig should exist');
+      assert.strictEqual(loadConfigCall.isAwaited, true, 'loadConfig CALL should have isAwaited: true');
+
+      const connectDBCall = allNodes.find(n => n.type === 'CALL' && n.name === 'connectDB');
+      assert.ok(connectDBCall, 'CALL node for connectDB should exist');
+      assert.strictEqual(connectDBCall.isAwaited, true, 'connectDB CALL should have isAwaited: true');
+
+      const fetchSyncCall = allNodes.find(n => n.type === 'CALL' && n.name === 'fetchSync');
+      assert.ok(fetchSyncCall, 'CALL node for fetchSync should exist');
+      assert.ok(!fetchSyncCall.isAwaited, 'fetchSync CALL should NOT have isAwaited');
+    });
+
+    it('should mark awaited call inside conditional at module level', async () => {
+      const projectPath = await setupTest({
+        'index.js': `
+const env = process.env.NODE_ENV;
+if (env === 'production') {
+  await setupProd();
+}
+        `.trim()
+      });
+
+      const orchestrator = createTestOrchestrator(backend);
+      await orchestrator.run(projectPath);
+
+      const allNodes = await backend.getAllNodes();
+
+      const moduleNode = allNodes.find(n => n.type === 'MODULE' && n.name === 'index.js');
+      assert.ok(moduleNode, 'MODULE node should exist');
+      assert.strictEqual(moduleNode.hasTopLevelAwait, true, 'MODULE should have hasTopLevelAwait: true');
+
+      const callNode = allNodes.find(n => n.type === 'CALL' && n.name === 'setupProd');
+      assert.ok(callNode, 'CALL node for setupProd should exist');
+      assert.strictEqual(callNode.isAwaited, true, 'setupProd CALL should have isAwaited: true');
+    });
+
+    it('should mark awaited call inside try/catch at module level', async () => {
+      const projectPath = await setupTest({
+        'index.js': `
+try {
+  await riskyInit();
+} catch (e) {
+  console.error(e);
+}
+        `.trim()
+      });
+
+      const orchestrator = createTestOrchestrator(backend);
+      await orchestrator.run(projectPath);
+
+      const allNodes = await backend.getAllNodes();
+
+      const moduleNode = allNodes.find(n => n.type === 'MODULE' && n.name === 'index.js');
+      assert.ok(moduleNode, 'MODULE node should exist');
+      assert.strictEqual(moduleNode.hasTopLevelAwait, true, 'MODULE should have hasTopLevelAwait: true');
+
+      const callNode = allNodes.find(n => n.type === 'CALL' && n.name === 'riskyInit');
+      assert.ok(callNode, 'CALL node for riskyInit should exist');
+      assert.strictEqual(callNode.isAwaited, true, 'riskyInit CALL should have isAwaited: true');
+    });
+  });
+
+  describe('Mixed scenarios', () => {
+    it('should set hasTopLevelAwait even when function-level await also exists', async () => {
+      const projectPath = await setupTest({
+        'index.js': `
+const config = await loadConfig();
+
+async function processData() {
+  const data = await fetchData();
+  return data;
+}
+
+export { config, processData };
+        `.trim()
+      });
+
+      const orchestrator = createTestOrchestrator(backend);
+      await orchestrator.run(projectPath);
+
+      const allNodes = await backend.getAllNodes();
+
+      const moduleNode = allNodes.find(n => n.type === 'MODULE' && n.name === 'index.js');
+      assert.ok(moduleNode, 'MODULE node should exist');
+      assert.strictEqual(moduleNode.hasTopLevelAwait, true, 'MODULE should have hasTopLevelAwait: true');
+
+      // Module-level call should be marked awaited
+      const loadConfigCall = allNodes.find(n => n.type === 'CALL' && n.name === 'loadConfig');
+      assert.ok(loadConfigCall, 'CALL node for loadConfig should exist');
+      assert.strictEqual(loadConfigCall.isAwaited, true, 'loadConfig should be isAwaited');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `hasTopLevelAwait` metadata to MODULE nodes when module uses top-level `await`
- Add `isAwaited` property to module-level CALL nodes wrapped in `await`
- Detect both `AwaitExpression` and `for await...of` at module scope

## Graph Queries Enabled

```
MODULE { hasTopLevelAwait: true }             — find async-initializing modules
CALL { isAwaited: true }                      — find awaited calls at module scope
MODULE --CONTAINS--> CALL { isAwaited: true } — what does this module await at startup?
```

## Test plan

- [x] 14 new tests in `TopLevelAwait.test.js`
- [x] Full suite: 1835/1835 pass, 0 regressions
- [x] Covers: basic await, method call, for-await-of, await variable, conditional, try/catch, mixed scenarios, negative cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)