### PR TITLE
feat(beam): wrapper-integration for SENDS_MESSAGE + PUBLISHES

### DIFF
--- a/packages/beam-analyzer/lib/beam_analyzer/rules/functions.ex
+++ b/packages/beam-analyzer/lib/beam_analyzer/rules/functions.ex
@@ -88,7 +88,13 @@ defmodule BeamAnalyzer.Rules.Functions do
       if exported and not callback_name?(name) do
         case BeamAnalyzer.Rules.Wrappers.detect_wrapper(keyword_body) do
           {:ok, wrap_info} ->
-            Context.merge_node_metadata(ctx, func_id, %{wraps: wrap_info})
+            # W5 looks only at the body, so wrappers that take the
+            # target as a parameter with default `__MODULE__` land as
+            # target: :var even though in practice the caller always
+            # hits the default. Promote those to :module_self here,
+            # where we do have the function's params.
+            refined = refine_wrapper_target(wrap_info, args)
+            Context.merge_node_metadata(ctx, func_id, %{wraps: refined})
 
           :no_wrap ->
             ctx
@@ -152,6 +158,31 @@ defmodule BeamAnalyzer.Rules.Functions do
 
   defp callback_name?(name) when is_atom(name), do: name in @callback_names
   defp callback_name?(_), do: false
+
+  # Rewrite a wrapper's target from :var → :module_self when the first
+  # parameter's default value is `__MODULE__`. Matches the canonical
+  # `def upsert(server \\ __MODULE__, ...), do: GenServer.call(server, ...)`
+  # public-API pattern: the wrapper accepts a pid override but always
+  # falls back to the current module, so from a caller's perspective
+  # the call is module-self by default. Cross-file resolvers can then
+  # actually target this wrapper instead of dropping it as var-target.
+  defp refine_wrapper_target(wrap_info, args) when is_map(wrap_info) and is_list(args) do
+    cond do
+      Map.get(wrap_info, :target) != :var -> wrap_info
+      first_arg_default_module?(List.first(args)) ->
+        %{wrap_info | target: :module_self}
+
+      true ->
+        wrap_info
+    end
+  end
+
+  defp refine_wrapper_target(wrap_info, _), do: wrap_info
+
+  # Detects `name \\ __MODULE__` parameter shape:
+  #   {:\\, _, [{name, _, ctx}, {:__MODULE__, _, _}]}
+  defp first_arg_default_module?({:\\, _, [_param, {:__MODULE__, _, _}]}), do: true
+  defp first_arg_default_module?(_), do: false
 
   defp process_params(args, ctx) do
     Enum.reduce(args, ctx, fn

--- a/packages/beam-analyzer/test/beam_analyzer_test.exs
+++ b/packages/beam-analyzer/test/beam_analyzer_test.exs
@@ -1494,6 +1494,50 @@ defmodule BeamAnalyzerTest do
       assert wraps_for(result, "subscribe/1") == nil
     end
 
+    test "first arg `server \\\\ __MODULE__` promotes target from :var to :module_self" do
+      # Canonical public-API shape: accept server override, default to __MODULE__.
+      # W5's single-expression detector only sees the body `GenServer.call(server, ...)`
+      # and marks target as :var — functions.ex must refine to :module_self using
+      # the function params.
+      result =
+        w5_analyze("""
+          def upsert(server \\\\ __MODULE__, id, record) do
+            GenServer.call(server, {:upsert, id, record})
+          end
+        """)
+
+      wraps = wraps_for(result, "upsert/3")
+      assert wraps.kind == :call
+      assert wraps.target == :module_self
+    end
+
+    test "var target stays :var when first arg has no __MODULE__ default" do
+      result =
+        w5_analyze("""
+          def forward(pid, msg) do
+            send(pid, msg)
+          end
+        """)
+
+      wraps = wraps_for(result, "forward/2")
+      assert wraps.kind == :send
+      assert wraps.target == :var
+    end
+
+    test "literal target is not overridden by default-arg refinement" do
+      result =
+        w5_analyze("""
+          def tick(msg) do
+            send(Ichi.Scheduler, msg)
+          end
+        """)
+
+      wraps = wraps_for(result, "tick/1")
+      assert wraps.kind == :send
+      assert wraps.target == :literal
+      assert wraps.target_hint == "Elixir.Ichi.Scheduler"
+    end
+
     test "full analysis with 3 wrappers is Jason-encodable" do
       result =
         w5_analyze("""

--- a/packages/beam-resolve/src/BeamMessageTypeResolution.hs
+++ b/packages/beam-resolve/src/BeamMessageTypeResolution.hs
@@ -38,11 +38,17 @@ import Grafema.GraphTraversal (lookupMetaText, lookupMetaBool)
 import Grafema.Protocol (PluginCommand(..), readNodesFromStdin, writeCommandsToStdout)
 
 import Data.Text (Text)
+import qualified Data.Text as T
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
 import Data.Maybe (fromMaybe, mapMaybe)
 
 import BeamShape (Shape, parseShape, unify)
+import BeamWrapperResolution
+  ( WrapperSite(..), WrapInfo(..), WrapKind(..), WrapTarget(..)
+  , resolvedWrapperSites, extractModuleFromId
+  )
+import Grafema.Types (gnSemanticId)
 
 -- ---------------------------------------------------------------------
 -- Indices
@@ -165,12 +171,68 @@ emitEdges ss matches =
 resolveAll :: [GraphNode] -> [PluginCommand]
 resolveAll nodes =
   let (msgByFile, procByName) = buildIndices nodes
-      sendSites               = mapMaybe toSendSite nodes
+      wrapperSites   = resolvedWrapperSites nodes
+
+      -- Direct send-sites come from analyzer-enriched CALL metadata.
+      -- Wrapper-call sites come from resolving CALLs that target
+      -- call/cast/send/send_after wrapper defs; we synthesize a
+      -- SendSite from the wrapper's @wraps@ metadata so downstream
+      -- shape-unify logic is the same as for direct sends.
+      sendSites =
+        mapMaybe toSendSite nodes
+          ++ mapMaybe wrapperToSendSite wrapperSites
+
       emit ss =
         case matchingHandlers ss (candidateMessageTypes msgByFile procByName ss) of
           []      -> []
           matches -> emitEdges ss matches
   in concatMap emit sendSites
+
+-- | Translate a send/call/cast/send_after wrapper-call into the same
+-- SendSite shape the direct path uses. target_hint is derived from
+-- the wrapper's @wraps.target@ field plus the wrapper FUNCTION's own
+-- module when the wrapper is @module_self@ (because the wrapper's
+-- body executes with __MODULE__ bound to the wrapper's module, not
+-- the caller's).
+wrapperToSendSite :: WrapperSite -> Maybe SendSite
+wrapperToSendSite ws = do
+  let wi = wsWrapInfo ws
+  (via, base) <- senderKind (wiKind wi)
+  shape <- wiMessageShape wi
+  let callNode = wsCall ws
+      wrapperNode = wsWrapper ws
+      hint = case wiTarget wi of
+        WTModuleSelf -> extractModuleFromId (gnSemanticId wrapperNode)
+        WTLiteral t  -> Just (stripElixirPrefixT t)
+        WTVar        -> Nothing
+      isSelf = case wiTarget wi of
+        WTModuleSelf -> gnFile callNode == gnFile wrapperNode
+        _            -> False
+  pure SendSite
+    { ssCallId       = gnId callNode
+    , ssSenderVia    = via
+    , ssSenderBase   = base
+    , ssShape        = parseShape shape
+    , ssTargetIsSelf = isSelf
+    , ssTargetHint   = hint
+    , ssCallFile     = gnFile callNode
+    }
+
+senderKind :: WrapKind -> Maybe (Text, Text)
+senderKind k = case k of
+  WKCall      -> Just ("call",  "GenServer.call")
+  WKCast      -> Just ("cast",  "GenServer.cast")
+  WKSend      -> Just ("info",  "send")
+  WKSendAfter -> Just ("info",  "Process.send_after")
+  _           -> Nothing
+
+-- | Strip the @Elixir.@ prefix that qualified module aliases carry in
+-- W5's target_hint so we match PROCESS names which are bare module
+-- paths (e.g. @Ichi.ArujiModel@).
+stripElixirPrefixT :: Text -> Text
+stripElixirPrefixT t
+  | T.isPrefixOf "Elixir." t = T.drop 7 t
+  | otherwise                = t
 
 -- | CLI entry point.
 run :: IO ()

--- a/packages/beam-resolve/src/BeamPubsubDelivery.hs
+++ b/packages/beam-resolve/src/BeamPubsubDelivery.hs
@@ -44,6 +44,10 @@ import Data.Map.Strict (Map)
 import Data.Maybe (fromMaybe, mapMaybe)
 
 import BeamShape (Shape, parseShape, unify)
+import BeamWrapperResolution
+  ( WrapperSite(..), WrapInfo(..), WrapKind(..)
+  , resolvedWrapperSites
+  )
 
 -- ---------------------------------------------------------------------
 -- Views
@@ -144,9 +148,60 @@ buildIndices nodes =
 
 resolveAll :: [GraphNode] -> [PluginCommand]
 resolveAll nodes =
-  let (subsByTopic, handlersByFile) = buildIndices nodes
-      broadcasts = mapMaybe toBroadcast nodes
-  in concatMap (emitFor subsByTopic handlersByFile) broadcasts
+  let (directSubsByTopic, handlersByFile) = buildIndices nodes
+      wrapperSites   = resolvedWrapperSites nodes
+
+      -- Subscribers include direct Phoenix.PubSub.subscribe CALLs AND
+      -- anyone calling a sub-kind wrapper def (e.g. `EventBus.subscribe`).
+      -- The wrapper itself doesn't carry a pubsub server — fold it in
+      -- under the sentinel "<wrapper>" server so wrapper-origin
+      -- broadcasts can match wrapper-origin subscribes without knowing
+      -- the real PubSub process. Direct broadcasts also check this
+      -- sentinel so wrapper-subscribed files receive them.
+      wrapperSubsByTopic = foldr addWrapperSub Map.empty wrapperSites
+      subsByTopic = Map.unionWith (++) directSubsByTopic wrapperSubsByTopic
+
+      directBroadcasts  = mapMaybe toBroadcast nodes
+      wrapperBroadcasts = mapMaybe wrapperBroadcastSite wrapperSites
+
+  in concatMap (emitFor subsByTopic handlersByFile)
+               (directBroadcasts ++ wrapperBroadcasts)
+
+-- | Fold a sub-kind wrapper call into the subscribers-by-topic index.
+addWrapperSub :: WrapperSite -> SubscribersByTopic -> SubscribersByTopic
+addWrapperSub ws acc = case wiKind (wsWrapInfo ws) of
+  WKSub -> case wiTopic (wsWrapInfo ws) of
+    Just topic ->
+      let key = (wrapperServerSentinel, topic)
+      in Map.insertWith (++) key [gnFile (wsCall ws)] acc
+    Nothing -> acc
+  _ -> acc
+
+-- | Turn a broadcast-kind wrapper call into a BroadcastSite. The topic
+-- comes from the wrapper FUNCTION's `wraps.topic` field; the shape
+-- from `wraps.message_shape`. Without a known shape we can't unify —
+-- skip.
+wrapperBroadcastSite :: WrapperSite -> Maybe BroadcastSite
+wrapperBroadcastSite ws = case wiKind (wsWrapInfo ws) of
+  WKBroadcast -> do
+    topic <- wiTopic (wsWrapInfo ws)
+    shape <- wiMessageShape (wsWrapInfo ws)
+    pure BroadcastSite
+      { bsCallId = gnId (wsCall ws)
+      , bsServer = wrapperServerSentinel
+      , bsTopic  = topic
+      , bsShape  = parseShape shape
+      }
+  _ -> Nothing
+
+-- | Sentinel server name for wrapper-mediated pubsub. Real Phoenix.PubSub
+-- calls that go through an `EventBus.subscribe/broadcast` helper don't
+-- record which PubSub server they target (W5 limitation), so we bucket
+-- all wrapper-origin pubsub under this name. Direct broadcasts that
+-- want to reach wrapper-subscribers use the same sentinel as a fallback
+-- (see 'emitFor').
+wrapperServerSentinel :: Text
+wrapperServerSentinel = "<wrapper>"
 
 emitFor
   :: SubscribersByTopic
@@ -155,7 +210,22 @@ emitFor
   -> [PluginCommand]
 emitFor subsByTopic handlersByFile bs =
   let subscriberFiles =
-        fromMaybe [] (Map.lookup (bsServer bs, bsTopic bs) subsByTopic)
+        if bsServer bs == wrapperServerSentinel
+          -- Wrapper-mediated broadcast. W5 doesn't record which PubSub
+          -- server the wrapper targets, so the resolver can't match on
+          -- server — any direct-sub with the same topic is a candidate.
+          then
+            [ f
+            | ((_srv, t), files) <- Map.toList subsByTopic
+            , t == bsTopic bs
+            , f <- files
+            ]
+          else
+            -- Direct broadcast with a known server. Match exact
+            -- (server, topic), plus fall back to the @<wrapper>@
+            -- bucket so wrapper-subscribed files are reachable too.
+            fromMaybe [] (Map.lookup (bsServer bs, bsTopic bs) subsByTopic)
+              ++ fromMaybe [] (Map.lookup (wrapperServerSentinel, bsTopic bs) subsByTopic)
       candidateHandlers = concatMap (lookupDefault handlersByFile) subscriberFiles
       matches = filter (handlerUnifies (bsShape bs)) candidateHandlers
   in map (mkPublishes bs) matches

--- a/packages/beam-resolve/src/BeamWrapperResolution.hs
+++ b/packages/beam-resolve/src/BeamWrapperResolution.hs
@@ -31,7 +31,17 @@
 -- wrapper targets; the resolver picks the only matching topic name if
 -- unique, else the one colocated with the wrapper. This is a known
 -- gap (see README for the W5 follow-up).
-module BeamWrapperResolution (run, resolveAll, readWrapInfo, WrapInfo(..), WrapKind(..), WrapTarget(..)) where
+module BeamWrapperResolution
+  ( run, resolveAll
+  , readWrapInfo, WrapInfo(..), WrapKind(..), WrapTarget(..)
+  -- Exposed for downstream resolvers (BeamMessageTypeResolution,
+  -- BeamPubsubDelivery) that need to follow the same wrapper-call
+  -- resolution logic. Without these, each resolver would have to copy
+  -- the index-building here.
+  , WrapperSite(..)
+  , resolvedWrapperSites
+  , extractModuleFromId
+  ) where
 
 import Grafema.Types (GraphNode(..), GraphEdge(..), MetaValue(..), gnSemanticId)
 import Grafema.Protocol (PluginCommand(..), readNodesFromStdin, writeCommandsToStdout)
@@ -301,6 +311,41 @@ buildTopicIdx ns =
     topicFor n = case Map.lookup "topic" (gnMetadata n) of
       Just (MetaText t) -> Just t
       _ -> let nm = gnName n in if T.null nm then Nothing else Just nm
+
+-- ---------------------------------------------------------------------
+-- Shared resolver view
+-- ---------------------------------------------------------------------
+
+-- | A single wrapper-call resolution. Downstream resolvers consume
+-- this to treat wrapper callers like direct sends/broadcasts without
+-- duplicating the call-resolution index logic.
+data WrapperSite = WrapperSite
+  { wsCall     :: !GraphNode
+  , wsWrapper  :: !GraphNode
+  , wsWrapInfo :: !WrapInfo
+  }
+
+-- | Walk every CALL, keep only the ones that resolve to a FUNCTION
+-- annotated with a @wraps@ metadata object. Reuses the local + qualified
+-- indices from this module.
+resolvedWrapperSites :: [GraphNode] -> [WrapperSite]
+resolvedWrapperSites nodes =
+  let lIdx  = buildLocalIdx nodes
+      lBase = buildLocalBaseIdx nodes
+      (qIdx, qBase, sIdx) = buildQualIdx nodes
+      funcById = Map.fromList [ (gnId n, n) | n <- nodes, gnType n == "FUNCTION" ]
+      calls    = filter ((== "CALL") . gnType) nodes
+  in
+    [ WrapperSite
+        { wsCall     = callNode
+        , wsWrapper  = fnNode
+        , wsWrapInfo = wi
+        }
+    | callNode <- calls
+    , Just targetFnId <- [resolveCallTarget lIdx lBase qIdx qBase sIdx callNode]
+    , Just fnNode     <- [Map.lookup targetFnId funcById]
+    , Just wi         <- [readWrapInfo fnNode]
+    ]
 
 -- ---------------------------------------------------------------------
 -- Main resolution

--- a/packages/beam-resolve/test/Spec.hs
+++ b/packages/beam-resolve/test/Spec.hs
@@ -1029,6 +1029,54 @@ main = hspec $ do
           cmds = BeamMessageTypeResolution.resolveAll nodes
       cmds `shouldBe` []
 
+    it "wrapper-integration: call/cast wrapper reaches matching handler via module_self" $ do
+      -- def upsert(server \\ __MODULE__, id, record), do: GenServer.call(server, {:upsert, id, record})
+      -- analyzer refines target to :module_self; resolver should pick up
+      -- the caller site and emit SENDS_MESSAGE to the matching handle_call.
+      let wrapperFn = (mkNode "fn:upsert" "FUNCTION" "upsert/3" "lib/aruji.ex")
+            { gnMetadata = Map.fromList
+                [ ("wraps", MetaMap (Map.fromList
+                    [ ("kind",   MetaText "call")
+                    , ("target", MetaText "module_self")
+                    , ("message_shape",
+                        tupleShape [atomShape "upsert", wildShape, wildShape])
+                    ]))
+                , ("semanticId",
+                    MetaText "lib/aruji.ex->FUNCTION->upsert/3[in:Ichi.ArujiModel]")
+                ]
+            }
+          handler = mkMsgType "mt:upsert" "call" "lib/aruji.ex"
+            (tupleShape [atomShape "upsert", wildShape, wildShape])
+          process = mkProcess "p:aruji" "Ichi.ArujiModel" "lib/aruji.ex"
+          wrapperCaller = (mkNode "c:callsite" "CALL" "Ichi.ArujiModel.upsert" "lib/caller.ex")
+            { gnMetadata = Map.fromList [("arity", MetaInt 2)] }
+          nodes = [process, handler, wrapperFn, wrapperCaller]
+          cmds = BeamMessageTypeResolution.resolveAll nodes
+      edgeTypes cmds `shouldBe` ["SENDS_MESSAGE"]
+      edgeTargets cmds `shouldBe` ["mt:upsert"]
+
+    it "wrapper-integration: literal target_hint is stripped of Elixir. prefix" $ do
+      let wrapperFn = (mkNode "fn:foo" "FUNCTION" "do_it/1" "lib/wrap.ex")
+            { gnMetadata = Map.fromList
+                [ ("wraps", MetaMap (Map.fromList
+                    [ ("kind",   MetaText "cast")
+                    , ("target", MetaText "literal")
+                    , ("target_hint", MetaText "Elixir.Ichi.Other")
+                    , ("message_shape", atomShape "go")
+                    ]))
+                , ("semanticId",
+                    MetaText "lib/wrap.ex->FUNCTION->do_it/1[in:Ichi.Wrap]")
+                ]
+            }
+          handler = mkMsgType "mt:go" "cast" "lib/other.ex" (atomShape "go")
+          process = mkProcess "p:other" "Ichi.Other" "lib/other.ex"
+          wrapperCaller = (mkNode "c:site" "CALL" "Ichi.Wrap.do_it" "lib/caller.ex")
+            { gnMetadata = Map.fromList [("arity", MetaInt 1)] }
+          nodes = [process, handler, wrapperFn, wrapperCaller]
+          cmds = BeamMessageTypeResolution.resolveAll nodes
+      -- Even with `Elixir.` prefix on the hint the process lookup succeeds.
+      edgeTargets cmds `shouldBe` ["mt:go"]
+
     it "cross-process Process.send_after stays SENDS_MESSAGE (not SELF_SCHEDULE)" $ do
       let nodes =
             [ mkProcess "p:1" "Other" "lib/other.ex"
@@ -1140,6 +1188,68 @@ main = hspec $ do
                 (atomShape "ping")
             ]
       publishesEdges (BeamPubsubDelivery.resolveAll nodes) `shouldBe` []
+
+    it "wrapper-integration: direct broadcast reaches wrapper-sub subscribers" $ do
+      -- Subscriber file `lib/sub.ex` calls a wrapper `EventBus.subscribe()`.
+      -- The wrapper FUNCTION in `lib/event_bus.ex` is WKSub with topic=events.
+      -- A DIRECT Phoenix.PubSub.broadcast to the same topic (but with a
+      -- real pubsub server) must reach the subscriber's handle_info
+      -- via the <wrapper> sentinel fallback in emitFor.
+      let wrapperFn = (mkNode "fn:sub" "FUNCTION" "subscribe/0" "lib/event_bus.ex")
+            { gnMetadata = Map.fromList
+                [ ("wraps", MetaMap (Map.fromList
+                    [ ("kind",  MetaText "sub")
+                    , ("topic", MetaText "events")
+                    , ("target", MetaText "literal")
+                    , ("target_hint", MetaText "Ichi.PubSub")
+                    ]))
+                , ("semanticId", MetaText "lib/event_bus.ex->FUNCTION->subscribe/0[in:Ichi.EventBus]")
+                ]
+            }
+          -- CALL in lib/sub.ex that resolves to the wrapper FUNCTION by name.
+          subModule = (mkNode "m:sub" "MODULE" "Ichi.Sub" "lib/sub.ex")
+          wrapperCaller = (mkNode "c:call" "CALL" "Ichi.EventBus.subscribe" "lib/sub.ex")
+            { gnMetadata = Map.fromList [("arity", MetaInt 0)] }
+          nodes =
+            [ subModule
+            , wrapperFn
+            , wrapperCaller
+            , mkInfoHandler "mt:1" "lib/sub.ex" (atomShape "foo")
+            , mkBroadcast "bc:1" "lib/pub.ex" "events" "Ichi.PubSub"
+                (atomShape "foo")
+            ]
+          cmds = publishesEdges (BeamPubsubDelivery.resolveAll nodes)
+      -- The direct broadcast reaches the subscriber via the <wrapper>
+      -- bucket that the subscribe-wrapper caller populated.
+      map geSource cmds `shouldBe` ["bc:1"]
+      map geTarget cmds `shouldBe` ["mt:1"]
+
+    it "wrapper-integration: broadcast wrapper reaches direct subscribers on same topic" $ do
+      let wrapperFn = (mkNode "fn:bc" "FUNCTION" "emit/1" "lib/event_bus.ex")
+            { gnMetadata = Map.fromList
+                [ ("wraps", MetaMap (Map.fromList
+                    [ ("kind",  MetaText "broadcast")
+                    , ("topic", MetaText "events")
+                    , ("target", MetaText "literal")
+                    , ("target_hint", MetaText "Ichi.PubSub")
+                    , ("message_shape", atomShape "ding")
+                    ]))
+                , ("semanticId", MetaText "lib/event_bus.ex->FUNCTION->emit/1[in:Ichi.EventBus]")
+                ]
+            }
+          wrapperCaller = (mkNode "c:bc" "CALL" "Ichi.EventBus.emit" "lib/pub.ex")
+            { gnMetadata = Map.fromList [("arity", MetaInt 1)] }
+          nodes =
+            [ mkNode "m:bus" "MODULE" "Ichi.EventBus" "lib/event_bus.ex"
+            , mkNode "m:pub" "MODULE" "Ichi.Pub"      "lib/pub.ex"
+            , wrapperFn
+            , wrapperCaller
+            , mkSubscribe "sub:1" "lib/sub.ex" "events" "Ichi.PubSub"
+            , mkInfoHandler "mt:1" "lib/sub.ex" (atomShape "ding")
+            ]
+          cmds = publishesEdges (BeamPubsubDelivery.resolveAll nodes)
+      map geSource cmds `shouldBe` ["c:bc"]
+      map geTarget cmds `shouldBe` ["mt:1"]
 
     it "carries topic + server provenance on the edge metadata" $ do
       let nodes =


### PR DESCRIPTION
## Summary

Closes the loop for Ichi's dominant message-passing pattern: most call/cast/send/subscribe/broadcast sites go through a module's own public-API wrapper (\`def upsert(x), do: GenServer.call(__MODULE__, {:upsert, x})\`) or through a shared bus helper (\`EventBus.subscribe\`). Direct-pubsub PUBLISHES (#251) and direct-send SENDS_MESSAGE (#249) never saw these wrapper callsites — dead-state detection on Ichi reported 20+ false positives in ArujiModel, Claude, Telegram, plus 15+ for PubSub subscribers.

## Changes

**BeamWrapperResolution** — new exports: \`resolvedWrapperSites\`, \`WrapperSite\`, \`extractModuleFromId\`. Downstream resolvers reuse the existing index-building instead of duplicating it. Existing edge-emission behaviour unchanged.

**BeamMessageTypeResolution** — feeds every call/cast/send/send_after wrapper-call into the same \`SendSite\` pipeline. \`:module_self\` target resolves to the wrapper's own module via \`extractModuleFromId\`. \`Elixir.\` prefix on literal targets stripped for PROCESS name match.

**BeamPubsubDelivery** — wrapper-sub callers fold into \`subsByTopic\` under a named \`<wrapper>\` sentinel. Wrapper-broadcast calls synthesize \`BroadcastSite\`; direct broadcasts consult the sentinel bucket, and wrapper-origin broadcasts fan out to all direct subs matching on topic (W5 doesn't record which PubSub server a wrapper targets).

**Analyzer (\`Rules.Functions.refine_wrapper_target/2\`)** — canonical public-API shape \`def upsert(server \\\\ __MODULE__, ...)\` was tagged \`target: :var\` by W5 (single-expression detector can't see function params). Post-process promotes to \`:module_self\` when first param's default is \`__MODULE__\`. Root-cause fix at the right layer.

## Validation

**Ichi end-to-end** (63 files, 3 clean runs):
- \`SENDS_MESSAGE\` edges: 130 → **323** (+193)
- \`PUBLISHES\` edges: 0 → **37** (+37)
- Dead handlers in state-machine map: 47 → **26** (-21)

Remaining 26 dead fall into three honest categories: external Port input (Claude OS Port, GatewayAdapter SSE stream, HTTPoison monitor DOWN), wrappers whose callers bypass the default server, and a handful of PubSub edge-cases.

**Tests:** 138/138 beam-analyzer (+3 new: \`server \\\\ __MODULE__\` → \`:module_self\` promotion, var kept as var, literal hint not overridden). 69/69 beam-resolve (+4 new: SENDS_MESSAGE via module_self wrapper, \`Elixir.\` prefix stripping, PUBLISHES via wrapper-sub fanout, PUBLISHES via wrapper-broadcast to direct subs).

**3-Review**: APPROVE from Steve Jobs, Вадим auto, Uncle Bob.

## Test plan

- [x] \`mix test\` — 138/138
- [x] \`cabal test\` — 69/69
- [x] Ichi e2e 3 clean runs, 0 Protocol errors, deterministic edge count
- [x] State-machine dead-handler count drops 47 → 26

🤖 Generated with [Claude Code](https://claude.com/claude-code)