### PR TITLE
feat(guarantees): beam-unreachable-handler-precise dead-state detector

### DIFF
--- a/.grafema/guarantees.yaml
+++ b/.grafema/guarantees.yaml
@@ -461,6 +461,21 @@ guarantees:
     rule: 'violation(X) :- node(X, "ISSUE"), attr(X, "finding_kind", "unreachable_handler").'
     severity: warning
 
+  - name: beam-unreachable-handler-precise
+    description: >
+      A MESSAGE_TYPE clause has no incoming precise-reachability edge
+      (SENDS_MESSAGE, SELF_SCHEDULE, or PUBLISHES) and is not the
+      module's catch-all. After the shape-aware resolvers run, this
+      means no statically-resolvable caller can deliver to this clause —
+      it is either dead code, driven by dynamic PID / external Port
+      input, or reached through a call path that static analysis
+      doesn't yet model (e.g. `me = self(); send(me, _)` chains).
+      Distinct from `beam-unreachable-handler`, which piggy-backs on
+      the older ISSUE-node path from BeamMessageFindings.
+    check: datalog
+    rule: 'violation(M) :- node(M, "MESSAGE_TYPE"), attr(M, "catchall", "false"), \+ incoming(M, _, "SENDS_MESSAGE"), \+ incoming(M, _, "SELF_SCHEDULE"), \+ incoming(M, _, "PUBLISHES").'
+    severity: warning
+
   - name: beam-orphan-send
     description: >
       A SENDS_TO edge carries a message whose shape does not unify


### PR DESCRIPTION
## Summary

Adds \`beam-unreachable-handler-precise\` Datalog guarantee — the final piece of the Elixir state-machine reachability model after PRs #249, #251, #252.

**Rule:**
\`\`\`datalog
violation(M) :- node(M, \"MESSAGE_TYPE\"),
                attr(M, \"catchall\", \"false\"),
                \\+ incoming(M, _, \"SENDS_MESSAGE\"),
                \\+ incoming(M, _, \"SELF_SCHEDULE\"),
                \\+ incoming(M, _, \"PUBLISHES\").
\`\`\`

A MESSAGE_TYPE with no incoming reachability edge and not a catch-all is either dead code, driven by external input (OS Port, HTTPoison monitor DOWN), or reached through a dataflow path the resolvers don't yet model.

## Usage

\`\`\`
grafema check beam-unreachable-handler-precise
\`\`\`

Reports each violating MESSAGE_TYPE by its human shape label (\`info:reflect/force\`, \`cast:upsert/_\`, …) and file+line. No bespoke CLI, no ISSUE-node plumbing — runs off the live graph through the standard \`grafema check\` pipeline.

## Why separate from \`beam-unreachable-handler\`

The existing guarantee consumes ISSUE nodes emitted by \`BeamMessageFindings.unreachableHandler\`, which reads SENDS_TO edges — but the CLI dispatch passes an empty edge list to that resolver, so it never fires in production. The precise variant works directly off the committed edge graph, so it sees everything the resolver pipeline has already proven.

## Real-world — Ichi

26 violations reported, split into three honest buckets:
- **~16 external-input** handlers: Claude OS Port (\`:data/_\`, \`:exit_status/_\`), GatewayAdapter SSE stream (\`sse_chunk/_\`), Process.monitor DOWN (\`DOWN/_/process/_/_\`)
- **~5 wrapper-call edge cases**: wrappers whose callers pass non-default servers (arity-mismatch fallback miss)
- **~5 value-tracing candidates**: \`me = self(); send(me, _)\` chains in TaskQueue, needing future value-tracing

On grafema's own repo: **0 violations** (0 MESSAGE_TYPE nodes — Elixir analyzer doesn't run on self-analysis path).

## Test plan

- [x] \`grafema check beam-unreachable-handler-precise\` executes and lists 26 violations with human labels on Ichi
- [x] Grafema self-check passes (no false positives on JS/TS/Rust repo)
- [x] Existing guarantees unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)