### PR TITLE
feat(beam-analyzer): precise handler-body scope + semantic state-field DFG

### DIFF
--- a/.claude/skills/rfdb-datalog-hash-join-shared-var/SKILL.md
+++ b/.claude/skills/rfdb-datalog-hash-join-shared-var/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: rfdb-datalog-hash-join-shared-var
+description: |
+  Fix silent incorrect results in RFDB Datalog queries that share a variable
+  between two edge atoms on opposite ends (e.g. self-join patterns like
+  `edge(M, C, "T1"), edge(C, M, "T2")`). Use when: (1) a Datalog rule
+  returns rows that look structurally wrong (e.g. a self-loop rule reports
+  hits but pinning M to each reported id refutes the edge existence),
+  (2) Cypher `MATCH (m)-[:R1]->(c)-[:R2]->(m)` returns the same bogus
+  rows (engine-level bug, not Datalog-specific), (3) results change when
+  you bind one variable explicitly vs. leave it free. Root cause: hash-
+  join fast path in `eval_edge_hash_join` / `eval_incoming_hash_join`
+  unconditionally rebinds the non-key Term::Var without checking
+  whether the variable is already bound in the current row.
+author: Claude Code
+version: 1.0.0
+date: 2026-04-20
+---
+
+# RFDB Datalog hash-join shared-var bug
+
+## Problem
+
+RFDB's Datalog engine has a fast path that kicks in once `current`
+bindings exceed `HASH_JOIN_THRESHOLD`: it pulls all edges of a given
+type and builds `HashMap<src, Vec<dst>>` (or the inverse for
+`incoming`) for O(1) lookups per binding.
+
+The bug: when the other end of the edge is a `Term::Var` whose name
+is **already bound** in the current row (i.e. a shared variable
+across two atoms), the fast path rebinds it unconditionally. Any
+value that satisfies the second edge pattern in isolation gets
+emitted as a "match," even when it contradicts the first atom's
+bindings.
+
+### Repro
+
+```
+edge(M, C, "CONTAINS"), edge(C, M, "SENDS_MESSAGE")
+```
+
+When you want: `M contains C` AND `C sends back to M` (self-loop).
+
+What you get with the bug: `M contains C` AND `C sends to *any* M'`,
+bleeding ~N false positives.
+
+Constraining M to a concrete id returns 0 rows; free M returns many.
+That delta is the symptom.
+
+## Trigger conditions
+
+1. Two `edge/3` or `incoming/3` atoms share a variable, each on
+   opposite sides of the edge direction.
+2. Current bindings for the *first* atom exceed `HASH_JOIN_THRESHOLD`
+   (default 256). Below that, nested-loop runs via `unify` which
+   handles bound vars correctly.
+3. Edge types are constants (hash-join requires const type).
+
+## Fix
+
+In `packages/rfdb-server/src/datalog/eval.rs`, both
+`eval_edge_hash_join` and `eval_incoming_hash_join` must check the
+non-key `Term::Var` against `bindings.get(var)` before accepting a
+row:
+
+```rust
+if let Term::Var(var) = dst_term {
+    if let Some(existing) = bindings.get(var).and_then(|v| v.as_id()) {
+        if existing != dst_id { continue; }
+    }
+}
+```
+
+(Mirror in `eval_incoming_hash_join` with `src_term` / `src_id`.)
+
+Put the check **before** `bindings.clone()` so mismatched rows are
+skipped without allocation.
+
+## Verification
+
+Regression tests in `packages/rfdb-server/src/datalog/tests.rs`:
+- `test_hash_join_shared_var_across_two_edges` — edge/3 self-join.
+- `test_incoming_hash_join_shared_var` — incoming/3 self-join.
+
+Both build a graph with `n = HASH_JOIN_THRESHOLD + 10` triples where
+exactly one pair forms a true round-trip. Without the fix, the
+rule returns n rows; with the fix, 1.
+
+## How we found it
+
+Adding `MESSAGE_TYPE → CONTAINS → CALL` edges to the BEAM graph and
+writing a Datalog guarantee for handler self-loops surfaced 13 hits
+on Ichi. Drilling into each "hit" M by binding it to a literal id
+showed zero incoming CONTAINS-that-sends-back edges. Reducing to the
+minimal repro `edge(A, B, "CONTAINS"), edge(B, A, "CONTAINS")` on a
+tree-shaped graph produced 15 spurious symmetric pairs — a tree has
+zero symmetric CONTAINS by construction. Cypher showed the same
+rows, ruling out the Datalog reorder/parser layer and pointing at
+the shared join engine.
+
+## Notes
+
+- Nested-loop path (via `unify`) is correct — the bug is isolated to
+  the hash-join fast path.
+- `eval_negation_hash_join` (for `\+ edge(X, _, "T")`) does not have
+  the same bug because it only projects one variable by design; the
+  other side is always `_` / `Wildcard`.
+- If you ever add a third variant of hash-join (e.g. for path/2
+  transitive closure), port the same check.

--- a/.grafema/guarantees.yaml
+++ b/.grafema/guarantees.yaml
@@ -567,3 +567,31 @@ guarantees:
     check: datalog
     rule: 'handler_writes(F) :- edge(M, F, "WRITES_STATE"), node(M, "MESSAGE_TYPE"). violation(F) :- node(F, "STATE_FIELD"), edge(_, F, "READS_STATE"), edge(_, F, "WRITES_STATE"), \+ handler_writes(F).'
     severity: info
+
+  - name: beam-state-truthy-guard-always-falsy
+    description: >
+      A state field is read in a truthy-test position (`if state.X
+      do`, `unless state.X`, `if Map.get(state, :X) do`) but every
+      writer of that field — init, handler clauses, and helper
+      functions — only ever sets it to a compile-time `false` / `nil`
+      literal (or deletes it, which reads back as nil). The truthy
+      branch of the guard is unreachable; the code inside is dead.
+      Requires zero WRITES_STATE_DYNAMIC edges so dynamic writers
+      (function-call results, variable references) don't mask a
+      potential truthy runtime value.
+    check: datalog
+    rule: 'violation(F) :- node(F, "STATE_FIELD"), edge(_, F, "READS_STATE_TRUTHY"), edge(_, F, "WRITES_STATE_FALSY"), \+ edge(_, F, "WRITES_STATE_TRUTHY"), \+ edge(_, F, "WRITES_STATE_DYNAMIC").'
+    severity: warning
+
+  - name: beam-state-truthy-guard-always-truthy
+    description: >
+      Mirror of beam-state-truthy-guard-always-falsy: every writer of
+      the field sets it to a compile-time truthy literal (atom, int,
+      struct, `true`, etc.), no writer emits a falsy value, and no
+      writer is dynamic. The `else` branch of `if state.X do ... else
+      ... end` (or the body of `unless state.X`) is unreachable dead
+      code. Often a sign that a flag was introduced for a toggle but
+      the "off" path was never wired up.
+    check: datalog
+    rule: 'violation(F) :- node(F, "STATE_FIELD"), edge(_, F, "READS_STATE_TRUTHY"), edge(_, F, "WRITES_STATE_TRUTHY"), \+ edge(_, F, "WRITES_STATE_FALSY"), \+ edge(_, F, "WRITES_STATE_DYNAMIC").'
+    severity: warning

--- a/.grafema/guarantees.yaml
+++ b/.grafema/guarantees.yaml
@@ -493,3 +493,43 @@ guarantees:
     check: datalog
     rule: 'violation(X) :- node(X, "ISSUE"), attr(X, "finding_kind", "topic_mismatch").'
     severity: warning
+
+  - name: beam-handler-self-loop-sends
+    description: >
+      A handler clause's body contains a call that delivers a message
+      back to the same handler clause — a classic `cast`/`call` echo
+      that can run a GenServer at 100% CPU until its mailbox floods.
+      Detected via MESSAGE_TYPE -[CONTAINS]-> CALL -[SENDS_MESSAGE]->
+      same MESSAGE_TYPE. SELF_SCHEDULE is excluded: the tick pattern
+      (`Process.send_after(self(), :tick, N)`) is a legitimate
+      liveness primitive — audit those with `beam-handler-unguarded-tick`.
+    check: datalog
+    rule: 'violation(M) :- edge(M, C, "CONTAINS"), edge(C, M, "SENDS_MESSAGE"), node(M, "MESSAGE_TYPE").'
+    severity: warning
+
+  - name: beam-handler-self-loop-publishes
+    description: >
+      A handler clause publishes to a PubSub topic whose subscriber
+      set includes the same clause — the handler re-enqueues itself
+      through fanout. Classic broadcast-storm pattern. Uses the
+      PUBLISHES edge emitted by BeamPubsubDelivery, so it only
+      fires when static topic unification says the handler really
+      will receive its own message.
+    check: datalog
+    rule: 'violation(M) :- edge(M, C, "CONTAINS"), edge(C, M, "PUBLISHES"), node(M, "MESSAGE_TYPE").'
+    severity: warning
+
+  - name: beam-handler-unguarded-tick
+    description: >
+      A handler clause issues `Process.send_after(self(), _, _)` /
+      `send(self(), _)` (SELF_SCHEDULE) with no BRANCH anywhere in
+      its own body — the next tick fires unconditionally. Usually
+      intentional for polling loops, but worth flagging: once the
+      process is alive it keeps ticking forever, even after its
+      downstream consumer is gone, its config is disabled, or its
+      subject has been removed. Add a guard
+      (`if state.running do schedule_next() end`) to make the
+      liveness condition visible.
+    check: datalog
+    rule: 'has_guard(M) :- edge(M, B, "CONTAINS"), node(B, "BRANCH"). violation(M) :- edge(M, C, "CONTAINS"), edge(C, _, "SELF_SCHEDULE"), node(M, "MESSAGE_TYPE"), \+ has_guard(M).'
+    severity: info

--- a/.grafema/guarantees.yaml
+++ b/.grafema/guarantees.yaml
@@ -533,3 +533,37 @@ guarantees:
     check: datalog
     rule: 'has_guard(M) :- edge(M, B, "CONTAINS"), node(B, "BRANCH"). violation(M) :- edge(M, C, "CONTAINS"), edge(C, _, "SELF_SCHEDULE"), node(M, "MESSAGE_TYPE"), \+ has_guard(M).'
     severity: info
+
+  - name: beam-state-guard-never-written
+    description: >
+      A handler clause reads a state field in a guard position
+      (`if state.X do`, `case state.X do`, `case Map.get(state, :X) do`)
+      but no handler clause AND no `init/1` ever writes to that
+      field. Since the field is never populated, guard branches that
+      depend on a truthy / specific value are permanently
+      unreachable — the corresponding work path is dead code. Built
+      on STATE_FIELD nodes + WRITES_STATE / READS_STATE edges
+      emitted by the beam-analyzer StateDFG pass.
+    check: datalog
+    rule: 'violation(F) :- node(F, "STATE_FIELD"), edge(_, F, "READS_STATE"), \+ edge(_, F, "WRITES_STATE").'
+    severity: warning
+
+  - name: beam-state-init-only-gate
+    description: >
+      A state field is read in a guard position of some handler but
+      the only writer is `init/1`. Three shapes are possible, from
+      safe to buggy:
+      (a) intentional immutable config — the GenServer receives the
+          value at start-up and branches on it for all eternity
+          (e.g. `state.role`, `state.name`); benign.
+      (b) one-shot initialisation — init writes a default and the
+          caller expects a handler to later mutate it, but the
+          handler implementation is missing; the state stays at its
+          init default forever.
+      (c) future-feature placeholder — field added with a default,
+          consumer exists, but the handler meant to toggle it was
+          never wired up.
+      Info-level: needs human judgement to classify.
+    check: datalog
+    rule: 'handler_writes(F) :- edge(M, F, "WRITES_STATE"), node(M, "MESSAGE_TYPE"). violation(F) :- node(F, "STATE_FIELD"), edge(_, F, "READS_STATE"), edge(_, F, "WRITES_STATE"), \+ handler_writes(F).'
+    severity: info

--- a/packages/beam-analyzer/lib/beam_analyzer/context.ex
+++ b/packages/beam-analyzer/lib/beam_analyzer/context.ex
@@ -14,7 +14,14 @@ defmodule BeamAnalyzer.Context do
     # Used to promote `send(me, msg)` / `Process.send_after(me, ...)`
     # into self-directed sends when `me = self()` was seen earlier in
     # the same function body. Reset on every function-body entry.
-    self_aliases: MapSet.new()
+    self_aliases: MapSet.new(),
+    # If non-nil, new CALL / BRANCH / LOOP nodes added via `add_node/2`
+    # automatically get a `MESSAGE_TYPE → CONTAINS → <node>` edge. Set
+    # by `Infrastructure.add_handler_edge/6` when a handler clause
+    # produces a MESSAGE_TYPE, cleared by `Functions.process_function`
+    # after walk_body. Gives Datalog rules a precise handler-body scope
+    # (required for cycle / unguarded-tick / pubsub-echo guarantees).
+    handler_clause_id: nil
   ]
 
   def new(file) do
@@ -25,8 +32,28 @@ defmodule BeamAnalyzer.Context do
   end
 
   def add_node(ctx, node) do
-    %{ctx | nodes: [node | ctx.nodes]}
+    ctx = %{ctx | nodes: [node | ctx.nodes]}
+    maybe_contain_in_handler_clause(ctx, node)
   end
+
+  # Automatically emit `MESSAGE_TYPE → CONTAINS → <node>` when the
+  # handler-clause scope is active and the node is something a Datalog
+  # rule would want to locate inside a clause (a call-site, a guard, or
+  # a loop). MESSAGE_TYPE itself is excluded — we don't contain a clause
+  # in itself when Infrastructure adds the clause node.
+  defp maybe_contain_in_handler_clause(%{handler_clause_id: nil} = ctx, _node), do: ctx
+
+  defp maybe_contain_in_handler_clause(ctx, %{type: type, id: id})
+       when type in ["CALL", "BRANCH", "LOOP"] do
+    add_edge(ctx, %{
+      src: ctx.handler_clause_id,
+      dst: id,
+      type: "CONTAINS",
+      metadata: %{}
+    })
+  end
+
+  defp maybe_contain_in_handler_clause(ctx, _node), do: ctx
 
   @doc """
   Merge additional metadata into a node identified by `id`. No-op if the
@@ -95,5 +122,24 @@ defmodule BeamAnalyzer.Context do
   """
   def reset_self_aliases(ctx) do
     %{ctx | self_aliases: MapSet.new()}
+  end
+
+  @doc """
+  Mark the given MESSAGE_TYPE id as the active handler clause. While
+  set, every CALL / BRANCH / LOOP node added via `add_node/2` gets a
+  CONTAINS edge from this clause.
+  """
+  def set_handler_clause(ctx, id) when is_binary(id) do
+    %{ctx | handler_clause_id: id}
+  end
+
+  def set_handler_clause(ctx, _), do: ctx
+
+  @doc """
+  Clear the active handler-clause scope. Called after a function body
+  has been walked so the next sibling def starts fresh.
+  """
+  def clear_handler_clause(ctx) do
+    %{ctx | handler_clause_id: nil}
   end
 end

--- a/packages/beam-analyzer/lib/beam_analyzer/rules/functions.ex
+++ b/packages/beam-analyzer/lib/beam_analyzer/rules/functions.ex
@@ -108,6 +108,12 @@ defmodule BeamAnalyzer.Rules.Functions do
 
     ctx = walk_body(keyword_body, ctx)
 
+    # Clear handler-clause scope so siblings don't inherit this def's
+    # MESSAGE_TYPE. Infrastructure only sets the scope for handle_*
+    # callback clauses that actually produced a MESSAGE_TYPE; for any
+    # other def this is a no-op.
+    ctx = Context.clear_handler_clause(ctx)
+
     Context.pop_scope(ctx)
   end
 
@@ -150,6 +156,12 @@ defmodule BeamAnalyzer.Rules.Functions do
     ctx = Enum.reduce(clauses, ctx, fn {:clause, _line, _args, _guards, body}, ctx ->
       Enum.reduce(body, ctx, &walk_erlang_expr/2)
     end)
+
+    # Clear handler-clause scope — same as the Elixir path. Erlang has
+    # a single MESSAGE_TYPE per handle_* function (first_arg = nil in
+    # Infrastructure), so all clause bodies above got CONTAINed by that
+    # one clause. Done for this def.
+    ctx = Context.clear_handler_clause(ctx)
 
     Context.pop_scope(ctx)
   end

--- a/packages/beam-analyzer/lib/beam_analyzer/rules/infrastructure.ex
+++ b/packages/beam-analyzer/lib/beam_analyzer/rules/infrastructure.ex
@@ -288,9 +288,27 @@ defmodule BeamAnalyzer.Rules.Infrastructure do
       func_name == "init/1" ->
         emit_state_field_edges(ctx, func_id, body, :init)
 
+      # Any other def/defp: propagate state-writes through private
+      # helpers so the guarantee engine sees the full write surface,
+      # not just the handler-clause body. Example: a handler calls
+      # `defp do_spawn(state, _)` which returns `%{state | running?: true}`.
+      #
+      # Gated on module having a PROCESS node (= it's actually a
+      # GenServer / Agent / Task). Without the gate, a non-GenServer
+      # module that happens to bind a local variable called `state`
+      # (e.g. `state = Ichi.Hormones.state()`) would emit bogus
+      # STATE_FIELD edges and pollute the semantic-state guarantees.
       true ->
-        ctx
+        if module_is_genserver?(ctx) do
+          emit_state_field_edges(ctx, func_id, body, :helper)
+        else
+          ctx
+        end
     end
+  end
+
+  defp module_is_genserver?(ctx) do
+    Enum.any?(ctx.nodes, fn n -> n.type == "PROCESS" and n.file == ctx.file end)
   end
 
   defp add_handler_edge(ctx, func_id, handler_type, first_arg, meta, body) do
@@ -392,14 +410,69 @@ defmodule BeamAnalyzer.Rules.Infrastructure do
   # mode = :init    (use map-literal / struct-literal semantics, since
   #                  init builds the initial state from scratch)
   defp emit_state_field_edges(ctx, src_id, body, mode) do
-    {writes, guards} =
-      case mode do
-        :handler -> BeamAnalyzer.Rules.StateDFG.extract(body)
-        :init -> {BeamAnalyzer.Rules.StateDFG.extract_init_writes(body), []}
-      end
+    case mode do
+      :handler ->
+        %{
+          writes: writes,
+          writes_truthy: writes_truthy,
+          writes_falsy: writes_falsy,
+          writes_dynamic: writes_dynamic,
+          guards: guards,
+          guards_truthy: guards_truthy,
+          uses: uses
+        } = BeamAnalyzer.Rules.StateDFG.extract(body)
 
-    ctx = Enum.reduce(writes, ctx, &add_field_edge(&2, src_id, &1, "WRITES_STATE"))
-    Enum.reduce(guards, ctx, &add_field_edge(&2, src_id, &1, "READS_STATE"))
+        ctx
+        |> emit_field_edges(src_id, writes, "WRITES_STATE")
+        |> emit_field_edges(src_id, writes_truthy, "WRITES_STATE_TRUTHY")
+        |> emit_field_edges(src_id, writes_falsy, "WRITES_STATE_FALSY")
+        |> emit_field_edges(src_id, writes_dynamic, "WRITES_STATE_DYNAMIC")
+        |> emit_field_edges(src_id, guards, "READS_STATE")
+        |> emit_field_edges(src_id, guards_truthy, "READS_STATE_TRUTHY")
+        |> emit_field_edges(src_id, uses, "USES_STATE")
+
+      :init ->
+        %{
+          writes: writes,
+          writes_truthy: writes_truthy,
+          writes_falsy: writes_falsy,
+          writes_dynamic: writes_dynamic
+        } = BeamAnalyzer.Rules.StateDFG.extract_init(body)
+
+        ctx
+        |> emit_field_edges(src_id, writes, "WRITES_STATE")
+        |> emit_field_edges(src_id, writes_truthy, "WRITES_STATE_TRUTHY")
+        |> emit_field_edges(src_id, writes_falsy, "WRITES_STATE_FALSY")
+        |> emit_field_edges(src_id, writes_dynamic, "WRITES_STATE_DYNAMIC")
+
+      :helper ->
+        # Private/helper function — same state-write semantics as a
+        # handler body (the `state` variable is the conventional name
+        # of the GenServer state passed as the last argument). Uses
+        # are emitted too so "field written but never read" rules see
+        # state.X references inside helper bodies. Guards are not
+        # emitted: a guard inside a helper only gates work when the
+        # helper is actually called from a handler, and the call
+        # graph already ties it back through CONTAINS/CALLS.
+        %{
+          writes: writes,
+          writes_truthy: writes_truthy,
+          writes_falsy: writes_falsy,
+          writes_dynamic: writes_dynamic,
+          uses: uses
+        } = BeamAnalyzer.Rules.StateDFG.extract(body)
+
+        ctx
+        |> emit_field_edges(src_id, writes, "WRITES_STATE")
+        |> emit_field_edges(src_id, writes_truthy, "WRITES_STATE_TRUTHY")
+        |> emit_field_edges(src_id, writes_falsy, "WRITES_STATE_FALSY")
+        |> emit_field_edges(src_id, writes_dynamic, "WRITES_STATE_DYNAMIC")
+        |> emit_field_edges(src_id, uses, "USES_STATE")
+    end
+  end
+
+  defp emit_field_edges(ctx, src_id, field_names, edge_type) do
+    Enum.reduce(field_names, ctx, &add_field_edge(&2, src_id, &1, edge_type))
   end
 
   defp add_field_edge(ctx, src_id, field_name, edge_type) do

--- a/packages/beam-analyzer/lib/beam_analyzer/rules/infrastructure.ex
+++ b/packages/beam-analyzer/lib/beam_analyzer/rules/infrastructure.ex
@@ -280,6 +280,14 @@ defmodule BeamAnalyzer.Rules.Infrastructure do
       String.starts_with?(func_name, "handle_event/") ->
         add_handler_edge(ctx, func_id, "event", first_arg, meta, body)
 
+      # init/1 — not a message handler but it DOES define the initial
+      # shape of state. Extracting writes from init body lets the
+      # state-field guarantees distinguish "field set once in init and
+      # never touched again" from "field not written anywhere" (the
+      # latter is the hard trap).
+      func_name == "init/1" ->
+        emit_state_field_edges(ctx, func_id, body, :init)
+
       true ->
         ctx
     end
@@ -351,6 +359,12 @@ defmodule BeamAnalyzer.Rules.Infrastructure do
           metadata: %{}
         })
 
+        # State-field DFG: every field the clause body writes or reads
+        # in guard position gets a STATE_FIELD node + WRITES_STATE /
+        # READS_STATE edge from this MESSAGE_TYPE. Enables the
+        # beam-state-* guarantees (field-guard-never-written, etc.).
+        ctx = emit_state_field_edges(ctx, msg_id, body, :handler)
+
         # Activate handler-clause scope so CALL / BRANCH / LOOP nodes
         # emitted by the walker while descending into this def's body
         # are automatically CONTAINed by this MESSAGE_TYPE. The caller
@@ -361,6 +375,57 @@ defmodule BeamAnalyzer.Rules.Infrastructure do
       [] ->
         ctx
     end
+  end
+
+  # Emit STATE_FIELD nodes + WRITES_STATE / READS_STATE edges for
+  # every field the given body touches. Invoked for:
+  #   - handler clauses (src = MESSAGE_TYPE id) — captures runtime
+  #     writes/guards per clause;
+  #   - `init/1` (src = FUNCTION id) — captures the initial-state
+  #     shape so "field never written" can distinguish init-only
+  #     fields from genuinely dangling reads.
+  #
+  # FIELD nodes are per-file so different modules keep independent
+  # field namespaces (two GenServers both with `state.paused` don't
+  # collapse into one node).
+  # mode = :handler (use map-update semantics on the `state` variable)
+  # mode = :init    (use map-literal / struct-literal semantics, since
+  #                  init builds the initial state from scratch)
+  defp emit_state_field_edges(ctx, src_id, body, mode) do
+    {writes, guards} =
+      case mode do
+        :handler -> BeamAnalyzer.Rules.StateDFG.extract(body)
+        :init -> {BeamAnalyzer.Rules.StateDFG.extract_init_writes(body), []}
+      end
+
+    ctx = Enum.reduce(writes, ctx, &add_field_edge(&2, src_id, &1, "WRITES_STATE"))
+    Enum.reduce(guards, ctx, &add_field_edge(&2, src_id, &1, "READS_STATE"))
+  end
+
+  defp add_field_edge(ctx, src_id, field_name, edge_type) do
+    field_id = "#{ctx.file}->STATE_FIELD->#{field_name}"
+
+    field_node = %{
+      id: field_id,
+      type: "STATE_FIELD",
+      name: field_name,
+      file: ctx.file,
+      line: 0,
+      column: 0,
+      endLine: 0,
+      endColumn: 0,
+      exported: false,
+      metadata: %{language: "elixir"}
+    }
+
+    ctx
+    |> Context.add_node(field_node)
+    |> Context.add_edge(%{
+      src: src_id,
+      dst: field_id,
+      type: edge_type,
+      metadata: %{}
+    })
   end
 
   # Catch-all pattern: bare variable, wildcard, or guarded bare variable.

--- a/packages/beam-analyzer/lib/beam_analyzer/rules/infrastructure.ex
+++ b/packages/beam-analyzer/lib/beam_analyzer/rules/infrastructure.ex
@@ -344,12 +344,19 @@ defmodule BeamAnalyzer.Rules.Infrastructure do
         ctx = Context.add_node(ctx, msg_node)
 
         # RECEIVES edge from process to message type
-        Context.add_edge(ctx, %{
+        ctx = Context.add_edge(ctx, %{
           src: process.id,
           dst: msg_id,
           type: "RECEIVES",
           metadata: %{}
         })
+
+        # Activate handler-clause scope so CALL / BRANCH / LOOP nodes
+        # emitted by the walker while descending into this def's body
+        # are automatically CONTAINed by this MESSAGE_TYPE. The caller
+        # (Rules.Functions.process_function/6) clears the scope after
+        # walk_body so the next sibling def starts fresh.
+        Context.set_handler_clause(ctx, msg_id)
 
       [] ->
         ctx

--- a/packages/beam-analyzer/lib/beam_analyzer/rules/state_dfg.ex
+++ b/packages/beam-analyzer/lib/beam_analyzer/rules/state_dfg.ex
@@ -1,0 +1,191 @@
+defmodule BeamAnalyzer.Rules.StateDFG do
+  @moduledoc """
+  Extract GenServer state field reads/writes from a handler-clause or
+  `init/1` body.
+
+  Gives the graph enough structure to answer semantic-state questions
+  that message-shape analysis alone cannot:
+  - which fields can a handler mutate?
+  - which fields are read by a guard that gates work?
+  - are there fields only written by `init/1` and then used as a
+    conditional elsewhere (permanent-state trap)?
+
+  Recognised write forms (the state variable is conservatively matched
+  by name; the common convention `def handle_*(msg, _from, state)` is
+  assumed):
+    %{state | field: value}                 # map update
+    %StructName{state | field: value}       # struct update
+    Map.put(state, :field, value)
+    Map.put_new(state, :field, value)
+    Map.delete(state, :field)
+    Map.update(state, :field, default, fun)
+    Map.update!(state, :field, fun)
+    Map.replace!(state, :field, value)
+
+  Recognised guard-read forms (field access in a position that drives
+  control flow):
+    if state.field do / if state.field, do: ...
+    unless state.field do
+    case state.field do
+    case Map.get(state, :field) do
+
+  Tuple-shaped updates returned from a handler
+  (`{:reply, _, %{state | field: _}}`, `{:noreply, %{state | ...}}`)
+  are walked transparently because the outer Macro.prewalk descends
+  into every sub-term.
+
+  What's intentionally out of scope for v1:
+    - Value tracking. We record only field *names*, not what they're
+      set to. A follow-up can attach a Patterns.normalize/1 shape per
+      (field, write-site).
+    - State variable aliasing (`new_state = %{state | ...}`).
+    - Nested field paths (`state.inner.field`).
+    - `for`/`reduce` accumulators that rebuild the map.
+  """
+
+  @doc """
+  Walk an AST fragment and return `{writes, guards}` where each entry
+  is a sorted, deduplicated list of field-name strings.
+  """
+  def extract(nil), do: {[], []}
+
+  def extract(ast) do
+    {_, acc} =
+      Macro.prewalk(ast, {MapSet.new(), MapSet.new()}, fn node, acc ->
+        {node, check_node(node, acc)}
+      end)
+
+    {writes, guards} = acc
+    {sorted(writes), sorted(guards)}
+  end
+
+  @doc """
+  Extract the set of state fields set by an `init/1` body. Unlike a
+  handler body, `init/1` builds state from scratch — the initial
+  state is a *literal* map or struct (`%{...}`, `%__MODULE__{...}`,
+  `%Other{...}`) — not an update against an existing `state` var.
+
+  We collect the keys of every map/struct literal we find during a
+  prewalk. This can over-capture if init calls a helper that builds
+  auxiliary maps, but init bodies are usually short and single-
+  purpose, so the noise is acceptable. The alternative — walking
+  only the init return position — misses the common
+  `state = %{...}; ...; {:ok, state}` pattern.
+
+  Returns a sorted, deduplicated list of field-name strings.
+  """
+  def extract_init_writes(nil), do: []
+
+  def extract_init_writes(ast) do
+    {_, writes} =
+      Macro.prewalk(ast, MapSet.new(), fn node, acc ->
+        {node, check_init_node(node, acc)}
+      end)
+
+    sorted(writes)
+  end
+
+  # Map literal `%{k: v, ...}` but NOT an update `%{state | k: v}`
+  defp check_init_node({:%{}, _, kv_list}, acc) when is_list(kv_list) do
+    if map_update?(kv_list) do
+      acc
+    else
+      put_keys(acc, kv_list)
+    end
+  end
+
+  # Struct literal `%Struct{k: v, ...}` but NOT an update `%Struct{state | k: v}`
+  defp check_init_node({:%, _, [_name, {:%{}, _, kv_list}]}, acc) when is_list(kv_list) do
+    if map_update?(kv_list) do
+      acc
+    else
+      put_keys(acc, kv_list)
+    end
+  end
+
+  defp check_init_node(_, acc), do: acc
+
+  defp map_update?([{:|, _, _} | _]), do: true
+  defp map_update?(_), do: false
+
+  defp put_keys(acc, kv_list) do
+    Enum.reduce(kv_list, acc, fn
+      {k, _v}, a when is_atom(k) -> MapSet.put(a, Atom.to_string(k))
+      _, a -> a
+    end)
+  end
+
+  defp sorted(set), do: set |> MapSet.to_list() |> Enum.sort()
+
+  # ── WRITES ─────────────────────────────────────────────────────────
+
+  # %{state | key: value, ...}
+  defp check_node(
+         {:%{}, _, [{:|, _, [{:state, _, ctx}, kv_list]}]},
+         acc
+       )
+       when is_atom(ctx) and is_list(kv_list) do
+    put_many(acc, :writes, kv_keys(kv_list))
+  end
+
+  # %Struct{state | key: value, ...}
+  defp check_node(
+         {:%, _, [_struct_name, {:%{}, _, [{:|, _, [{:state, _, ctx}, kv_list]}]}]},
+         acc
+       )
+       when is_atom(ctx) and is_list(kv_list) do
+    put_many(acc, :writes, kv_keys(kv_list))
+  end
+
+  # Map.<op>(state, :field, ...)
+  defp check_node(
+         {{:., _, [{:__aliases__, _, [:Map]}, op]}, _, [{:state, _, ctx}, key | _]},
+         acc
+       )
+       when is_atom(ctx) and is_atom(key) and
+              op in [:put, :put_new, :delete, :update, :update!, :replace!] do
+    put_one(acc, :writes, Atom.to_string(key))
+  end
+
+  # ── GUARDS ─────────────────────────────────────────────────────────
+
+  # if / unless — first arg is the condition
+  defp check_node({kind, _, [cond_ast | _rest]}, acc) when kind in [:if, :unless] do
+    maybe_record_guard(cond_ast, acc)
+  end
+
+  # case — first arg is the scrutinee
+  defp check_node({:case, _, [scrutinee | _]}, acc) do
+    maybe_record_guard(scrutinee, acc)
+  end
+
+  defp check_node(_, acc), do: acc
+
+  # Direct `state.field` field access in guard position
+  defp maybe_record_guard({{:., _, [{:state, _, ctx}, field]}, _, []}, acc)
+       when is_atom(ctx) and is_atom(field) do
+    put_one(acc, :guards, Atom.to_string(field))
+  end
+
+  # `Map.get(state, :field)` — common alternative to state.field
+  defp maybe_record_guard(
+         {{:., _, [{:__aliases__, _, [:Map]}, :get]}, _, [{:state, _, ctx}, key | _]},
+         acc
+       )
+       when is_atom(ctx) and is_atom(key) do
+    put_one(acc, :guards, Atom.to_string(key))
+  end
+
+  defp maybe_record_guard(_, acc), do: acc
+
+  # ── Helpers ────────────────────────────────────────────────────────
+
+  defp kv_keys(kv_list) do
+    for {k, _v} <- kv_list, is_atom(k), do: Atom.to_string(k)
+  end
+
+  defp put_one({w, g}, :writes, field), do: {MapSet.put(w, field), g}
+  defp put_one({w, g}, :guards, field), do: {w, MapSet.put(g, field)}
+
+  defp put_many(acc, tag, fields), do: Enum.reduce(fields, acc, &put_one(&2, tag, &1))
+end

--- a/packages/beam-analyzer/lib/beam_analyzer/rules/state_dfg.ex
+++ b/packages/beam-analyzer/lib/beam_analyzer/rules/state_dfg.ex
@@ -44,19 +44,73 @@ defmodule BeamAnalyzer.Rules.StateDFG do
   """
 
   @doc """
-  Walk an AST fragment and return `{writes, guards}` where each entry
-  is a sorted, deduplicated list of field-name strings.
+  Walk an AST fragment and return `%{writes, writes_truthy, writes_falsy,
+  guards, guards_truthy}` where each entry is a sorted, deduplicated
+  list of field-name strings.
+
+  * `:writes` — every field written against the `state` variable, any
+    value. Use this for "does anything write X at all?" questions.
+  * `:writes_truthy` — subset of `:writes` where the RHS is a literal
+    value Elixir would treat as truthy (any atom except `false` and
+    `nil`, any number, binary, list, tuple — anything that isn't
+    `false`/`nil`). Only literals we can syntactically confirm are
+    truthy land here; dynamic expressions stay in `:writes`.
+  * `:writes_falsy` — subset of `:writes` where the RHS is a literal
+    `false` or `nil`.
+  * `:writes_dynamic` — subset of `:writes` where the RHS is NOT a
+    compile-time literal — a variable, a function-call result, an
+    expression. A Datalog rule can use the absence of this set to
+    conclude "every writer is literal-classified," which is a
+    prerequisite for "always falsy / always truthy" analysis.
+  * `:uses` — every field read anywhere in the body, including
+    guards, call arguments, return values, and string interpolations
+    (`"tag: \#{state.foo}"`). Superset of `:guards`. Lets a rule
+    distinguish "field is written but never read at all" (dead
+    ballast) from "field is read, just not gated on".
+  * `:guards` — every field read in a conditional scrutinee
+    (`if`/`unless`/`case`). Use this for "does anything gate on X?".
+  * `:guards_truthy` — subset of `:guards` where the guard is an
+    explicit truthy test (`if state.X do` / `unless state.X`).
+    Needed for the "always-falsy / always-truthy" Datalog rules
+    because those tests can only be judged dead when paired with
+    literal-value writers.
   """
-  def extract(nil), do: {[], []}
+  def extract(nil), do: empty_result()
 
   def extract(ast) do
+    acc0 = %{
+      writes: MapSet.new(),
+      writes_truthy: MapSet.new(),
+      writes_falsy: MapSet.new(),
+      writes_dynamic: MapSet.new(),
+      guards: MapSet.new(),
+      guards_truthy: MapSet.new(),
+      uses: MapSet.new()
+    }
+
     {_, acc} =
-      Macro.prewalk(ast, {MapSet.new(), MapSet.new()}, fn node, acc ->
+      Macro.prewalk(ast, acc0, fn node, acc ->
         {node, check_node(node, acc)}
       end)
 
-    {writes, guards} = acc
-    {sorted(writes), sorted(guards)}
+    finalize(acc)
+  end
+
+  defp empty_result do
+    %{
+      writes: [],
+      writes_truthy: [],
+      writes_falsy: [],
+      writes_dynamic: [],
+      guards: [],
+      guards_truthy: [],
+      uses: []
+    }
+  end
+
+  defp finalize(%{} = acc) do
+    acc
+    |> Map.new(fn {k, set} -> {k, sorted(set)} end)
   end
 
   @doc """
@@ -77,12 +131,39 @@ defmodule BeamAnalyzer.Rules.StateDFG do
   def extract_init_writes(nil), do: []
 
   def extract_init_writes(ast) do
-    {_, writes} =
-      Macro.prewalk(ast, MapSet.new(), fn node, acc ->
+    extract_init(ast) |> Map.fetch!(:writes)
+  end
+
+  @doc """
+  Like `extract/1` but for an `init/1` body. The result shape is
+  `%{writes, writes_truthy, writes_falsy}` — guards are not
+  applicable for init. Walks every map / struct *literal* (keys
+  and their RHS values) to classify each initial field as truthy
+  or falsy when the RHS is a compile-time literal.
+  """
+  def extract_init(nil) do
+    %{writes: [], writes_truthy: [], writes_falsy: [], writes_dynamic: []}
+  end
+
+  def extract_init(ast) do
+    acc0 = %{
+      writes: MapSet.new(),
+      writes_truthy: MapSet.new(),
+      writes_falsy: MapSet.new(),
+      writes_dynamic: MapSet.new()
+    }
+
+    {_, acc} =
+      Macro.prewalk(ast, acc0, fn node, acc ->
         {node, check_init_node(node, acc)}
       end)
 
-    sorted(writes)
+    %{
+      writes: sorted(acc.writes),
+      writes_truthy: sorted(acc.writes_truthy),
+      writes_falsy: sorted(acc.writes_falsy),
+      writes_dynamic: sorted(acc.writes_dynamic)
+    }
   end
 
   # Map literal `%{k: v, ...}` but NOT an update `%{state | k: v}`
@@ -90,7 +171,7 @@ defmodule BeamAnalyzer.Rules.StateDFG do
     if map_update?(kv_list) do
       acc
     else
-      put_keys(acc, kv_list)
+      record_literal_kv_writes(acc, kv_list)
     end
   end
 
@@ -99,7 +180,7 @@ defmodule BeamAnalyzer.Rules.StateDFG do
     if map_update?(kv_list) do
       acc
     else
-      put_keys(acc, kv_list)
+      record_literal_kv_writes(acc, kv_list)
     end
   end
 
@@ -108,10 +189,19 @@ defmodule BeamAnalyzer.Rules.StateDFG do
   defp map_update?([{:|, _, _} | _]), do: true
   defp map_update?(_), do: false
 
-  defp put_keys(acc, kv_list) do
+  defp record_literal_kv_writes(acc, kv_list) do
     Enum.reduce(kv_list, acc, fn
-      {k, _v}, a when is_atom(k) -> MapSet.put(a, Atom.to_string(k))
-      _, a -> a
+      {k, v}, a when is_atom(k) ->
+        field = Atom.to_string(k)
+
+        case classify_value(v) do
+          :truthy -> a |> put_one(:writes, field) |> put_one(:writes_truthy, field)
+          :falsy -> a |> put_one(:writes, field) |> put_one(:writes_falsy, field)
+          :unknown -> a |> put_one(:writes, field) |> put_one(:writes_dynamic, field)
+        end
+
+      _, a ->
+        a
     end)
   end
 
@@ -125,7 +215,7 @@ defmodule BeamAnalyzer.Rules.StateDFG do
          acc
        )
        when is_atom(ctx) and is_list(kv_list) do
-    put_many(acc, :writes, kv_keys(kv_list))
+    record_kv_writes(acc, kv_list)
   end
 
   # %Struct{state | key: value, ...}
@@ -134,58 +224,156 @@ defmodule BeamAnalyzer.Rules.StateDFG do
          acc
        )
        when is_atom(ctx) and is_list(kv_list) do
-    put_many(acc, :writes, kv_keys(kv_list))
+    record_kv_writes(acc, kv_list)
   end
 
-  # Map.<op>(state, :field, ...)
+  # Map.put(state, :field, value) / Map.put_new / Map.replace!
+  defp check_node(
+         {{:., _, [{:__aliases__, _, [:Map]}, op]}, _, [{:state, _, ctx}, key, value]},
+         acc
+       )
+       when is_atom(ctx) and is_atom(key) and
+              op in [:put, :put_new, :replace!] do
+    record_value_write(acc, Atom.to_string(key), value)
+  end
+
+  # Map.delete(state, :field) — field becomes absent; a subsequent
+  # `state.field` / `Map.get(state, :field)` returns `nil`, which
+  # Elixir treats as falsy. Classify accordingly so "always-falsy"
+  # analysis sees deletes as falsy writes.
+  defp check_node(
+         {{:., _, [{:__aliases__, _, [:Map]}, :delete]}, _, [{:state, _, ctx}, key]},
+         acc
+       )
+       when is_atom(ctx) and is_atom(key) do
+    field = Atom.to_string(key)
+    acc |> put_one(:writes, field) |> put_one(:writes_falsy, field)
+  end
+
+  # Map.update / Map.update! — writer whose new value comes from a
+  # fn applied to the old; conservatively :dynamic.
   defp check_node(
          {{:., _, [{:__aliases__, _, [:Map]}, op]}, _, [{:state, _, ctx}, key | _]},
          acc
        )
-       when is_atom(ctx) and is_atom(key) and
-              op in [:put, :put_new, :delete, :update, :update!, :replace!] do
-    put_one(acc, :writes, Atom.to_string(key))
+       when is_atom(ctx) and is_atom(key) and op in [:update, :update!] do
+    field = Atom.to_string(key)
+    acc |> put_one(:writes, field) |> put_one(:writes_dynamic, field)
   end
 
   # ── GUARDS ─────────────────────────────────────────────────────────
 
-  # if / unless — first arg is the condition
+  # if / unless — first arg is the condition. These are truthy-tests
+  # (except when the condition is a full expression like `state.X == :foo`).
   defp check_node({kind, _, [cond_ast | _rest]}, acc) when kind in [:if, :unless] do
-    maybe_record_guard(cond_ast, acc)
+    maybe_record_guard(cond_ast, acc, :truthy)
   end
 
-  # case — first arg is the scrutinee
+  # case — first arg is the scrutinee. Not a pure truthy test.
   defp check_node({:case, _, [scrutinee | _]}, acc) do
-    maybe_record_guard(scrutinee, acc)
+    maybe_record_guard(scrutinee, acc, :plain)
   end
 
-  defp check_node(_, acc), do: acc
-
-  # Direct `state.field` field access in guard position
-  defp maybe_record_guard({{:., _, [{:state, _, ctx}, field]}, _, []}, acc)
+  # Any bare `state.field` access anywhere in the body — captures
+  # reads used as data (call arguments, return values, string
+  # interpolations) in addition to the guard-position reads above.
+  # Matches the Elixir AST of `state.field`:
+  #   {{:., _, [{:state, _, ctx}, field]}, _, []}
+  # Excludes the `state` variable itself (no method name).
+  defp check_node({{:., _, [{:state, _, ctx}, field]}, _, []}, acc)
        when is_atom(ctx) and is_atom(field) do
-    put_one(acc, :guards, Atom.to_string(field))
+    put_one(acc, :uses, Atom.to_string(field))
   end
 
-  # `Map.get(state, :field)` — common alternative to state.field
-  defp maybe_record_guard(
+  # `Map.get(state, :field, ...)` — also a read, even outside a
+  # guard scrutinee.
+  defp check_node(
          {{:., _, [{:__aliases__, _, [:Map]}, :get]}, _, [{:state, _, ctx}, key | _]},
          acc
        )
        when is_atom(ctx) and is_atom(key) do
-    put_one(acc, :guards, Atom.to_string(key))
+    put_one(acc, :uses, Atom.to_string(key))
   end
 
-  defp maybe_record_guard(_, acc), do: acc
+  # `Map.fetch!(state, :field)` / `Map.fetch(state, :field)`
+  defp check_node(
+         {{:., _, [{:__aliases__, _, [:Map]}, op]}, _, [{:state, _, ctx}, key]},
+         acc
+       )
+       when is_atom(ctx) and is_atom(key) and op in [:fetch, :fetch!, :has_key?] do
+    put_one(acc, :uses, Atom.to_string(key))
+  end
+
+  defp check_node(_, acc), do: acc
+
+  # `state.field` directly in guard position — this IS a truthy test
+  # when seen under `if/unless`.
+  defp maybe_record_guard({{:., _, [{:state, _, ctx}, field]}, _, []}, acc, kind)
+       when is_atom(ctx) and is_atom(field) do
+    record_guard(acc, Atom.to_string(field), kind)
+  end
+
+  # `Map.get(state, :field)` — common alternative.
+  defp maybe_record_guard(
+         {{:., _, [{:__aliases__, _, [:Map]}, :get]}, _, [{:state, _, ctx}, key | _]},
+         acc,
+         kind
+       )
+       when is_atom(ctx) and is_atom(key) do
+    record_guard(acc, Atom.to_string(key), kind)
+  end
+
+  defp maybe_record_guard(_, acc, _kind), do: acc
+
+  defp record_guard(acc, field, :truthy) do
+    acc |> put_one(:guards, field) |> put_one(:guards_truthy, field)
+  end
+
+  defp record_guard(acc, field, :plain), do: put_one(acc, :guards, field)
 
   # ── Helpers ────────────────────────────────────────────────────────
 
-  defp kv_keys(kv_list) do
-    for {k, _v} <- kv_list, is_atom(k), do: Atom.to_string(k)
+  # Map-update keyword list: record each `key: value` write.
+  defp record_kv_writes(acc, kv_list) do
+    Enum.reduce(kv_list, acc, fn
+      {k, v}, a when is_atom(k) -> record_value_write(a, Atom.to_string(k), v)
+      _, a -> a
+    end)
   end
 
-  defp put_one({w, g}, :writes, field), do: {MapSet.put(w, field), g}
-  defp put_one({w, g}, :guards, field), do: {w, MapSet.put(g, field)}
+  defp record_value_write(acc, field, value_ast) do
+    case classify_value(value_ast) do
+      :truthy -> acc |> put_one(:writes, field) |> put_one(:writes_truthy, field)
+      :falsy -> acc |> put_one(:writes, field) |> put_one(:writes_falsy, field)
+      :unknown -> acc |> put_one(:writes, field) |> put_one(:writes_dynamic, field)
+    end
+  end
 
-  defp put_many(acc, tag, fields), do: Enum.reduce(fields, acc, &put_one(&2, tag, &1))
+  # Classify the RHS of a write as syntactically truthy, falsy, or
+  # unknown. A value is provably truthy/falsy only when it's a
+  # compile-time literal with an unambiguous truthiness. Anything
+  # computed — function calls, variable refs, arithmetic — lands in
+  # :unknown so the Datalog rules can't false-positive on a dynamic
+  # writer that happens to produce a falsy value at runtime.
+  defp classify_value(nil), do: :falsy
+  defp classify_value(false), do: :falsy
+  defp classify_value(true), do: :truthy
+  defp classify_value(atom) when is_atom(atom), do: :truthy
+  defp classify_value(n) when is_integer(n) or is_float(n), do: :truthy
+  defp classify_value(s) when is_binary(s), do: :truthy
+  defp classify_value([]), do: :truthy    # [] is truthy in Elixir
+  defp classify_value([_ | _]), do: :truthy
+  defp classify_value({:{}, _, _}), do: :truthy      # tuple literal >2
+  defp classify_value({_, _}), do: :truthy           # 2-tuple literal
+  defp classify_value({:%{}, _, _}), do: :truthy     # map literal
+  defp classify_value({:%, _, _}), do: :truthy       # struct literal
+  defp classify_value({:<<>>, _, _}), do: :truthy    # binary literal
+  # `&capture/arity`, `fn -> ... end` — always a function, truthy.
+  defp classify_value({:&, _, _}), do: :truthy
+  defp classify_value({:fn, _, _}), do: :truthy
+  defp classify_value(_), do: :unknown
+
+  defp put_one(acc, key, field) when is_map_key(acc, key) do
+    Map.update!(acc, key, &MapSet.put(&1, field))
+  end
 end

--- a/packages/beam-analyzer/test/beam_analyzer_test.exs
+++ b/packages/beam-analyzer/test/beam_analyzer_test.exs
@@ -893,6 +893,122 @@ defmodule BeamAnalyzerTest do
 
       assert {:ok, _} = Jason.encode(result)
     end
+
+    # Precise handler-body scope: MESSAGE_TYPE → CONTAINS → CALL / BRANCH / LOOP
+    # Required for cycle / unguarded-tick / pubsub-echo Datalog rules.
+    # Without this edge, rules can only file-level-match call-sites to
+    # clauses, which conflates wrapper functions in the same module with
+    # real in-handler sends.
+    test "handler-clause CONTAINS its body's CALL / BRANCH / LOOP nodes" do
+      result =
+        w2_analyze("""
+          def handle_info(:tick, state) do
+            case state do
+              %{running: true} -> Process.send_after(self(), :tick, 1000)
+              _ -> :noop
+            end
+            for x <- state.queue, do: log(x)
+            {:noreply, state}
+          end
+        """)
+
+      [msg] = msg_nodes(result) |> Enum.filter(&(&1.metadata.handler_type == "info"))
+
+      contains_from_clause =
+        Enum.filter(result.edges, &(&1.type == "CONTAINS" and &1.src == msg.id))
+
+      # `send_after` + `log` + (any helper CALLs from walkers)
+      call_targets =
+        contains_from_clause
+        |> Enum.filter(fn e -> node_type(result, e.dst) == "CALL" end)
+        |> Enum.map(fn e -> node_name(result, e.dst) end)
+
+      assert "Process.send_after" in call_targets
+      assert "log" in call_targets
+
+      branch_targets =
+        contains_from_clause
+        |> Enum.filter(fn e -> node_type(result, e.dst) == "BRANCH" end)
+        |> Enum.map(fn e -> node_name(result, e.dst) end)
+
+      assert "case" in branch_targets
+
+      loop_targets =
+        contains_from_clause
+        |> Enum.filter(fn e -> node_type(result, e.dst) == "LOOP" end)
+
+      assert length(loop_targets) == 1
+    end
+
+    test "sibling handler clauses do not leak CONTAINS into each other" do
+      result =
+        w2_analyze("""
+          def handle_info(:a, state) do
+            call_a(state)
+            {:noreply, state}
+          end
+
+          def handle_info(:b, state) do
+            call_b(state)
+            {:noreply, state}
+          end
+        """)
+
+      msgs = msg_nodes(result) |> Enum.filter(&(&1.metadata.handler_type == "info"))
+      %{id: id_a} = Enum.find(msgs, &(&1.name == "info:a"))
+      %{id: id_b} = Enum.find(msgs, &(&1.name == "info:b"))
+
+      names_under = fn clause_id ->
+        result.edges
+        |> Enum.filter(&(&1.type == "CONTAINS" and &1.src == clause_id))
+        |> Enum.map(fn e -> node_name(result, e.dst) end)
+      end
+
+      assert "call_a" in names_under.(id_a)
+      refute "call_b" in names_under.(id_a)
+      assert "call_b" in names_under.(id_b)
+      refute "call_a" in names_under.(id_b)
+    end
+
+    test "non-handler def does not attach CONTAINS to any MESSAGE_TYPE" do
+      result =
+        w2_analyze("""
+          def handle_call(:ping, _from, state), do: {:reply, :pong, state}
+
+          def helper(state) do
+            helper_call(state)
+          end
+        """)
+
+      msg_ids = msg_nodes(result) |> Enum.map(& &1.id) |> MapSet.new()
+
+      helper_call_node =
+        Enum.find(result.nodes, &(&1.type == "CALL" and &1.name == "helper_call"))
+
+      assert helper_call_node != nil
+
+      offending =
+        Enum.filter(result.edges, fn e ->
+          e.type == "CONTAINS" and e.dst == helper_call_node.id and
+            MapSet.member?(msg_ids, e.src)
+        end)
+
+      assert offending == []
+    end
+  end
+
+  defp node_type(result, id) do
+    case Enum.find(result.nodes, &(&1.id == id)) do
+      nil -> nil
+      node -> node.type
+    end
+  end
+
+  defp node_name(result, id) do
+    case Enum.find(result.nodes, &(&1.id == id)) do
+      nil -> nil
+      node -> node.name
+    end
   end
 
   # ==================================================================

--- a/packages/beam-analyzer/test/beam_analyzer_test.exs
+++ b/packages/beam-analyzer/test/beam_analyzer_test.exs
@@ -1037,6 +1037,70 @@ defmodule BeamAnalyzerTest do
       assert Map.get(reads_by_clause, "cast:check") == "mode"
     end
 
+    test "helper defp writes emit WRITES_STATE edges (trans-procedural)" do
+      # Regression for the planner_trigger false-positive: without
+      # walking private helpers, `do_spawn` setting running?: true is
+      # invisible and the always-falsy rule fires on a healthy codebase.
+      result =
+        w2_analyze("""
+          def handle_call(:go, _from, state) do
+            {:reply, :ok, spawn_work(state)}
+          end
+
+          defp spawn_work(state) do
+            %{state | running?: true}
+          end
+        """)
+
+      writes = Enum.filter(result.edges, &(&1.type == "WRITES_STATE_TRUTHY"))
+      writer_names = Enum.map(writes, fn e -> node_name(result, e.src) end)
+
+      assert "spawn_work/1" in writer_names
+    end
+
+    test "fixture with true dead-branch triggers the always-falsy classifier" do
+      # A synthetic GenServer where `state.done?` starts false and no
+      # handler / helper ever flips it to a truthy value. The
+      # `if state.done? do` branch is truly dead.
+      result =
+        w2_analyze("""
+          def init(_), do: {:ok, %{done?: false}}
+
+          def handle_call(:status, _from, state) do
+            if state.done? do
+              {:reply, :finished, state}
+            else
+              {:reply, :pending, state}
+            end
+          end
+
+          def handle_cast(:reset, state) do
+            {:noreply, %{state | done?: false}}
+          end
+        """)
+
+      done_field =
+        Enum.find(result.nodes, &(&1.type == "STATE_FIELD" and &1.name == "done?"))
+
+      assert done_field != nil
+
+      edge_types =
+        result.edges
+        |> Enum.filter(&(&1.dst == done_field.id))
+        |> Enum.map(& &1.type)
+        |> Enum.sort()
+        |> Enum.uniq()
+
+      # Expected shape: WRITES_STATE + WRITES_STATE_FALSY on both init
+      # and the :reset handler; READS_STATE + READS_STATE_TRUTHY on
+      # :status handler. No TRUTHY writer, no DYNAMIC writer.
+      assert "WRITES_STATE" in edge_types
+      assert "WRITES_STATE_FALSY" in edge_types
+      assert "READS_STATE_TRUTHY" in edge_types
+      refute "WRITES_STATE_TRUTHY" in edge_types
+      refute "WRITES_STATE_DYNAMIC" in edge_types
+    end
+
     test "init/1 writes are attached to the init FUNCTION, not to any MESSAGE_TYPE" do
       result =
         w2_analyze("""

--- a/packages/beam-analyzer/test/beam_analyzer_test.exs
+++ b/packages/beam-analyzer/test/beam_analyzer_test.exs
@@ -970,6 +970,107 @@ defmodule BeamAnalyzerTest do
       refute "call_a" in names_under.(id_b)
     end
 
+    test "handler body writes to state fields emit WRITES_STATE edges to STATE_FIELD nodes" do
+      result =
+        w2_analyze("""
+          def init(_) do
+            {:ok, %{paused: false, counter: 0}}
+          end
+
+          def handle_cast(:pause, state) do
+            {:noreply, %{state | paused: true}}
+          end
+
+          def handle_cast(:tick, state) do
+            {:noreply, %{state | counter: state.counter + 1}}
+          end
+        """)
+
+      state_fields = Enum.filter(result.nodes, &(&1.type == "STATE_FIELD"))
+      field_names = Enum.map(state_fields, & &1.name) |> Enum.uniq() |> Enum.sort()
+      assert field_names == ["counter", "paused"]
+
+      writes = Enum.filter(result.edges, &(&1.type == "WRITES_STATE"))
+      assert length(writes) >= 2
+
+      # :pause clause writes `paused`
+      %{id: pause_id} =
+        Enum.find(msg_nodes(result), &(&1.name == "cast:pause"))
+
+      pause_writes =
+        writes
+        |> Enum.filter(&(&1.src == pause_id))
+        |> Enum.map(fn e -> node_name(result, e.dst) end)
+
+      assert pause_writes == ["paused"]
+    end
+
+    test "handler guard reads emit READS_STATE edges" do
+      result =
+        w2_analyze("""
+          def handle_call(:work, _from, state) do
+            if state.running do
+              {:reply, :ok, state}
+            else
+              {:reply, :paused, state}
+            end
+          end
+
+          def handle_cast(:check, state) do
+            case state.mode do
+              :a -> {:noreply, state}
+              :b -> {:noreply, state}
+            end
+          end
+        """)
+
+      reads = Enum.filter(result.edges, &(&1.type == "READS_STATE"))
+
+      reads_by_clause =
+        for r <- reads,
+            into: %{} do
+          {node_name(result, r.src), node_name(result, r.dst)}
+        end
+
+      # call:work reads `running`, cast:check reads `mode`
+      assert Map.get(reads_by_clause, "call:work") == "running"
+      assert Map.get(reads_by_clause, "cast:check") == "mode"
+    end
+
+    test "init/1 writes are attached to the init FUNCTION, not to any MESSAGE_TYPE" do
+      result =
+        w2_analyze("""
+          def init(_) do
+            {:ok, %{timer: nil, queue: []}}
+          end
+
+          def handle_call(:status, _from, state) do
+            {:reply, state.timer, state}
+          end
+        """)
+
+      init_fn = Enum.find(result.nodes, &(&1.type == "FUNCTION" and &1.name == "init/1"))
+      assert init_fn != nil
+
+      init_writes =
+        result.edges
+        |> Enum.filter(&(&1.type == "WRITES_STATE" and &1.src == init_fn.id))
+        |> Enum.map(fn e -> node_name(result, e.dst) end)
+        |> Enum.sort()
+
+      assert init_writes == ["queue", "timer"]
+
+      # No WRITES_STATE edge from any MESSAGE_TYPE (handle_call :status only reads)
+      msg_ids = msg_nodes(result) |> Enum.map(& &1.id) |> MapSet.new()
+
+      msg_writes =
+        Enum.filter(result.edges, fn e ->
+          e.type == "WRITES_STATE" and MapSet.member?(msg_ids, e.src)
+        end)
+
+      assert msg_writes == []
+    end
+
     test "non-handler def does not attach CONTAINS to any MESSAGE_TYPE" do
       result =
         w2_analyze("""

--- a/packages/beam-analyzer/test/state_dfg_test.exs
+++ b/packages/beam-analyzer/test/state_dfg_test.exs
@@ -3,139 +3,238 @@ defmodule BeamAnalyzer.Rules.StateDFGTest do
 
   alias BeamAnalyzer.Rules.StateDFG
 
-  # Parse an Elixir snippet as an expression/block AST.
   defp body(src) do
     {:ok, ast} = Code.string_to_quoted(src)
     ast
   end
 
-  describe "writes" do
+  describe "writes — names only" do
     test "map update %{state | field: _}" do
-      ast = body("%{state | foo: 1}")
-      assert {["foo"], []} = StateDFG.extract(ast)
+      r = StateDFG.extract(body("%{state | foo: 1}"))
+      assert r.writes == ["foo"]
     end
 
     test "map update with multiple fields" do
-      ast = body("%{state | foo: 1, bar: 2, baz: 3}")
-      assert {["bar", "baz", "foo"], []} = StateDFG.extract(ast)
+      r = StateDFG.extract(body("%{state | foo: 1, bar: 2, baz: 3}"))
+      assert r.writes == ["bar", "baz", "foo"]
     end
 
     test "struct update %Struct{state | field: _}" do
-      ast = body("%MyMod{state | paused: true}")
-      assert {["paused"], []} = StateDFG.extract(ast)
+      r = StateDFG.extract(body("%MyMod{state | paused: true}"))
+      assert r.writes == ["paused"]
     end
 
     test "Map.put(state, :field, _)" do
-      ast = body("Map.put(state, :queue, [])")
-      assert {["queue"], []} = StateDFG.extract(ast)
+      r = StateDFG.extract(body("Map.put(state, :queue, [])"))
+      assert r.writes == ["queue"]
     end
 
     test "Map.delete(state, :field)" do
-      ast = body("Map.delete(state, :stale_ref)")
-      assert {["stale_ref"], []} = StateDFG.extract(ast)
+      r = StateDFG.extract(body("Map.delete(state, :stale_ref)"))
+      assert r.writes == ["stale_ref"]
     end
 
-    test "Map.update!(state, :counter, &(&1 + 1))" do
-      ast = body("Map.update!(state, :counter, &(&1 + 1))")
-      assert {["counter"], []} = StateDFG.extract(ast)
+    test "Map.update!(state, :counter, fn)" do
+      r = StateDFG.extract(body("Map.update!(state, :counter, &(&1 + 1))"))
+      assert r.writes == ["counter"]
     end
 
     test "nested update inside return tuple" do
-      ast = body("{:noreply, %{state | last: now}}")
-      assert {["last"], []} = StateDFG.extract(ast)
-    end
-
-    test "multiple write sites in one body" do
-      ast =
-        body("""
-          s1 = %{state | a: 1}
-          Map.put(s1, :b, 2)
-          %{state | c: 3}
-        """)
-
-      # only writes against the `state` variable are recorded (not s1)
-      assert {["a", "c"], []} = StateDFG.extract(ast)
+      r = StateDFG.extract(body("{:noreply, %{state | last: now}}"))
+      assert r.writes == ["last"]
     end
 
     test "ignores writes against a variable not named `state`" do
-      ast = body("%{other | field: 1}")
-      assert {[], []} = StateDFG.extract(ast)
+      r = StateDFG.extract(body("%{other | field: 1}"))
+      assert r.writes == []
+    end
+  end
+
+  describe "writes — value classification" do
+    test "literal true → writes_truthy" do
+      r = StateDFG.extract(body("%{state | paused: true}"))
+      assert r.writes == ["paused"]
+      assert r.writes_truthy == ["paused"]
+      assert r.writes_falsy == []
+    end
+
+    test "literal false → writes_falsy" do
+      r = StateDFG.extract(body("%{state | paused: false}"))
+      assert r.writes == ["paused"]
+      assert r.writes_truthy == []
+      assert r.writes_falsy == ["paused"]
+    end
+
+    test "nil → writes_falsy" do
+      r = StateDFG.extract(body("%{state | task: nil}"))
+      assert r.writes == ["task"]
+      assert r.writes_falsy == ["task"]
+    end
+
+    test "atom → writes_truthy" do
+      r = StateDFG.extract(body("%{state | mode: :running}"))
+      assert r.writes_truthy == ["mode"]
+    end
+
+    test "integer → writes_truthy" do
+      r = StateDFG.extract(body("%{state | count: 0}"))
+      assert r.writes_truthy == ["count"]
+    end
+
+    test "dynamic RHS lands in writes_dynamic, not truthy/falsy" do
+      r = StateDFG.extract(body("%{state | x: other_var, y: compute()}"))
+      assert r.writes == ["x", "y"]
+      assert r.writes_dynamic == ["x", "y"]
+      assert r.writes_truthy == []
+      assert r.writes_falsy == []
+    end
+
+    test "Map.put with literal RHS classified" do
+      r = StateDFG.extract(body("Map.put(state, :running, true)"))
+      assert r.writes_truthy == ["running"]
+    end
+
+    test "Map.delete is classified as falsy (subsequent read returns nil)" do
+      r = StateDFG.extract(body("Map.delete(state, :ref)"))
+      assert r.writes == ["ref"]
+      assert r.writes_falsy == ["ref"]
+    end
+
+    test "Map.update!/3 is classified as dynamic" do
+      r = StateDFG.extract(body("Map.update!(state, :counter, &(&1 + 1))"))
+      assert r.writes == ["counter"]
+      assert r.writes_dynamic == ["counter"]
     end
   end
 
   describe "guards" do
-    test "if state.field do" do
-      ast = body("if state.running, do: :go")
-      assert {[], ["running"]} = StateDFG.extract(ast)
+    test "if state.field → guards_truthy" do
+      r = StateDFG.extract(body("if state.running, do: :go"))
+      assert r.guards == ["running"]
+      assert r.guards_truthy == ["running"]
     end
 
-    test "unless state.field" do
-      ast = body("unless state.halted, do: :go")
-      assert {[], ["halted"]} = StateDFG.extract(ast)
+    test "unless state.field → guards_truthy" do
+      r = StateDFG.extract(body("unless state.halted, do: :go"))
+      assert r.guards_truthy == ["halted"]
     end
 
-    test "case state.field do" do
-      ast =
-        body("""
+    test "case state.field → guards (plain), NOT guards_truthy" do
+      r =
+        StateDFG.extract(
+          body("""
           case state.mode do
             :a -> 1
             :b -> 2
           end
-        """)
+          """)
+        )
 
-      assert {[], ["mode"]} = StateDFG.extract(ast)
+      assert r.guards == ["mode"]
+      assert r.guards_truthy == []
     end
 
-    test "case Map.get(state, :field) do" do
-      ast =
-        body("""
+    test "case Map.get(state, :field) → guards" do
+      r =
+        StateDFG.extract(
+          body("""
           case Map.get(state, :stash) do
             nil -> :none
             v -> v
           end
-        """)
+          """)
+        )
 
-      assert {[], ["stash"]} = StateDFG.extract(ast)
-    end
-
-    test "function call on state is not a guard read" do
-      # `do_something(state.x)` is a call argument, not a control-flow
-      # scrutinee — we conservatively don't record it.
-      ast = body("do_something(state.x)")
-      assert {[], []} = StateDFG.extract(ast)
+      assert r.guards == ["stash"]
     end
   end
 
-  describe "combined" do
-    test "handler that reads a guard and writes a field" do
-      ast =
-        body("""
-          if state.paused do
-            state
-          else
-            %{state | count: state.count + 1}
-          end
-        """)
+  describe "extract_init" do
+    test "init map literal captures keys and classifies values" do
+      r =
+        StateDFG.extract_init(
+          body("""
+          {:ok, %{paused: false, counter: 0, task: nil}}
+          """)
+        )
 
-      assert {["count"], ["paused"]} = StateDFG.extract(ast)
+      assert r.writes == ["counter", "paused", "task"]
+      assert r.writes_truthy == ["counter"]
+      assert r.writes_falsy == ["paused", "task"]
     end
 
-    test "dedup when same field appears twice" do
-      ast =
-        body("""
-          _ = state.foo
-          if state.foo do
-            %{state | foo: :new}
-          end
-        """)
+    test "init struct literal" do
+      r =
+        StateDFG.extract_init(
+          body("""
+          {:ok, %__MODULE__{running: true, timer: nil}}
+          """)
+        )
 
-      # foo appears as a guard (from `if state.foo`) and as a write.
-      # Should each appear exactly once.
-      assert {["foo"], ["foo"]} = StateDFG.extract(ast)
+      assert r.writes == ["running", "timer"]
+      assert r.writes_truthy == ["running"]
+      assert r.writes_falsy == ["timer"]
+    end
+
+    test "init with dynamic values → writes_dynamic" do
+      r =
+        StateDFG.extract_init(
+          body("""
+          {:ok, %{path: some_path, count: start_count()}}
+          """)
+        )
+
+      assert r.writes == ["count", "path"]
+      assert r.writes_dynamic == ["count", "path"]
+      assert r.writes_truthy == []
+      assert r.writes_falsy == []
+    end
+
+    test "backwards-compat shim extract_init_writes returns the writes list" do
+      ast = body("{:ok, %{a: 1}}")
+      assert StateDFG.extract_init_writes(ast) == ["a"]
     end
   end
 
-  test "nil AST returns empty lists" do
-    assert {[], []} = StateDFG.extract(nil)
+  describe "uses" do
+    test "state.field in call argument" do
+      r = StateDFG.extract(body("send_msg(state.topic, :event)"))
+      assert r.uses == ["topic"]
+    end
+
+    test "state.field inside return tuple" do
+      r = StateDFG.extract(body("{:reply, state.counter, state}"))
+      assert r.uses == ["counter"]
+    end
+
+    test "state.field inside string interpolation" do
+      r = StateDFG.extract(body(~s|"count: " <> to_string(state.n)|))
+      assert r.uses == ["n"]
+    end
+
+    test "uses is superset of guards" do
+      r = StateDFG.extract(body("if state.running, do: state.count"))
+      assert r.guards == ["running"]
+      assert r.guards_truthy == ["running"]
+      # both `running` (from the if-cond) and `count` (from the do-body)
+      # end up in uses.
+      assert r.uses == ["count", "running"]
+    end
+
+    test "Map.fetch!/2 is a use" do
+      r = StateDFG.extract(body("Map.fetch!(state, :cfg)"))
+      assert r.uses == ["cfg"]
+    end
+  end
+
+  test "nil AST returns empty everything" do
+    r = StateDFG.extract(nil)
+    assert r.writes == []
+    assert r.guards == []
+    assert r.guards_truthy == []
+    assert r.writes_truthy == []
+    assert r.writes_falsy == []
+    assert r.writes_dynamic == []
+    assert r.uses == []
   end
 end

--- a/packages/beam-analyzer/test/state_dfg_test.exs
+++ b/packages/beam-analyzer/test/state_dfg_test.exs
@@ -1,0 +1,141 @@
+defmodule BeamAnalyzer.Rules.StateDFGTest do
+  use ExUnit.Case, async: true
+
+  alias BeamAnalyzer.Rules.StateDFG
+
+  # Parse an Elixir snippet as an expression/block AST.
+  defp body(src) do
+    {:ok, ast} = Code.string_to_quoted(src)
+    ast
+  end
+
+  describe "writes" do
+    test "map update %{state | field: _}" do
+      ast = body("%{state | foo: 1}")
+      assert {["foo"], []} = StateDFG.extract(ast)
+    end
+
+    test "map update with multiple fields" do
+      ast = body("%{state | foo: 1, bar: 2, baz: 3}")
+      assert {["bar", "baz", "foo"], []} = StateDFG.extract(ast)
+    end
+
+    test "struct update %Struct{state | field: _}" do
+      ast = body("%MyMod{state | paused: true}")
+      assert {["paused"], []} = StateDFG.extract(ast)
+    end
+
+    test "Map.put(state, :field, _)" do
+      ast = body("Map.put(state, :queue, [])")
+      assert {["queue"], []} = StateDFG.extract(ast)
+    end
+
+    test "Map.delete(state, :field)" do
+      ast = body("Map.delete(state, :stale_ref)")
+      assert {["stale_ref"], []} = StateDFG.extract(ast)
+    end
+
+    test "Map.update!(state, :counter, &(&1 + 1))" do
+      ast = body("Map.update!(state, :counter, &(&1 + 1))")
+      assert {["counter"], []} = StateDFG.extract(ast)
+    end
+
+    test "nested update inside return tuple" do
+      ast = body("{:noreply, %{state | last: now}}")
+      assert {["last"], []} = StateDFG.extract(ast)
+    end
+
+    test "multiple write sites in one body" do
+      ast =
+        body("""
+          s1 = %{state | a: 1}
+          Map.put(s1, :b, 2)
+          %{state | c: 3}
+        """)
+
+      # only writes against the `state` variable are recorded (not s1)
+      assert {["a", "c"], []} = StateDFG.extract(ast)
+    end
+
+    test "ignores writes against a variable not named `state`" do
+      ast = body("%{other | field: 1}")
+      assert {[], []} = StateDFG.extract(ast)
+    end
+  end
+
+  describe "guards" do
+    test "if state.field do" do
+      ast = body("if state.running, do: :go")
+      assert {[], ["running"]} = StateDFG.extract(ast)
+    end
+
+    test "unless state.field" do
+      ast = body("unless state.halted, do: :go")
+      assert {[], ["halted"]} = StateDFG.extract(ast)
+    end
+
+    test "case state.field do" do
+      ast =
+        body("""
+          case state.mode do
+            :a -> 1
+            :b -> 2
+          end
+        """)
+
+      assert {[], ["mode"]} = StateDFG.extract(ast)
+    end
+
+    test "case Map.get(state, :field) do" do
+      ast =
+        body("""
+          case Map.get(state, :stash) do
+            nil -> :none
+            v -> v
+          end
+        """)
+
+      assert {[], ["stash"]} = StateDFG.extract(ast)
+    end
+
+    test "function call on state is not a guard read" do
+      # `do_something(state.x)` is a call argument, not a control-flow
+      # scrutinee — we conservatively don't record it.
+      ast = body("do_something(state.x)")
+      assert {[], []} = StateDFG.extract(ast)
+    end
+  end
+
+  describe "combined" do
+    test "handler that reads a guard and writes a field" do
+      ast =
+        body("""
+          if state.paused do
+            state
+          else
+            %{state | count: state.count + 1}
+          end
+        """)
+
+      assert {["count"], ["paused"]} = StateDFG.extract(ast)
+    end
+
+    test "dedup when same field appears twice" do
+      ast =
+        body("""
+          _ = state.foo
+          if state.foo do
+            %{state | foo: :new}
+          end
+        """)
+
+      # foo appears as a guard (from `if state.foo`) and as a write.
+      # Should each appear exactly once.
+      assert {["foo"], ["foo"]} = StateDFG.extract(ast)
+    end
+  end
+
+  test "nil AST returns empty lists" do
+    assert {[], []} = StateDFG.extract(nil)
+  end
+end

--- a/packages/rfdb-server/src/datalog/eval.rs
+++ b/packages/rfdb-server/src/datalog/eval.rs
@@ -560,6 +560,20 @@ impl<'a> Evaluator<'a> {
                         }
                     }
 
+                    // Check dst filter if already-bound variable — critical for
+                    // self-join patterns like `edge(M, C, T1), edge(C, M, T2)`.
+                    // Without this, the second edge unconditionally rebinds `M`
+                    // to any outgoing dst of `C`, silently producing cross-joined
+                    // rows that don't satisfy the pattern. See RFDB-??? (RFDB
+                    // join correctness for shared vars across two edge atoms).
+                    if let Term::Var(var) = dst_term {
+                        if let Some(existing) = bindings.get(var).and_then(|v| v.as_id()) {
+                            if existing != dst_id {
+                                continue;
+                            }
+                        }
+                    }
+
                     let mut new_bindings = bindings.clone();
 
                     // Bind dst
@@ -619,6 +633,19 @@ impl<'a> Evaluator<'a> {
                     if let Term::Const(expected_src) = src_term {
                         if expected_src.parse::<u128>().ok() != Some(src_id) {
                             continue;
+                        }
+                    }
+
+                    // Check src filter if already-bound variable. Same bug
+                    // as eval_edge_hash_join — without this, joins that
+                    // share a variable on opposite ends of two edge atoms
+                    // (e.g. `incoming(A, B, T1), incoming(B, A, T2)`) silently
+                    // produce incorrect rows.
+                    if let Term::Var(var) = src_term {
+                        if let Some(existing) = bindings.get(var).and_then(|v| v.as_id()) {
+                            if existing != src_id {
+                                continue;
+                            }
                         }
                     }
 

--- a/packages/rfdb-server/src/datalog/tests.rs
+++ b/packages/rfdb-server/src/datalog/tests.rs
@@ -4229,6 +4229,184 @@ mod hash_join_tests {
         }
     }
 
+    /// Mirror of `test_hash_join_shared_var_across_two_edges` but for the
+    /// `incoming/3` flavour of the same bug: the non-key term must honor
+    /// already-bound variables instead of rebinding them.
+    #[test]
+    fn test_incoming_hash_join_shared_var() {
+        let mut engine = GraphEngineV2::create_ephemeral();
+        let n = HASH_JOIN_THRESHOLD + 10;
+
+        let mut nodes = Vec::with_capacity(3 * n);
+        for i in 1..=n {
+            nodes.push(NodeRecord {
+                id: i as u128,
+                node_type: Some("A".to_string()),
+                name: Some(format!("a_{}", i)),
+                file: Some("t.ex".to_string()),
+                file_id: 0, name_offset: 0, version: "main".into(),
+                exported: false, replaces: None, deleted: false,
+                metadata: None, semantic_id: None,
+            });
+            nodes.push(NodeRecord {
+                id: (n + i) as u128,
+                node_type: Some("B".to_string()),
+                name: Some(format!("b_{}", i)),
+                file: Some("t.ex".to_string()),
+                file_id: 0, name_offset: 0, version: "main".into(),
+                exported: false, replaces: None, deleted: false,
+                metadata: None, semantic_id: None,
+            });
+            nodes.push(NodeRecord {
+                id: (2 * n + i) as u128,
+                node_type: Some("A".to_string()),
+                name: Some(format!("other_a_{}", i)),
+                file: Some("t.ex".to_string()),
+                file_id: 0, name_offset: 0, version: "main".into(),
+                exported: false, replaces: None, deleted: false,
+                metadata: None, semantic_id: None,
+            });
+        }
+        engine.add_nodes(nodes);
+
+        // F: a_i -> b_i
+        let fw: Vec<EdgeRecord> = (1..=n).map(|i| EdgeRecord {
+            src: i as u128,
+            dst: (n + i) as u128,
+            edge_type: Some("F".to_string()),
+            version: "main".into(), metadata: None, deleted: false,
+        }).collect();
+        engine.add_edges(fw, false);
+        // G: b_i -> other_a_i, plus one true round-trip b_1 -> a_1
+        let mut bk: Vec<EdgeRecord> = (1..=n).map(|i| EdgeRecord {
+            src: (n + i) as u128,
+            dst: (2 * n + i) as u128,
+            edge_type: Some("G".to_string()),
+            version: "main".into(), metadata: None, deleted: false,
+        }).collect();
+        bk.push(EdgeRecord {
+            src: (n + 1) as u128,
+            dst: 1u128,
+            edge_type: Some("G".to_string()),
+            version: "main".into(), metadata: None, deleted: false,
+        });
+        engine.add_edges(bk, false);
+
+        let evaluator = Evaluator::new(&engine);
+        // Anchor A via node/1 so the planner can place `incoming` with at
+        // least one bound var; then `incoming(A, B, "G")` binds B while
+        // `incoming(B, A, "F")` re-binds through the hash-join path — the
+        // exact case the shared-var fix must honour.
+        let literals = parse_query(
+            "node(A, \"A\"), incoming(A, B, \"G\"), incoming(B, A, \"F\")"
+        ).unwrap();
+        let results = evaluator.eval_query(&literals).unwrap();
+        assert_eq!(results.len(), 1, "only one true round-trip exists");
+        let b = &results[0];
+        assert_eq!(b.get("A").unwrap().as_id().unwrap(), 1);
+        assert_eq!(b.get("B").unwrap().as_id().unwrap(), (n + 1) as u128);
+    }
+
+    /// Regression: when a variable appears in *both* edge atoms on opposite
+    /// sides (self-join pattern `edge(A, B, T1), edge(B, A, T2)`), the hash-
+    /// join path must verify the variable still unifies — not rebind it to
+    /// any hash-joined value. Without the check, any pair satisfying first
+    /// edge AND some second edge anywhere in the graph bleeds through as a
+    /// false match. Hit in practice when adding MESSAGE_TYPE → CONTAINS →
+    /// CALL edges on Ichi and querying for handler self-loops.
+    #[test]
+    fn test_hash_join_shared_var_across_two_edges() {
+        let mut engine = GraphEngineV2::create_ephemeral();
+
+        // Build > HASH_JOIN_THRESHOLD entities so both edge atoms trip the
+        // hash-join path. We create three layers of nodes:
+        //  - MESSAGE_TYPE nodes msg_i (ids 1..=n)
+        //  - CALL nodes call_i      (ids n+1..=2n)
+        //  - "other" MESSAGE_TYPE   (ids 2n+1..=3n) to be the SENDS_MESSAGE
+        //    target of each call, so SENDS_MESSAGE has edges, but almost
+        //    none of them land back at the CONTAINing msg.
+        //
+        // Correct answer: exactly one pair — msg_1 contains call_1 and
+        // call_1 additionally SENDS_MESSAGE back to msg_1.
+        let n = HASH_JOIN_THRESHOLD + 10;
+
+        let mut nodes = Vec::with_capacity(3 * n);
+        for i in 1..=n {
+            nodes.push(NodeRecord {
+                id: i as u128,
+                node_type: Some("MESSAGE_TYPE".to_string()),
+                name: Some(format!("msg_{}", i)),
+                file: Some("t.ex".to_string()),
+                file_id: 0, name_offset: 0, version: "main".into(),
+                exported: false, replaces: None, deleted: false,
+                metadata: None, semantic_id: None,
+            });
+            nodes.push(NodeRecord {
+                id: (n + i) as u128,
+                node_type: Some("CALL".to_string()),
+                name: Some(format!("call_{}", i)),
+                file: Some("t.ex".to_string()),
+                file_id: 0, name_offset: 0, version: "main".into(),
+                exported: false, replaces: None, deleted: false,
+                metadata: None, semantic_id: None,
+            });
+            nodes.push(NodeRecord {
+                id: (2 * n + i) as u128,
+                node_type: Some("MESSAGE_TYPE".to_string()),
+                name: Some(format!("other_msg_{}", i)),
+                file: Some("t.ex".to_string()),
+                file_id: 0, name_offset: 0, version: "main".into(),
+                exported: false, replaces: None, deleted: false,
+                metadata: None, semantic_id: None,
+            });
+        }
+        engine.add_nodes(nodes);
+
+        // CONTAINS: msg_i -> call_i (n edges)
+        let contains: Vec<EdgeRecord> = (1..=n).map(|i| EdgeRecord {
+            src: i as u128,
+            dst: (n + i) as u128,
+            edge_type: Some("CONTAINS".to_string()),
+            version: "main".into(), metadata: None, deleted: false,
+        }).collect();
+        engine.add_edges(contains, false);
+
+        // SENDS_MESSAGE: call_i -> other_msg_i for every i,
+        // PLUS one real self-loop call_1 -> msg_1.
+        let mut sends: Vec<EdgeRecord> = (1..=n).map(|i| EdgeRecord {
+            src: (n + i) as u128,
+            dst: (2 * n + i) as u128,
+            edge_type: Some("SENDS_MESSAGE".to_string()),
+            version: "main".into(), metadata: None, deleted: false,
+        }).collect();
+        sends.push(EdgeRecord {
+            src: (n + 1) as u128,
+            dst: 1_u128,
+            edge_type: Some("SENDS_MESSAGE".to_string()),
+            version: "main".into(), metadata: None, deleted: false,
+        });
+        engine.add_edges(sends, false);
+
+        let evaluator = Evaluator::new(&engine);
+        // Self-loop rule: `edge(M, C, CONTAINS), edge(C, M, SENDS_MESSAGE)`
+        let literals = parse_query(
+            "edge(M, C, \"CONTAINS\"), edge(C, M, \"SENDS_MESSAGE\")"
+        ).unwrap();
+        let results = evaluator.eval_query(&literals).unwrap();
+
+        // Correct: only (msg_1, call_1). Before the fix, the second edge
+        // atom rebinds M to every SENDS_MESSAGE dst, yielding ~n spurious
+        // rows where M is an other_msg_i that the CONTAIN'ing msg_i never
+        // points to.
+        assert_eq!(
+            results.len(), 1,
+            "hash-join must honor already-bound variables in both edge atoms"
+        );
+        let b = &results[0];
+        assert_eq!(b.get("M").unwrap().as_id().unwrap(), 1);
+        assert_eq!(b.get("C").unwrap().as_id().unwrap(), (n + 1) as u128);
+    }
+
     #[test]
     fn test_hash_join_negation_correctness() {
         // Negation with hash join: \+ edge(F, _, "CALLS") uses existence set


### PR DESCRIPTION
## Summary

Five commits pushing the BEAM analysis model two levels deeper so Datalog guarantees can reason about **semantic** state, not just message reachability.

1. **fix(rfdb): datalog hash-join honors already-bound shared vars** — fixes silent wrong results on self-join queries like \`edge(M, C, T1), edge(C, M, T2)\`. The hash-join fast path was rebinding the non-key \`Term::Var\` unconditionally. Surfaced while writing handler-self-loop guarantees; affects any Grafema Datalog rule with a shared variable across two edge atoms. Regression tests for both \`edge/3\` and \`incoming/3\` variants.
2. **feat(beam-analyzer): MESSAGE_TYPE → CONTAINS → CALL / BRANCH / LOOP** — emit CONTAINS edges from a handler-clause MESSAGE_TYPE down to the call-sites, branches, and loops that live inside its body. Previously the only way to tie a send-site to its enclosing clause was file-level equality, which conflates wrapper functions (\`def foo(x), do: GenServer.call(__MODULE__, …)\`) with real in-handler sends (89 noisy hits vs. 0 real ones on Ichi's 28 GenServers).
3. **feat(guarantees): handler self-loops + unguarded-tick** — three rules built on the new precise scope:
   - \`beam-handler-self-loop-sends\` (warning)
   - \`beam-handler-self-loop-publishes\` (warning)
   - \`beam-handler-unguarded-tick\` (info) — \`SELF_SCHEDULE\` with no BRANCH in its clause body
4. **feat(beam-analyzer): state-field DFG** — new \`Rules.StateDFG\` module + \`STATE_FIELD\` nodes + \`WRITES_STATE\` / \`READS_STATE\` / \`USES_STATE\` edges from handlers and \`init/1\`. Also ships \`beam-state-guard-never-written\` and \`beam-state-init-only-gate\` guarantees.
5. **feat(beam-analyzer): value-tracking + trans-procedural DFG** — classify every write as truthy/falsy/dynamic (\`WRITES_STATE_TRUTHY\` / \`_FALSY\` / \`_DYNAMIC\`) and every truthy-test guard (\`READS_STATE_TRUTHY\`). Propagate writes through private helpers (\`defp\`) so a flag set inside a helper called from a handler isn't invisible to the rule engine. Gated on module having a PROCESS node so non-GenServer modules that happen to bind a local variable named \`state\` don't emit bogus FIELD edges. Two new guarantees: \`beam-state-truthy-guard-always-falsy\` and \`-always-truthy\`.

## Ichi validation (62 Elixir files, 28 GenServers)

| Guarantee | Severity | Hits |
|---|---|---|
| beam-handler-self-loop-sends | warning | 0 |
| beam-handler-self-loop-publishes | warning | 0 |
| beam-handler-unguarded-tick | info | 5 (verified intentional polling loops / reconnect backoff) |
| beam-state-guard-never-written | warning | 0 |
| beam-state-init-only-gate | info | 2 (\`state.name\`, \`state.task_id\` — verified immutable config) |
| beam-state-truthy-guard-always-falsy | warning | 0 |
| beam-state-truthy-guard-always-truthy | warning | 0 |

One semantic-trap candidate surfaced during development (\`state.running?\` in planner_trigger.ex) but turned out to be an analyzer limitation — the truthy writer lived in a private helper. Fixed via trans-procedural propagation, Ichi is clean.

## Out of scope / follow-ups

- Pattern-match destructure reads (\`def handle_call(m, _, %{x: x} = state)\`).
- Value-match guards (\`case state.X do :specific_value -> ...\`).
- Clause-return analysis (detect \`{:stop, _, state}\` + \`Process.send_after\` in the same clause).
- \`defstruct\` default tracking (fields defined with a default and never written explicitly).

Documented in the analyzer module moduledoc.

## Test plan

- [x] \`cd packages/beam-analyzer && mix test\` — 180 tests, 0 failures
- [x] \`cd packages/rfdb-server && cargo test --release --lib hash_join\` — 11 passes including two shared-var regressions
- [x] Full \`grafema analyze --clear\` on Ichi — 19 464 nodes, 14 273 edges, 0 errors
- [x] \`grafema check -f .grafema/guarantees.yaml\` on Ichi — all 7 new guarantees run; warning-level rules are 0-hit, info-level hits manually verified against source
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)