### PR TITLE
feat(beam): PUBLISHES edges from PubSub broadcasts to subscribers

### DIFF
--- a/packages/beam-analyzer/lib/beam_analyzer/rules/calls.ex
+++ b/packages/beam-analyzer/lib/beam_analyzer/rules/calls.ex
@@ -104,9 +104,11 @@ defmodule BeamAnalyzer.Rules.Calls do
   defp maybe_dispatch_pubsub(ctx, dot, args, call_name, line, col, _dot_meta) do
     case BeamAnalyzer.Rules.PubSub.classify(dot) do
       {:pubsub, :subscribe} ->
+        scope = Context.current_scope(ctx) || "module"
+        call_id = SemanticId.call_id(ctx.file, call_name, scope, line, col)
         pubsub_ast = Enum.at(args, 0)
         topic_ast = Enum.at(args, 1)
-        BeamAnalyzer.Rules.PubSub.process_subscribe(ctx, pubsub_ast, topic_ast, nil)
+        BeamAnalyzer.Rules.PubSub.process_subscribe(ctx, call_id, pubsub_ast, topic_ast, nil)
 
       {:pubsub, op} ->
         scope = Context.current_scope(ctx) || "module"

--- a/packages/beam-analyzer/lib/beam_analyzer/rules/pubsub.ex
+++ b/packages/beam-analyzer/lib/beam_analyzer/rules/pubsub.ex
@@ -34,10 +34,20 @@ defmodule BeamAnalyzer.Rules.PubSub do
   Handle `Phoenix.PubSub.subscribe(pubsub, topic)`. No-op if the pubsub
   server is not a literal alias or the topic is not a string literal.
   """
-  def process_subscribe(ctx, pubsub_ast, topic_ast, _meta) do
+  def process_subscribe(ctx, call_id, pubsub_ast, topic_ast, _meta) do
     with pubsub_name when is_binary(pubsub_name) <- pubsub_name_of(pubsub_ast),
          {:ok, topic} <- literal_topic(topic_ast) do
       {ctx, topic_id} = ensure_topic_node(ctx, pubsub_name, topic)
+
+      # Enrich the CALL node so the PubSub-delivery resolver can find
+      # subscribe sites without crawling edges (resolver API is
+      # nodes-only).
+      ctx =
+        Context.merge_node_metadata(ctx, call_id, %{
+          pubsub_topic: topic,
+          pubsub_server: pubsub_name,
+          pubsub_op: "subscribe"
+        })
 
       edge = %{
         src: ctx.module_id,
@@ -66,6 +76,16 @@ defmodule BeamAnalyzer.Rules.PubSub do
         msg_ast
         |> Patterns.normalize()
         |> Patterns.shape_to_meta()
+
+      # Enrich CALL node metadata so the PubSub-delivery resolver can
+      # see the topic and shape without edge visibility.
+      ctx =
+        Context.merge_node_metadata(ctx, call_id, %{
+          pubsub_topic: topic,
+          pubsub_server: pubsub_name,
+          pubsub_op: "broadcast",
+          message_shape: message_shape
+        })
 
       edge = %{
         src: call_id,

--- a/packages/beam-resolve/beam-resolve.cabal
+++ b/packages/beam-resolve/beam-resolve.cabal
@@ -19,6 +19,7 @@ executable beam-resolve
     BeamShape
     BeamMessageFindings
     BeamMessageTypeResolution
+    BeamPubsubDelivery
 
   build-depends:
     base                 >= 4.17 && < 5,
@@ -46,6 +47,7 @@ test-suite spec
     BeamShape
     BeamMessageFindings
     BeamMessageTypeResolution
+    BeamPubsubDelivery
 
 
   build-depends:

--- a/packages/beam-resolve/src/BeamPubsubDelivery.hs
+++ b/packages/beam-resolve/src/BeamPubsubDelivery.hs
@@ -1,0 +1,192 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | BEAM PubSub delivery resolution (GAP-C follow-up to REG-1098 W7).
+--
+-- Closes the loop in Phoenix.PubSub topologies. The analyzer already
+-- emits:
+--
+--   * PUBSUB_TOPIC nodes  (server + literal topic)
+--   * BROADCASTS_TO edges (CALL → TOPIC, with message_shape)
+--   * SUBSCRIBES_TO edges (MODULE → TOPIC)
+--
+-- What was missing: broadcast CALLs had no direct link to the
+-- @handle_info@ clauses that actually receive them. From the
+-- dead-state detector's point of view, every @info:event/*@ handler
+-- looked unreachable because nothing pointed at it via SENDS_MESSAGE
+-- or SELF_SCHEDULE.
+--
+-- This resolver closes that gap with a third precise edge type:
+--
+--   * @PUBLISHES@ — CALL → MESSAGE_TYPE. Emitted per (broadcast site,
+--     subscriber handler) pair whose shape unifies. Distinct from
+--     SENDS_MESSAGE because the delivery mechanism is one-to-many
+--     topic fanout, not a direct send. A dead-state rule can now
+--     consult three complementary precise edges:
+--
+--         reachable(M) :- incoming(M, _, "SENDS_MESSAGE").
+--         reachable(M) :- incoming(M, _, "SELF_SCHEDULE").
+--         reachable(M) :- incoming(M, _, "PUBLISHES").
+--         unreachable(M) :- node(M, "MESSAGE_TYPE"), !reachable(M).
+--
+-- Analyzer-enriched CALL metadata used here:
+--   * pubsub_op     : "broadcast" | "subscribe"
+--   * pubsub_topic  : literal topic string
+--   * pubsub_server : fully qualified PubSub server module
+--   * message_shape : present on broadcast CALLs only
+module BeamPubsubDelivery (run, resolveAll) where
+
+import Grafema.Types (GraphNode(..), GraphEdge(..), MetaValue(..))
+import Grafema.GraphTraversal (lookupMetaText)
+import Grafema.Protocol (PluginCommand(..), readNodesFromStdin, writeCommandsToStdout)
+
+import Data.Text (Text)
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
+import Data.Maybe (fromMaybe, mapMaybe)
+
+import BeamShape (Shape, parseShape, unify)
+
+-- ---------------------------------------------------------------------
+-- Views
+-- ---------------------------------------------------------------------
+
+-- | A Phoenix.PubSub.broadcast* call site, with everything the
+-- resolver needs to emit a PUBLISHES edge.
+data BroadcastSite = BroadcastSite
+  { bsCallId :: !Text
+  , bsServer :: !Text  -- ^ fully-qualified PubSub server module
+  , bsTopic  :: !Text
+  , bsShape  :: !Shape
+  }
+
+-- | A Phoenix.PubSub.subscribe call site — its file is the subscriber
+-- module's file, which is where the matching handle_info clauses
+-- live.
+data SubscribeSite = SubscribeSite
+  { ssServer :: !Text
+  , ssTopic  :: !Text
+  , ssFile   :: !Text
+  }
+
+toBroadcast :: GraphNode -> Maybe BroadcastSite
+toBroadcast n = do
+  guardCall n
+  op <- lookupMetaText "pubsub_op" n
+  case op of
+    "broadcast" -> do
+      topic  <- lookupMetaText "pubsub_topic"  n
+      server <- lookupMetaText "pubsub_server" n
+      shape  <- Map.lookup "message_shape" (gnMetadata n)
+      pure BroadcastSite
+        { bsCallId = gnId n
+        , bsServer = server
+        , bsTopic  = topic
+        , bsShape  = parseShape shape
+        }
+    _ -> Nothing
+
+toSubscribe :: GraphNode -> Maybe SubscribeSite
+toSubscribe n = do
+  guardCall n
+  op <- lookupMetaText "pubsub_op" n
+  case op of
+    "subscribe" -> do
+      topic  <- lookupMetaText "pubsub_topic"  n
+      server <- lookupMetaText "pubsub_server" n
+      pure SubscribeSite
+        { ssServer = server
+        , ssTopic  = topic
+        , ssFile   = gnFile n
+        }
+    _ -> Nothing
+
+guardCall :: GraphNode -> Maybe ()
+guardCall n = if gnType n == "CALL" then Just () else Nothing
+
+-- ---------------------------------------------------------------------
+-- Indices
+-- ---------------------------------------------------------------------
+
+-- | Subscriber files keyed by (server, topic). Multiple subscribers per
+-- topic are normal — each keeps its own entry in the list.
+type SubscribersByTopic = Map (Text, Text) [Text]
+
+-- | handle_info MESSAGE_TYPE nodes grouped by their containing file.
+type InfoHandlersByFile = Map Text [GraphNode]
+
+buildIndices
+  :: [GraphNode]
+  -> (SubscribersByTopic, InfoHandlersByFile)
+buildIndices nodes =
+  let subscribers = mapMaybe toSubscribe nodes
+      infoHandlers =
+        [ n
+        | n <- nodes
+        , gnType n == "MESSAGE_TYPE"
+        , lookupMetaText "handler_type" n == Just "info"
+        ]
+
+      subsByTopic =
+        foldr
+          (\s acc -> Map.insertWith (++) (ssServer s, ssTopic s) [ssFile s] acc)
+          Map.empty
+          subscribers
+
+      handlersByFile =
+        foldr
+          (\n acc -> Map.insertWith (++) (gnFile n) [n] acc)
+          Map.empty
+          infoHandlers
+  in (subsByTopic, handlersByFile)
+
+-- ---------------------------------------------------------------------
+-- Resolution
+-- ---------------------------------------------------------------------
+
+resolveAll :: [GraphNode] -> [PluginCommand]
+resolveAll nodes =
+  let (subsByTopic, handlersByFile) = buildIndices nodes
+      broadcasts = mapMaybe toBroadcast nodes
+  in concatMap (emitFor subsByTopic handlersByFile) broadcasts
+
+emitFor
+  :: SubscribersByTopic
+  -> InfoHandlersByFile
+  -> BroadcastSite
+  -> [PluginCommand]
+emitFor subsByTopic handlersByFile bs =
+  let subscriberFiles =
+        fromMaybe [] (Map.lookup (bsServer bs, bsTopic bs) subsByTopic)
+      candidateHandlers = concatMap (lookupDefault handlersByFile) subscriberFiles
+      matches = filter (handlerUnifies (bsShape bs)) candidateHandlers
+  in map (mkPublishes bs) matches
+
+lookupDefault :: Ord k => Map k [v] -> k -> [v]
+lookupDefault m k = fromMaybe [] (Map.lookup k m)
+
+handlerUnifies :: Shape -> GraphNode -> Bool
+handlerUnifies sent handler =
+  let clauseShape = case Map.lookup "pattern_shape" (gnMetadata handler) of
+        Just v  -> parseShape v
+        Nothing -> parseShape (MetaList [MetaText "unknown"])
+  in unify sent clauseShape
+
+mkPublishes :: BroadcastSite -> GraphNode -> PluginCommand
+mkPublishes bs handler = EmitEdge GraphEdge
+  { geSource   = bsCallId bs
+  , geTarget   = gnId handler
+  , geType     = "PUBLISHES"
+  , geMetadata = Map.fromList
+      [ ("resolvedVia", MetaText "beam-pubsub-delivery")
+      , ("topic",       MetaText (bsTopic bs))
+      , ("server",      MetaText (bsServer bs))
+      ]
+  }
+
+-- ---------------------------------------------------------------------
+-- CLI entry point
+-- ---------------------------------------------------------------------
+
+run :: IO ()
+run = do
+  nodes <- readNodesFromStdin
+  writeCommandsToStdout (resolveAll nodes)

--- a/packages/beam-resolve/src/Main.hs
+++ b/packages/beam-resolve/src/Main.hs
@@ -15,6 +15,7 @@ import qualified BeamRuntimeGlobals
 import qualified BeamWrapperResolution
 import qualified BeamMessageFindings
 import qualified BeamMessageTypeResolution
+import qualified BeamPubsubDelivery
 import qualified Grafema.RuntimeGlobals as RG
 import Grafema.Types (GraphNode)
 import Grafema.Protocol (PluginCommand(..), readFrame, writeFrame, encodeMsgpack, decodeMsgpack)
@@ -93,6 +94,7 @@ dispatch cache "beam-runtime-globals" nodes = do
   return $ ResOk (BeamRuntimeGlobals.resolveAll db nodes)
 dispatch _ "beam-wrapper-resolve" nodes = return $ ResOk (BeamWrapperResolution.resolveAll nodes)
 dispatch _ "beam-message-types" nodes = return $ ResOk (BeamMessageTypeResolution.resolveAll nodes)
+dispatch _ "beam-pubsub-delivery" nodes = return $ ResOk (BeamPubsubDelivery.resolveAll nodes)
 dispatch _ "beam-message-findings" nodes = return $ ResOk (BeamMessageFindings.runFindings nodes [])
 dispatch _ cmd _ = return $ ResError ("unknown command: " ++ T.unpack cmd)
 
@@ -105,6 +107,7 @@ data Command
   | CmdBeamRuntimeGlobals
   | CmdBeamWrapperResolve
   | CmdBeamMessageTypes
+  | CmdBeamPubsubDelivery
   | CmdBeamMessageFindings
 
 commandParser :: Parser Command
@@ -123,6 +126,8 @@ commandParser = subparser
     (info (pure CmdBeamWrapperResolve) (progDesc "Emit virtual side-effect edges for calls to public-API wrapper functions (REG-1098 W6)"))
   <> command "beam-message-types"
     (info (pure CmdBeamMessageTypes) (progDesc "Emit SENDS_MESSAGE / SELF_SCHEDULE edges from CALL send-sites to matching MESSAGE_TYPE clauses"))
+  <> command "beam-pubsub-delivery"
+    (info (pure CmdBeamPubsubDelivery) (progDesc "Emit PUBLISHES edges from Phoenix.PubSub broadcasts to subscriber MESSAGE_TYPE clauses"))
   <> command "beam-message-findings"
     (info (pure CmdBeamMessageFindings) (progDesc "Emit ISSUE nodes for BEAM MessageFlow findings (REG-1098 W9)"))
   )
@@ -153,4 +158,5 @@ main = do
         CmdBeamRuntimeGlobals -> BeamRuntimeGlobals.run
         CmdBeamWrapperResolve -> BeamWrapperResolution.run
         CmdBeamMessageTypes   -> BeamMessageTypeResolution.run
+        CmdBeamPubsubDelivery -> BeamPubsubDelivery.run
         CmdBeamMessageFindings -> BeamMessageFindings.run

--- a/packages/beam-resolve/test/Spec.hs
+++ b/packages/beam-resolve/test/Spec.hs
@@ -15,6 +15,7 @@ import qualified BeamProtocolResolution
 import qualified BeamWrapperResolution
 import qualified BeamMessageFindings
 import qualified BeamMessageTypeResolution
+import qualified BeamPubsubDelivery
 import BeamShape
 
 -- | Helper to create a minimal GraphNode.
@@ -1037,3 +1038,118 @@ main = hspec $ do
             ]
           cmds = BeamMessageTypeResolution.resolveAll nodes
       edgeTypes cmds `shouldBe` ["SENDS_MESSAGE"]
+
+  describe "BeamPubsubDelivery (PUBLISHES edges)" $ do
+    -- Test helpers ------------------------------------------------
+    let mkBroadcast nid file topic server shape =
+          (mkNode nid "CALL" "Phoenix.PubSub.broadcast" file)
+            { gnMetadata = Map.fromList
+                [ ("pubsub_op",     MetaText "broadcast")
+                , ("pubsub_topic",  MetaText topic)
+                , ("pubsub_server", MetaText server)
+                , ("message_shape", shape)
+                ]
+            }
+
+        mkSubscribe nid file topic server =
+          (mkNode nid "CALL" "Phoenix.PubSub.subscribe" file)
+            { gnMetadata = Map.fromList
+                [ ("pubsub_op",     MetaText "subscribe")
+                , ("pubsub_topic",  MetaText topic)
+                , ("pubsub_server", MetaText server)
+                ]
+            }
+
+        mkInfoHandler nid file clauseShape =
+          (mkNode nid "MESSAGE_TYPE" "info" file)
+            { gnMetadata = Map.fromList
+                [ ("handler_type",  MetaText "info")
+                , ("pattern_shape", clauseShape)
+                ]
+            }
+
+        atomShape a  = MetaList [MetaText "atom", MetaText a]
+        tupleShape xs = MetaList [MetaText "tuple", MetaList xs]
+        wildShape    = MetaList [MetaText "wildcard"]
+
+        publishesEdges cmds = [ e | EmitEdge e <- cmds, geType e == "PUBLISHES" ]
+
+    it "emits PUBLISHES from broadcast to subscriber handle_info clause on shape match" $ do
+      let nodes =
+            [ mkSubscribe "sub:1" "lib/sub.ex" "events" "Ichi.PubSub"
+            , mkInfoHandler "mt:1" "lib/sub.ex"
+                (tupleShape [atomShape "user_added", wildShape])
+            , mkBroadcast "bc:1" "lib/pub.ex" "events" "Ichi.PubSub"
+                (tupleShape [atomShape "user_added", wildShape])
+            ]
+          edges = publishesEdges (BeamPubsubDelivery.resolveAll nodes)
+      map geSource edges `shouldBe` ["bc:1"]
+      map geTarget edges `shouldBe` ["mt:1"]
+
+    it "does NOT emit when topic differs" $ do
+      let nodes =
+            [ mkSubscribe "sub:1" "lib/sub.ex" "other" "Ichi.PubSub"
+            , mkInfoHandler "mt:1" "lib/sub.ex" (atomShape "foo")
+            , mkBroadcast "bc:1" "lib/pub.ex" "events" "Ichi.PubSub"
+                (atomShape "foo")
+            ]
+      publishesEdges (BeamPubsubDelivery.resolveAll nodes) `shouldBe` []
+
+    it "does NOT emit when PubSub server differs" $ do
+      let nodes =
+            [ mkSubscribe "sub:1" "lib/sub.ex" "events" "A.PubSub"
+            , mkInfoHandler "mt:1" "lib/sub.ex" (atomShape "foo")
+            , mkBroadcast "bc:1" "lib/pub.ex" "events" "B.PubSub"
+                (atomShape "foo")
+            ]
+      publishesEdges (BeamPubsubDelivery.resolveAll nodes) `shouldBe` []
+
+    it "does NOT emit when handler shape does not unify" $ do
+      let nodes =
+            [ mkSubscribe "sub:1" "lib/sub.ex" "events" "Ichi.PubSub"
+            , mkInfoHandler "mt:1" "lib/sub.ex" (atomShape "other")
+            , mkBroadcast "bc:1" "lib/pub.ex" "events" "Ichi.PubSub"
+                (atomShape "foo")
+            ]
+      publishesEdges (BeamPubsubDelivery.resolveAll nodes) `shouldBe` []
+
+    it "fans out to multiple subscribers on the same topic" $ do
+      let nodes =
+            [ mkSubscribe "sub:1" "lib/a.ex" "events" "Ichi.PubSub"
+            , mkInfoHandler "mt:a" "lib/a.ex" (atomShape "ping")
+            , mkSubscribe "sub:2" "lib/b.ex" "events" "Ichi.PubSub"
+            , mkInfoHandler "mt:b" "lib/b.ex" (atomShape "ping")
+            , mkBroadcast "bc:1" "lib/pub.ex" "events" "Ichi.PubSub"
+                (atomShape "ping")
+            ]
+          edges = publishesEdges (BeamPubsubDelivery.resolveAll nodes)
+      Set.fromList (map geTarget edges) `shouldBe` Set.fromList ["mt:a", "mt:b"]
+
+    it "filters subscriber's own non-info handlers (no hit on handle_call)" $ do
+      let nodes =
+            [ mkSubscribe "sub:1" "lib/sub.ex" "events" "Ichi.PubSub"
+            -- A handle_call in the subscriber module should not receive PUBLISHES
+            -- even if its shape matches — PubSub delivers as handle_info only.
+            , (mkInfoHandler "mt:call" "lib/sub.ex" (atomShape "ping"))
+                { gnMetadata = Map.fromList
+                    [ ("handler_type",  MetaText "call")
+                    , ("pattern_shape", atomShape "ping")
+                    ]
+                }
+            , mkBroadcast "bc:1" "lib/pub.ex" "events" "Ichi.PubSub"
+                (atomShape "ping")
+            ]
+      publishesEdges (BeamPubsubDelivery.resolveAll nodes) `shouldBe` []
+
+    it "carries topic + server provenance on the edge metadata" $ do
+      let nodes =
+            [ mkSubscribe "sub:1" "lib/sub.ex" "events" "Ichi.PubSub"
+            , mkInfoHandler "mt:1" "lib/sub.ex" (atomShape "foo")
+            , mkBroadcast "bc:1" "lib/pub.ex" "events" "Ichi.PubSub"
+                (atomShape "foo")
+            ]
+          [edge] = publishesEdges (BeamPubsubDelivery.resolveAll nodes)
+      Map.lookup "topic"  (geMetadata edge) `shouldBe` Just (MetaText "events")
+      Map.lookup "server" (geMetadata edge) `shouldBe` Just (MetaText "Ichi.PubSub")
+      Map.lookup "resolvedVia" (geMetadata edge)
+        `shouldBe` Just (MetaText "beam-pubsub-delivery")

--- a/packages/grafema-orchestrator/src/main.rs
+++ b/packages/grafema-orchestrator/src/main.rs
@@ -1514,6 +1514,10 @@ async fn main() -> Result<()> {
                                 // SENDS_MESSAGE / SELF_SCHEDULE edges to MESSAGE_TYPE clauses
                                 // (needs wrapper-resolve first so virtual calls from wrappers are seen)
                                 ("beam-message-types", &[]),
+                                // GAP-C: close the PubSub delivery loop — emit PUBLISHES edges
+                                // from broadcast CALLs to subscriber handle_info clauses by
+                                // matching (pubsub_server, topic) + shape unification.
+                                ("beam-pubsub-delivery", &[]),
                                 // REG-1098 W9: emit ISSUE nodes for MessageFlow findings
                                 // (runs last; reads the post-resolution node snapshot)
                                 ("beam-message-findings", &[]),
@@ -2376,6 +2380,8 @@ async fn main() -> Result<()> {
                                 ("beam-wrapper-resolve", &[]),
                                 // REG-1098 W6.5: precise CALL→MESSAGE_TYPE edges via shape unification
                                 ("beam-message-types", &[]),
+                                // GAP-C: PUBLISHES edges from broadcasts to subscriber handlers
+                                ("beam-pubsub-delivery", &[]),
                                 // REG-1098 W9: emit ISSUE nodes for MessageFlow findings
                                 ("beam-message-findings", &[]),
                             ],


### PR DESCRIPTION
## Summary

Closes GAP-C from the Ichi state-machine dogfooding — PubSub broadcasts and the @handle_info@ clauses that receive them had no direct graph link. Every @info:event/*@ handler reachable only through Phoenix.PubSub looked unreachable to dead-state detection.

### New edge type

| Edge | From → To | Semantics |
|---|---|---|
| \`PUBLISHES\` | CALL → MESSAGE_TYPE | Broadcast-call can deliver this shape to this subscriber clause via topic fan-out |

Distinct from \`SENDS_MESSAGE\` (direct send) and \`SELF_SCHEDULE\` (delayed self) because delivery is one-to-many topic fan-out. Dead-state rule now consults three complementary precise edges.

### Implementation

**Analyzer (\`pubsub.ex\`)**: \`process_broadcast\` and \`process_subscribe\` enrich their CALL node with \`pubsub_op\`, \`pubsub_topic\`, \`pubsub_server\` (plus \`message_shape\` on broadcasts). Resolver protocol is nodes-only, so the CALL node carries everything.

**Resolver (\`BeamPubsubDelivery.hs\`, new, ~150 LOC)**: indexes subscribe-CALLs by \`(server, topic)\` → subscriber files; indexes \`handle_info\` MESSAGE_TYPEs by file; for each broadcast CALL finds subscriber files with that topic, filters non-info clauses, unifies shape via existing \`BeamShape.unify\`, emits \`PUBLISHES\` with topic+server provenance on the edge.

**Orchestrator**: new \`beam-pubsub-delivery\` step after \`beam-message-types\` in both BEAM resolve pipelines.

### Scope

Direct \`Phoenix.PubSub.broadcast\` / \`subscribe\` calls only. Wrapper-mediated flows (\`EventBus.subscribe\`, custom publishers) are a follow-up: \`BeamWrapperResolution\` already identifies wrapper callsites and emits virtual \`SUBSCRIBES_TO\` / \`BROADCASTS_TO\` edges, but doesn't yet write \`pubsub_*\` metadata back onto the caller's CALL node. Extending it to do so is a self-contained ~20-line change.

### Validation

- **Unit tests**: +7 hspec cases covering topic/server match, topic mismatch, server mismatch, shape unify, multi-subscriber fan-out, non-info-clause exclusion, edge provenance. 65/65.
- **Analyzer tests**: 135/135 (no regression from enrichment).
- **Ichi end-to-end**: analyze runs clean. 0 Protocol errors. PUBLISHES currently emits 0 edges on Ichi — correct, as Ichi wraps every PubSub call through \`Ichi.EventBus\` helpers and has no \`handle_info\` clauses in the directly-subscribing modules. The wrapper-integration follow-up will unlock the expected ~30 PUBLISHES edges to Kagami/Naikan/LinearSync/Hormones \`info:event/*\` handlers.

## Test plan

- [x] \`mix test\` — 135/135
- [x] \`cabal test\` — 65/65
- [x] Direct-pubsub resolver path unit-covered for all branches
- [x] Ichi e2e clean runs, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)