### PR TITLE
feat(rust-resolve): dyn/impl Trait dispatch + IMPLEMENTS edges

### DIFF
--- a/packages/grafema-orchestrator/src/main.rs
+++ b/packages/grafema-orchestrator/src/main.rs
@@ -1059,7 +1059,7 @@ async fn main() -> Result<()> {
                         let results = plugin::stream_and_resolve_single_worker(
                             &mut rfdb,
                             &[config::Language::Rust],
-                            &[("rust-imports", &[]), ("rust-calls", &[]), ("rust-cross-methods", &[]), ("rust-globals", &[])],
+                            &[("rust-imports", &[]), ("rust-calls", &[]), ("rust-cross-methods", &[]), ("rust-trait-resolve", &[]), ("rust-globals", &[])],
                             &rs_pool,
                         ).await?;
                         for (cmd, mut output) in results {
@@ -1068,6 +1068,7 @@ async fn main() -> Result<()> {
                                 "rust-imports" => "rust-import-resolution",
                                 "rust-calls"   => "rust-call-resolution",
                                 "rust-cross-methods" => "rust-cross-method-calls",
+                                "rust-trait-resolve" => "rust-trait-resolution",
                                 "rust-globals" => "rust-runtime-globals",
                                 _ => &cmd,
                             };
@@ -1962,7 +1963,7 @@ async fn main() -> Result<()> {
                         let results = plugin::stream_and_resolve_single_worker(
                             &mut rfdb,
                             &[config::Language::Rust],
-                            &[("rust-imports", &[]), ("rust-calls", &[]), ("rust-cross-methods", &[]), ("rust-globals", &[])],
+                            &[("rust-imports", &[]), ("rust-calls", &[]), ("rust-cross-methods", &[]), ("rust-trait-resolve", &[]), ("rust-globals", &[])],
                             &pool,
                         ).await?;
                         for (cmd, mut output) in results {
@@ -1970,6 +1971,7 @@ async fn main() -> Result<()> {
                                 "rust-imports" => "rust-import-resolution",
                                 "rust-calls"   => "rust-call-resolution",
                                 "rust-cross-methods" => "rust-cross-method-calls",
+                                "rust-trait-resolve" => "rust-trait-resolution",
                                 "rust-globals" => "rust-runtime-globals",
                                 _ => &cmd,
                             };

--- a/packages/grafema-orchestrator/src/rust_analyzer.rs
+++ b/packages/grafema-orchestrator/src/rust_analyzer.rs
@@ -91,6 +91,9 @@ struct Ctx {
     scope_stack: Vec<String>,    // current scope ID (head = innermost)
     scope_kinds: Vec<ScopeKind>, // parallel to scope_stack
     enclosing_fn: Option<String>, // nearest enclosing function node ID
+    /// Trait name if we are inside a `impl TraitName for Type` block.
+    /// Used to tag FUNCTION nodes with `metadata["trait"]` for dyn dispatch resolution.
+    enclosing_trait: Option<String>,
     nodes: Vec<GraphNode>,
     edges: Vec<GraphEdge>,
     exports: Vec<ExportInfo>,
@@ -113,6 +116,7 @@ impl Ctx {
             scope_stack: vec![module_id],
             scope_kinds: vec![ScopeKind::Module],
             enclosing_fn: None,
+            enclosing_trait: None,
             nodes: Vec::new(),
             edges: Vec::new(),
             exports: Vec::new(),
@@ -594,8 +598,6 @@ fn walk_fn_param(param: &syn::FnArg, fn_id: &str, ctx: &mut Ctx) {
             });
         }
         syn::FnArg::Typed(t) => {
-            // Use walk_pat_bindings for all patterns (simple ident + complex destructuring).
-            // Temporarily set enclosing_fn to fn_id so semantic IDs get the right parent.
             let prev_fn = ctx.enclosing_fn.replace(fn_id.to_string());
             // Thread type annotation through to PARAMETER node metadata
             let type_str = type_to_name(&t.ty);
@@ -807,11 +809,14 @@ fn walk_impl(i: &syn::ItemImpl, ctx: &mut Ctx) {
         extra: HashMap::new(),
     });
 
+    let prev_trait = ctx.enclosing_trait.take();
+    ctx.enclosing_trait = trait_name;
     ctx.push_scope(&node_id, ScopeKind::Impl);
     for impl_item in &i.items {
         walk_impl_item(impl_item, ctx);
     }
     ctx.pop_scope();
+    ctx.enclosing_trait = prev_trait;
 }
 
 fn walk_impl_item(item: &syn::ImplItem, ctx: &mut Ctx) {
@@ -835,6 +840,11 @@ fn walk_impl_item(item: &syn::ImplItem, ctx: &mut Ctx) {
                     let (k, v) = Ctx::meta_text("returnType", &return_type);
                     method_meta.insert(k, v);
                 }
+            }
+            // Tag impl-of-trait methods with the trait name so that dyn/impl Trait
+            // dispatch resolution can build a TraitMethodIndex without graph traversal.
+            if let Some(trait_name) = &ctx.enclosing_trait {
+                method_meta.insert("trait".to_string(), serde_json::json!(trait_name));
             }
             ctx.emit_declaration(GraphNode {
                 id: node_id.clone(),
@@ -1690,6 +1700,22 @@ fn type_to_name(ty: &syn::Type) -> String {
         syn::Type::Paren(p) => type_to_name(&p.elem),
         syn::Type::Group(g) => type_to_name(&g.elem),
         syn::Type::Slice(s) => type_to_name(&s.elem),
+        syn::Type::TraitObject(t) => {
+            for bound in &t.bounds {
+                if let syn::TypeParamBound::Trait(tb) = bound {
+                    return format!("dyn {}", path_to_string(&tb.path));
+                }
+            }
+            "<type>".to_string()
+        }
+        syn::Type::ImplTrait(t) => {
+            for bound in &t.bounds {
+                if let syn::TypeParamBound::Trait(tb) = bound {
+                    return format!("impl {}", path_to_string(&tb.path));
+                }
+            }
+            "<type>".to_string()
+        }
         _ => "<type>".to_string(),
     }
 }

--- a/packages/grafema-resolve/grafema-resolve.cabal
+++ b/packages/grafema-resolve/grafema-resolve.cabal
@@ -43,6 +43,7 @@ test-suite grafema-resolve-test
     PropertyAccess
     ImportResolution
     SameFileCalls
+    JsThisMethodCalls
     ResolveUtil
 
   build-depends:

--- a/packages/grafema-resolve/test/Spec.hs
+++ b/packages/grafema-resolve/test/Spec.hs
@@ -10,6 +10,7 @@ import Grafema.Types (GraphNode(..), GraphEdge(..), MetaValue(..))
 import Grafema.Protocol (PluginCommand(..))
 import qualified PropertyAccess
 import qualified SameFileCalls
+import qualified JsThisMethodCalls
 
 -- ---------------------------------------------------------------------------
 -- Test helpers
@@ -136,6 +137,12 @@ runTest name Pass = do
 runTest name (Fail msg) = do
   hPutStrLn stderr $ "  FAIL: " ++ name ++ " -- " ++ msg
   return False
+
+-- | Run a test whose check requires IO (e.g. calls a plugin's IO resolveAll).
+runTestIO :: String -> IO TestResult -> IO Bool
+runTestIO name action = do
+  result <- action
+  runTest name result
 
 -- ---------------------------------------------------------------------------
 -- Tests
@@ -546,6 +553,59 @@ testMultipleClassesSameMethod =
     _ -> Fail $ "Expected 1 CALLS edge to Bar.doSomething, got: " ++ show edges
 
 -- ---------------------------------------------------------------------------
+-- JsThisMethodCalls tests
+-- ---------------------------------------------------------------------------
+
+-- | Happy path: this.bar() resolves to METHOD bar when exactly one candidate
+-- exists in the same file.
+testJsThisResolved :: IO TestResult
+testJsThisResolved = do
+  let file = "src/app.ts"
+      nodes =
+        [ mkMethod file "Foo" "bar"
+        , mkMethodCall file "this.bar" 10
+            (file <> "->CALL->this.bar[in:baz,h:1]")
+        ]
+  cmds <- JsThisMethodCalls.resolveAll nodes []
+  let edges = extractEdges cmds
+  return $ case edges of
+    [e] | geType e == "CALLS"
+        , geTarget e == file <> "->METHOD->bar[in:Foo]"
+        -> Pass
+    _ -> Fail $ "Expected 1 CALLS edge to Foo.bar, got: " ++ show edges
+
+-- | Unresolved: this.foo() when no METHOD named foo exists → 0 edges.
+testJsThisUnresolved :: IO TestResult
+testJsThisUnresolved = do
+  let file = "src/app.ts"
+      nodes =
+        [ mkMethod file "Foo" "bar"  -- not "foo"
+        , mkMethodCall file "this.foo" 10
+            (file <> "->CALL->this.foo[in:baz,h:1]")
+        ]
+  cmds <- JsThisMethodCalls.resolveAll nodes []
+  let edges = extractEdges cmds
+  return $ case edges of
+    [] -> Pass
+    _  -> Fail $ "Expected 0 edges for unresolved this.foo(), got: " ++ show edges
+
+-- | Ambiguous: two classes with same method name → skipped (0 edges).
+testJsThisAmbiguous :: IO TestResult
+testJsThisAmbiguous = do
+  let file = "src/app.ts"
+      nodes =
+        [ mkMethod file "Foo" "bar"
+        , mkMethod file "Baz" "bar"
+        , mkMethodCall file "this.bar" 10
+            (file <> "->CALL->this.bar[in:q,h:1]")
+        ]
+  cmds <- JsThisMethodCalls.resolveAll nodes []
+  let edges = extractEdges cmds
+  return $ case edges of
+    [] -> Pass
+    _  -> Fail $ "Expected 0 edges for ambiguous this.bar(), got: " ++ show edges
+
+-- ---------------------------------------------------------------------------
 -- Main
 -- ---------------------------------------------------------------------------
 
@@ -581,7 +641,14 @@ main = do
     , runTest "this.method() outside class no resolution" testThisOutsideClass
     , runTest "multiple classes same method resolves to correct class" testMultipleClassesSameMethod
     ]
-  let allResults = paResults ++ sfcResults
+  putStrLn ""
+  putStrLn "JsThisMethodCalls unit tests:"
+  jsResults <- sequence
+    [ runTestIO "this.bar() resolves to single METHOD" testJsThisResolved
+    , runTestIO "this.foo() unresolved when no METHOD matches" testJsThisUnresolved
+    , runTestIO "this.bar() ambiguous (two classes) skipped" testJsThisAmbiguous
+    ]
+  let allResults = paResults ++ sfcResults ++ jsResults
       total = length allResults
       passed = length (filter id allResults)
   putStrLn $ "\n" ++ show passed ++ "/" ++ show total ++ " tests passed"

--- a/packages/haskell-resolve/haskell-resolve.cabal
+++ b/packages/haskell-resolve/haskell-resolve.cabal
@@ -34,6 +34,8 @@ test-suite spec
 
   other-modules:
     HaskellImportResolution
+    HaskellLocalCalls
+    HaskellCrossModuleCalls
 
   build-depends:
     base                 >= 4.17 && < 5,

--- a/packages/haskell-resolve/test/Spec.hs
+++ b/packages/haskell-resolve/test/Spec.hs
@@ -16,81 +16,110 @@ import Data.Text (Text)
 import qualified Data.Map.Strict as Map
 
 import HaskellImportResolution (resolveAll)
-import Grafema.Types (GraphNode(..), GraphEdge(..))
+import qualified HaskellLocalCalls
+import qualified HaskellCrossModuleCalls
+import Grafema.Types (GraphNode(..), GraphEdge(..), MetaValue(..))
 import Grafema.Protocol (PluginCommand(..))
 
 -- ── Test node constructors ──────────────────────────────────────────
 
 mkModuleNode :: Text -> Text -> Text -> GraphNode
 mkModuleNode name file nodeId = GraphNode
-  { gnId       = nodeId
-  , gnType     = "MODULE"
-  , gnName     = name
-  , gnFile     = file
-  , gnLine     = 1
-  , gnColumn   = 0
-  , gnExported = True
-  , gnMetadata = Map.empty
+  { gnId        = nodeId
+  , gnType      = "MODULE"
+  , gnName      = name
+  , gnFile      = file
+  , gnLine      = 1
+  , gnColumn    = 0
+  , gnEndLine   = 0
+  , gnEndColumn = 0
+  , gnExported  = True
+  , gnMetadata  = Map.empty
   }
 
 mkFunctionNode :: Text -> Text -> Text -> Bool -> GraphNode
 mkFunctionNode name file nodeId exported = GraphNode
-  { gnId       = nodeId
-  , gnType     = "FUNCTION"
-  , gnName     = name
-  , gnFile     = file
-  , gnLine     = 5
-  , gnColumn   = 0
-  , gnExported = exported
-  , gnMetadata = Map.empty
+  { gnId        = nodeId
+  , gnType      = "FUNCTION"
+  , gnName      = name
+  , gnFile      = file
+  , gnLine      = 5
+  , gnColumn    = 0
+  , gnEndLine   = 0
+  , gnEndColumn = 0
+  , gnExported  = exported
+  , gnMetadata  = Map.empty
   }
 
 mkImportNode :: Text -> Text -> Text -> GraphNode
 mkImportNode moduleName file nodeId = GraphNode
-  { gnId       = nodeId
-  , gnType     = "IMPORT"
-  , gnName     = moduleName
-  , gnFile     = file
-  , gnLine     = 1
-  , gnColumn   = 0
-  , gnExported = False
-  , gnMetadata = Map.empty
+  { gnId        = nodeId
+  , gnType      = "IMPORT"
+  , gnName      = moduleName
+  , gnFile      = file
+  , gnLine      = 1
+  , gnColumn    = 0
+  , gnEndLine   = 0
+  , gnEndColumn = 0
+  , gnExported  = False
+  , gnMetadata  = Map.empty
   }
 
 mkImportBindingNode :: Text -> Text -> Text -> Text -> GraphNode
 mkImportBindingNode name _moduleName file nodeId = GraphNode
-  { gnId       = nodeId
-  , gnType     = "IMPORT_BINDING"
-  , gnName     = name
-  , gnFile     = file
-  , gnLine     = 1
-  , gnColumn   = 0
-  , gnExported = False
-  , gnMetadata = Map.empty
+  { gnId        = nodeId
+  , gnType      = "IMPORT_BINDING"
+  , gnName      = name
+  , gnFile      = file
+  , gnLine      = 1
+  , gnColumn    = 0
+  , gnEndLine   = 0
+  , gnEndColumn = 0
+  , gnExported  = False
+  , gnMetadata  = Map.empty
   }
 
 mkExportBindingNode :: Text -> Text -> Text -> GraphNode
 mkExportBindingNode name file nodeId = GraphNode
-  { gnId       = nodeId
-  , gnType     = "EXPORT_BINDING"
-  , gnName     = name
-  , gnFile     = file
-  , gnLine     = 0
-  , gnColumn   = 0
-  , gnExported = True
-  , gnMetadata = Map.empty
+  { gnId        = nodeId
+  , gnType      = "EXPORT_BINDING"
+  , gnName      = name
+  , gnFile      = file
+  , gnLine      = 0
+  , gnColumn    = 0
+  , gnEndLine   = 0
+  , gnEndColumn = 0
+  , gnExported  = True
+  , gnMetadata  = Map.empty
   }
 
 mkDataTypeNode :: Text -> Text -> Text -> GraphNode
 mkDataTypeNode name file nodeId = GraphNode
-  { gnId       = nodeId
-  , gnType     = "DATA_TYPE"
-  , gnName     = name
-  , gnFile     = file
-  , gnLine     = 3
-  , gnColumn   = 0
-  , gnExported = True
-  , gnMetadata = Map.empty
+  { gnId        = nodeId
+  , gnType      = "DATA_TYPE"
+  , gnName      = name
+  , gnFile      = file
+  , gnLine      = 3
+  , gnColumn    = 0
+  , gnEndLine   = 0
+  , gnEndColumn = 0
+  , gnExported  = True
+  , gnMetadata  = Map.empty
+  }
+
+-- | Create a CALL node in a Haskell file.
+mkCallNode :: Text -> Text -> Text -> GraphNode
+mkCallNode name file nodeId = GraphNode
+  { gnId        = nodeId
+  , gnType      = "CALL"
+  , gnName      = name
+  , gnFile      = file
+  , gnLine      = 5
+  , gnColumn    = 4
+  , gnEndLine   = 0
+  , gnEndColumn = 0
+  , gnExported  = False
+  , gnMetadata  = Map.empty
   }
 
 -- ── Helpers ─────────────────────────────────────────────────────────
@@ -277,3 +306,103 @@ main = hspec $ do
           geType   edge `shouldBe` "IMPORTS_FROM"
           geTarget edge `shouldBe` "src/Lib.hs->FUNCTION->foo"
         _ -> expectationFailure $ "Expected 1 binding edge, got " ++ show (length bindingEdges)
+
+  -- ── 10. HaskellLocalCalls ──────────────────────────────────────
+  describe "HaskellLocalCalls" $ do
+
+    it "resolves same-file CALL to local FUNCTION" $ do
+      let nodes =
+            [ mkFunctionNode "foo" "src/A.hs" "src/A.hs->FUNCTION->foo" True
+            , mkCallNode     "foo" "src/A.hs" "src/A.hs->CALL->foo@5:4"
+            ]
+      cmds <- HaskellLocalCalls.resolveAll nodes []
+      let edges = extractEdges cmds
+      length edges `shouldBe` 1
+      case edges of
+        [e] -> do
+          geType   e `shouldBe` "CALLS"
+          geTarget e `shouldBe` "src/A.hs->FUNCTION->foo"
+        _ -> expectationFailure "Expected 1 CALLS edge"
+
+    it "skips CALL when an IMPORT_BINDING with same name exists" $ do
+      let nodes =
+            [ mkFunctionNode "foo" "src/A.hs" "src/A.hs->FUNCTION->foo" True
+            , mkImportBindingNode "foo" "B" "src/A.hs" "src/A.hs->IMPORT_BINDING->foo[in:B]"
+            , mkCallNode     "foo" "src/A.hs" "src/A.hs->CALL->foo@5:4"
+            ]
+      cmds <- HaskellLocalCalls.resolveAll nodes []
+      let edges = extractEdges cmds
+      length edges `shouldBe` 0
+
+  -- ── 11. HaskellCrossModuleCalls ────────────────────────────────
+  describe "HaskellCrossModuleCalls" $ do
+
+    it "resolves imported CALL to FUNCTION in exporting module" $ do
+      let nodes =
+            [ mkModuleNode   "B" "src/B.hs" "MODULE#src/B.hs"
+            , mkFunctionNode "foo" "src/B.hs" "src/B.hs->FUNCTION->foo" True
+            , mkImportBindingNode "foo" "B" "src/A.hs"
+                "src/A.hs->IMPORT_BINDING->foo[in:B]"
+            , mkCallNode     "foo" "src/A.hs" "src/A.hs->CALL->foo@5:4"
+            ]
+      cmds <- HaskellCrossModuleCalls.resolveAll nodes []
+      let edges = extractEdges cmds
+      length edges `shouldBe` 1
+      case edges of
+        [e] -> do
+          geType   e `shouldBe` "CALLS"
+          geSource e `shouldBe` "src/A.hs->CALL->foo@5:4"
+          geTarget e `shouldBe` "src/B.hs->FUNCTION->foo"
+        _ -> expectationFailure "Expected 1 CALLS edge"
+
+    it "produces no edge when name is not imported" $ do
+      let nodes =
+            [ mkModuleNode   "B" "src/B.hs" "MODULE#src/B.hs"
+            , mkFunctionNode "foo" "src/B.hs" "src/B.hs->FUNCTION->foo" True
+            , mkCallNode     "foo" "src/A.hs" "src/A.hs->CALL->foo@5:4"
+            ]
+      cmds <- HaskellCrossModuleCalls.resolveAll nodes []
+      let edges = extractEdges cmds
+      length edges `shouldBe` 0
+
+  -- ── 12. Regression: local + cross-module are disjoint ─────────
+  --
+  -- HaskellLocalCalls skips CALLs whose name matches an IMPORT_BINDING in
+  -- the same file. HaskellCrossModuleCalls only fires for CALLs whose name
+  -- DOES match an IMPORT_BINDING. Therefore for any given CALL node at most
+  -- ONE of the two plugins emits a CALLS edge. This regression test
+  -- exercises both on the same node set and asserts no double emission.
+  describe "Regression: local + cross-module disjoint partition" $ do
+
+    it "emits exactly one CALLS edge for an imported call (no double emission)" $ do
+      let nodes =
+            [ mkModuleNode   "B" "src/B.hs" "MODULE#src/B.hs"
+            , mkFunctionNode "foo" "src/B.hs" "src/B.hs->FUNCTION->foo" True
+            -- Same-name "foo" ALSO declared locally in A.hs (pathological
+            -- shadowing scenario). The import should win — local skips.
+            , mkFunctionNode "foo" "src/A.hs" "src/A.hs->FUNCTION->foo" False
+            , mkImportBindingNode "foo" "B" "src/A.hs"
+                "src/A.hs->IMPORT_BINDING->foo[in:B]"
+            , mkCallNode     "foo" "src/A.hs" "src/A.hs->CALL->foo@5:4"
+            ]
+      localCmds <- HaskellLocalCalls.resolveAll nodes []
+      crossCmds <- HaskellCrossModuleCalls.resolveAll nodes []
+      let localEdges = extractEdges localCmds
+          crossEdges = extractEdges crossCmds
+          allEdges   = localEdges ++ crossEdges
+      length localEdges `shouldBe` 0
+      length crossEdges `shouldBe` 1
+      length allEdges   `shouldBe` 1
+      case crossEdges of
+        [e] -> geTarget e `shouldBe` "src/B.hs->FUNCTION->foo"
+        _ -> expectationFailure "Expected exactly 1 cross-module CALLS edge"
+
+    it "emits exactly one CALLS edge via local when name is NOT imported" $ do
+      let nodes =
+            [ mkFunctionNode "bar" "src/A.hs" "src/A.hs->FUNCTION->bar" False
+            , mkCallNode     "bar" "src/A.hs" "src/A.hs->CALL->bar@5:4"
+            ]
+      localCmds <- HaskellLocalCalls.resolveAll nodes []
+      crossCmds <- HaskellCrossModuleCalls.resolveAll nodes []
+      length (extractEdges localCmds) `shouldBe` 1
+      length (extractEdges crossCmds) `shouldBe` 0

--- a/packages/mcp/src/handlers/query-handlers.ts
+++ b/packages/mcp/src/handlers/query-handlers.ts
@@ -436,6 +436,7 @@ export async function handleFindNodes(args: FindNodesArgs): Promise<ToolResult> 
   // === Rich context enrichment ===
   // For each found node, add structural context (methods, calls, imports)
   // Only enrich when result set is small enough (≤10 nodes) to avoid latency
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const enriched = nodes.length <= 10
     ? await enrichNodes(db as any, nodes)
     : nodes;

--- a/packages/mcp/src/handlers/query-handlers.ts
+++ b/packages/mcp/src/handlers/query-handlers.ts
@@ -436,7 +436,6 @@ export async function handleFindNodes(args: FindNodesArgs): Promise<ToolResult> 
   // === Rich context enrichment ===
   // For each found node, add structural context (methods, calls, imports)
   // Only enrich when result set is small enough (≤10 nodes) to avoid latency
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const enriched = nodes.length <= 10
     ? await enrichNodes(db as any, nodes)
     : nodes;

--- a/packages/rust-resolve/rust-resolve.cabal
+++ b/packages/rust-resolve/rust-resolve.cabal
@@ -13,6 +13,7 @@ executable grafema-rust-resolve
     RustImportResolution
     RustCallResolution
     RustCrossMethodCalls
+    RustTraitResolution
 
   build-depends:
     base                 >= 4.17 && < 5,
@@ -35,6 +36,7 @@ test-suite spec
     RustImportResolution
     RustCallResolution
     RustCrossMethodCalls
+    RustTraitResolution
 
   build-depends:
     base                 >= 4.17 && < 5,

--- a/packages/rust-resolve/src/Main.hs
+++ b/packages/rust-resolve/src/Main.hs
@@ -10,6 +10,7 @@ import Options.Applicative
 import qualified RustImportResolution
 import qualified RustCallResolution
 import qualified RustCrossMethodCalls
+import qualified RustTraitResolution
 import Grafema.Types (GraphNode, GraphEdge)
 import Grafema.Protocol (PluginCommand(..), readFrame, writeFrame, encodeMsgpack, decodeMsgpack, readNodesFromStdin, writeCommandsToStdout)
 import Grafema.RuntimeGlobals (NameStrategy(..), NodeFilter(..), SymbolDB, loadSymbolDB, resolveAll)
@@ -79,14 +80,15 @@ daemonLoop symbolDb = do
 
 -- | Dispatch a command to the resolver.
 dispatch :: SymbolDB -> Text -> [GraphNode] -> [GraphEdge] -> IO DaemonResponse
-dispatch _        "rust-imports" nodes _     = ResOk <$> RustImportResolution.resolveAll nodes
-dispatch _        "rust-calls"   nodes _     = ResOk <$> RustCallResolution.resolveAll nodes
+dispatch _        "rust-imports"       nodes _     = ResOk <$> RustImportResolution.resolveAll nodes
+dispatch _        "rust-calls"         nodes _     = ResOk <$> RustCallResolution.resolveAll nodes
 dispatch _        "rust-cross-methods" nodes edges = ResOk <$> RustCrossMethodCalls.resolveAll nodes edges
-dispatch symbolDb "rust-globals" nodes _     = return $ ResOk (resolveAll rustStrategy symbolDb nodes)
-dispatch _        cmd            _     _     = return $ ResError ("unknown command: " ++ T.unpack cmd)
+dispatch _        "rust-trait-resolve" nodes _     = return $ ResOk (RustTraitResolution.resolveAll nodes)
+dispatch symbolDb "rust-globals"       nodes _     = return $ ResOk (resolveAll rustStrategy symbolDb nodes)
+dispatch _        cmd                  _     _     = return $ ResError ("unknown command: " ++ T.unpack cmd)
 
 -- | CLI subcommand parser.
-data Command = CmdRustImports | CmdRustCalls | CmdRustCrossMethods | CmdRustGlobals
+data Command = CmdRustImports | CmdRustCalls | CmdRustCrossMethods | CmdRustTraitResolve | CmdRustGlobals
 
 commandParser :: Parser Command
 commandParser = subparser
@@ -96,6 +98,8 @@ commandParser = subparser
     (info (pure CmdRustCalls) (progDesc "Resolve Rust intra-file function calls"))
  <> command "rust-cross-methods"
     (info (pure CmdRustCrossMethods) (progDesc "Resolve Rust cross-file method calls via type annotations"))
+ <> command "rust-trait-resolve"
+    (info (pure CmdRustTraitResolve) (progDesc "Emit IMPLEMENTS edges for Rust trait implementations"))
  <> command "rust-globals"
     (info (pure CmdRustGlobals) (progDesc "Resolve Rust stdlib globals for unresolved calls"))
   )
@@ -119,9 +123,12 @@ main = do
     else do
       cmd <- execParser cliOpts
       case cmd of
-        CmdRustImports -> RustImportResolution.run
-        CmdRustCalls   -> RustCallResolution.run
+        CmdRustImports      -> RustImportResolution.run
+        CmdRustCalls        -> RustCallResolution.run
         CmdRustCrossMethods -> RustCrossMethodCalls.run
+        CmdRustTraitResolve -> do
+          nodes <- readNodesFromStdin
+          writeCommandsToStdout (RustTraitResolution.resolveAll nodes)
         CmdRustGlobals -> do
           symbolDb <- loadEffectsDB
           nodes <- readNodesFromStdin

--- a/packages/rust-resolve/src/RustCrossMethodCalls.hs
+++ b/packages/rust-resolve/src/RustCrossMethodCalls.hs
@@ -31,6 +31,11 @@ import System.IO (hPutStrLn, stderr)
 -- whose semantic ID contains @IMPL_BLOCK->TypeName@.
 type ImplMethodIndex = Map (Text, Text) Text
 
+-- | (traitName, methodName) → [method node ID]. Built from FUNCTION nodes
+-- with @metadata[\"trait\"]@ set by the orchestrator for trait impl methods.
+-- A list because multiple types may implement the same trait.
+type TraitMethodIndex = Map (Text, Text) [Text]
+
 -- | (file, varName) → VARIABLE/PARAMETER node.
 type VarIndex = Map (Text, Text) GraphNode
 
@@ -51,6 +56,30 @@ buildImplMethodIndex nodes =
     , not (T.null (gnName n))
     , Just typeName <- [G.extractByMarker (gnSemanticId n) "IMPL_BLOCK->"]
     ]
+
+-- | Build the trait method index from FUNCTION nodes tagged with
+-- @metadata[\"trait\"]@ by the orchestrator.
+buildTraitMethodIndex :: [GraphNode] -> TraitMethodIndex
+buildTraitMethodIndex nodes =
+  Map.fromListWith (++)
+    [ ((traitName, gnName n), [gnId n])
+    | n <- nodes
+    , gnType n == "FUNCTION"
+    , not (T.null (gnName n))
+    , Just traitName <- [G.lookupMetaText "trait" n]
+    ]
+
+-- | Extract the trait name from a @dyn Trait@ or @impl Trait@ type string.
+--
+-- Examples:
+--   @extractDynTrait "dyn Draw"@    -> @Just "Draw"@
+--   @extractDynTrait "impl Serialize"@ -> @Just "Serialize"@
+--   @extractDynTrait "MyStruct"@    -> @Nothing@
+extractDynTrait :: Text -> Maybe Text
+extractDynTrait tn
+  | "dyn "  `T.isPrefixOf` tn = Just $ T.drop 4 tn
+  | "impl " `T.isPrefixOf` tn = Just $ T.drop 5 tn
+  | otherwise                  = Nothing
 
 buildVarIndex :: [GraphNode] -> VarIndex
 buildVarIndex nodes =
@@ -121,14 +150,16 @@ constructorTypeFromCallName name =
 
 resolveAll :: [GraphNode] -> [GraphEdge] -> IO [PluginCommand]
 resolveAll nodes edges = do
-  let implIdx  = buildImplMethodIndex nodes
-      varIdx   = buildVarIndex nodes
-      fieldIdx = buildFieldTypeIndex nodes
-      nodeIdx  = G.buildNodeIndex nodes
-      adj      = G.buildAdjacency edges
+  let implIdx   = buildImplMethodIndex nodes
+      traitIdx  = buildTraitMethodIndex nodes
+      varIdx    = buildVarIndex nodes
+      fieldIdx  = buildFieldTypeIndex nodes
+      nodeIdx   = G.buildNodeIndex nodes
+      adj       = G.buildAdjacency edges
       callNodes = filter isMethodCall nodes
-      results = concatMap (resolveOne implIdx varIdx fieldIdx nodeIdx adj) callNodes
+      results   = concatMap (resolveOne implIdx traitIdx varIdx fieldIdx nodeIdx adj) callNodes
   hPutStrLn stderr $ "[rust-cross-methods] implIdx=" ++ show (Map.size implIdx)
+    ++ " traitIdx=" ++ show (Map.size traitIdx)
     ++ " varIdx=" ++ show (Map.size varIdx)
     ++ " fieldIdx=" ++ show (Map.size fieldIdx)
     ++ " edges=" ++ show (length edges)
@@ -141,9 +172,9 @@ isMethodCall n =
   gnType n == "CALL" && G.lookupMetaBool "method" n == Just True
 
 resolveOne
-  :: ImplMethodIndex -> VarIndex -> FieldTypeIndex
+  :: ImplMethodIndex -> TraitMethodIndex -> VarIndex -> FieldTypeIndex
   -> G.NodeIndex -> G.Adjacency -> GraphNode -> [PluginCommand]
-resolveOne implIdx varIdx fieldIdx nodeIdx adj callNode =
+resolveOne implIdx traitIdx varIdx fieldIdx nodeIdx adj callNode =
   let file     = gnFile callNode
       methName = gnName callNode
       mReceiver = lookupReceiver callNode
@@ -167,7 +198,6 @@ resolveOne implIdx varIdx fieldIdx nodeIdx adj callNode =
           -- Strip generic suffixes: "Vec<String>" → "Vec"
           let baseType = T.takeWhile (\c -> c /= '<' && c /= ':') tn
           in case Map.lookup (baseType, methName) implIdx of
-            Nothing -> []
             Just targetId ->
               [ EmitEdge GraphEdge
                   { geSource   = gnId callNode
@@ -179,6 +209,23 @@ resolveOne implIdx varIdx fieldIdx nodeIdx adj callNode =
                       ]
                   }
               ]
+            Nothing ->
+              -- Fall back to dyn/impl Trait dispatch
+              case extractDynTrait tn of
+                Nothing -> []
+                Just traitName ->
+                  [ EmitEdge GraphEdge
+                      { geSource   = gnId callNode
+                      , geTarget   = targetId
+                      , geType     = "CALLS"
+                      , geMetadata = Map.fromList
+                          [ ("resolvedVia",  MetaText "rust-dyn-dispatch")
+                          , ("receiverType", MetaText tn)
+                          , ("traitName",    MetaText traitName)
+                          ]
+                      }
+                  | targetId <- Map.findWithDefault [] (traitName, methName) traitIdx
+                  ]
 
 lookupReceiver :: GraphNode -> Maybe Text
 lookupReceiver node = case G.lookupMetaText "receiver" node of

--- a/packages/rust-resolve/src/RustTraitResolution.hs
+++ b/packages/rust-resolve/src/RustTraitResolution.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Rust trait implementation resolver.
+--
+-- Emits @IMPLEMENTS@ edges from @STRUCT@ nodes to @TRAIT@ nodes for each
+-- explicit @impl Trait for Struct@ block recorded in the graph.
+--
+-- == Algorithm
+--
+-- 1. Build a TRAIT index: trait name → TRAIT node ID.
+-- 2. Build a STRUCT index: struct name → STRUCT node ID.
+-- 3. For each IMPL_BLOCK node with @metadata[\"trait\"]@, extract the
+--    struct name from the semantic ID via the @IMPL_BLOCK->@ marker, then
+--    look up both node IDs and emit an IMPLEMENTS edge.
+--
+-- The @metadata[\"trait\"]@ field is written by the Rust orchestrator for
+-- every @impl TraitName for TypeName@ block (see @rust_analyzer.rs@).
+module RustTraitResolution (resolveAll) where
+
+import Grafema.Types (GraphNode(..), GraphEdge(..))
+import Grafema.Protocol (PluginCommand(..))
+import qualified Grafema.GraphTraversal as G
+
+import qualified Data.Map.Strict as Map
+
+resolveAll :: [GraphNode] -> [PluginCommand]
+resolveAll nodes =
+  let traitIdx  = Map.fromList [(gnName n, gnId n) | n <- nodes, gnType n == "TRAIT"]
+      structIdx = Map.fromList [(gnName n, gnId n) | n <- nodes, gnType n == "STRUCT"]
+  in [ EmitEdge GraphEdge
+         { geSource   = structId
+         , geTarget   = traitId
+         , geType     = "IMPLEMENTS"
+         , geMetadata = Map.empty
+         }
+     | n <- nodes
+     , gnType n == "IMPL_BLOCK"
+     , Just traitName <- [G.lookupMetaText "trait" n]
+     , Just typeName  <- [G.extractByMarker (gnId n) "IMPL_BLOCK->"]
+     , Just structId  <- [Map.lookup typeName structIdx]
+     , Just traitId   <- [Map.lookup traitName traitIdx]
+     ]

--- a/packages/rust-resolve/src/RustTraitResolution.hs
+++ b/packages/rust-resolve/src/RustTraitResolution.hs
@@ -16,16 +16,25 @@
 -- every @impl TraitName for TypeName@ block (see @rust_analyzer.rs@).
 module RustTraitResolution (resolveAll) where
 
-import Grafema.Types (GraphNode(..), GraphEdge(..))
+import Grafema.Types (GraphNode(..), GraphEdge(..), gnSemanticId)
 import Grafema.Protocol (PluginCommand(..))
 import qualified Grafema.GraphTraversal as G
 
+import Data.Text (Text)
 import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
+
+-- | Index nodes of a given type by name, returning @name -> gnId@.
+indexByName :: Text -> [GraphNode] -> Map Text Text
+indexByName ty nodes =
+  fmap gnId (G.buildIndexBy key nodes)
+  where
+    key n = if gnType n == ty then Just (gnName n) else Nothing
 
 resolveAll :: [GraphNode] -> [PluginCommand]
 resolveAll nodes =
-  let traitIdx  = Map.fromList [(gnName n, gnId n) | n <- nodes, gnType n == "TRAIT"]
-      structIdx = Map.fromList [(gnName n, gnId n) | n <- nodes, gnType n == "STRUCT"]
+  let traitIdx  = indexByName "TRAIT"  nodes
+      structIdx = indexByName "STRUCT" nodes
   in [ EmitEdge GraphEdge
          { geSource   = structId
          , geTarget   = traitId
@@ -35,7 +44,7 @@ resolveAll nodes =
      | n <- nodes
      , gnType n == "IMPL_BLOCK"
      , Just traitName <- [G.lookupMetaText "trait" n]
-     , Just typeName  <- [G.extractByMarker (gnId n) "IMPL_BLOCK->"]
+     , Just typeName  <- [G.extractByMarker (gnSemanticId n) "IMPL_BLOCK->"]
      , Just structId  <- [Map.lookup typeName structIdx]
      , Just traitId   <- [Map.lookup traitName traitIdx]
      ]

--- a/packages/rust-resolve/test/Spec.hs
+++ b/packages/rust-resolve/test/Spec.hs
@@ -18,6 +18,8 @@ import qualified Data.Map.Strict as Map
 
 import RustImportResolution (resolveAll)
 import qualified RustCallResolution
+import qualified RustTraitResolution
+import qualified RustCrossMethodCalls
 import Grafema.Types (GraphNode(..), GraphEdge(..), MetaValue(..))
 import Grafema.Protocol (PluginCommand(..))
 
@@ -610,3 +612,186 @@ main = hspec $ do
         [e] ->
           Map.lookup "resolvedVia" (geMetadata e) `shouldBe` Just (MetaText "rust-calls")
         _ -> expectationFailure "Expected 1 edge with metadata"
+
+  -- ── RustTraitResolution ──────────────────────────────────────────
+  describe "RustTraitResolution — IMPLEMENTS edges" $ do
+
+    let mkImplBlock :: Text -> Text -> Maybe Text -> GraphNode
+        mkImplBlock semId file mTrait = GraphNode
+          { gnId        = semId
+          , gnType      = "IMPL_BLOCK"
+          , gnName      = ""
+          , gnFile      = file
+          , gnLine      = 1
+          , gnColumn    = 0
+          , gnEndLine   = 5
+          , gnEndColumn = 1
+          , gnExported  = False
+          , gnMetadata  = case mTrait of
+              Just t  -> Map.fromList
+                [ ("semanticId", MetaText semId)
+                , ("trait",      MetaText t)
+                ]
+              Nothing -> Map.fromList
+                [ ("semanticId", MetaText semId) ]
+          }
+
+    it "emits IMPLEMENTS edge STRUCT -> TRAIT for `impl Draw for Circle`" $ do
+      let nodes =
+            [ mkStructNode "Circle" "src/shapes.rs" "src/shapes.rs->STRUCT->Circle" True
+            , mkTraitNode  "Draw"   "src/traits.rs" "src/traits.rs->TRAIT->Draw"    True
+            , mkImplBlock  "src/shapes.rs->IMPL_BLOCK->Circle"
+                           "src/shapes.rs" (Just "Draw")
+            ]
+          cmds = RustTraitResolution.resolveAll nodes
+          edges = extractEdges cmds
+      length edges `shouldBe` 1
+      case edges of
+        [e] -> do
+          geType   e `shouldBe` "IMPLEMENTS"
+          geSource e `shouldBe` "src/shapes.rs->STRUCT->Circle"
+          geTarget e `shouldBe` "src/traits.rs->TRAIT->Draw"
+        _ -> expectationFailure "Expected 1 IMPLEMENTS edge"
+
+    it "emits 0 edges when IMPL_BLOCK has no trait metadata" $ do
+      -- Inherent impl: `impl Circle { ... }` (no trait) should not emit.
+      let nodes =
+            [ mkStructNode "Circle" "src/shapes.rs" "src/shapes.rs->STRUCT->Circle" True
+            , mkImplBlock  "src/shapes.rs->IMPL_BLOCK->Circle"
+                           "src/shapes.rs" Nothing
+            ]
+          cmds = RustTraitResolution.resolveAll nodes
+          edges = extractEdges cmds
+      length edges `shouldBe` 0
+
+    it "emits 0 edges when struct is unknown" $ do
+      let nodes =
+            [ mkTraitNode "Draw" "src/traits.rs" "src/traits.rs->TRAIT->Draw" True
+            , mkImplBlock "src/shapes.rs->IMPL_BLOCK->Mystery"
+                          "src/shapes.rs" (Just "Draw")
+            ]
+          cmds = RustTraitResolution.resolveAll nodes
+      length (extractEdges cmds) `shouldBe` 0
+
+  -- ── RustCrossMethodCalls ─────────────────────────────────────────
+  describe "RustCrossMethodCalls — cross-file method resolution" $ do
+
+    let mkParamWithType :: Text -> Text -> Text -> Text -> GraphNode
+        mkParamWithType name ty file nodeId = GraphNode
+          { gnId        = nodeId
+          , gnType      = "PARAMETER"
+          , gnName      = name
+          , gnFile      = file
+          , gnLine      = 3
+          , gnColumn    = 0
+          , gnEndLine   = 3
+          , gnEndColumn = 10
+          , gnExported  = False
+          , gnMetadata  = Map.fromList [("typeAnnotation", MetaText ty)]
+          }
+
+        -- Mirrors analyzer format: FUNCTION inside IMPL_BLOCK has semanticId
+        --   {file}->FUNCTION->{name}[in:{file}->IMPL_BLOCK->{type}]
+        -- extractByMarker "IMPL_BLOCK->" stops at `[`/`]`, so it extracts the
+        -- type name cleanly.
+        mkMethodNode :: Text -> Text -> Text -> GraphNode
+        mkMethodNode name implType file =
+          let implId = file <> "->IMPL_BLOCK->" <> implType
+              sid    = file <> "->FUNCTION->" <> name <> "[in:" <> implId <> "]"
+          in GraphNode
+            { gnId        = sid
+            , gnType      = "FUNCTION"
+            , gnName      = name
+            , gnFile      = file
+            , gnLine      = 10
+            , gnColumn    = 0
+            , gnEndLine   = 15
+            , gnEndColumn = 1
+            , gnExported  = True
+            , gnMetadata  = Map.fromList [("semanticId", MetaText sid)]
+            }
+
+        mkTraitMethodNode :: Text -> Text -> Text -> Text -> GraphNode
+        mkTraitMethodNode name traitName implType file =
+          let implId = file <> "->IMPL_BLOCK->" <> implType
+              sid    = file <> "->FUNCTION->" <> name <> "[in:" <> implId <> "]"
+          in GraphNode
+            { gnId        = sid
+            , gnType      = "FUNCTION"
+            , gnName      = name
+            , gnFile      = file
+            , gnLine      = 10
+            , gnColumn    = 0
+            , gnEndLine   = 15
+            , gnEndColumn = 1
+            , gnExported  = True
+            , gnMetadata  = Map.fromList
+                [ ("semanticId", MetaText sid)
+                , ("trait",      MetaText traitName)
+                ]
+            }
+
+        mkMethodCallNode :: Text -> Text -> Text -> Text -> GraphNode
+        mkMethodCallNode receiver methodName file nodeId = GraphNode
+          { gnId        = nodeId
+          , gnType      = "CALL"
+          , gnName      = methodName
+          , gnFile      = file
+          , gnLine      = 20
+          , gnColumn    = 4
+          , gnEndLine   = 20
+          , gnEndColumn = 30
+          , gnExported  = False
+          , gnMetadata  = Map.fromList
+              [ ("method",   MetaBool True)
+              , ("receiver", MetaText receiver)
+              ]
+          }
+
+    it "resolves method call via PARAMETER typeAnnotation" $ do
+      let nodes =
+            [ mkParamWithType "x" "Foo" "src/main.rs" "src/main.rs->PARAMETER->x"
+            , mkMethodNode "bar" "Foo" "src/lib.rs"
+            , mkMethodCallNode "x" "bar" "src/main.rs"
+                "src/main.rs->CALL->bar@20:4"
+            ]
+      cmds <- RustCrossMethodCalls.resolveAll nodes []
+      let edges = extractEdges cmds
+      length edges `shouldBe` 1
+      case edges of
+        [e] -> do
+          geType   e `shouldBe` "CALLS"
+          geSource e `shouldBe` "src/main.rs->CALL->bar@20:4"
+          geTarget e `shouldBe` "src/lib.rs->FUNCTION->bar[in:src/lib.rs->IMPL_BLOCK->Foo]"
+          Map.lookup "resolvedVia" (geMetadata e)
+            `shouldBe` Just (MetaText "rust-cross-method")
+        _ -> expectationFailure "Expected 1 CALLS edge"
+
+    it "produces no edge when receiver type is unknown" $ do
+      let nodes =
+            [ mkMethodNode "bar" "Foo" "src/lib.rs"
+            , mkMethodCallNode "x" "bar" "src/main.rs"
+                "src/main.rs->CALL->bar@20:4"
+            ]
+      cmds <- RustCrossMethodCalls.resolveAll nodes []
+      length (extractEdges cmds) `shouldBe` 0
+
+    it "dyn-dispatch fans out to all trait implementers" $ do
+      -- x: dyn Draw; x.draw()  -> fan out to every FUNCTION tagged trait=Draw
+      let nodes =
+            [ mkParamWithType "x" "dyn Draw" "src/main.rs"
+                "src/main.rs->PARAMETER->x"
+            , mkTraitMethodNode "draw" "Draw" "Circle" "src/shapes.rs"
+            , mkTraitMethodNode "draw" "Draw" "Square" "src/squares.rs"
+            , mkMethodCallNode "x" "draw" "src/main.rs"
+                "src/main.rs->CALL->draw@20:4"
+            ]
+      cmds <- RustCrossMethodCalls.resolveAll nodes []
+      let edges = extractEdges cmds
+      length edges `shouldBe` 2
+      let targets = map geTarget edges
+      targets `shouldContain` ["src/shapes.rs->FUNCTION->draw[in:src/shapes.rs->IMPL_BLOCK->Circle]"]
+      targets `shouldContain` ["src/squares.rs->FUNCTION->draw[in:src/squares.rs->IMPL_BLOCK->Square]"]
+      mapM_ (\e ->
+        Map.lookup "resolvedVia" (geMetadata e)
+          `shouldBe` Just (MetaText "rust-dyn-dispatch")) edges


### PR DESCRIPTION
## Summary

- **RustTraitResolution.hs** (new): emits `IMPLEMENTS` edges from `STRUCT` nodes to `TRAIT` nodes for every `impl Trait for Struct` block. Uses the `metadata["trait"]` field written by the orchestrator in commit 5b347a59. Indexes deduped via `Grafema.GraphTraversal.buildIndexBy`.
- **RustCrossMethodCalls.hs**: when concrete-type lookup misses, falls back to `TraitMethodIndex`. Receiver types `dyn Draw` / `impl Serialize` now emit `CALLS` edges to all known implementors (tagged `resolvedVia=rust-dyn-dispatch`).
- **Orchestrator**: `rust-trait-resolve` wired into `stream_and_resolve_single_worker` at both analyze sites (commit_name `rust-trait-resolution`).
- **Main.hs**: new `rust-trait-resolve` daemon command + CLI subcommand.

## Integration check (fixture: 2 traits, 3 structs, 3 impl blocks, `&dyn Draw` + `impl Draw` callers)

```
rust-call-resolution          edges=2
rust-cross-method-calls       edges=4  (2 via rust-dyn-dispatch, traitName=Draw)
rust-trait-resolution         edges=3
```

Verified on disk via `strings segments/*/seg_*_edges.seg`:
```
2 CALLS{"_source":"rust-cross-method-calls","resolvedVia":"rust-dyn-dispatch","traitName":"Draw"}
1 CALLS{"_source":"rust-call-resolution","resolvedVia":"rust-calls"}
3 IMPLEMENTS{"_source":"rust-trait-resolution"}
```

## Test plan

- [x] `cabal build` passes clean (GHC 9.8.4, no warnings promoted to errors)
- [x] rust-resolve tests: 34/34 pass (includes RustTraitResolution + RustCrossMethodCalls happy/unresolved/dyn-dispatch-fan-out)
- [x] haskell-resolve tests: 15/15 pass (includes disjoint-partition regression test locking in the HaskellLocalCalls ↔ HaskellCrossModuleCalls invariant)
- [x] grafema-resolve tests: 26/26 pass (includes JsThisMethodCalls resolved/unresolved/ambiguous)
- [x] Integration: analyze Rust fixture with `dyn Trait` params, verify CALLS edges to implementations (2 dyn-dispatch edges, see above)
- [x] Integration: verify IMPLEMENTS edges for `impl Draw for Circle` blocks (3 edges, see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)