### PR TITLE
feat(beam): self-alias tracking — me = self() sends resolve to handlers

### DIFF
--- a/packages/beam-analyzer/lib/beam_analyzer/context.ex
+++ b/packages/beam-analyzer/lib/beam_analyzer/context.ex
@@ -9,7 +9,12 @@ defmodule BeamAnalyzer.Context do
     nodes: [],
     edges: [],
     exports: [],
-    next_id: 0
+    next_id: 0,
+    # Variable names that are bound to `self()` in the current scope.
+    # Used to promote `send(me, msg)` / `Process.send_after(me, ...)`
+    # into self-directed sends when `me = self()` was seen earlier in
+    # the same function body. Reset on every function-body entry.
+    self_aliases: MapSet.new()
   ]
 
   def new(file) do
@@ -64,5 +69,31 @@ defmodule BeamAnalyzer.Context do
   def set_module(ctx, module_name) do
     module_id = "#{ctx.file}->MODULE->#{module_name}"
     %{ctx | module_name: module_name, module_id: module_id}
+  end
+
+  @doc """
+  Mark a variable name as a `self()` alias for the remainder of the
+  current function body. Used by the walker when it sees
+  `me = self()` so later `send(me, ...)` sites know their target is
+  this process.
+  """
+  def add_self_alias(ctx, name) when is_atom(name) do
+    %{ctx | self_aliases: MapSet.put(ctx.self_aliases, name)}
+  end
+
+  def add_self_alias(ctx, _), do: ctx
+
+  def self_alias?(ctx, name) when is_atom(name) do
+    MapSet.member?(ctx.self_aliases, name)
+  end
+
+  def self_alias?(_, _), do: false
+
+  @doc """
+  Drop every tracked self-alias. Called on function-body entry so one
+  function's `me = self()` binding doesn't leak into a sibling.
+  """
+  def reset_self_aliases(ctx) do
+    %{ctx | self_aliases: MapSet.new()}
   end
 end

--- a/packages/beam-analyzer/lib/beam_analyzer/rules/functions.ex
+++ b/packages/beam-analyzer/lib/beam_analyzer/rules/functions.ex
@@ -79,6 +79,9 @@ defmodule BeamAnalyzer.Rules.Functions do
 
     # Walk function body for calls, variables, control flow
     ctx = Context.push_scope(ctx, "#{name}/#{arity}")
+    # Reset self-alias tracking so `me = self()` from one function
+    # doesn't bleed into the next.
+    ctx = Context.reset_self_aliases(ctx)
 
     # Process parameters as variables
     ctx = process_params(args, ctx)
@@ -223,8 +226,20 @@ defmodule BeamAnalyzer.Rules.Functions do
 
   defp walk_expr({:=, _meta, [left, right]}, ctx) do
     ctx = BeamAnalyzer.Rules.Variables.process_match(left, ctx)
+    ctx = track_self_binding(left, right, ctx)
     walk_expr(right, ctx)
   end
+
+  # `me = self()` — remember `me` as a self-alias for the rest of the
+  # function body. Enables `send(me, _)` / `Process.send_after(me, ...)`
+  # to be recognised as self-directed sends (routine Elixir idiom for
+  # passing self() into a Task.async closure).
+  defp track_self_binding({name, _, ctx_atom}, {:self, _, []}, ctx)
+       when is_atom(name) and is_atom(ctx_atom) do
+    Context.add_self_alias(ctx, name)
+  end
+
+  defp track_self_binding(_left, _right, ctx), do: ctx
 
   defp walk_expr({:|>, meta, [left, right]}, ctx) do
     BeamAnalyzer.Rules.Calls.process_pipe(left, right, meta, ctx)

--- a/packages/beam-analyzer/lib/beam_analyzer/rules/infrastructure.ex
+++ b/packages/beam-analyzer/lib/beam_analyzer/rules/infrastructure.ex
@@ -213,6 +213,12 @@ defmodule BeamAnalyzer.Rules.Infrastructure do
       {:__aliases__, _, parts} when is_list(parts) ->
         alias_matches_module?(parts, ctx.module_name)
 
+      # Bare variable whose binding is `self()` earlier in the body —
+      # e.g. `me = self(); send(me, :tick)`. Covered by the walker's
+      # self-alias tracking in `track_self_binding/3`.
+      {name, _, ctx_atom} when is_atom(name) and is_atom(ctx_atom) ->
+        Context.self_alias?(ctx, name)
+
       _ ->
         false
     end

--- a/packages/beam-analyzer/test/beam_analyzer_test.exs
+++ b/packages/beam-analyzer/test/beam_analyzer_test.exs
@@ -1083,6 +1083,58 @@ defmodule BeamAnalyzerTest do
       assert call.metadata.sender_via == "info"
     end
 
+    test "self() bound to variable is tracked: send(me, _) is self-directed" do
+      # Elixir idiom: `me = self()` then pass `me` into a spawned
+      # Task closure so the task can send messages back to the
+      # starter process. Before self-alias tracking, `send(me, msg)`
+      # looked like a send to a bare var (target_is_self=false) and
+      # never resolved to a handler.
+      result =
+        w3_analyze("""
+          def start do
+            me = self()
+            send(me, :tick)
+          end
+        """)
+
+      call = call_node(result, "send")
+      assert call.metadata.target_is_self == true
+    end
+
+    test "unrelated var assignment does not mark send as self-directed" do
+      result =
+        w3_analyze("""
+          def relay(pid) do
+            me = pid
+            send(me, :tick)
+          end
+        """)
+
+      call = call_node(result, "send")
+      assert call.metadata.target_is_self == false
+    end
+
+    test "self-alias tracking is scoped to the function — doesn't leak" do
+      result =
+        w3_analyze("""
+          def first do
+            me = self()
+            send(me, :a)
+          end
+
+          def second(pid) do
+            send(me, :b)
+          end
+        """)
+
+      calls = Enum.filter(result.nodes, &(&1.type == "CALL" and &1.name == "send"))
+      [call_first, call_second] = Enum.sort_by(calls, & &1.line)
+      assert call_first.metadata.target_is_self == true
+      # `me` in second/1 is unbound (would be a compile error in real
+      # code but walker must still not carry over the alias).
+      assert call_second.metadata.target_is_self == false
+    end
+
     test "Process.send_after is recognised as a message sender" do
       result =
         w3_analyze("""


### PR DESCRIPTION
## Summary

Closes GAP-B — recognises the canonical Elixir pattern where a GenServer stashes its own pid in a variable so a spawned Task can send messages back:

\`\`\`elixir
def handle_call(_, _from, state) do
  me = self()
  Task.async(fn ->
    work = do_the_thing()
    send(me, {:task_complete, work})
  end)
  {:noreply, state}
end
\`\`\`

Before this pass, \`send(me, _)\` was treated as a bare-var target (target_is_self=false, no target_hint), and the receiving handler was reported as unreachable. Ichi's TaskQueue uses this pattern three times — every \`:task_complete\` / \`:task_requeue\` / \`:task_overflow\` handler was a false positive.

## Implementation

- \`Context.self_aliases :: MapSet.t()\` + accessors (\`add_self_alias/2\`, \`self_alias?/2\`, \`reset_self_aliases/1\`).
- \`Rules.Functions.track_self_binding/3\` — on every \`{:=, _, [lhs, rhs]}\` where rhs is \`{:self, _, []}\`, record the lhs name.
- Self-aliases reset on function-body entry — one function's \`me = self()\` doesn't leak into a sibling.
- \`Rules.Infrastructure.self_target?/2\` — new clause: bare-var target whose name is in \`ctx.self_aliases\` → target_is_self=true.

## Validation

**Ichi state-machine:**
- \`beam-unreachable-handler-precise\` violations: **26 → 17** (-9)
- SENDS_MESSAGE edges: 323 → 338 (+15)
- Remaining 17 dead are mostly legitimate external input: OS Port (\`:data/_\`, \`:exit_status/_\`), HTTPoison/Process.monitor DOWN (\`DOWN/_/process/_/_\`), plus a few wrapper-call edge cases

**Tests:** +3 scenarios in W3 describe:
- \`me = self()\` → send(me, _) promoted to self-target
- unrelated var (\`me = pid\`) → stays non-self
- function-boundary isolation (self-alias in fn A doesn't leak into fn B)

141/141 pass.

## Test plan

- [x] \`mix test\` — 141/141
- [x] Ichi e2e clean run, 0 errors, deterministic 16277 nodes
- [x] \`grafema check beam-unreachable-handler-precise\` drops from 26 to 17 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)