### PR TITLE
REG-414: Support Agent Skills standard for Grafema

### DIFF
--- a/_tasks/REG-414/001-user-request.md
+++ b/_tasks/REG-414/001-user-request.md
@@ -1,0 +1,33 @@
+# REG-414: Support Agent Skills Standard for Grafema
+
+## Request
+
+Add support for Agent Skills standard alongside existing MCP tools. This will make Grafema accessible to agents across different platforms (Claude Code, Cursor, Copilot, Gemini CLI, etc.).
+
+## Background
+
+Grafema currently has:
+- **24 MCP tools** for code graph analysis
+- **10 internal skills** in `.claude/skills/` (for Grafema development)
+- **CLI with 18 commands**
+
+## Requirements
+
+1. **Public Grafema Skill** (`grafema-codebase-analysis/SKILL.md`)
+   - Teaches agents WHEN and HOW to use Grafema MCP tools
+   - Cross-platform compatible (not Claude Code-specific)
+
+2. **Resource files**
+   - Query examples for common tasks
+   - Node/edge type cheat sheet
+
+3. **CLI command** (`grafema setup-skill`)
+   - Installs skill into user's project
+   - Idempotent, safe to run multiple times
+
+## Constraints
+
+- Must follow Agent Skills specification (agentskills.io/specification)
+- SKILL.md must be under 500 lines (move heavy reference to `references/`)
+- Description field is critical for agent discovery
+- Must work across multiple AI agent platforms

--- a/_tasks/REG-414/002-don-plan.md
+++ b/_tasks/REG-414/002-don-plan.md
@@ -1,0 +1,341 @@
+# Don Melton — High-Level Plan: REG-414
+
+**Date:** 2026-02-14  
+**Task:** Support Agent Skills standard for Grafema
+
+---
+
+## Analysis
+
+This task is about **making Grafema discoverable and usable by AI agents** across platforms. The current MCP server is excellent for tool provision, but agents need **guidance on WHEN and HOW to use those tools**. That's what Agent Skills provides.
+
+### Key Insight
+
+**Agent Skills is NOT a replacement for MCP — it's a complement.**
+
+- **MCP tools** = the "hands" (what agents can DO)
+- **Agent Skill** = the "brain" (WHEN to use those hands, and HOW)
+
+The skill teaches agents:
+1. **Discovery**: "When should I activate Grafema?" (frontmatter description)
+2. **Strategy**: "What tool should I use for this task?" (decision tree in body)
+3. **Execution**: "How do I construct this query?" (examples in references/)
+
+### What Makes This RIGHT vs. Just Working
+
+**WRONG approaches:**
+- Duplicate tool definitions in SKILL.md (creates sync problem)
+- Put all 24 tools in SKILL.md (overwhelming, violates progressive disclosure)
+- Make it Claude Code-specific (defeats cross-platform purpose)
+- Create generic "use MCP tools" skill (agents already know that)
+
+**RIGHT approach:**
+- Skill focuses on STRATEGY and DECISION-MAKING
+- Reference files contain TACTICAL details (queries, node types)
+- Keep MCP tools as single source of truth for tool signatures
+- Teach the GRAFEMA WAY of thinking about code
+
+---
+
+## Core Design Decisions
+
+### 1. Where Should the Public Skill Live?
+
+**Recommendation:** `packages/cli/skills/grafema-codebase-analysis/`
+
+**Rationale:**
+- **Part of published package**: `files: ["dist", "src", "skills"]` in package.json
+- **Versioned with Grafema**: skill evolves with tool capabilities
+- **Clear separation**: `.claude/skills/` = internal dev, `packages/cli/skills/` = public
+- **Natural install path**: CLI can copy from its own bundled resources
+
+**Directory structure:**
+```
+packages/cli/
+├── skills/                                    # NEW: Public skills (bundled in npm)
+│   └── grafema-codebase-analysis/
+│       ├── SKILL.md                          # Main skill file (<500 lines)
+│       ├── references/
+│       │   ├── node-edge-types.md            # Schema reference
+│       │   ├── query-patterns.md             # Common Datalog patterns
+│       │   └── decision-tree.md              # Tool selection flowchart
+│       └── assets/
+│           └── workflow-diagram.md           # Visual guide (optional)
+```
+
+### 2. What Should SKILL.md Contain?
+
+**Philosophy: Teach agents to THINK like Grafema users.**
+
+**Frontmatter:**
+```yaml
+name: grafema-codebase-analysis
+description: |
+  Analyze codebases using graph queries instead of reading files. Use when:
+  (1) understanding code architecture, dependencies, or data flow
+  (2) finding functions, calls, or usage patterns
+  (3) checking invariants or validating assumptions
+  (4) user mentions "how does X work", "where is Y used", "trace Z"
+  Grafema builds a queryable graph from code—prefer querying over reading.
+license: Apache-2.0
+compatibility: Requires Grafema MCP server running (npx @grafema/mcp --project .)
+metadata:
+  author: Grafema
+  version: "0.2.5-beta"
+```
+
+**Body structure** (~400 lines, staying well under 500):
+
+1. **The Grafema Philosophy** (~50 lines)
+   - "AI should query the graph, not read code"
+   - When to prefer Grafema over file reading
+   - What Grafema CAN and CANNOT do
+
+2. **Quick Start** (~50 lines)
+   - Prerequisites (MCP server running)
+   - First query examples
+   - How to verify graph is ready
+
+3. **Decision Tree: Which Tool to Use** (~150 lines)
+   - "I want to find..." → use `find_nodes` or `find_calls`
+   - "I want to trace..." → use `trace_dataflow` or `trace_alias`
+   - "I want to understand..." → use `get_context` or `get_file_overview`
+   - "I want to check..." → use `check_invariant` or `check_guarantees`
+   - "I need raw power..." → use `query_graph` (Datalog)
+
+4. **Common Patterns** (~100 lines)
+   - Finding entry points
+   - Tracing user input to database
+   - Finding all uses of a function
+   - Checking for security issues
+   - Understanding service boundaries
+
+5. **Anti-Patterns** (~30 lines)
+   - DON'T: Read file → search manually → build mental model
+   - DO: Query graph → get structured results → ask follow-ups
+   - DON'T: Use Grafema for single-file analysis (Read tool faster)
+   - DO: Use Grafema for cross-file relationships
+
+6. **Troubleshooting** (~20 lines)
+   - Graph not analyzed → run `analyze_project`
+   - Query returns nothing → check `get_schema` for available types
+   - Unexpected results → use `explain: true` flag
+
+**Key principle:** SKILL.md is for STRATEGY. Tactical details go in `references/`.
+
+### 3. What Reference Files?
+
+#### `references/node-edge-types.md` (~200 lines)
+Generated from `get_schema`, but human-curated for agent consumption:
+- Node types with descriptions and examples
+- Edge types with semantics
+- Common attributes per node type
+- Quick lookup table
+
+#### `references/query-patterns.md` (~300 lines)
+Datalog query cookbook:
+- Basic patterns (find function, find calls, find dependencies)
+- Intermediate patterns (transitive closure, recursive queries)
+- Advanced patterns (inter-procedural analysis, taint tracking)
+- Each pattern with explanation + example
+
+#### `references/decision-tree.md` (~150 lines)
+Detailed flowchart for tool selection:
+- Input: user's question
+- Output: which tool(s) to use + order
+- Examples: "Where is X used?" → `find_calls` → `get_context` on results
+
+### 4. CLI Command Design
+
+**Command:** `grafema setup-skill`
+
+**What it does:**
+```bash
+# Default: install in .claude/skills/ (Claude Code)
+grafema setup-skill
+
+# Support other platforms
+grafema setup-skill --cursor    # Install in .cursor/skills/
+grafema setup-skill --copilot   # Install in .github/copilot/skills/
+grafema setup-skill --path ./custom/path/skills/
+```
+
+**Implementation:**
+1. Check if skill already exists (compare version in metadata)
+2. If outdated or missing → copy from `packages/cli/skills/grafema-codebase-analysis/`
+3. Print confirmation + next steps
+4. Idempotent: running twice = no-op if same version
+
+**Edge cases:**
+- No .claude/ dir → create it
+- Skill exists but different version → prompt to upgrade
+- Custom path → validate it exists
+
+**Integration with `grafema init`:**
+- After initial analysis, suggest: `grafema setup-skill` to enable AI assistance
+- NOT automatic (user should opt-in)
+
+### 5. Cross-Platform Compatibility
+
+**CRITICAL: Use ONLY standard Agent Skills spec fields.**
+
+**Avoid:**
+- Claude Code-specific extensions
+- Custom frontmatter fields not in spec
+- References to Claude-only features
+
+**Ensure:**
+- Description uses generic language ("AI agents" not "Claude")
+- Examples use standard MCP tool invocation
+- No assumptions about agent capabilities beyond spec
+
+**Testing cross-platform:**
+- Validate with `skills-ref validate` (official validator)
+- Test in Claude Code, Cursor (once they ship skills support)
+- Document any platform-specific quirks in compatibility field
+
+---
+
+## What Could Go Wrong? (Architectural Risks)
+
+### Risk 1: Skill Becomes Stale
+**Problem:** MCP tools evolve, skill documentation lags behind.
+
+**Mitigation:**
+- Version skill in metadata (match Grafema version)
+- CI check: fail if SKILL.md references undefined MCP tools
+- Release checklist: update skill when tools change
+
+### Risk 2: Too Much or Too Little Detail
+**Problem:** Either agents ignore skill (too long) or don't know what to do (too vague).
+
+**Mitigation:**
+- Keep SKILL.md under 400 lines (target 350)
+- Move ALL Datalog syntax to `references/query-patterns.md`
+- Test with real tasks: "Find where req.body is used" — can agent do it?
+
+### Risk 3: Duplication with MCP Tool Descriptions
+**Problem:** Tool descriptions in `definitions.ts` vs skill body = sync nightmare.
+
+**Mitigation:**
+- SKILL.md does NOT repeat tool signatures
+- SKILL.md focuses on WHEN to use each tool, not WHAT it does
+- Link to MCP tool docs for parameter details
+
+### Risk 4: Agents Don't Activate the Skill
+**Problem:** Poor frontmatter description → agents never discover Grafema.
+
+**Mitigation:**
+- Frontmatter description MUST contain trigger keywords:
+  - "code analysis", "dependencies", "data flow", "find functions"
+  - "architecture", "call graph", "trace", "query"
+- Test: ask agent "How does authentication work in this codebase?"
+  - If it reads files instead of activating Grafema → description failed
+
+---
+
+## High-Level Implementation Plan
+
+### Phase 1: Skill Structure (~2 days)
+1. Create `packages/cli/skills/grafema-codebase-analysis/` directory
+2. Write SKILL.md frontmatter + body outline
+3. Validate with `skills-ref validate`
+4. Get Steve's approval on structure before filling content
+
+### Phase 2: Reference Files (~3 days)
+1. Generate `node-edge-types.md` from schema (script or manual)
+2. Write `query-patterns.md` cookbook (curate from existing docs + tests)
+3. Create `decision-tree.md` flowchart
+4. Review: can agent solve 10 common tasks with these references?
+
+### Phase 3: CLI Command (~2 days)
+1. Implement `setup-skill` command in `packages/cli/src/commands/`
+2. Handle platform detection (Claude Code, Cursor, Copilot)
+3. Add tests (unit + integration)
+4. Update `grafema init` to suggest setup-skill
+
+### Phase 4: Integration & Publishing (~2 days)
+1. Update `packages/cli/package.json` to include `skills/` in published files
+2. Update CHANGELOG.md
+3. Write blog post / announcement (how to use)
+4. Test end-to-end: fresh install → setup-skill → agent uses it
+
+### Phase 5: Validation (~1 day)
+1. Test with real questions in Claude Code
+2. Measure: % of time agent queries graph vs reads files
+3. Iterate on skill description if activation rate low
+
+**Total estimate:** 10-11 days (including iteration)
+
+---
+
+## Success Criteria
+
+**Must have:**
+1. ✅ SKILL.md validates with `skills-ref validate`
+2. ✅ `grafema setup-skill` installs working skill
+3. ✅ Agent can answer "Where is function X used?" without reading files
+4. ✅ Skill works in Claude Code (primary target)
+
+**Should have:**
+5. ✅ Under 500 lines in SKILL.md, under 5000 tokens total
+6. ✅ Decision tree covers 90% of common use cases
+7. ✅ Agent activates skill for architecture questions
+
+**Nice to have:**
+8. ✅ Works in Cursor, Copilot (when they ship Agent Skills support)
+9. ✅ Automated tests that SKILL.md references valid MCP tools
+
+---
+
+## Open Questions for User (Вадим)
+
+1. **Skill naming:** `grafema-codebase-analysis` vs `grafema` vs `codebase-graph-query`?
+   - Recommendation: `grafema-codebase-analysis` (descriptive, discoverable)
+
+2. **Setup-skill auto-run:** Should `grafema init` automatically run `setup-skill`?
+   - Recommendation: NO. Let users opt-in. Mention in output.
+
+3. **Multiple skills:** Should we create SEPARATE skills for different use cases?
+   - `grafema-security-analysis` (focus on taint tracking, invariants)
+   - `grafema-architecture-review` (focus on dependencies, modules)
+   - Recommendation: NO. Start with ONE skill. Split later if agents get confused.
+
+4. **Skill versioning:** Match Grafema version (0.2.5-beta) or independent (1.0.0)?
+   - Recommendation: Match Grafema. Skill is tightly coupled to tool capabilities.
+
+---
+
+## Alignment with Grafema Vision
+
+**"AI should query the graph, not read code."**
+
+This task is CORE to that vision. Without Agent Skills:
+- Agents don't know Grafema exists
+- Agents read files manually (defeating the purpose)
+- Grafema is just "another tool" instead of the FIRST choice
+
+With Agent Skills:
+- Agents DISCOVER Grafema via frontmatter description
+- Agents PREFER graph queries over file reading (decision tree guides them)
+- Grafema becomes the STANDARD way agents understand code
+
+**This is not a feature. This is the UX layer for Grafema's core thesis.**
+
+---
+
+## Next Steps
+
+If this plan is approved:
+1. Joel expands into detailed technical spec
+2. Steve reviews for vision alignment
+3. Вадим confirms or requests changes
+
+If rejected:
+- What's missing? What's wrong?
+- Back to research phase.
+
+---
+
+**Don Melton**  
+Tech Lead, Grafema

--- a/_tasks/REG-414/003-joel-tech-plan.md
+++ b/_tasks/REG-414/003-joel-tech-plan.md
@@ -1,0 +1,100 @@
+# Joel Spolsky — Technical Specification: REG-414
+
+## Summary
+
+Create public Agent Skills support for Grafema: SKILL.md + reference files + CLI command.
+
+## Deliverables
+
+1. **SKILL.md** (~350 lines) — strategy-focused skill file
+2. **references/node-edge-types.md** — graph schema reference
+3. **references/query-patterns.md** — Datalog cookbook
+4. **setup-skill** CLI command — copies skill to user's project
+5. **Package.json & init updates** — distribution + discoverability
+
+## Architecture
+
+### Skill Location
+
+```
+packages/cli/skills/grafema-codebase-analysis/
+├── SKILL.md                        # Main skill (<500 lines)
+└── references/
+    ├── node-edge-types.md          # Schema reference
+    └── query-patterns.md           # Datalog cookbook
+```
+
+### SKILL.md Frontmatter (Standard Spec Only)
+
+```yaml
+---
+name: grafema-codebase-analysis
+description: >
+  Analyze codebases using graph queries instead of reading files. Use when
+  understanding code architecture, dependencies, data flow, or finding functions
+  and call patterns. Grafema builds a queryable code graph — prefer graph queries
+  over reading source files manually.
+license: Apache-2.0
+compatibility: Requires Grafema MCP server running (grafema or @grafema/mcp)
+metadata:
+  author: Grafema
+  version: "0.2.5"
+---
+```
+
+**Note:** Only standard Agent Skills spec fields (name, description, license, compatibility, metadata). No Claude Code extensions — this skill must work across all agents.
+
+### SKILL.md Body Sections
+
+1. **Core Principle** (~30 lines) — "Query the graph, not read code"
+2. **Essential Tools** (~120 lines) — Tier 1: find_nodes, find_calls, get_function_details, get_context, trace_dataflow
+3. **Decision Tree** (~80 lines) — Which tool for which question
+4. **Common Workflows** (~60 lines) — Multi-step examples
+5. **Anti-Patterns** (~30 lines) — What NOT to do
+6. **Advanced Tools** (~20 lines) — Tier 2/3 with references to docs
+7. **Troubleshooting** (~10 lines)
+
+### Tool Tiers
+
+| Tier | Tools | Usage |
+|------|-------|-------|
+| 1 (Essential, ~80%) | find_nodes, find_calls, get_function_details, get_context, trace_dataflow | Covers most agent queries |
+| 2 (Common, ~15%) | query_graph, get_file_overview, trace_alias, check_invariant, get_schema, get_stats | When Tier 1 isn't enough |
+| 3 (Specialized, ~5%) | Guarantees, lifecycle, config, reporting | Infrastructure/setup |
+
+### CLI Command: `grafema setup-skill`
+
+```bash
+grafema setup-skill                          # Default: .claude/skills/
+grafema setup-skill --output-dir ./custom/   # Custom path
+grafema setup-skill --force                  # Overwrite existing
+```
+
+**Implementation:**
+- Copy from bundled `packages/cli/skills/` to target dir
+- Check if already exists (require --force to overwrite)
+- Create parent dirs as needed
+- Print success + next steps
+
+### Files to Create
+
+1. `packages/cli/skills/grafema-codebase-analysis/SKILL.md`
+2. `packages/cli/skills/grafema-codebase-analysis/references/node-edge-types.md`
+3. `packages/cli/skills/grafema-codebase-analysis/references/query-patterns.md`
+4. `packages/cli/src/commands/setup-skill.ts`
+5. `test/unit/setup-skill.test.js`
+
+### Files to Modify
+
+1. `packages/cli/src/cli.ts` — register setupSkillCommand
+2. `packages/cli/src/commands/init.ts` — mention setup-skill in next steps
+3. `packages/cli/package.json` — add `skills` to `files` array
+
+## Implementation Order
+
+1. Write SKILL.md content
+2. Write reference files
+3. Implement setup-skill command
+4. Wire into CLI + init
+5. Update package.json
+6. Write tests

--- a/_tasks/REG-414/004-steve-review.md
+++ b/_tasks/REG-414/004-steve-review.md
@@ -1,0 +1,35 @@
+# Steve Jobs Review: REG-414
+
+## Verdict: REJECT (fixable)
+
+## Required Fixes
+
+### 1. Cross-Platform Reality
+**Issue:** Each platform has its OWN skill directory:
+- Claude Code: `.claude/skills/`
+- Gemini CLI: `.gemini/skills/`
+- Cursor: `.cursor/skills/` (likely)
+
+The SKILL.md **format** is cross-platform, but the **install location** is not.
+
+**Fix:** `setup-skill` must support multiple platforms via `--platform` flag or auto-detect.
+
+### 2. Auto-Install vs Opt-In
+**Issue:** `setup-skill` as separate command = friction = low adoption.
+
+**Recommendation:** Auto-install during `grafema init`. Opt-out (delete file) is easier than opt-in (discover + run command).
+
+### 3. Versioning Strategy
+**Issue:** After Grafema update, skill in user's project becomes stale.
+
+**Fix:** Include version in skill metadata. Warn during `grafema analyze` if skill is outdated. `setup-skill --update` to refresh.
+
+### 4. Validation Plan
+**Issue:** No plan to verify agents actually USE the skill correctly.
+
+**Fix:** After implementation, test with real agent session. Document results.
+
+### 5. More Inline Examples
+**Issue:** References are good for progressive disclosure, but SKILL.md itself must have 10-15 micro-examples inline.
+
+**Fix:** Already in plan (Essential Tools section has examples). Ensure sufficient density.

--- a/_tasks/REG-414/005-steve-final-review.md
+++ b/_tasks/REG-414/005-steve-final-review.md
@@ -1,0 +1,377 @@
+# Steve Jobs Final Review: REG-414 Agent Skills Support
+
+**Date:** 2026-02-14
+**Reviewer:** Steve Jobs (High-level Review)
+**Task:** REG-414 — Agent Skills Support for Grafema
+
+---
+
+## Verdict: **APPROVE WITH RESERVATIONS**
+
+The implementation is fundamentally sound and addresses all five concerns from the initial review. However, there are philosophical and practical issues that need discussion before I can give full confidence.
+
+---
+
+## What Got Built (Summary)
+
+### 1. Core Skill: SKILL.md (295 lines)
+- Standard Agent Skills frontmatter (name, description, license, version, compatibility)
+- Core principle: "Query the graph, not read code" (front and center)
+- Essential Tools section (Tier 1): 5 most-used tools with inline examples
+- Decision Tree: "What do you need?" workflow for tool selection
+- 5 Common Workflows: Impact analysis, security audit, onboarding, dependency analysis, dead code detection
+- Anti-patterns section based on real agent behaviors
+- Tier 2/3 tools organized by specificity
+
+**Assessment:** EXCELLENT. The structure matches how agents discover and consume information. Examples are terse but clear. Decision tree is actionable.
+
+### 2. Reference Docs (328 lines total)
+- `references/node-edge-types.md` (123 lines): Complete graph schema, attribute reference, quick patterns
+- `references/query-patterns.md` (205 lines): Datalog cookbook with basic, edge traversal, negation, invariant, join patterns
+
+**Assessment:** GOOD. Progressive disclosure works. Agents can start with SKILL.md and deep-dive when needed.
+
+### 3. CLI Command: `grafema setup-skill`
+- Installs skill to project's `.claude/skills/` (default)
+- `--platform` flag supports gemini/cursor (cross-platform)
+- `--output-dir` for custom paths
+- Version checking: skips if same version, warns if different version exists
+- `--force` to overwrite
+- Exported `installSkill()` function for programmatic use
+
+**Assessment:** SOLID. Command does exactly one thing well. Version handling is pragmatic.
+
+### 4. Auto-Install During Init
+- `grafema init` auto-installs skill to `.claude/skills/`
+- Non-blocking: init doesn't fail if skill install fails
+- Prints confirmation message
+
+**Assessment:** PERFECT. Opt-out (delete file) is better UX than opt-in (discover command).
+
+### 5. Tests (7 tests, all passing)
+- Help output verification
+- Default installation to `.claude/skills/`
+- Idempotent behavior (same version = skip)
+- Force overwrite
+- Platform support (gemini)
+- Custom output dir
+- Auto-install during init
+
+**Assessment:** SUFFICIENT for current scope. Tests verify mechanics, not educational effectiveness.
+
+---
+
+## All Five Review Concerns Addressed
+
+### ✅ 1. Cross-Platform
+- **Concern:** Skill install location differs per platform
+- **Resolution:** `--platform` flag, separate dirs per platform
+- **Status:** RESOLVED
+
+### ✅ 2. Auto-Install
+- **Concern:** Opt-in = low adoption
+- **Resolution:** Auto-install during `grafema init`
+- **Status:** RESOLVED
+
+### ✅ 3. Versioning
+- **Concern:** Stale skills after Grafema updates
+- **Resolution:** Version in metadata, idempotent install, `--force` to update
+- **Status:** RESOLVED (sufficient for v0.2)
+
+### ✅ 4. Validation Plan
+- **Concern:** No proof agents will use it correctly
+- **Resolution:** Real-world testing deferred post-release (valid for MVP)
+- **Status:** DEFERRED (acceptable risk)
+
+### ✅ 5. Inline Examples
+- **Concern:** Not enough examples in SKILL.md
+- **Resolution:** ~15 inline examples across Essential Tools, Decision Tree, Workflows
+- **Status:** RESOLVED
+
+---
+
+## The Big Question: Will This Actually Change Agent Behavior?
+
+**The honest answer: I DON'T KNOW.**
+
+Here's the problem: Agent Skills is a **push** model. We're teaching agents "here's how to use Grafema" BEFORE they need it. But agents are reactive — they use tools when solving specific problems.
+
+### What Could Go Wrong
+
+1. **Agent doesn't read the skill before choosing tools**
+   If the agent's tool selection happens at the LLM layer (not skill-aware), this is just nice documentation nobody reads.
+
+2. **Agent reads skill but ignores it**
+   Skills compete with system prompts, context, and prior training. If the model was pre-trained to "read code to understand it," our skill fights muscle memory.
+
+3. **Agent uses tools but uses them wrong**
+   Example: Agent reads "use find_calls for callers" but still runs `find_calls` then reads all those files anyway. We taught tool selection, not workflow discipline.
+
+4. **Skill is TOO good at teaching high-level tools**
+   Agent learns to use `find_nodes`, `find_calls`, `get_function_details` for EVERYTHING and never discovers Datalog power for complex patterns.
+
+### What Could Go Right
+
+1. **Decision Tree drives behavior**
+   If agents actually follow "START: What do you need?" → tool selection, we've won. This is the strongest part of the skill.
+
+2. **Anti-patterns prevent common mistakes**
+   "Don't read files to find call sites" — if agents internalize this, massive win.
+
+3. **Common Workflows scaffold learning**
+   Copy-paste workflows are easier than thinking. If agent hits "Impact Analysis" workflow and it WORKS, they'll reuse it.
+
+---
+
+## What I'm Worried About
+
+### 1. No Feedback Loop
+
+We're shipping this blind. No telemetry for:
+- How often agents open SKILL.md
+- Which tools they choose after reading it
+- Whether they follow Decision Tree vs just grepping tool list
+- Whether anti-patterns actually prevent mistakes
+
+**Implication:** We won't know if this works until users complain or praise.
+
+### 2. Progressive Disclosure Might Be Too Gentle
+
+SKILL.md says "see references/ for details" but doesn't FORCE agents to look. What if agent needs Datalog for complex query but stops at Tier 1 tools?
+
+**Counterpoint:** This is by design. Tier 1 should handle 80% of cases. If agent hits a Tier 1 limitation, they'll search for alternatives.
+
+### 3. No Enforcement Mechanism
+
+Nothing stops an agent from:
+- Ignoring the skill entirely
+- Reading files before trying graph queries
+- Using Datalog for simple lookups
+
+**Counterpoint:** That's true of ALL documentation. We can lead horses to water...
+
+---
+
+## What's Missing (But Acceptable for v0.2)
+
+### 1. No "Try This First" Forcing Function
+If I could add ONE thing, it would be: **MANDATORY starter example.**
+
+Top of SKILL.md should have:
+```
+BEFORE ANYTHING ELSE: Try this query to verify MCP is working:
+  find_nodes({ type: "MODULE" })
+
+If this fails, Grafema MCP server is not configured. Stop here.
+```
+
+This forces agents to verify setup BEFORE spending tokens on wrong approaches.
+
+**Status:** MISSING but easy to add later.
+
+### 2. No Comparison to Alternatives
+SKILL.md doesn't say:
+- "Grafema vs TypeScript LSP: when to use which"
+- "Grafema vs grep: here's what grep can't do"
+- "Grafema vs AST querying: Grafema is FASTER for cross-file patterns"
+
+**Counterpoint:** This might confuse more than help. Better to stay focused on Grafema's strengths.
+
+### 3. No Performance Hints
+Agents don't know:
+- `find_calls` is O(1) lookup (indexed)
+- `query_graph` without constraints is O(n) disaster
+- `get_context` with no filters = full graph traversal
+
+**Implication:** Agents might avoid fast tools (thinking they're slow) or spam slow tools (thinking they're fast).
+
+**Status:** Query patterns doc has "Performance Tips" but not prominent enough.
+
+---
+
+## Complexity & Architecture Review
+
+### Does It Use Existing Abstractions? ✅
+
+**GOOD:**
+- Skill stored in `packages/cli/skills/` (alongside dist/)
+- CLI command uses standard Commander pattern
+- `installSkill()` exported function = reusable
+- Auto-install in `init.ts` uses exported function (DRY)
+
+**NO RED FLAGS:**
+- No new "skill management system"
+- No plugin architecture for skills
+- No dynamic skill loading
+- Just: copy files from package to project
+
+This is **exactly right** for v0.2. If we need skill updates, version bumps, auto-sync — those are v0.3 features.
+
+### Iteration Complexity: O(1) ✅
+
+Installation is O(1):
+- Find source dir (package root)
+- Copy to target dir (user project)
+- No traversal, no scanning, no parsing
+
+**GOOD.**
+
+---
+
+## The Real Test: Would I Show This On Stage?
+
+**The demo:**
+
+1. User runs `grafema init` → skill auto-installed
+2. Agent opens Claude Code, sees Grafema skill in `.claude/skills/`
+3. User asks: "Where is `processPayment` called?"
+4. Agent reads skill → Decision Tree → "Find who calls function X" → `find_calls`
+5. Agent runs: `find_calls({ name: "processPayment" })` → instant results
+6. Agent DOESN'T read 20 files, DOESN'T grep, DOESN'T guess
+
+**Would that demo work?**
+
+**If the agent cooperates: YES.**
+**If the agent ignores the skill: NO.**
+
+And that's the problem. This feature's success depends on agent compliance, which we can't control.
+
+---
+
+## Philosophical Concerns
+
+### Is Agent Skills the Right Abstraction?
+
+Agent Skills assumes:
+- Agents read documentation before acting (optimistic)
+- Skills can override model training (unproven)
+- Static markdown > dynamic prompting (debatable)
+
+**Alternative approach:** Grafema MCP server could RETURN skill hints in tool responses.
+
+Example:
+```json
+{
+  "error": "find_calls returned 0 results",
+  "hint": "Try find_nodes first to verify the function exists",
+  "see_also": "SKILL.md#decision-tree"
+}
+```
+
+This is **reactive teaching** vs **proactive teaching**. Skills are proactive. In-band hints are reactive.
+
+**Verdict:** We're doing proactive (skills). Reactive (hints in responses) is v0.3 territory.
+
+---
+
+## What Would Make Me Confident?
+
+### 1. Real-World Dogfooding (Post-Release)
+
+After merge:
+- Use Grafema WITH this skill for 5 real tasks
+- Track: Did agent follow Decision Tree? Did anti-patterns prevent mistakes?
+- Document failures → iterate
+
+**This is validation, not implementation.** Do it AFTER merge.
+
+### 2. Telemetry (Future)
+
+Add to MCP server:
+- `get_skill_version()` tool → agents can check if skill is current
+- Log tool usage patterns → see if skill changes behavior
+- Compare: sessions WITH skill vs WITHOUT skill
+
+**Status:** Out of scope for REG-414, but should be REG-XXX for v0.3.
+
+### 3. A/B Test (Ambitious)
+
+Run same query with two agents:
+- Agent A: No skill, just MCP tools
+- Agent B: Has skill installed
+
+Measure:
+- Time to solution
+- Number of tool calls
+- Number of file reads (anti-pattern)
+
+**Status:** Research-level effort. Not blocking v0.2 release.
+
+---
+
+## Final Thoughts
+
+This is **good work**. The implementation is clean, the documentation is thoughtful, the testing is adequate. It ships what the spec promised.
+
+But here's what keeps me up at night: **We're betting on agent behavior we can't control.**
+
+If agents DON'T read skills before acting → this is just pretty documentation.
+If agents DO read skills but IGNORE them → we've wasted effort.
+If agents read skills and FOLLOW them → we've built something transformative.
+
+**We won't know which until real users try it.**
+
+---
+
+## Verdict Justification
+
+### Why APPROVE?
+
+1. **All review concerns addressed** — cross-platform, auto-install, versioning, examples
+2. **Clean implementation** — no architectural debt, uses existing patterns
+3. **Tests pass** — mechanics verified
+4. **Aligns with vision** — "Query the graph, not read code" is FRONT AND CENTER
+5. **Low risk** — worst case, agents ignore it and nothing breaks
+
+### Why RESERVATIONS?
+
+1. **No proof it works** — we're shipping blind, no validation plan beyond "try it and see"
+2. **No feedback loop** — can't measure adoption or effectiveness
+3. **Assumes agent compliance** — success depends on agent reading + following skill
+
+### What Would Block Approval?
+
+- If SKILL.md had NO examples (but it has ~15)
+- If auto-install was missing (but it's there)
+- If version handling was broken (but it works)
+- If tests failed (but 7/7 pass)
+
+None of these are true. The implementation is SOLID.
+
+---
+
+## Recommendation
+
+**MERGE TO MAIN.**
+
+Then:
+1. Dogfood for 1 week (use Grafema WITH skill for real work)
+2. Document agent behavior (did they use Decision Tree? follow anti-patterns?)
+3. Create Linear issue for telemetry (v0.3)
+4. Create Linear issue for in-band hints (v0.3)
+
+If dogfooding reveals fundamental issues → patch in v0.2.1.
+If agents ignore skill entirely → revisit Agent Skills abstraction in v0.3.
+
+---
+
+## One Last Thing
+
+The Decision Tree is the star of this implementation. If agents actually follow:
+
+```
+"Find who calls function X"
+  -> find_calls({ name: "X" })
+  -> For full details: get_function_details({ name: "X" })
+```
+
+...then this feature is a HOME RUN.
+
+If they don't follow it, we've learned something valuable: **agents need reactive guidance, not proactive documentation.**
+
+Either way, we learn. That's worth shipping.
+
+---
+
+**Status:** APPROVED
+**Escalation:** Ready for Вадим's review

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,8 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "skills"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/cli/skills/grafema-codebase-analysis/SKILL.md
+++ b/packages/cli/skills/grafema-codebase-analysis/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: grafema-codebase-analysis
+description: >
+  Analyze codebases using a graph database instead of reading source files.
+  Use when understanding code architecture, finding functions or call patterns,
+  tracing data flow, checking dependencies, or answering "where is X used?"
+  questions. Grafema builds a queryable code graph from static analysis —
+  prefer querying the graph over reading files manually.
+license: Apache-2.0
+compatibility: Requires Grafema MCP server configured (grafema or @grafema/mcp package)
+metadata:
+  author: Grafema
+  version: "0.2.5"
+---
+
+# Grafema: Graph-Based Codebase Analysis
+
+## Core Principle
+
+**Query the graph, not read code.**
+
+Grafema builds a graph database from your codebase via static analysis.
+Instead of reading dozens of files to understand how code connects,
+query the graph to get structured, complete answers instantly.
+
+```
+BAD:  Read 20 files hoping to find all callers of a function
+GOOD: find_calls({ name: "processPayment" }) -> get all callers in one query
+
+BAD:  Grep for variable name across files, miss aliased references
+GOOD: trace_dataflow({ source: "userInput", direction: "forward" }) -> complete data flow
+
+BAD:  Read file by file to understand module dependencies
+GOOD: get_file_overview({ file: "src/api.ts" }) -> structured imports, exports, classes, functions
+```
+
+### When to Use Grafema
+
+- Finding where functions/methods are called
+- Understanding module dependencies and imports
+- Tracing data flow (forward or backward)
+- Getting function details (signature, callers, callees)
+- Checking code invariants with Datalog rules
+- Exploring file structure and entity relationships
+
+### When NOT to Use Grafema
+
+- Reading a single specific file (use your editor/Read tool — faster)
+- Editing code (Grafema is read-only analysis)
+- Runtime behavior questions (Grafema is static analysis)
+- Files not yet analyzed (run `analyze_project` first)
+
+## Essential Tools (Tier 1)
+
+These 5 tools handle ~80% of queries. Start here.
+
+### find_nodes — Find entities by type, name, or file
+
+```json
+find_nodes({ type: "FUNCTION", name: "validateUser" })
+find_nodes({ type: "CLASS", file: "src/auth.ts" })
+find_nodes({ type: "http:request" })
+find_nodes({ type: "MODULE" })
+```
+
+**Use when:** "Find all X", "What functions are in file Y", "List all routes"
+
+**Node types:** MODULE, FUNCTION, METHOD, CLASS, VARIABLE, PARAMETER,
+CALL, PROPERTY_ACCESS, METHOD_CALL, CALL_SITE,
+http:route, http:request, db:query, socketio:emit, socketio:on
+
+### find_calls — Find function/method call sites
+
+```json
+find_calls({ name: "processPayment" })
+find_calls({ name: "query", className: "Database" })
+```
+
+**Use when:** "Where is X called?", "Who calls this function?", "Find all usages"
+
+Returns call sites with file locations and whether the target is resolved.
+
+### get_function_details — Complete function info
+
+```json
+get_function_details({ name: "handleRequest" })
+get_function_details({ name: "validate", file: "src/auth.ts" })
+get_function_details({ name: "processOrder", transitive: true })
+```
+
+**Use when:** "What does function X do?", "What does it call?", "Who calls it?"
+
+Returns: signature, parameters, what it calls, who calls it.
+Use `transitive: true` to follow call chains (A calls B calls C, max depth 5).
+
+### get_context — Deep context for any node
+
+```json
+get_context({ semanticId: "src/api.ts:handleRequest#fn" })
+get_context({ semanticId: "src/db.ts:Database#class", edgeType: "CALLS" })
+```
+
+**Use when:** "Tell me everything about this entity", "Show me its relationships"
+
+Returns: node info, source code, ALL incoming/outgoing edges with code context.
+Use after `find_nodes` to deep-dive into a specific result.
+
+### trace_dataflow — Trace data flow
+
+```json
+trace_dataflow({ source: "userInput", file: "src/handler.ts", direction: "forward" })
+trace_dataflow({ source: "dbResult", file: "src/query.ts", direction: "backward" })
+trace_dataflow({ source: "config", direction: "both", max_depth: 5 })
+```
+
+**Use when:** "Where does this value end up?", "Where does this data come from?",
+"Is user input reaching the database unsanitized?"
+
+Directions: `forward` (where does it go?), `backward` (where did it come from?), `both`.
+
+## Decision Tree
+
+```
+START: What do you need?
+|
+|-- "Find entities (functions, classes, routes)"
+|   -> find_nodes({ type, name, file })
+|
+|-- "Find who calls function X"
+|   -> find_calls({ name: "X" })
+|   -> For full details: get_function_details({ name: "X" })
+|
+|-- "Understand a specific entity deeply"
+|   -> First: find_nodes to get its semantic ID
+|   -> Then: get_context({ semanticId: "..." })
+|
+|-- "Trace data flow"
+|   -> trace_dataflow({ source, file, direction })
+|
+|-- "Understand a file's structure"
+|   -> get_file_overview({ file: "path/to/file.ts" })
+|
+|-- "Trace an alias/re-export chain"
+|   -> trace_alias({ variableName: "alias", file: "path.ts" })
+|
+|-- "Check a code rule/invariant"
+|   -> check_invariant({ rule: "violation(X) :- ..." })
+|
+|-- "Custom complex query"
+|   -> query_graph({ query: "violation(X) :- ..." })
+|   -> See references/query-patterns.md for Datalog syntax
+|
+|-- "Explore unknown codebase"
+|   -> get_stats() for high-level overview
+|   -> get_schema() for available node/edge types
+|   -> find_nodes({ type: "MODULE" }) for module list
+|   -> get_file_overview for specific files
+```
+
+## Common Workflows
+
+### 1. Impact Analysis: "What breaks if I change function X?"
+
+```
+get_function_details({ name: "X", transitive: true })
+-> Check calledBy array for all callers (direct + transitive)
+-> For critical callers: get_context({ semanticId }) for full picture
+```
+
+### 2. Security Audit: "Does user input reach the database?"
+
+```
+find_nodes({ type: "http:request" })
+-> For each route, trace_dataflow({ source: requestParam, direction: "forward" })
+-> Check if flow reaches db:query nodes
+-> Use find_guards to check for sanitization
+```
+
+### 3. Onboarding: "How is this codebase structured?"
+
+```
+get_stats()                              -> Node/edge counts by type
+find_nodes({ type: "MODULE" })           -> All modules
+get_file_overview({ file: "src/index.ts" })  -> Entry point structure
+find_nodes({ type: "http:request" })     -> All API endpoints
+```
+
+### 4. Dependency Analysis: "What does module X depend on?"
+
+```
+get_file_overview({ file: "src/service.ts" })
+-> Check imports section for dependencies
+-> For each import: get_context for deeper relationships
+```
+
+### 5. Find Dead Code: "What functions have no callers?"
+
+```
+query_graph({
+  query: 'violation(X) :- node(X, "FUNCTION"), \\+ edge(_, X, "CALLS").'
+})
+```
+
+## Anti-Patterns
+
+**Don't read files to find call sites.** Use `find_calls` — it finds ALL callers across
+the entire codebase, including indirect references you'd miss by grepping.
+
+**Don't use `query_graph` for simple lookups.** `find_nodes`, `find_calls`, and
+`get_function_details` are optimized for common queries. Reserve Datalog for
+complex patterns (joins, transitive closure, invariant checks).
+
+**Don't skip analysis status.** If you just ran `analyze_project`, check
+`get_analysis_status` before querying — partial results are misleading.
+
+**Don't request excessive depth.** `get_context` with no filters returns everything.
+Use `edgeType` filter to focus on specific relationships (e.g., `"CALLS,ASSIGNED_FROM"`).
+
+**Don't use Grafema for single-file questions.** If you only need to read one file,
+use your editor. Grafema shines for cross-file relationships.
+
+## Advanced Tools (Tier 2)
+
+### query_graph — Custom Datalog queries
+
+For complex patterns not covered by high-level tools.
+See [references/query-patterns.md](references/query-patterns.md) for syntax and examples.
+
+```json
+query_graph({
+  query: "violation(X) :- node(X, \"CALL\"), attr(X, \"name\", \"eval\").",
+  explain: true
+})
+```
+
+Available predicates: `node(Id, Type)`, `edge(Src, Dst, Type)`, `attr(Id, Name, Value)`.
+Must define `violation/1` predicate for results. Use `explain: true` to debug empty results.
+
+### get_file_overview — File-level structure
+
+Structured overview of imports, exports, classes, functions, variables with relationships.
+Recommended first step when exploring a specific file before using `get_context`.
+
+### trace_alias — Resolve alias chains
+
+For code like `const alias = obj.method; alias()` — traces "alias" back to "obj.method".
+
+### get_schema — Available types
+
+Returns all node and edge types in the graph. Use when you need exact type names.
+
+### check_invariant — Code rule checking
+
+Check if a Datalog rule has violations. For persistent rules, use `create_guarantee`.
+
+## Specialized Tools (Tier 3)
+
+| Tool | Purpose |
+|------|---------|
+| get_stats | Graph statistics (node/edge counts by type) |
+| get_coverage | Analysis coverage for a path |
+| find_guards | Conditional guards protecting a node |
+| create_guarantee | Create persistent code invariant |
+| list_guarantees | List all guarantees |
+| check_guarantees | Check guarantee violations |
+| delete_guarantee | Remove a guarantee |
+| discover_services | Discover services without full analysis |
+| analyze_project | Run/re-run analysis |
+| get_analysis_status | Check analysis progress |
+| read_project_structure | Directory tree |
+| write_config | Update .grafema/config.yaml |
+| get_documentation | Grafema usage docs |
+| report_issue | Report bugs |
+
+## Troubleshooting
+
+**Query returns nothing?**
+1. Check analysis ran: `get_analysis_status`
+2. Check type names: `get_schema` for available types
+3. Use `explain: true` in `query_graph` to debug
+4. Check file paths match (relative to project root)
+
+**Need help with Datalog syntax?**
+- See [references/query-patterns.md](references/query-patterns.md)
+- Use `get_documentation({ topic: "queries" })` for inline help
+
+**Graph seems incomplete?**
+- Run `get_coverage({ path: "src/" })` to check coverage
+- Re-analyze with `analyze_project({ force: true })`
+- Check `.grafema/config.yaml` for include/exclude patterns
+
+## References
+
+- [Node and Edge Types](references/node-edge-types.md) — Complete graph schema
+- [Query Patterns](references/query-patterns.md) — Datalog cookbook with examples

--- a/packages/cli/skills/grafema-codebase-analysis/references/node-edge-types.md
+++ b/packages/cli/skills/grafema-codebase-analysis/references/node-edge-types.md
@@ -1,0 +1,123 @@
+# Grafema Graph Schema: Node and Edge Types
+
+## Node Types
+
+### Core Entities
+
+| Type | Description | Key Attributes |
+|------|-------------|----------------|
+| `MODULE` | A source file/module | name, file |
+| `FUNCTION` | Function declaration | name, file, line, async |
+| `METHOD` | Class method | name, file, line, className |
+| `CLASS` | Class declaration | name, file, line |
+| `VARIABLE` | Variable declaration | name, file, line, kind (const/let/var) |
+| `PARAMETER` | Function parameter | name, file, line, index |
+
+### Call & Access Nodes
+
+| Type | Description | Key Attributes |
+|------|-------------|----------------|
+| `CALL` | Function call expression | name, file, line, resolved |
+| `METHOD_CALL` | Method call expression | name, file, line, object, resolved |
+| `CALL_SITE` | Call site context | file, line |
+| `PROPERTY_ACCESS` | Property access (obj.prop) | name, object, file, line |
+
+### Domain-Specific Nodes
+
+| Type | Description | Key Attributes |
+|------|-------------|----------------|
+| `http:route` | HTTP route definition | path, method |
+| `http:request` | HTTP request handler | path, method, file, line |
+| `db:query` | Database query | file, line |
+| `socketio:emit` | Socket.IO emit call | event, file, line |
+| `socketio:on` | Socket.IO event listener | event, file, line |
+
+### Structural Nodes
+
+| Type | Description |
+|------|-------------|
+| `SCOPE` | Code scope (function body, if block, loop) |
+| `OBJECT_LITERAL` | Object literal expression |
+| `ARRAY_LITERAL` | Array literal expression |
+| `LITERAL` | Primitive literal value |
+| `IMPORT` | Import declaration |
+| `EXPORT` | Export declaration |
+
+## Edge Types
+
+| Type | Direction | Description |
+|------|-----------|-------------|
+| `CONTAINS` | Parent -> Child | Structural containment (module contains function) |
+| `CALLS` | Caller -> Callee | Function/method call relationship |
+| `DEPENDS_ON` | Module -> Module | Module dependency (import) |
+| `ASSIGNED_FROM` | Variable -> Source | Value assignment source |
+| `INSTANCE_OF` | Instance -> Class | Class instantiation |
+| `PASSES_ARGUMENT` | Call -> Value | Argument passing at call site |
+| `HAS_SCOPE` | Function -> Scope | Function's scope chain |
+| `EXTENDS` | Class -> Class | Class inheritance |
+| `IMPLEMENTS` | Class -> Interface | Interface implementation |
+| `RETURNS` | Function -> Type | Return type relationship |
+| `DATAFLOW` | Source -> Sink | Data flow edge |
+| `GUARDED_BY` | Node -> Scope | Conditional guard relationship |
+
+## Common Attribute Names
+
+These can be used with `attr(Id, Name, Value)` in Datalog queries:
+
+| Attribute | Types | Description |
+|-----------|-------|-------------|
+| `name` | All named nodes | Entity name |
+| `file` | All nodes | Source file path (relative) |
+| `line` | All located nodes | Line number |
+| `column` | All located nodes | Column number |
+| `type` | All nodes | Node type (via `node(Id, Type)`) |
+| `async` | FUNCTION, METHOD | Is async function |
+| `kind` | VARIABLE | const, let, or var |
+| `method` | http:request | HTTP method (GET, POST, etc.) |
+| `path` | http:request, http:route | URL path pattern |
+| `resolved` | CALL, METHOD_CALL | Whether call target is resolved |
+| `object` | METHOD_CALL, PROPERTY_ACCESS | Receiver object name |
+| `className` | METHOD | Owning class name |
+| `event` | socketio:emit, socketio:on | Socket.IO event name |
+
+## Quick Reference: Finding Common Patterns
+
+### Find all functions
+```
+node(X, "FUNCTION")
+```
+
+### Find all classes
+```
+node(X, "CLASS")
+```
+
+### Find all HTTP endpoints
+```
+node(X, "http:request")
+```
+
+### Find calls to a specific function
+```
+node(X, "CALL"), attr(X, "name", "targetFunction")
+```
+
+### Find all methods of a class
+```
+node(C, "CLASS"), attr(C, "name", "MyClass"), edge(C, M, "CONTAINS"), node(M, "METHOD")
+```
+
+### Find module dependencies
+```
+edge(A, B, "DEPENDS_ON"), node(A, "MODULE"), node(B, "MODULE")
+```
+
+### Find data flow from a variable
+```
+node(X, "VARIABLE"), attr(X, "name", "myVar"), edge(X, Y, "DATAFLOW")
+```
+
+### Find unresolved calls
+```
+node(X, "CALL"), attr(X, "resolved", "false")
+```

--- a/packages/cli/skills/grafema-codebase-analysis/references/query-patterns.md
+++ b/packages/cli/skills/grafema-codebase-analysis/references/query-patterns.md
@@ -1,0 +1,205 @@
+# Grafema Datalog Query Patterns
+
+All queries use `query_graph` tool. Every query must define a `violation/1` predicate —
+matching nodes are returned as results.
+
+## Syntax Quick Reference
+
+```
+violation(X) :- <body>.         # Rule: X is a result if body is true
+node(X, "TYPE")                 # Match node by type
+edge(X, Y, "TYPE")             # Match edge: X -> Y of given type
+attr(X, "name", "value")       # Match node attribute
+\+ <condition>                  # Negation: condition is NOT true
+```
+
+## Basic Patterns
+
+### Find nodes by type
+
+```datalog
+violation(X) :- node(X, "FUNCTION").
+```
+
+### Find nodes by type and name
+
+```datalog
+violation(X) :- node(X, "FUNCTION"), attr(X, "name", "processPayment").
+```
+
+### Find nodes by type and file
+
+```datalog
+violation(X) :- node(X, "FUNCTION"), attr(X, "file", "src/api.ts").
+```
+
+### Find nodes matching multiple criteria
+
+```datalog
+violation(X) :- node(X, "CALL"), attr(X, "name", "eval"), attr(X, "file", "src/handler.ts").
+```
+
+## Edge Traversal
+
+### One-hop: Find all calls from a function
+
+```datalog
+violation(Call) :-
+  node(F, "FUNCTION"), attr(F, "name", "main"),
+  edge(F, S, "HAS_SCOPE"), edge(S, Call, "CONTAINS"),
+  node(Call, "CALL").
+```
+
+### One-hop: Find all callers of a function
+
+```datalog
+violation(Caller) :-
+  node(Target, "FUNCTION"), attr(Target, "name", "validate"),
+  edge(Call, Target, "CALLS"),
+  edge(Scope, Call, "CONTAINS"),
+  edge(Caller, Scope, "HAS_SCOPE"),
+  node(Caller, "FUNCTION").
+```
+
+### Find module dependencies
+
+```datalog
+violation(Dep) :-
+  node(M, "MODULE"), attr(M, "name", "api"),
+  edge(M, Dep, "DEPENDS_ON"), node(Dep, "MODULE").
+```
+
+### Find what a variable is assigned from
+
+```datalog
+violation(Source) :-
+  node(V, "VARIABLE"), attr(V, "name", "config"),
+  edge(V, Source, "ASSIGNED_FROM").
+```
+
+## Negation Patterns
+
+### Functions with no callers (potential dead code)
+
+```datalog
+violation(X) :-
+  node(X, "FUNCTION"),
+  \+ edge(_, X, "CALLS").
+```
+
+### Modules with no dependents (unused modules)
+
+```datalog
+violation(X) :-
+  node(X, "MODULE"),
+  \+ edge(_, X, "DEPENDS_ON").
+```
+
+### Unresolved calls (external/dynamic targets)
+
+```datalog
+violation(X) :-
+  node(X, "CALL"),
+  attr(X, "resolved", "false").
+```
+
+## Invariant Patterns
+
+### No eval() usage
+
+```datalog
+violation(X) :- node(X, "CALL"), attr(X, "name", "eval").
+```
+
+### No direct database queries outside service layer
+
+```datalog
+violation(X) :-
+  node(X, "db:query"),
+  attr(X, "file", File),
+  \+ attr(X, "file", "src/services/").
+```
+
+Note: File matching is exact. For pattern matching, use the `find_nodes` tool instead.
+
+### All HTTP endpoints must have handlers
+
+```datalog
+violation(X) :-
+  node(X, "http:request"),
+  \+ edge(_, X, "CALLS").
+```
+
+## Join Patterns
+
+### Find functions that call both X and Y
+
+```datalog
+violation(F) :-
+  node(F, "FUNCTION"),
+  edge(F, S, "HAS_SCOPE"),
+  edge(S, C1, "CONTAINS"), node(C1, "CALL"), attr(C1, "name", "readFile"),
+  edge(S, C2, "CONTAINS"), node(C2, "CALL"), attr(C2, "name", "writeFile").
+```
+
+### Find classes that extend a specific base class
+
+```datalog
+violation(Child) :-
+  node(Base, "CLASS"), attr(Base, "name", "BaseService"),
+  edge(Child, Base, "EXTENDS"),
+  node(Child, "CLASS").
+```
+
+## Performance Tips
+
+1. **Put most selective filters first.** `attr(X, "name", "specific")` before `node(X, "FUNCTION")`.
+
+2. **Avoid unconstrained joins.** Every variable should be bounded by at least one specific condition.
+
+3. **Use high-level tools when possible.** `find_calls` is faster than writing a Datalog query for the same pattern — it uses optimized indexes.
+
+4. **Use `explain: true` to debug.** If a query returns nothing, add `explain: true` to see step-by-step execution.
+
+5. **Use `limit` and `offset` for large result sets.** Default limit applies, but you can paginate through results.
+
+## Common Mistakes
+
+### Wrong: Unbound variable
+
+```datalog
+# BAD: Y is never constrained
+violation(X) :- node(X, "FUNCTION"), edge(X, Y, "CALLS").
+```
+
+```datalog
+# GOOD: Constrain Y
+violation(X) :- node(X, "FUNCTION"), edge(X, Y, "CALLS"), node(Y, "FUNCTION").
+```
+
+### Wrong: Using wrong edge direction
+
+```datalog
+# BAD: CALLS edge goes Caller -> Callee, not reverse
+violation(X) :- node(X, "FUNCTION"), edge(X, Target, "CALLS").
+```
+
+The CALLS edge typically goes from CALL/CALL_SITE node to target FUNCTION,
+not directly from FUNCTION to FUNCTION. Check [node-edge-types.md](node-edge-types.md)
+for correct edge directions.
+
+### Wrong: Missing scope traversal
+
+Functions don't directly CONTAIN calls — they have scopes that contain calls:
+
+```datalog
+# BAD: No direct CONTAINS edge from FUNCTION to CALL
+violation(C) :- node(F, "FUNCTION"), edge(F, C, "CONTAINS"), node(C, "CALL").
+```
+
+```datalog
+# GOOD: Go through HAS_SCOPE
+violation(C) :-
+  node(F, "FUNCTION"), edge(F, S, "HAS_SCOPE"),
+  edge(S, C, "CONTAINS"), node(C, "CALL").
+```

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -26,6 +26,7 @@ import { doctorCommand } from './commands/doctor.js';
 import { schemaCommand } from './commands/schema.js';
 import { explainCommand } from './commands/explain.js';
 import { fileCommand } from './commands/file.js';
+import { setupSkillCommand } from './commands/setup-skill.js';
 
 // Read version from package.json
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -58,5 +59,6 @@ program.addCommand(doctorCommand);
 program.addCommand(schemaCommand);
 program.addCommand(explainCommand);
 program.addCommand(fileCommand);
+program.addCommand(setupSkillCommand);
 
 program.parse();

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -10,6 +10,7 @@ import { createInterface } from 'readline';
 import { fileURLToPath } from 'url';
 import { stringify as stringifyYAML } from 'yaml';
 import { DEFAULT_CONFIG, GRAFEMA_VERSION, getSchemaVersion } from '@grafema/core';
+import { installSkill } from './setup-skill.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -183,6 +184,16 @@ Examples:
         );
         console.log('✓ Updated .gitignore');
       }
+    }
+
+    // Auto-install Agent Skill for AI-assisted development
+    try {
+      const installed = installSkill(projectPath);
+      if (installed) {
+        console.log('✓ Installed Agent Skill (.claude/skills/grafema-codebase-analysis/)');
+      }
+    } catch {
+      // Non-critical — don't fail init if skill install fails
     }
 
     printNextSteps();

--- a/packages/cli/src/commands/setup-skill.ts
+++ b/packages/cli/src/commands/setup-skill.ts
@@ -1,0 +1,162 @@
+/**
+ * Setup-skill command - Install Grafema Agent Skill into a project
+ */
+
+import { Command } from 'commander';
+import { resolve, join } from 'path';
+import { existsSync, mkdirSync, readFileSync, cpSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
+/** Default install paths per platform */
+const PLATFORM_PATHS: Record<string, string> = {
+  claude: '.claude/skills',
+  gemini: '.gemini/skills',
+  cursor: '.cursor/skills',
+};
+
+const SKILL_DIR_NAME = 'grafema-codebase-analysis';
+
+interface SetupSkillOptions {
+  outputDir?: string;
+  platform?: string;
+  force?: boolean;
+}
+
+/**
+ * Get the bundled skill source directory.
+ * In the published package, skills/ is at the package root alongside dist/.
+ */
+function getSkillSourceDir(): string {
+  // __dirname is dist/commands/ -> go up to package root, then into skills/
+  return join(__dirname, '..', '..', 'skills', SKILL_DIR_NAME);
+}
+
+/**
+ * Read version from skill metadata.
+ */
+function getSkillVersion(skillDir: string): string | null {
+  const skillMd = join(skillDir, 'SKILL.md');
+  if (!existsSync(skillMd)) return null;
+
+  const content = readFileSync(skillMd, 'utf-8');
+  const versionMatch = content.match(/version:\s*"?([^"\n]+)"?/);
+  return versionMatch ? versionMatch[1].trim() : null;
+}
+
+/**
+ * Resolve the target directory for skill installation.
+ */
+function resolveTargetDir(projectPath: string, options: SetupSkillOptions): string {
+  if (options.outputDir) {
+    return resolve(options.outputDir, SKILL_DIR_NAME);
+  }
+
+  const platform = options.platform || 'claude';
+  const basePath = PLATFORM_PATHS[platform];
+  if (!basePath) {
+    throw new Error(
+      `Unknown platform: ${platform}. Supported: ${Object.keys(PLATFORM_PATHS).join(', ')}`
+    );
+  }
+
+  return join(projectPath, basePath, SKILL_DIR_NAME);
+}
+
+/**
+ * Copy skill directory recursively.
+ */
+function copySkill(sourceDir: string, targetDir: string): void {
+  mkdirSync(targetDir, { recursive: true });
+  cpSync(sourceDir, targetDir, { recursive: true });
+}
+
+/**
+ * Install the Grafema Agent Skill into a project directory.
+ * Returns true if skill was installed, false if skipped.
+ */
+export function installSkill(projectPath: string, options: SetupSkillOptions = {}): boolean {
+  const sourceDir = getSkillSourceDir();
+
+  if (!existsSync(sourceDir)) {
+    throw new Error(`Skill source not found at ${sourceDir}. Package may be corrupted.`);
+  }
+
+  const targetDir = resolveTargetDir(projectPath, options);
+
+  // Check if already installed
+  if (existsSync(targetDir) && !options.force) {
+    const installedVersion = getSkillVersion(targetDir);
+    const sourceVersion = getSkillVersion(sourceDir);
+
+    if (installedVersion === sourceVersion) {
+      return false; // Same version, skip
+    }
+
+    // Different version — warn but don't overwrite without --force
+    console.log(`  Skill exists (v${installedVersion}), latest is v${sourceVersion}`);
+    console.log('  Use --force to update, or run: grafema setup-skill --force');
+    return false;
+  }
+
+  copySkill(sourceDir, targetDir);
+  return true;
+}
+
+export const setupSkillCommand = new Command('setup-skill')
+  .description('Install Grafema Agent Skill into your project')
+  .argument('[path]', 'Project path', '.')
+  .option('--output-dir <path>', 'Custom output directory (overrides --platform)')
+  .option('--platform <name>', 'Target platform: claude, gemini, cursor', 'claude')
+  .option('-f, --force', 'Overwrite existing skill')
+  .addHelpText('after', `
+Examples:
+  grafema setup-skill                     Install for Claude Code (.claude/skills/)
+  grafema setup-skill --platform gemini   Install for Gemini CLI (.gemini/skills/)
+  grafema setup-skill --force             Update existing skill
+  grafema setup-skill --output-dir ./my-skills/
+`)
+  .action(async (path: string, options: SetupSkillOptions) => {
+    const projectPath = resolve(path);
+    const sourceDir = getSkillSourceDir();
+
+    if (!existsSync(sourceDir)) {
+      console.error('✗ Skill source not found. Package may be corrupted.');
+      process.exit(1);
+    }
+
+    const targetDir = resolveTargetDir(projectPath, options);
+
+    // Check if already installed
+    if (existsSync(targetDir) && !options.force) {
+      const installedVersion = getSkillVersion(targetDir);
+      const sourceVersion = getSkillVersion(sourceDir);
+
+      if (installedVersion === sourceVersion) {
+        console.log(`✓ Grafema skill already installed (v${installedVersion})`);
+        console.log(`  Location: ${targetDir}`);
+        return;
+      }
+
+      console.log(`  Skill exists (v${installedVersion}), latest is v${sourceVersion}`);
+      console.log('  Use --force to update');
+      return;
+    }
+
+    try {
+      copySkill(sourceDir, targetDir);
+    } catch (err) {
+      console.error('✗ Failed to install skill:', (err as Error).message);
+      process.exit(1);
+    }
+
+    const sourceVersion = getSkillVersion(sourceDir);
+    console.log(`✓ Grafema skill installed (v${sourceVersion})`);
+    console.log(`  Location: ${targetDir}`);
+    console.log('');
+    console.log('Next steps:');
+    console.log('  1. Ensure Grafema MCP server is configured in your AI agent');
+    console.log('  2. Run "grafema analyze" to build the code graph');
+    console.log('  3. Your AI agent will now prefer graph queries over reading files');
+  });

--- a/packages/cli/test/setup-skill.test.ts
+++ b/packages/cli/test/setup-skill.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for `grafema setup-skill` command - REG-414
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const cliPath = join(__dirname, '../dist/cli.js');
+const fixturesDir = join(__dirname, 'fixtures');
+const testDir = join(fixturesDir, 'setup-skill-test');
+
+function runCli(args: string[], cwd: string = testDir): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('node', [cliPath, ...args], {
+      cwd,
+      env: { ...process.env, NO_COLOR: '1' },
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.on('data', (data) => { stdout += data.toString(); });
+    proc.stderr.on('data', (data) => { stderr += data.toString(); });
+    proc.on('error', reject);
+    proc.on('close', (code) => resolve({ stdout, stderr, code }));
+  });
+}
+
+describe('setup-skill command', () => {
+  before(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true });
+    }
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  after(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true });
+    }
+  });
+
+  it('should show help', async () => {
+    const { stdout, code } = await runCli(['setup-skill', '--help']);
+    assert.strictEqual(code, 0);
+    assert.ok(stdout.includes('Install Grafema Agent Skill'), 'help should describe command');
+    assert.ok(stdout.includes('--platform'), 'help should show --platform option');
+    assert.ok(stdout.includes('--force'), 'help should show --force option');
+  });
+
+  it('should install skill to default .claude/skills/ directory', async () => {
+    const skillDir = join(testDir, '.claude', 'skills', 'grafema-codebase-analysis');
+
+    const { stdout, code } = await runCli(['setup-skill', testDir]);
+    assert.strictEqual(code, 0, `setup-skill failed: stdout=${stdout}`);
+    assert.ok(stdout.includes('Grafema skill installed'), 'should confirm installation');
+
+    // Verify SKILL.md exists and has correct content
+    const skillMd = join(skillDir, 'SKILL.md');
+    assert.ok(existsSync(skillMd), 'SKILL.md should exist');
+    const content = readFileSync(skillMd, 'utf-8');
+    assert.ok(content.includes('name: grafema-codebase-analysis'), 'SKILL.md should have correct name');
+    assert.ok(content.includes('description:'), 'SKILL.md should have description');
+
+    // Verify reference files exist
+    assert.ok(
+      existsSync(join(skillDir, 'references', 'node-edge-types.md')),
+      'node-edge-types.md should exist'
+    );
+    assert.ok(
+      existsSync(join(skillDir, 'references', 'query-patterns.md')),
+      'query-patterns.md should exist'
+    );
+  });
+
+  it('should skip if already installed with same version', async () => {
+    const { stdout, code } = await runCli(['setup-skill', testDir]);
+    assert.strictEqual(code, 0);
+    assert.ok(stdout.includes('already installed'), 'should indicate already installed');
+  });
+
+  it('should overwrite with --force', async () => {
+    const { stdout, code } = await runCli(['setup-skill', testDir, '--force']);
+    assert.strictEqual(code, 0);
+    assert.ok(stdout.includes('Grafema skill installed'), 'should confirm fresh install');
+  });
+
+  it('should support --platform gemini', async () => {
+    const geminiDir = join(testDir, '.gemini', 'skills', 'grafema-codebase-analysis');
+
+    const { stdout, code } = await runCli(['setup-skill', testDir, '--platform', 'gemini']);
+    assert.strictEqual(code, 0);
+    assert.ok(existsSync(join(geminiDir, 'SKILL.md')), 'SKILL.md should exist in .gemini/skills/');
+  });
+
+  it('should support custom --output-dir', async () => {
+    const customDir = join(testDir, 'custom-skills');
+    const targetDir = join(customDir, 'grafema-codebase-analysis');
+
+    const { stdout, code } = await runCli(['setup-skill', testDir, '--output-dir', customDir]);
+    assert.strictEqual(code, 0);
+    assert.ok(existsSync(join(targetDir, 'SKILL.md')), 'SKILL.md should exist in custom dir');
+  });
+});
+
+describe('init auto-installs skill', () => {
+  const initDir = join(fixturesDir, 'init-skill-test');
+
+  before(() => {
+    if (existsSync(initDir)) {
+      rmSync(initDir, { recursive: true });
+    }
+    mkdirSync(initDir, { recursive: true });
+    // init requires package.json
+    writeFileSync(join(initDir, 'package.json'), '{"name":"skill-test"}');
+  });
+
+  after(() => {
+    if (existsSync(initDir)) {
+      rmSync(initDir, { recursive: true });
+    }
+  });
+
+  it('should auto-install skill during grafema init', async () => {
+    const { stdout, code } = await runCli(['init', '--yes'], initDir);
+    assert.strictEqual(code, 0, `init failed: stdout=${stdout}`);
+    assert.ok(stdout.includes('Agent Skill'), 'should mention Agent Skill installation');
+
+    const skillPath = join(initDir, '.claude', 'skills', 'grafema-codebase-analysis', 'SKILL.md');
+    assert.ok(existsSync(skillPath), 'SKILL.md should be auto-installed by init');
+  });
+});


### PR DESCRIPTION
## Summary

- Add public Agent Skill (`grafema-codebase-analysis`) that teaches AI agents when and how to use Grafema MCP tools
- SKILL.md with decision tree, inline examples, anti-patterns, common workflows (295 lines)
- Reference files: node-edge-types.md (graph schema), query-patterns.md (Datalog cookbook)
- `grafema setup-skill` CLI command with `--platform` (claude/gemini/cursor) and `--force` flags
- Auto-install skill during `grafema init`
- Cross-platform compatible (standard Agent Skills spec, no Claude Code extensions)

## Test plan

- [x] 7 tests passing (help, install, idempotent, force, gemini platform, custom dir, init auto-install)
- [x] Existing CLI tests unaffected
- [x] Build succeeds
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)