### PR TITLE
feat(REG-1100 follow-up): dynamic HTTP port + openMap auto-start + databaseName

### DIFF
--- a/packages/rfdb-server/src/bin/rfdb_server.rs
+++ b/packages/rfdb-server/src/bin/rfdb_server.rs
@@ -3168,18 +3168,18 @@ async fn main() {
             }
         });
 
+    // `--http-port 0` = OS-assigned free port (dynamic allocation).
+    // The actual port is written to `<data_dir>/rfdb-http.port` after bind
+    // so clients (VS Code extension, etc.) can discover it without relying
+    // on a fixed default that may collide with unrelated processes.
     let http_port: Option<u16> = args.iter()
         .position(|a| a == "--http-port")
         .and_then(|i| args.get(i + 1))
         .map(|s| {
             match s.parse::<u16>() {
-                Ok(0) => {
-                    eprintln!("[rfdb-server] ERROR: --http-port 0 is not allowed (port must be 1-65535)");
-                    std::process::exit(1);
-                }
                 Ok(port) => port,
                 Err(_) => {
-                    eprintln!("[rfdb-server] ERROR: Invalid --http-port value '{}' (must be 1-65535)", s);
+                    eprintln!("[rfdb-server] ERROR: Invalid --http-port value '{}' (must be 0-65535)", s);
                     std::process::exit(1);
                 }
             }
@@ -3352,10 +3352,17 @@ async fn main() {
     };
     eprintln!("[rfdb-server] Listening on {}", socket_path);
 
+    // HTTP port lockfile path (written after HTTP bind succeeds, removed on
+    // graceful shutdown). `data_dir` is the directory Grafema stores per-db
+    // state in, so placing the lockfile next to `rfdb.pid` keeps discovery
+    // trivial for clients.
+    let http_lockfile_path: PathBuf = data_dir.join("rfdb-http.port");
+
     // Set up signal handler for graceful shutdown
     let manager_for_signal = Arc::clone(&manager);
     let socket_path_for_signal = socket_path.to_string();
     let shard_reg_for_signal = shard_registration_path.clone();
+    let http_lockfile_for_signal = http_lockfile_path.clone();
     let mut signals = signal_hook::iterator::Signals::new(&[
         signal_hook::consts::SIGINT,
         signal_hook::consts::SIGTERM,
@@ -3378,6 +3385,11 @@ async fn main() {
             }
 
             let _ = std::fs::remove_file(&socket_path_for_signal);
+
+            // Remove HTTP port lockfile so stale readers don't point at a
+            // dead process. Harmless if the file was never written (e.g.
+            // server started without --http-port).
+            let _ = std::fs::remove_file(&http_lockfile_for_signal);
 
             // Federation: remove shard registration
             if let Some(ref reg_path) = shard_reg_for_signal {
@@ -3453,7 +3465,31 @@ async fn main() {
             ),
             Err(e) => eprintln!("[rfdb-server] warmup task failed: {} (HTTP will still start)", e),
         }
-        tokio::spawn(rfdb::http_server::start(http_state, port));
+        // Bind synchronously so we can read back the actual port (handles
+        // --http-port 0 → OS-assigned). Write the lockfile + emit the
+        // canonical "HTTP listening on port N" stderr line BEFORE starting
+        // to serve so clients polling the lockfile see the port immediately.
+        match rfdb::http_server::bind(http_state, port).await {
+            Ok((actual_port, serve)) => {
+                eprintln!("[rfdb-server] HTTP listening on port {}", actual_port);
+                if let Some(parent) = http_lockfile_path.parent() {
+                    let _ = std::fs::create_dir_all(parent);
+                }
+                if let Err(e) = std::fs::write(&http_lockfile_path, actual_port.to_string()) {
+                    eprintln!(
+                        "[rfdb-server] WARN: failed to write HTTP port lockfile {}: {}",
+                        http_lockfile_path.display(),
+                        e
+                    );
+                }
+                tokio::spawn(serve);
+            }
+            Err(e) => {
+                eprintln!("[rfdb-server] ERROR: Failed to bind HTTP port {}: {}", port, e);
+                eprintln!("[rfdb-server] Hint: Port may be in use. Try --http-port 0 for OS-assigned.");
+                std::process::exit(1);
+            }
+        }
     }
 
     // Spawn WebSocket accept loop (if enabled)

--- a/packages/rfdb-server/src/http_server.rs
+++ b/packages/rfdb-server/src/http_server.rs
@@ -199,15 +199,40 @@ pub fn build_router_with_ui(state: HttpState, ui: UiConfig) -> Router {
     }
 }
 
-/// Start the HTTP server on the given port using a pre-built `HttpState`.
-pub async fn start(state: HttpState, port: u16) {
+/// Bind the HTTP listener and return `(actual_port, serve_future)`.
+///
+/// When `port == 0` the OS picks a free port; the actual port is read back
+/// from `local_addr()` so the caller can advertise it (lockfile, stderr,
+/// workspaceState, etc.) before awaiting the serve future.
+///
+/// Returns `Err` if bind fails — lets the caller fall back to a different
+/// port or surface a user-facing error without panicking the process.
+pub async fn bind(
+    state: HttpState,
+    port: u16,
+) -> std::io::Result<(u16, impl std::future::Future<Output = ()> + Send + 'static)> {
     let app = build_router(state);
-
     let addr = format!("127.0.0.1:{}", port);
-    let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
-    eprintln!("[rfdb-server] HTTP server listening on http://{}", addr);
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    let actual_port = listener.local_addr()?.port();
+    eprintln!(
+        "[rfdb-server] HTTP server listening on http://127.0.0.1:{}",
+        actual_port
+    );
+    let serve = async move {
+        let _ = axum::serve(listener, app).await;
+    };
+    Ok((actual_port, serve))
+}
 
-    axum::serve(listener, app).await.unwrap();
+/// Start the HTTP server on the given port using a pre-built `HttpState`.
+///
+/// Backward-compatible wrapper. Panics if bind fails (legacy behavior).
+pub async fn start(state: HttpState, port: u16) {
+    let (_actual, serve) = bind(state, port)
+        .await
+        .expect("Failed to bind HTTP listener");
+    serve.await;
 }
 
 // ── Query parameters ────────────────────────────────────────────────────

--- a/packages/rfdb-server/tests/port_zero.rs
+++ b/packages/rfdb-server/tests/port_zero.rs
@@ -1,0 +1,142 @@
+//! Integration test: `--http-port 0` → OS-assigned port + lockfile (DAI-15).
+//!
+//! Spawns `rfdb-server` with `--http-port 0`, then asserts:
+//!   1. The server binds successfully on a free OS-picked port.
+//!   2. A `rfdb-http.port` lockfile appears in the data dir containing that
+//!      port number.
+//!   3. The server's stderr includes `[rfdb-server] HTTP listening on port N`
+//!      with the same N.
+//!   4. Sending SIGTERM removes the lockfile on graceful shutdown.
+//!
+//! This protects the contract relied on by the VS Code extension: callers
+//! discover the HTTP port from the lockfile rather than guessing 3335.
+
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn binary_path() -> PathBuf {
+    // `CARGO_BIN_EXE_<name>` is set by cargo for integration tests and
+    // points at the freshly-built binary under target/{debug,release}/.
+    PathBuf::from(env!("CARGO_BIN_EXE_rfdb-server"))
+}
+
+#[test]
+fn http_port_zero_writes_lockfile_and_logs_actual_port() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let db_path = tempdir.path().join("graph.rfdb");
+    std::fs::create_dir_all(&db_path).expect("create db dir");
+
+    let data_dir = tempdir.path().to_path_buf();
+    let lockfile = data_dir.join("rfdb-http.port");
+    let socket_path = tempdir.path().join("rfdb.sock");
+
+    let mut child = Command::new(binary_path())
+        .arg(&db_path)
+        .arg("--socket")
+        .arg(&socket_path)
+        .arg("--data-dir")
+        .arg(&data_dir)
+        .arg("--http-port")
+        .arg("0")
+        .arg("--no-ui")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn rfdb-server");
+
+    // Stream stderr on a background thread so the child doesn't block on
+    // a full pipe; capture lines via a channel so we can grep for the
+    // "HTTP listening on port N" marker without dropping output.
+    let stderr = child.stderr.take().expect("take stderr");
+    let (tx, rx) = mpsc::channel::<String>();
+    let stderr_thread = thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines().map_while(Result::ok) {
+            let _ = tx.send(line);
+        }
+    });
+
+    // Poll for lockfile up to 30s — warmup + bind can be slow on cold runs.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut lockfile_port: Option<u16> = None;
+    while Instant::now() < deadline {
+        if lockfile.exists() {
+            let txt = std::fs::read_to_string(&lockfile).unwrap_or_default();
+            if let Ok(n) = txt.trim().parse::<u16>() {
+                if n > 0 {
+                    lockfile_port = Some(n);
+                    break;
+                }
+            }
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    let port = match lockfile_port {
+        Some(p) => p,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!(
+                "rfdb-http.port lockfile did not appear at {} within 30s",
+                lockfile.display()
+            );
+        }
+    };
+
+    // Drain stderr messages captured so far and assert the canonical line.
+    let mut seen_marker = false;
+    let marker_deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < marker_deadline && !seen_marker {
+        match rx.recv_timeout(Duration::from_millis(200)) {
+            Ok(line) => {
+                if line.contains(&format!("HTTP listening on port {}", port)) {
+                    seen_marker = true;
+                }
+            }
+            Err(_) => {}
+        }
+    }
+
+    // Graceful shutdown — unix-only; send SIGTERM and confirm the lockfile
+    // is cleaned up.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        let pid = child.id() as i32;
+        unsafe { libc::kill(pid, libc::SIGTERM) };
+        let status = child.wait().expect("wait child");
+        // The signal handler calls std::process::exit(0); accept either a
+        // clean exit code 0 or termination by SIGTERM as valid shutdown.
+        assert!(
+            status.success()
+                || status.signal() == Some(libc::SIGTERM)
+                || status.code() == Some(0),
+            "unexpected exit: {:?}",
+            status
+        );
+
+        assert!(
+            !lockfile.exists(),
+            "lockfile {} should be removed on graceful shutdown",
+            lockfile.display()
+        );
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    let _ = stderr_thread.join();
+    assert!(
+        seen_marker,
+        "stderr should include '[rfdb-server] HTTP listening on port {}'",
+        port
+    );
+}

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -448,7 +448,12 @@
           "default": 3335,
           "minimum": 0,
           "maximum": 65535,
-          "description": "HTTP port for rfdb-server's /ui and /api endpoints. Used by the Map panel to iframe the graph visualization."
+          "description": "HTTP port for rfdb-server's /ui and /api endpoints. Used by the Map panel to iframe the graph visualization. Leave at the default to let Grafema pick a free port dynamically (recommended)."
+        },
+        "grafema.databaseName": {
+          "type": "string",
+          "default": "default",
+          "description": "RFDB database name to visualize in the Map panel. Leave as \"default\" unless you have a multi-database setup."
         },
         "grafema.codeLens.enabled": {
           "type": "boolean",

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -8,6 +8,7 @@
 import * as vscode from 'vscode';
 import type { WireNode } from '@grafema/types';
 import { GrafemaClientManager } from './grafemaClient';
+import type * as GrafemaClientModule from './grafemaClient';
 import { EdgesProvider } from './edgesProvider';
 import { StatusProvider } from './statusProvider';
 import { DebugProvider } from './debugProvider';
@@ -730,8 +731,45 @@ function registerCommands(): vscode.Disposable[] {
   }));
 
   // Open Map panel
-  disposables.push(vscode.commands.registerCommand('grafema.openMap', () => {
+  //
+  // DAI-17: auto-start rfdb-server before creating the panel so users don't
+  // see a 60-second "Waiting for RFDB server" dead-wait when they invoke
+  // `Grafema: Open Map` without having run `Grafema: Analyze` first. If the
+  // server is already up, the startServer() call is a cheap no-op (probe
+  // succeeds, early return). Failures surface as a warning toast rather
+  // than silently hanging.
+  disposables.push(vscode.commands.registerCommand('grafema.openMap', async () => {
     const { MapPanel } = require('./mapPanel');
+    const grafemaClientMod = require('./grafemaClient') as typeof GrafemaClientModule;
+    const { getRfdbHttpPort } = grafemaClientMod;
+
+    if (clientManager) {
+      try {
+        await clientManager.startServer();
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        vscode.window.showWarningMessage(
+          `Grafema: could not start rfdb-server (${msg}). Run "Grafema: Analyze" first or check the output for details.`,
+        );
+        return;
+      }
+
+      // Wait up to 10s for the HTTP port to be discoverable (lockfile or
+      // pinned). Without this the panel would poll /api/stats for up to
+      // 60s — a bad UX when startup actually failed.
+      const deadline = Date.now() + 10_000;
+      while (Date.now() < deadline) {
+        if (typeof getRfdbHttpPort() === 'number') break;
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      if (typeof getRfdbHttpPort() !== 'number') {
+        vscode.window.showWarningMessage(
+          'Grafema: rfdb-server started but no HTTP port was advertised. Run "Grafema: Analyze" first or check the output for errors.',
+        );
+        return;
+      }
+    }
+
     MapPanel.createOrShow();
   }));
 

--- a/packages/vscode/src/grafemaClient.ts
+++ b/packages/vscode/src/grafemaClient.ts
@@ -24,11 +24,14 @@ const DB_FILE = 'graph.rfdb';
  * Default HTTP port for the rfdb-server /ui and /api endpoints (the GUI
  * is served from the same process as the Unix-socket RPC listener).
  *
- * TODO: make dynamic — probe for a free port when spawning rfdb-server
- * and surface it via workspaceState. For now the extension passes this
- * fixed port via `--http-port` and MapPanel reads it via getRfdbHttpPort().
+ * DAI-15: dynamic allocation is preferred. startServer() passes
+ * `--http-port 0` by default (OS picks a free port) and discovers the
+ * actual port via the `<workspace>/.grafema/rfdb-http.port` lockfile.
+ * Users can pin a specific port by setting `grafema.rfdbHttpPort` to a
+ * non-default value.
  */
 const DEFAULT_RFDB_HTTP_PORT = 3335;
+const HTTP_PORT_LOCKFILE = 'rfdb-http.port';
 
 /**
  * Module-level holder for the currently-active rfdb HTTP port. Populated
@@ -39,28 +42,85 @@ const DEFAULT_RFDB_HTTP_PORT = 3335;
 let activeRfdbHttpPort: number | undefined;
 
 /**
+ * Test hook: reset module-level state between tests. Not part of the
+ * public API — only used by unit tests that re-require the module.
+ */
+export function _resetActiveRfdbHttpPortForTests(): void {
+  activeRfdbHttpPort = undefined;
+}
+
+/**
+ * Read the rfdb-http.port lockfile from a workspace (if present). Returns
+ * `undefined` on any I/O / parse error — callers treat this as "no port
+ * discovered yet" and fall back to config or default.
+ */
+export function readRfdbHttpPortLockfile(workspaceRoot: string): number | undefined {
+  try {
+    const p = join(workspaceRoot, GRAFEMA_DIR, HTTP_PORT_LOCKFILE);
+    if (!existsSync(p)) return undefined;
+    const txt = readFileSync(p, 'utf-8').trim();
+    const n = Number.parseInt(txt, 10);
+    if (Number.isFinite(n) && n > 0 && n < 65536) return n;
+  } catch {
+    // ignore — stale or missing lockfile is a soft failure
+  }
+  return undefined;
+}
+
+/**
+ * Returns true when the user has explicitly overridden `grafema.rfdbHttpPort`
+ * at any scope (workspace/user/folder). Lets startServer() decide between
+ * "pin the requested port" (explicit) vs "let the OS pick" (default).
+ */
+function isExplicitRfdbHttpPortSet(): boolean {
+  try {
+    const info = vscode.workspace.getConfiguration('grafema').inspect<number>('rfdbHttpPort');
+    if (!info) return false;
+    return (
+      info.globalValue !== undefined ||
+      info.workspaceValue !== undefined ||
+      info.workspaceFolderValue !== undefined
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Report the HTTP port the rfdb-server is listening on.
  *
  * Resolution order:
- *   1. Port recorded by the last successful startServer() call.
- *   2. `grafema.rfdbHttpPort` VS Code setting.
- *   3. `GRAFEMA_RFDB_HTTP_PORT` environment variable.
- *   4. DEFAULT_RFDB_HTTP_PORT (3335).
+ *   1. Port recorded by the last successful startServer() call (discovered
+ *      from the lockfile or from the explicit `--http-port` CLI arg).
+ *   2. Explicit `grafema.rfdbHttpPort` VS Code setting (non-default).
+ *   3. Lockfile `<workspace>/.grafema/rfdb-http.port` written by a live
+ *      rfdb-server — covers the case where the server was spawned by
+ *      `grafema analyze` (CLI) outside the extension.
+ *   4. `GRAFEMA_RFDB_HTTP_PORT` environment variable.
+ *   5. DEFAULT_RFDB_HTTP_PORT (3335).
  *
  * Returns `undefined` only if the caller explicitly sets the setting
  * to 0 — otherwise always returns a positive port.
  */
-export function getRfdbHttpPort(): number | undefined {
+export function getRfdbHttpPort(workspaceRoot?: string): number | undefined {
   if (typeof activeRfdbHttpPort === 'number' && activeRfdbHttpPort > 0) {
     return activeRfdbHttpPort;
   }
   try {
     const config = vscode.workspace.getConfiguration('grafema');
     const configured = config.get<number>('rfdbHttpPort');
-    if (typeof configured === 'number' && configured > 0) return configured;
-    if (configured === 0) return undefined; // explicit opt-out
+    if (isExplicitRfdbHttpPortSet()) {
+      if (configured === 0) return undefined; // explicit opt-out
+      if (typeof configured === 'number' && configured > 0) return configured;
+    }
   } catch {
     // vscode API may not be available (e.g., unit tests) — fall through.
+  }
+  // Lockfile discovery — covers CLI-started server.
+  const root = workspaceRoot ?? resolveWorkspaceRoot();
+  if (root) {
+    const fromLock = readRfdbHttpPortLockfile(root);
+    if (typeof fromLock === 'number') return fromLock;
   }
   const env = process.env.GRAFEMA_RFDB_HTTP_PORT;
   if (env) {
@@ -68,6 +128,16 @@ export function getRfdbHttpPort(): number | undefined {
     if (Number.isFinite(parsed) && parsed > 0) return parsed;
   }
   return DEFAULT_RFDB_HTTP_PORT;
+}
+
+function resolveWorkspaceRoot(): string | undefined {
+  try {
+    const folders = vscode.workspace.workspaceFolders;
+    if (folders && folders.length > 0) return folders[0].uri.fsPath;
+  } catch {
+    // no workspace (unit test) — ignore
+  }
+  return undefined;
 }
 
 /**
@@ -400,18 +470,32 @@ export class GrafemaClientManager extends EventEmitter {
       );
     }
 
-    const httpPort = getRfdbHttpPort() ?? DEFAULT_RFDB_HTTP_PORT;
+    // DAI-15: prefer OS-assigned port (--http-port 0) unless the user
+    // has explicitly pinned one via `grafema.rfdbHttpPort`. Avoids
+    // collisions when 3335 is taken by another rfdb-server / process.
+    const lockfilePath = join(this.workspaceRoot, GRAFEMA_DIR, HTTP_PORT_LOCKFILE);
+    // Remove any stale lockfile so the post-spawn read can't pick up an
+    // old port from a dead server. `ensureStaleLockfileCleared` also
+    // tries to connect first; if the pre-flight probe above already
+    // reaped a stale socket, the lockfile left behind is guaranteed
+    // stale too.
+    try { if (existsSync(lockfilePath)) unlinkSync(lockfilePath); } catch { /* ignore */ }
+
+    const explicit = isExplicitRfdbHttpPortSet();
+    const requestedPort = explicit
+      ? vscode.workspace.getConfiguration('grafema').get<number>('rfdbHttpPort') ?? 0
+      : 0;
+
     this.serverProcess = spawn(
       binaryPath,
-      [this.dbPath, '--socket', this.socketPath, '--http-port', String(httpPort)],
+      [this.dbPath, '--socket', this.socketPath, '--http-port', String(requestedPort)],
       {
         stdio: ['ignore', 'pipe', 'pipe'],
         detached: true,
       },
     );
-    // Record the port so MapPanel and other callers of getRfdbHttpPort()
-    // see the actual listening port (not just the configured default).
-    activeRfdbHttpPort = httpPort;
+    // Provisional — replaced below once the real port is discovered.
+    activeRfdbHttpPort = requestedPort > 0 ? requestedPort : undefined;
 
     // Don't let server process prevent VS Code from exiting
     this.serverProcess.unref();
@@ -447,6 +531,21 @@ export class GrafemaClientManager extends EventEmitter {
     if (!existsSync(this.socketPath)) {
       throw new Error(`RFDB server failed to start (socket not created after ${attempts * 100}ms)`);
     }
+
+    // Discover the actual HTTP port from the lockfile (written by the
+    // server after bind succeeds). Poll up to 10s — warmup can delay
+    // lockfile appearance when the graph is large.
+    for (let i = 0; i < 100; i++) {
+      const p = readRfdbHttpPortLockfile(this.workspaceRoot);
+      if (typeof p === 'number' && p > 0) {
+        activeRfdbHttpPort = p;
+        break;
+      }
+      await sleep(100);
+    }
+    // If the lockfile never appeared but the user pinned an explicit port,
+    // keep the provisional value — getRfdbHttpPort() will still hand out
+    // a usable port.
   }
 
   /**

--- a/packages/vscode/src/mapPanel.ts
+++ b/packages/vscode/src/mapPanel.ts
@@ -102,6 +102,19 @@ export class MapPanel {
       this.disposables
     );
 
+    // DAI-16: rebuild the iframe when the user changes `grafema.databaseName`
+    // or `grafema.rfdbHttpPort`. Without this the panel would keep pointing
+    // at the old db even after the setting is updated, forcing a reload.
+    const configSub = vscode.workspace.onDidChangeConfiguration((e) => {
+      if (
+        e.affectsConfiguration('grafema.databaseName') ||
+        e.affectsConfiguration('grafema.rfdbHttpPort')
+      ) {
+        this.ensureServerAndLoad();
+      }
+    });
+    this.disposables.push(configSub);
+
     this.panel.webview.html = this.getLoaderHtml();
     this.ensureServerAndLoad();
   }

--- a/packages/vscode/test/unit/extension.test.ts
+++ b/packages/vscode/test/unit/extension.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for extension.ts — DAI-17 (grafema.openMap auto-start).
+ *
+ * We avoid booting the full VS Code extension host here: activation wires
+ * dozens of providers with side effects. Instead we assert structural
+ * invariants on the source that lock the DAI-17 contract in place:
+ *
+ *   - The `grafema.openMap` handler is `async`.
+ *   - It calls `clientManager.startServer()` before `MapPanel.createOrShow()`.
+ *   - On startup failure it shows a warning message instead of silently
+ *     hanging.
+ *
+ * If the handler is ever simplified back to a fire-and-forget
+ * `createOrShow()`, these assertions fail loudly — catching the regression
+ * REG-1100/DAI-17 was created to prevent.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SOURCE_PATH = join(__dirname, '..', '..', 'src', 'extension.ts');
+const source = readFileSync(SOURCE_PATH, 'utf-8');
+
+/** Extract the body of the `grafema.openMap` command registration so the
+ * assertions below are scoped to that handler and don't accidentally match
+ * unrelated code elsewhere in extension.ts. */
+function extractOpenMapHandler(): string {
+  const start = source.indexOf("registerCommand('grafema.openMap'");
+  assert.ok(start >= 0, 'grafema.openMap command registration must exist');
+  // Find the closing ')); of the registerCommand call.
+  const endMarker = '}));';
+  const end = source.indexOf(endMarker, start);
+  assert.ok(end > start, 'openMap handler must be properly closed');
+  return source.slice(start, end + endMarker.length);
+}
+
+describe('extension.ts — grafema.openMap (DAI-17)', () => {
+  const handler = extractOpenMapHandler();
+
+  it('openMap handler is async', () => {
+    assert.match(
+      handler,
+      /registerCommand\('grafema\.openMap',\s*async\s*\(/,
+      `openMap must be async for startServer() auto-start flow:\n${handler}`,
+    );
+  });
+
+  it('openMap calls clientManager.startServer() before MapPanel.createOrShow()', () => {
+    const startIdx = handler.indexOf('startServer()');
+    const createIdx = handler.indexOf('MapPanel.createOrShow()');
+    assert.ok(startIdx >= 0, 'openMap handler should call clientManager.startServer()');
+    assert.ok(createIdx >= 0, 'openMap handler should call MapPanel.createOrShow()');
+    assert.ok(
+      startIdx < createIdx,
+      `startServer() must run before createOrShow() — DAI-17 acceptance:\n${handler}`,
+    );
+  });
+
+  it('openMap shows a warning on failure (no silent 60s hang)', () => {
+    assert.match(
+      handler,
+      /showWarningMessage/,
+      `openMap must surface failures via showWarningMessage instead of silently letting MapPanel poll for 60s:\n${handler}`,
+    );
+  });
+
+  it('openMap bounds readiness polling (uses a deadline, not infinite wait)', () => {
+    // DAI-17 cap: 10s. Asserting the magic number protects against drift
+    // toward "poll forever" on startup failures.
+    assert.match(
+      handler,
+      /10_?000/,
+      `openMap should bound readiness polling (expected a 10_000 ms deadline):\n${handler}`,
+    );
+  });
+});

--- a/packages/vscode/test/unit/grafemaClient.test.ts
+++ b/packages/vscode/test/unit/grafemaClient.test.ts
@@ -75,6 +75,22 @@ require.cache['vscode'] = {
             ? mockConfigValues[fullKey]
             : defaultValue;
         },
+        // inspect() surfaces whether a user explicitly set a value at any
+        // scope. Tests drive this via mockConfigValues — any key present
+        // is treated as "explicitly set" at workspace scope.
+        inspect: (key: string) => {
+          const fullKey = section ? `${section}.${key}` : key;
+          if (fullKey in mockConfigValues) {
+            return {
+              key,
+              defaultValue: undefined,
+              globalValue: undefined,
+              workspaceValue: mockConfigValues[fullKey],
+              workspaceFolderValue: undefined,
+            };
+          }
+          return { key, defaultValue: undefined };
+        },
       }),
     },
     languages: { registerCodeLensProvider: () => ({ dispose: () => {} }) },
@@ -477,4 +493,98 @@ describe('GrafemaClientManager — negotiateAndSelectDatabase', () => {
       );
     });
   });
+});
+
+// ============================================================================
+// DAI-15: getRfdbHttpPort lockfile + resolution order
+// ============================================================================
+
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join as pathJoin } from 'node:path';
+
+const {
+  readRfdbHttpPortLockfile,
+  _resetActiveRfdbHttpPortForTests,
+  getRfdbHttpPort,
+} = grafemaClientModule as {
+  readRfdbHttpPortLockfile: (root: string) => number | undefined;
+  _resetActiveRfdbHttpPortForTests: () => void;
+  getRfdbHttpPort: (workspaceRoot?: string) => number | undefined;
+};
+
+describe('readRfdbHttpPortLockfile — DAI-15', () => {
+  let workspace: string;
+
+  beforeEach(() => {
+    workspace = pathJoin(tmpdir(), `grafema-lock-${Date.now()}-${Math.random()}`);
+    mkdirSync(pathJoin(workspace, '.grafema'), { recursive: true });
+  });
+
+  it('returns undefined when lockfile is missing', () => {
+    assert.strictEqual(readRfdbHttpPortLockfile(workspace), undefined);
+  });
+
+  it('reads the port integer from the lockfile', () => {
+    writeFileSync(pathJoin(workspace, '.grafema', 'rfdb-http.port'), '45123\n');
+    assert.strictEqual(readRfdbHttpPortLockfile(workspace), 45123);
+  });
+
+  it('returns undefined on unparseable content', () => {
+    writeFileSync(pathJoin(workspace, '.grafema', 'rfdb-http.port'), 'not-a-port');
+    assert.strictEqual(readRfdbHttpPortLockfile(workspace), undefined);
+  });
+
+  it('returns undefined for out-of-range values', () => {
+    writeFileSync(pathJoin(workspace, '.grafema', 'rfdb-http.port'), '99999');
+    assert.strictEqual(readRfdbHttpPortLockfile(workspace), undefined);
+  });
+});
+
+describe('getRfdbHttpPort — resolution order (DAI-15)', () => {
+  let workspace: string;
+  const originalFolders = (
+    require.cache['vscode'] as unknown as { exports: { workspace: { workspaceFolders: unknown } } }
+  ).exports.workspace.workspaceFolders;
+
+  beforeEach(() => {
+    _resetActiveRfdbHttpPortForTests();
+    setMockConfig({});
+    workspace = pathJoin(tmpdir(), `grafema-port-${Date.now()}-${Math.random()}`);
+    mkdirSync(pathJoin(workspace, '.grafema'), { recursive: true });
+    delete process.env.GRAFEMA_RFDB_HTTP_PORT;
+  });
+
+  it('falls back to lockfile when no explicit config and no active port', () => {
+    writeFileSync(pathJoin(workspace, '.grafema', 'rfdb-http.port'), '42042');
+    assert.strictEqual(getRfdbHttpPort(workspace), 42042);
+  });
+
+  it('prefers explicitly-pinned config over lockfile', () => {
+    // User pinned a specific port — must win even if a lockfile advertises
+    // a different port (e.g., a background server bound elsewhere).
+    setMockConfig({ 'grafema.rfdbHttpPort': 7777 });
+    writeFileSync(pathJoin(workspace, '.grafema', 'rfdb-http.port'), '51234');
+    assert.strictEqual(getRfdbHttpPort(workspace), 7777);
+  });
+
+  it('falls through to lockfile when config is not explicitly set', () => {
+    setMockConfig({}); // nothing pinned
+    writeFileSync(pathJoin(workspace, '.grafema', 'rfdb-http.port'), '51234');
+    assert.strictEqual(getRfdbHttpPort(workspace), 51234);
+  });
+
+  it('falls back to DEFAULT when nothing else is available', () => {
+    rmSync(pathJoin(workspace, '.grafema', 'rfdb-http.port'), { force: true });
+    assert.strictEqual(getRfdbHttpPort(workspace), 3335);
+  });
+
+  it('honors GRAFEMA_RFDB_HTTP_PORT env var over default', () => {
+    process.env.GRAFEMA_RFDB_HTTP_PORT = '9090';
+    assert.strictEqual(getRfdbHttpPort(workspace), 9090);
+    delete process.env.GRAFEMA_RFDB_HTTP_PORT;
+  });
+
+  // keep vscode workspace untouched
+  void originalFolders;
 });

--- a/packages/vscode/test/unit/mapPanel.test.ts
+++ b/packages/vscode/test/unit/mapPanel.test.ts
@@ -126,8 +126,12 @@ require.cache['vscode'] = {
         return [{ uri: { fsPath: mockWorkspaceRoot } }];
       },
       getConfiguration: () => ({
-        get: (_key: string, defaultValue?: unknown) => defaultValue,
+        get: (key: string, defaultValue?: unknown) => {
+          if (key === 'databaseName') return mockDbName;
+          return defaultValue;
+        },
       }),
+      onDidChangeConfiguration: (_handler: unknown) => ({ dispose: () => {} }),
     },
   },
 } as unknown as NodeModule;
@@ -289,6 +293,38 @@ describe('MapPanel — behavior', () => {
       MapPanel.createOrShow();
       assert.strictEqual(lastCreatedPanel, firstPanel, 'Second call reuses the same panel');
       assert.ok(firstPanel!.revealed, 'Existing panel should be revealed');
+    });
+
+    it('uses the value returned by grafema.databaseName config (DAI-16)', async () => {
+      mockDbName = 'customProject';
+      MapPanel.createOrShow();
+      await new Promise((r) => setTimeout(r, 200));
+
+      const html = lastCreatedPanel!.webview.html;
+      assert.match(
+        html,
+        /http:\/\/localhost:\d+\/ui\/customProject/,
+        `HTML should embed /ui/customProject, got: ${html.slice(0, 500)}`,
+      );
+    });
+
+    it('source subscribes to onDidChangeConfiguration for databaseName', () => {
+      // Lock the behavior structurally — without the listener, changing
+      // grafema.databaseName would require closing and reopening the panel.
+      const source = readFileSync(
+        join(__dirname, '..', '..', 'src', 'mapPanel.ts'),
+        'utf-8',
+      );
+      assert.match(
+        source,
+        /onDidChangeConfiguration/,
+        'mapPanel.ts should subscribe to onDidChangeConfiguration',
+      );
+      assert.match(
+        source,
+        /affectsConfiguration\(['"]grafema\.databaseName['"]\)/,
+        'mapPanel.ts should react to grafema.databaseName changes',
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Three REG-1100 follow-up DAIs landed together (bundled because DAI-17 without DAI-15 regresses on port conflicts).

**DAI-15** — rfdb-server accepts `--http-port 0` (OS-picked), writes port to `<data_dir>/rfdb-http.port` lockfile, cleans up on SIGTERM. VS Code reads lockfile. Default behavior uses port 0 unless user explicitly pins `grafema.rfdbHttpPort` (distinguished from default via `config.inspect()`).

**DAI-17** — `grafema.openMap` is now async; awaits `startServer()` + polls port lockfile up to 10s + `showWarningMessage` on timeout. First-time users get the map in ~10s instead of 60s dead-wait.

**DAI-16** — New `grafema.databaseName` config (default `"default"`). `mapPanel.ts` subscribes to `onDidChangeConfiguration` and rebuilds iframe URL.

## Why bundled

DAI-17 alone would regress: auto-starting rfdb-server on hardcoded port 3335 collides with anything already listening. Without dynamic port allocation (DAI-15), auto-start = more user-facing bind errors.

## Tests

- rfdb-server: 839 lib + 69 bin + 12 ui_routes + new `port_zero.rs` — all green
- VS Code: 186 unit tests (+15 new)
- `pnpm lint` clean, `cargo build` both feature configs clean

## Test plan

- [x] `Grafema: Open Map` on fresh workspace without prior Analyze — auto-starts, loads in ~10s
- [x] Occupy port 3335 with unrelated process → map still works (OS picks another port)
- [x] Change `grafema.databaseName` with panel open → iframe rebuilds
- [x] Send SIGTERM to rfdb-server → lockfile cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)