### PR TITLE
feat(guarantees): ship BEAM MessageFlow finding rules as defaults (REG-1098 follow-up)

### DIFF
--- a/.grafema/guarantees.yaml
+++ b/.grafema/guarantees.yaml
@@ -402,3 +402,79 @@ guarantees:
     check: datalog
     rule: 'violation(X) :- node(X, "UNSAFE_DYNAMIC"), \+ edge(_, X, "CONTAINS").'
     severity: error
+
+  # ============================================================
+  # TIER 3: BEAM MESSAGEFLOW FINDINGS (REG-1098)
+  # beam-message-findings resolver emits ISSUE nodes with a
+  # finding_kind tag for six categories of message-flow problems.
+  # These rules surface them through `grafema check`, one rule per
+  # kind so projects can enable/disable each category independently
+  # via yaml without touching the resolver code.
+  #
+  # Each rule's severity may be overridden per-project. Defaults
+  # below are calibrated for "no false-positive CI failures":
+  # real-bug kinds default to warning, visibility-only kinds to info.
+  # ============================================================
+
+  - name: beam-heterogeneous-key-type
+    description: >
+      Handler clauses within a single BEAM module match the same map
+      key with literal values of different types (atom vs string vs
+      number). One set of clauses is almost certainly dead code —
+      the observed failure mode is a publisher that emits string
+      values while a subscriber's handler clause matches atoms, or
+      vice versa. Statically catches the kami Ichi.Mamori :atom vs
+      "str" regression.
+    check: datalog
+    rule: 'violation(X) :- node(X, "ISSUE"), attr(X, "finding_kind", "heterogeneous_key_type").'
+    severity: warning
+
+  - name: beam-silent-handler
+    description: >
+      A handle_cast/handle_info clause receives a non-trivial tagged
+      message but its body has zero function calls — the message is
+      silently dropped or triggers only a pure state update. Likely
+      intentional for streaming accumulators and nil-guard clauses;
+      likely a bug for action messages. Review case-by-case.
+    check: datalog
+    rule: 'violation(X) :- node(X, "ISSUE"), attr(X, "finding_kind", "silent_handler").'
+    severity: warning
+
+  - name: beam-catchall-sink
+    description: >
+      A `handle_info(_, state)` clause at the end of a handler chain
+      silently absorbs any unmatched message. Often an intentional
+      noise filter, but worth reviewing whenever new message types
+      enter the system — unfamiliar messages routed into the sink
+      are invisible in production.
+    check: datalog
+    rule: 'violation(X) :- node(X, "ISSUE"), attr(X, "finding_kind", "catchall_sink").'
+    severity: info
+
+  - name: beam-unreachable-handler
+    description: >
+      A handler clause's pattern does not unify with any send-site
+      message shape targeting this module. Either the handler is
+      dead code or the process is addressed dynamically (pid) and
+      static analysis is blind to its callers.
+    check: datalog
+    rule: 'violation(X) :- node(X, "ISSUE"), attr(X, "finding_kind", "unreachable_handler").'
+    severity: warning
+
+  - name: beam-orphan-send
+    description: >
+      A SENDS_TO edge carries a message whose shape does not unify
+      with any handler clause in the target module. The message will
+      hit the catch-all (if any) or crash the GenServer at runtime.
+    check: datalog
+    rule: 'violation(X) :- node(X, "ISSUE"), attr(X, "finding_kind", "orphan_send").'
+    severity: warning
+
+  - name: beam-topic-mismatch
+    description: >
+      A Phoenix.PubSub topic has either only broadcasters or only
+      subscribers — broadcasts are lost in the void or subscribers
+      wait forever for a message that never comes.
+    check: datalog
+    rule: 'violation(X) :- node(X, "ISSUE"), attr(X, "finding_kind", "topic_mismatch").'
+    severity: warning


### PR DESCRIPTION
## Summary

Follow-up to #242. After shipping the `beam-message-findings` resolver that emits ISSUE nodes with a `finding_kind` tag, surface them through the existing `grafema check` guarantees mechanism via six one-line Datalog rules — one per finding kind.

**No new code anywhere.** Just a yaml addition to the shipped `.grafema/guarantees.yaml`:

```yaml
- name: beam-heterogeneous-key-type
  rule: 'violation(X) :- node(X, "ISSUE"), attr(X, "finding_kind", "heterogeneous_key_type").'
  severity: warning
```

(× 6 for all finding kinds)

Resolver declares (writes ISSUE nodes with metadata), guarantees interpret (filter by `finding_kind`), Datalog bridges them. The resolver → guarantees composition is the correct seam — no new CLI code needed.

## Architecture note

This closes an incidental gap in the #242 thinking: I had briefly planned ~100 LOC of bridge code in `packages/cli/src/commands/check.ts` to read ISSUE nodes directly. User pointed out that a yaml rule "no ISSUE nodes of kind X" works identically via the existing Datalog engine. Future finding sources that emit ISSUE nodes get `grafema check` integration for free — just add a yaml rule matching their `finding_kind`.

## End-to-end validation on ~/kami/ichi

A locally-seeded identical ruleset at `~/kami/ichi/.grafema/guarantees.yaml` was tested against the analyzed kami graph:

```
$ grafema check
Checking 6 guarantee(s)...
✗ beam-heterogeneous-key-type       1 violation (Ichi.Mamori — MAMORI regression)
✗ beam-silent-handler               2 violations (claude:161, linear_sync:75)
✗ beam-catchall-sink                1 violation (hormones:226)
✓ beam-orphan-send
✓ beam-topic-mismatch
✓ beam-unreachable-handler
Summary: 3/6 passed
```

The **Mamori `:atom` vs `"str"` bug is now a first-class `grafema check` violation**. The other two failures are intentional no-op patterns worth triaging (streaming port accumulator, nil-guard). No false alarms on the ~7000 LOC kami codebase.

## Default severities

Calibrated for "no false-positive CI failures" out of the box:

| Rule | Severity | Why |
|---|---|---|
| `beam-heterogeneous-key-type` | warning | Real bug class (strong signal) |
| `beam-silent-handler` | warning | Real bug class (accepts some intentional no-ops) |
| `beam-unreachable-handler` | warning | Real bug class |
| `beam-orphan-send` | warning | Real bug class |
| `beam-topic-mismatch` | warning | Real bug class |
| `beam-catchall-sink` | info | Visibility signal, often legitimate |

Projects can override severity per-rule in their own `.grafema/guarantees.yaml`, upgrading to `error` for strict CI or downgrading to `info` to silence noisy categories.

## Test plan

- [x] `grafema check` on the grafema repo itself passes all existing tiers (BEAM rules are no-ops because grafema has no BEAM sources)
- [x] `grafema check` on `~/kami/ichi` fires 3 of 6 new rules with exactly the expected violations — confirmed end-to-end, Mamori regression reproducible
- [x] Pre-commit hook: `pnpm lint` + `regressions.test.ts` 21/21
- [ ] CI: tests, typecheck, lint, build, version-sync, CodeQL (pending auto-merge)

Refs: #242 merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)