### PR TITLE
feat(python-analyzer): emit ASSIGNED_FROM for self-attribute assignments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to Grafema
+
+## Development setup
+
+```bash
+pnpm install
+pnpm build
+```
+
+## Running with the compaction enricher
+
+The compaction enricher synthesizes shortcut edges (CO_DEPENDS_ON, DIRECT_CALLS, etc.) between
+nodes that are connected through hidden pass-through nodes. Without it, `grafema analyze` only
+produces raw parser edges.
+
+The enricher is configured in `.grafema/orchestrator.config.yaml`, which is gitignored so each
+developer maintains their own copy. A template is provided:
+
+```bash
+cp _ai/orchestrator.config.example.yaml .grafema/orchestrator.config.yaml
+sed -i '' "s|<GRAFEMA_ROOT>|$(pwd)|g" .grafema/orchestrator.config.yaml
+```
+
+Then run:
+
+```bash
+grafema analyze
+```
+
+If the city map shows "flow types = 0" after analysis, check that the `command` path in
+`.grafema/orchestrator.config.yaml` points to a built `compactionEnricher.js` (`pnpm build` first).
+
+## Running tests
+
+```bash
+pnpm test
+```
+
+Rust packages:
+
+```bash
+cargo test -p grafema-orchestrator
+cargo test -p rfdb-server
+```

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -66,7 +66,7 @@ Honest list of what works, what doesn't, and when we plan to fix it.
 
 - ~~**REG-655: `get_file_overview` shows empty calls**~~ — Fixed: line-range fallback in `FileOverview.buildFunctionOverview()` now queries both `CALL` and `METHOD_CALL` nodes by file+line range when `findCallsInFunction` returns empty. TS class methods now report calls correctly.
 - ~~**REG-656: Rust intra-file CALLS missing**~~ — Fixed: `rust-resolve` now runs `rust-calls` command that matches CALL nodes to same-file FUNCTION nodes by name (exact or last `::` segment).
-- **REG-625: JS/TS MODULE names have absolute paths** — MODULE node `name` field contains absolute paths instead of relative. The `file` field is correct. Cosmetic issue.
+- ~~**REG-625: JS/TS MODULE names have absolute paths**~~ — Fixed: `node.name` now stripped to relative path in `relativize_paths()` alongside `node.file` (commit `96b30173`).
 - ~~**REG-652: MCP not workspace-aware**~~ — Fixed: MCP server auto-detects project root by walking up from `process.cwd()` looking for `grafema.yaml` or `.grafema/`. `--project` flag still works as an explicit override. MCP clients (Claude Code, Cursor) set CWD = workspace root when spawning the server, so no config is needed.
 - **RFDB stale socket** — `grafema doctor` detects stale `rfdb.sock` after crash, but doesn't auto-clean. Run `grafema analyze` to restart.
 - **`grafema init` config** — fixed in v0.3.0: generated config previously used phased plugin map that orchestrator couldn't parse.

--- a/packages/cli/src/commands/explore.tsx
+++ b/packages/cli/src/commands/explore.tsx
@@ -749,27 +749,33 @@ function Explorer({ backend, startNode, projectPath }: ExplorerProps) {
 
       {/* Help overlay */}
       {state.showHelp && (
-        <Box flexDirection="column" borderStyle="round" borderColor="yellow" padding={1}>
-          <Text bold color="yellow">Справка</Text>
-          <Text>  q        Выход</Text>
-          <Text>  /        Поиск</Text>
-          <Text>  ?        Эта справка</Text>
-          <Text>  m        Переключить режим</Text>
-          <Text>  Space    Предпросмотр кода</Text>
-          <Text>  ←/h      Callers / Fields / Sources</Text>
-          <Text>  →/l      Callees / Methods / Targets</Text>
-          <Text>  ↑/k      Вверх</Text>
-          <Text>  ↓/j      Вниз</Text>
-          <Text>  Enter    Перейти к узлу</Text>
-          <Text>  ⌫        Назад</Text>
-          <Text>  Tab      Toggle callers/callees</Text>
+        <Box
+          flexDirection="column"
+          borderStyle="single"
+          borderColor="cyan"
+          paddingX={1}
+          marginBottom={1}
+        >
+          <Text bold color="cyan"> Клавиши управления </Text>
+          <Text>  q        — выход</Text>
+          <Text>  /        — поиск</Text>
+          <Text>  ?        — помощь (это окно)</Text>
+          <Text>  m        — переключить режим (модули/функции)</Text>
+          <Text>  Space    — предпросмотр кода</Text>
+          <Text>  ←/h      — callers / fields / sources</Text>
+          <Text>  →/l      — callees / methods / targets</Text>
+          <Text>  ↑/k      — предыдущий элемент</Text>
+          <Text>  ↓/j      — следующий элемент</Text>
+          <Text>  Enter    — перейти к узлу</Text>
+          <Text>  Bksp     — назад</Text>
+          <Text>  Tab      — toggle callers/callees</Text>
         </Box>
       )}
 
       {/* Help footer */}
       <Box marginTop={1} borderStyle="single" borderColor="gray" paddingX={1}>
         <Text color="gray">
-          ↑↓: Select | ←→: Panel | Enter: Open | Backspace: Back | /: Search | m: Modules | Space: Code | o: Editor | q: Quit
+          ↑↓: Select | ←→: Panel | Enter: Open | Backspace: Back | /: Search | m: Modules | Space: Code | o: Editor | ?: Help | q: Quit
         </Text>
       </Box>
     </Box>

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -299,7 +299,7 @@ module.exports = { hello, greet };
     assert.ok(existsSync(configPath), '.grafema/config.yaml should be created');
 
     // Step 2: Run analyze with --clear flag
-    const analyzeResult = await runCliInDir(e2eDir, ['analyze', '--clear', '--auto-start']);
+    const analyzeResult = await runCliInDir(e2eDir, ['analyze', '--clear']);
     assert.strictEqual(analyzeResult.code, 0, `analyze failed: ${analyzeResult.stderr}`);
     assert.ok(analyzeResult.stdout.includes('Analysis complete'), 'analyze should complete');
     assert.ok(analyzeResult.stdout.includes('Nodes:'), 'analyze should show node count');

--- a/packages/grafema-orchestrator/src/analyzer.rs
+++ b/packages/grafema-orchestrator/src/analyzer.rs
@@ -114,6 +114,7 @@ impl FileAnalysis {
         for node in &mut self.nodes {
             node.id = strip(&node.id);
             node.file = strip(&node.file);
+            node.name = strip(&node.name);
         }
         for edge in &mut self.edges {
             edge.src = strip(&edge.src);
@@ -5697,6 +5698,7 @@ mod tests {
         analysis.relativize_paths("/home/user/project");
 
         assert_eq!(analysis.nodes[0].id, "MODULE#src/app.ts");
+        assert_eq!(analysis.nodes[0].name, "src/app.ts");
         assert_eq!(analysis.nodes[0].file, "src/app.ts");
         assert_eq!(analysis.edges[0].src, "MODULE#src/app.ts");
         assert_eq!(analysis.edges[0].dst, "src/app.ts->FUNCTION->main");

--- a/packages/python-analyzer/src/Rules/Declarations.hs
+++ b/packages/python-analyzer/src/Rules/Declarations.hs
@@ -239,12 +239,14 @@ walkDeclarations (ClassDef name bases keywords body decos sp) = do
     withNamedParent name $
       mapM_ walkDeclarations body
 
--- AssignStmt → VARIABLE nodes
-walkDeclarations (AssignStmt targets _value sp) = do
-  mapM_ (walkAssignTarget sp) targets
+-- AssignStmt → VARIABLE nodes (plus ASSIGNED_FROM edge to the value, when
+-- the value is an expression that gets its own graph node — see
+-- 'valueNodeId' below).
+walkDeclarations (AssignStmt targets value sp) = do
+  mapM_ (walkAssignTarget sp value) targets
 
 -- AnnAssignStmt → VARIABLE node with annotation
-walkDeclarations (AnnAssignStmt target annotation _value _simple sp) = do
+walkDeclarations (AnnAssignStmt target annotation mValue _simple sp) = do
   file    <- askFile
   scopeId <- askScopeId
   parent  <- askNamedParent
@@ -297,6 +299,9 @@ walkDeclarations (AnnAssignStmt target annotation _value _simple sp) = do
           }
         Nothing -> pure ()
 
+      -- ASSIGNED_FROM to value, if value is an expression that becomes a node
+      emitAssignedFromEdge file parent nodeId mValue
+
     -- self.x: int = ...
     AttributeExpr (NameExpr receiver _) attr _ | receiver == "self" -> do
       let hash   = contentHash [("line", T.pack (show line))]
@@ -334,6 +339,9 @@ walkDeclarations (AnnAssignStmt target annotation _value _simple sp) = do
           , geMetadata = Map.empty
           }
         Nothing -> pure ()
+
+      -- ASSIGNED_FROM to value, if any
+      emitAssignedFromEdge file parent nodeId mValue
 
     _ -> pure ()
 
@@ -378,9 +386,11 @@ walkMember = walkDeclarations
 
 -- ── Assignment target walker ─────────────────────────────────────────
 
--- | Walk a single assignment target, emitting VARIABLE nodes.
-walkAssignTarget :: Span -> PythonExpr -> Analyzer ()
-walkAssignTarget sp target = do
+-- | Walk a single assignment target, emitting VARIABLE nodes and an
+-- ASSIGNED_FROM edge to the value expression's node (when the value is an
+-- expression that gets its own graph node — see 'valueNodeId').
+walkAssignTarget :: Span -> PythonExpr -> PythonExpr -> Analyzer ()
+walkAssignTarget sp value target = do
   file    <- askFile
   scopeId <- askScopeId
   parent  <- askNamedParent
@@ -431,6 +441,9 @@ walkAssignTarget sp target = do
           }
         Nothing -> pure ()
 
+      -- ASSIGNED_FROM to value (Just value because AssignStmt always has one)
+      emitAssignedFromEdge file parent nodeId (Just value)
+
     -- self.x = ...
     AttributeExpr (NameExpr receiver _) attr _ | receiver == "self" -> do
       let hash   = contentHash [("line", T.pack (show line))]
@@ -468,13 +481,74 @@ walkAssignTarget sp target = do
           }
         Nothing -> pure ()
 
+      -- ASSIGNED_FROM to value
+      emitAssignedFromEdge file parent nodeId (Just value)
+
     -- Tuple unpacking: (a, b) = ... or [a, b] = ...
-    TupleExpr elts _ -> mapM_ (walkAssignTarget sp) elts
-    ListExpr  elts _ -> mapM_ (walkAssignTarget sp) elts
-    StarredExpr inner _ -> walkAssignTarget sp inner
+    -- We pass `value` through unchanged — every unpacked target gets the
+    -- same ASSIGNED_FROM target. That is imprecise (real semantics is
+    -- per-element), but matches what other analyzers do at this level
+    -- of resolution and keeps the edge useful for downstream consumers.
+    TupleExpr elts _ -> mapM_ (walkAssignTarget sp value) elts
+    ListExpr  elts _ -> mapM_ (walkAssignTarget sp value) elts
+    StarredExpr inner _ -> walkAssignTarget sp value inner
 
     -- Other targets (subscript, etc.) — skip
     _ -> pure ()
+
+-- ── ASSIGNED_FROM emission ───────────────────────────────────────────
+--
+-- Predict the semantic ID of the value-expression's graph node and emit
+-- an ASSIGNED_FROM edge from the freshly-emitted VARIABLE to it. The
+-- target node is emitted later by 'Rules.Calls.walkExpr' (Walker order:
+-- walkDeclarations runs before walkStmtExprs in walkStmt) — Grafema
+-- accepts forward-reference edges because semantic IDs are deterministic.
+--
+-- We only emit an edge when the value-expression-walker emits a node:
+--   CallExpr      → CALL
+--   AttributeExpr → PROPERTY_ACCESS
+--   NameExpr      → REFERENCE
+-- Other value forms (literals, lambdas, comprehensions, …) are skipped:
+--   Calls.walkExpr does not emit nodes for them today (e.g. ConstantExpr
+--   is explicitly a no-op), so there is nothing to point at. Adding
+--   LITERAL emission is a separate change.
+
+emitAssignedFromEdge :: Text -> Maybe Text -> Text -> Maybe PythonExpr -> Analyzer ()
+emitAssignedFromEdge _    _      _      Nothing      = pure ()
+emitAssignedFromEdge file parent srcVar (Just expr) =
+  case valueNodeId file parent expr of
+    Nothing  -> pure ()
+    Just dst -> emitEdge GraphEdge
+      { geSource   = srcVar
+      , geTarget   = dst
+      , geType     = "ASSIGNED_FROM"
+      , geMetadata = Map.empty
+      }
+
+valueNodeId :: Text -> Maybe Text -> PythonExpr -> Maybe Text
+valueNodeId file parent expr = case expr of
+  CallExpr func _ _ sp ->
+    let (line, col) = (posLine (spanStart sp), posCol (spanStart sp))
+        hash        = contentHash [("line", T.pack (show line)), ("col", T.pack (show col))]
+    in Just (semanticId file "CALL" (callFuncName func) parent (Just hash))
+  AttributeExpr _ attr sp ->
+    let (line, col) = (posLine (spanStart sp), posCol (spanStart sp))
+        hash        = contentHash [("line", T.pack (show line)), ("col", T.pack (show col))]
+    in Just (semanticId file "PROPERTY_ACCESS" attr parent (Just hash))
+  NameExpr name sp ->
+    let (line, col) = (posLine (spanStart sp), posCol (spanStart sp))
+        hash        = contentHash [("line", T.pack (show line)), ("col", T.pack (show col))]
+    in Just (semanticId file "REFERENCE" name parent (Just hash))
+  _ -> Nothing
+
+-- | Mirror of 'Rules.Calls.extractFuncName' — duplicated here to avoid a
+-- module-level import cycle (Calls already imports nothing from Declarations
+-- but a future shared helpers module would be a cleaner refactor).
+callFuncName :: PythonExpr -> Text
+callFuncName (NameExpr n _)        = n
+callFuncName (AttributeExpr _ a _) = a
+callFuncName (CallExpr func _ _ _) = callFuncName func
+callFuncName _                     = "<expr>"
 
 -- ── Lambda and expression declaration walker ─────────────────────────
 

--- a/packages/util/src/storage/backends/RFDBServerBackend.ts
+++ b/packages/util/src/storage/backends/RFDBServerBackend.ts
@@ -20,7 +20,7 @@
 
 import { RFDBClient, type BatchHandle } from '@grafema/rfdb-client';
 import type { ChildProcess } from 'child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, unlinkSync } from 'node:fs';
 import { setTimeout as sleep } from 'timers/promises';
 import { join, dirname } from 'path';
 import { createHash } from 'crypto';
@@ -314,6 +314,10 @@ export class RFDBServerBackend {
     this.connected = false;
     this.serverProcess = null;
     await this._waitForPidExit(pidPath, 5000);
+    // Explicitly remove PID and socket so checkExistingServer returns 'none'
+    // and the subsequent connect() spawns a fresh server unconditionally.
+    try { unlinkSync(pidPath); } catch { /* already gone */ }
+    try { unlinkSync(this.socketPath); } catch { /* already gone */ }
   }
 
   /**

--- a/plugins/field-instance-resolver.mjs
+++ b/plugins/field-instance-resolver.mjs
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+/**
+ * Field Instance Resolver — Grafema batch plugin
+ *
+ * Resolves CALLs whose receiver is an instance attribute initialized to a
+ * known library constructor. Closes the gap exposed by gs-115b's deep dive
+ * of dpc-messenger, where 6/9 HTTP calls were invisible because they go
+ * through `self.http_client.<method>(...)` after `self.http_client =
+ * httpx.AsyncClient(...)` in `__init__`.
+ *
+ * Strategy (per-file):
+ *   1. Index VARIABLE nodes with kind="instance_variable" — these are
+ *      `self.<name>` declarations. Group by file → name → [VARIABLE].
+ *   2. Find CALL nodes whose `receiver` matches one of the instance
+ *      attribute names in that file. These are candidates: e.g.
+ *      `self.http_client.get(...)`, where Python analyzer flattens
+ *      `receiver` to just the attribute name (`http_client`).
+ *   3. For each candidate file, scan the source for `self.<name> = <ctor>(...)`
+ *      statements (regex over the actual .py file is cheap and the only path
+ *      that works today — the Python analyzer does not emit ASSIGNED_FROM
+ *      edges for instance-attribute assignments, so the graph alone cannot
+ *      resolve the constructor; see "Plan B" below for the long-term fix).
+ *   4. Resolve `<ctor>` against per-file imports (also regex-extracted) into
+ *      a fully-qualified library symbol (e.g. `httpx.AsyncClient`).
+ *   5. For each candidate CALL whose method is in the library's known method
+ *      set, write back a `READS_FROM[kind=field_receiver]` edge from the
+ *      CALL to the field VARIABLE, with edge metadata recording the resolved
+ *      library, subtype, ctor and method. Existing batch plugins (method-
+ *      call-resolver, ipc-bridge-detector) all enrich via edges only — node
+ *      metadata mutation isn't part of the public RFDBClient API today, so
+ *      enrichment data lives on the edge.
+ *
+ * Consumer pattern (Cypher):
+ *
+ *   MATCH (c:CALL)-[r:READS_FROM]->(v:VARIABLE)
+ *   WHERE r.kind = "field_receiver"
+ *   RETURN c.file, c.name, r.resolved_library, r.resolved_subtype
+ *
+ * Output: stderr-only progress + final counts. The graph is mutated in place.
+ *
+ * Environment:
+ *   RFDB_SOCKET   — path to RFDB unix socket (required)
+ *   RFDB_DATABASE — database name (optional)
+ *   PROJECT_ROOT  — absolute path to the analyzed project (required for
+ *                   source scanning; defaults to CWD).
+ *   DRY_RUN       — if "1" or "true", classify but do not write edges/metadata
+ */
+
+import { RFDBClient } from '../packages/rfdb/dist/client.js';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+/**
+ * Library constructor → classification.
+ * `methods` lists the method names that, when called on an instance of this
+ * library, should be classified by `subtype`. Method-set membership is the
+ * filter that prevents over-eager tagging of e.g. `self.http_client.foo()`
+ * where `foo` is some unrelated method.
+ */
+const LIBRARY_PATTERNS = {
+  // HTTP clients
+  'httpx.Client':        { library: 'httpx',       subtype: 'IO:HTTP:REQUEST', methods: HTTP_METHODS() },
+  'httpx.AsyncClient':   { library: 'httpx',       subtype: 'IO:HTTP:REQUEST', methods: HTTP_METHODS() },
+  'requests.Session':    { library: 'requests',    subtype: 'IO:HTTP:REQUEST', methods: HTTP_METHODS() },
+  'aiohttp.ClientSession':{library: 'aiohttp',    subtype: 'IO:HTTP:REQUEST', methods: HTTP_METHODS() },
+  // Sockets
+  'socket.socket':            { library: 'socket', subtype: 'IO:SOCKET',  methods: SOCKET_METHODS() },
+  'socket.create_connection': { library: 'socket', subtype: 'IO:SOCKET:CONNECT', methods: SOCKET_METHODS() },
+  'socket.create_server':     { library: 'socket', subtype: 'IO:SOCKET:LISTEN',  methods: SOCKET_METHODS() },
+  // WebSocket clients (return value of websockets.connect — async ctx mgr)
+  'websockets.connect':       { library: 'websockets', subtype: 'IO:WEBSOCKET', methods: WS_METHODS() },
+  'websockets.WebSocketClientProtocol': { library: 'websockets', subtype: 'IO:WEBSOCKET', methods: WS_METHODS() },
+  // Subprocess (Popen instance)
+  'subprocess.Popen': { library: 'subprocess', subtype: 'IO:PROCESS:SPAWN', methods: new Set(['communicate','wait','poll','kill','terminate','send_signal']) },
+};
+
+function HTTP_METHODS()   { return new Set(['get','post','put','delete','patch','head','options','request','stream','send']); }
+function SOCKET_METHODS() { return new Set(['connect','bind','listen','accept','send','sendall','sendto','recv','recvfrom','close','shutdown']); }
+function WS_METHODS()     { return new Set(['send','recv','send_text','send_bytes','send_json','recv_text','close','ping','pong']); }
+
+// ── Setup ───────────────────────────────────────────────────────────────────
+
+const socketPath = process.env.RFDB_SOCKET;
+const dbName = process.env.RFDB_DATABASE;
+const projectRoot = process.env.PROJECT_ROOT || process.cwd();
+const dryRun = /^(1|true|yes)$/i.test(process.env.DRY_RUN || '');
+
+if (!socketPath) {
+  console.error('[field-instance-resolver] RFDB_SOCKET not set');
+  process.exit(1);
+}
+
+const client = new RFDBClient(socketPath, 'field-instance-resolver');
+
+const safeParse = (s) => {
+  if (!s) return {};
+  if (typeof s !== 'string') return s;
+  try { return JSON.parse(s); } catch { return {}; }
+};
+
+try {
+  await client.connect();
+  if (dbName) await client.openDatabase(dbName);
+
+  // Step 1: Index instance_variable VARIABLE nodes per file
+  console.error('[field-instance-resolver] Indexing instance variables...');
+  const fieldsByFile = new Map(); // file -> Map(fieldName -> [variableNodeId])
+  let varCount = 0;
+  for await (const v of client.queryNodes({ type: 'VARIABLE' })) {
+    const meta = safeParse(v.metadata);
+    if (meta.kind !== 'instance_variable') continue;
+    if (!v.file || !v.file.endsWith('.py')) continue;
+    if (!v.name) continue;
+    if (!fieldsByFile.has(v.file)) fieldsByFile.set(v.file, new Map());
+    const map = fieldsByFile.get(v.file);
+    if (!map.has(v.name)) map.set(v.name, []);
+    map.get(v.name).push(String(v.id));
+    varCount++;
+  }
+  console.error(`[field-instance-resolver]   ${varCount} instance_variable nodes across ${fieldsByFile.size} files`);
+
+  // Step 2: For every Python file with instance variables, scan the source to
+  // discover `self.<field> = <ctor>(...)` and `import` lines. We need the
+  // source because the Python analyzer does not emit ASSIGNED_FROM edges for
+  // instance-attribute assignments today — see "Plan B" in the design doc.
+  console.error('[field-instance-resolver] Scanning source for ctor assignments...');
+  const fieldCtor = new Map();   // file -> Map(field -> resolvedSymbol)
+  for (const file of fieldsByFile.keys()) {
+    const abs = join(projectRoot, file);
+    if (!existsSync(abs)) continue;
+    let text;
+    try { text = readFileSync(abs, 'utf-8'); } catch { continue; }
+
+    // Build per-file import alias map: localName -> fullDottedSymbol
+    /** @type {Map<string, string>} */
+    const aliases = new Map();
+    for (const line of text.split('\n')) {
+      let m;
+      if ((m = line.match(/^\s*import\s+([\w.]+)(?:\s+as\s+(\w+))?/))) {
+        const full = m[1];
+        const local = m[2] || full.split('.')[0];
+        aliases.set(local, m[2] ? full : full); // "import httpx" → httpx; "import x.y as z" → z=x.y
+      } else if ((m = line.match(/^\s*from\s+([\w.]+)\s+import\s+(.+)/))) {
+        const from = m[1];
+        for (const part of m[2].split(',')) {
+          const mm = part.trim().match(/^(\w+)(?:\s+as\s+(\w+))?/);
+          if (!mm) continue;
+          const imported = mm[1];
+          const local = mm[2] || imported;
+          aliases.set(local, `${from}.${imported}`);
+        }
+      }
+    }
+
+    // Resolve a dotted reference written in source against the alias map
+    const resolve = (ref) => {
+      const parts = ref.split('.');
+      const head = parts[0];
+      const tail = parts.slice(1).join('.');
+      const headFull = aliases.get(head) || head;
+      return tail ? `${headFull}.${tail}` : headFull;
+    };
+
+    // Match `self.<field> = (await )?<ctor>(...)` — single-line, single-stmt.
+    // We deliberately do NOT match multi-line expressions to keep the regex
+    // honest; chained constructors (`httpx.AsyncClient(...).get(...)`) won't
+    // round-trip but are rare in __init__.
+    const re = /(?:^|\n)\s*self\.(\w+)\s*=\s*(?:await\s+)?([\w.]+)\s*\(/g;
+    const ctorMap = new Map();
+    let mm;
+    while ((mm = re.exec(text)) !== null) {
+      const field = mm[1];
+      const ctor = mm[2];
+      const resolved = resolve(ctor);
+      ctorMap.set(field, resolved);
+    }
+    if (ctorMap.size > 0) fieldCtor.set(file, ctorMap);
+  }
+  console.error(`[field-instance-resolver]   ctor assignments resolved in ${fieldCtor.size} files`);
+
+  // Step 3: Walk CALL nodes whose receiver matches a known field. For each
+  // match, check that we already produced an edge in a previous run (the
+  // edge itself is the idempotency marker — re-running won't double-write
+  // because we test for presence first).
+  console.error('[field-instance-resolver] Classifying field-method calls...');
+  let scanned = 0, classified = 0, skippedAlreadyTagged = 0, skippedUnknown = 0;
+  const newEdges = [];
+
+  for await (const call of client.queryNodes({ type: 'CALL' })) {
+    if (!call.file || !call.file.endsWith('.py')) continue;
+    scanned++;
+    const meta = safeParse(call.metadata);
+    const recv = meta.receiver;
+    if (!recv) continue;
+
+    const ctorMap = fieldCtor.get(call.file);
+    if (!ctorMap) continue;
+    const ctor = ctorMap.get(recv);
+    if (!ctor) continue;
+
+    // Match against LIBRARY_PATTERNS. Try direct, then suffix-match (handles
+    // `from httpx import AsyncClient` → resolved as "httpx.AsyncClient" by
+    // the alias resolver, which is what the pattern key expects).
+    let pattern = LIBRARY_PATTERNS[ctor];
+    if (!pattern) {
+      // Try last-two-segments fallback (e.g. "x.httpx.Client" → "httpx.Client")
+      const parts = ctor.split('.');
+      if (parts.length >= 2) {
+        const tail = parts.slice(-2).join('.');
+        pattern = LIBRARY_PATTERNS[tail];
+      }
+    }
+    if (!pattern) { skippedUnknown++; continue; }
+
+    if (!pattern.methods.has(call.name)) continue;
+
+    // Idempotency: skip if we already wrote a field_receiver edge for this CALL
+    const callId = String(call.id);
+    const existingOut = await client.getOutgoingEdges(callId);
+    const already = existingOut.some(e => {
+      if (e.type !== 'READS_FROM') return false;
+      const em = safeParse(e.metadata);
+      return em.kind === 'field_receiver';
+    });
+    if (already) { skippedAlreadyTagged++; continue; }
+
+    classified++;
+
+    // Pick the representative field VARIABLE to link to. Existing batch
+    // plugins enrich purely via edges (see method-call-resolver,
+    // ipc-bridge-detector) — `client.updateNode` is not part of the public
+    // RFDBClient API, so all enrichment data lives on the edge.
+    const fieldVars = fieldsByFile.get(call.file)?.get(recv) || [];
+    if (fieldVars.length === 0) continue;
+
+    newEdges.push({
+      src: callId,
+      dst: fieldVars[0],
+      type: 'READS_FROM',
+      metadata: JSON.stringify({
+        _source: 'field-instance-resolver',
+        kind: 'field_receiver',
+        resolved_library: pattern.library,
+        resolved_subtype: pattern.subtype,
+        resolved_ctor: ctor,
+        resolved_method: call.name,
+      }),
+    });
+  }
+
+  console.error(
+    `[field-instance-resolver]   scanned=${scanned} classified=${classified} ` +
+    `skipped_already=${skippedAlreadyTagged} skipped_unknown_ctor=${skippedUnknown}`,
+  );
+
+  if (dryRun) {
+    console.error('[field-instance-resolver] DRY_RUN — not writing edges');
+  } else if (newEdges.length > 0) {
+    const BATCH = 500;
+    console.error(`[field-instance-resolver] Adding ${newEdges.length} READS_FROM[kind=field_receiver] edges...`);
+    for (let i = 0; i < newEdges.length; i += BATCH) {
+      await client.addEdges(newEdges.slice(i, i + BATCH));
+    }
+  }
+
+  console.error('[field-instance-resolver] Done.');
+  await client.close();
+} catch (err) {
+  console.error(`[field-instance-resolver] Error: ${err && err.stack ? err.stack : err}`);
+  try { await client.close(); } catch { /* ignore */ }
+  process.exit(1);
+}


### PR DESCRIPTION
Implements ASSIGNED_FROM edges for self.x = expr patterns in Python analyzer.

## What

When Python code assigns to a self-attribute in `__init__`:
```python
self.http_client = httpx.AsyncClient(...)
```
The analyzer now emits:
```
VARIABLE(http_client) --[ASSIGNED_FROM]--> CALL(AsyncClient)
```

## Why

Closes the gap that forced field-instance-resolver plugin (commit 1895b4f4) to use regex source-scan instead of pure graph queries.

## Known limitations

- `self.x += v` (AugAssignStmt): different semantics, out of scope
- Walrus operator `:=`: rare pattern, out of scope
- `ConstantExpr` targets: LITERAL nodes not emitted

Reviewed-by: operator (tg-1839)