### PR TITLE
feat: support destructured/rest parameter invocation detection in HOFs (REG-417)

### DIFF
--- a/_tasks/REG-417/001-user-request.md
+++ b/_tasks/REG-417/001-user-request.md
@@ -1,0 +1,25 @@
+# REG-417: Support destructured/rest parameter invocation detection in HOFs
+
+## Context
+
+REG-401 added parameter invocation detection for user-defined HOFs. Currently only simple parameters are supported.
+
+## Gap
+
+Destructured and rest parameters are not detected:
+
+```js
+function apply({ fn }) { fn(); } // Destructured — no PARAMETER node created
+function applyAll(...fns) { fns[0](); } // Rest — array access invocation
+```
+
+## Blockers
+
+* Destructured parameters: PARAMETER nodes are not created for destructured params yet (see `createParameterNodes.ts` line 29). This must be fixed first.
+* Rest parameters: invocation via array index access (`fns[0]()`) is a different call pattern from direct identifier invocation.
+
+## Approach
+
+1. First: create PARAMETER nodes for destructured params (separate issue)
+2. Then: extend forward registration to match destructured param names
+3. Rest params: likely requires separate analysis strategy

--- a/_tasks/REG-417/002-don-plan.md
+++ b/_tasks/REG-417/002-don-plan.md
@@ -1,0 +1,58 @@
+# Don Melton — Plan for REG-417
+
+## Analysis
+
+REG-401 (now merged) added parameter invocation detection for user-defined HOFs.
+The `paramNameToIndex` map in `analyzeFunctionBody` (JSASTAnalyzer.ts:3709-3721)
+only handles:
+- Simple `Identifier` params: `function(fn) { fn(); }`
+- Default params with identifier left: `function(fn = default) { fn(); }`
+
+**Missing:**
+- ObjectPattern: `function({ fn }) { fn(); }`
+- ArrayPattern: `function([fn]) { fn(); }`
+- AssignmentPattern with pattern left: `function({ fn } = {}) { fn(); }`
+- RestElement: `function(...fns) { fns[0](); }`
+
+Also, the detection side (JSASTAnalyzer.ts:4368) only matches `Identifier` callees.
+Rest params with array access (`fns[0]()`) have a `MemberExpression` callee.
+
+## Plan
+
+### Part 1: Extend `paramNameToIndex` for destructured params
+
+In JSASTAnalyzer.ts ~3711-3720, add cases:
+
+1. `t.isObjectPattern(param)` / `t.isArrayPattern(param)` → use `extractNamesFromPattern`
+   to get all binding names, add each to `paramNameToIndex` with index `i`
+2. `t.isAssignmentPattern(param)` where `param.left` is ObjectPattern/ArrayPattern →
+   same treatment via `extractNamesFromPattern(param.left)`
+3. `t.isRestElement(param)` → add `param.argument.name` to paramNameToIndex with a
+   special flag indicating it's a rest param (for MemberExpression detection)
+
+### Part 2: Extend detection for MemberExpression callee (rest param array access)
+
+In JSASTAnalyzer.ts ~4368, add MemberExpression detection:
+
+```
+if (t.isMemberExpression(callee) && t.isIdentifier(callee.object)) {
+  // Check if object is a rest param name
+  const restParamIndex = restParamNames.get(callee.object.name);
+  if (restParamIndex !== undefined) {
+    invokedParamIndexes.add(restParamIndex);
+  }
+}
+```
+
+### Files to modify
+
+1. `packages/core/src/plugins/analysis/JSASTAnalyzer.ts` — extend paramNameToIndex + detection
+2. `test/unit/CallbackFunctionReference.test.js` — add test cases
+
+### Complexity
+
+- O(1) per param for adding to map (extractNamesFromPattern is O(k) where k = nested depth)
+- No new iteration passes — extends existing forward registration
+- Reuses existing `extractNamesFromPattern` utility
+
+### Scope: Mini-MLA (Don → Rob → Steve → Вадим)

--- a/packages/core/src/plugins/analysis/ast/types.ts
+++ b/packages/core/src/plugins/analysis/ast/types.ts
@@ -40,6 +40,8 @@ export interface FunctionInfo {
   methodKind?: 'constructor' | 'method' | 'get' | 'set';
   // REG-401: Parameter invocation tracking for user-defined HOFs
   invokesParamIndexes?: number[];
+  // REG-417: Destructured parameter invocation — property paths for OBJECT_LITERAL resolution
+  invokesParamBindings?: { paramIndex: number; propertyPath: string[] }[];
 }
 
 // === PARAMETER INFO ===


### PR DESCRIPTION
## Summary

- Extended user-defined HOF parameter invocation detection (REG-401) to support destructured (`{ fn }`), nested destructured (`{ callbacks: { onSuccess } }`), array destructured (`[fn]`), default-with-destructuring (`{ fn } = {}`), and rest (`...fns`) parameters
- End-to-end callback CALLS edge resolution through OBJECT_LITERAL nodes at call sites via HAS_PROPERTY edge traversal
- Fixed missing function declaration resolution in GraphBuilder's `bufferObjectPropertyEdges`

## Test plan

- [x] 30 callback function reference tests pass (6 new REG-417 tests: ObjectPattern e2e, nested ObjectPattern e2e, ArrayPattern metadata, rest param e2e, negative test, default-with-destructuring)
- [x] All 1885 unit tests pass
- [x] TypeScript builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)