### PR TITLE
fix: resolution bugs, compaction perf, god-file data loss

### DIFF
--- a/packages/core-v2/test/constant-value-source.test.mjs
+++ b/packages/core-v2/test/constant-value-source.test.mjs
@@ -1,0 +1,146 @@
+/**
+ * Tests for CONSTANT value source invariant:
+ * Every CONSTANT node must have an outgoing ASSIGNED_FROM edge
+ * whose target is a LITERAL node.
+ *
+ * Non-literal initialisers (calls, new-expressions, etc.) produce
+ * VARIABLE nodes instead of CONSTANT.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { walkFile } from '../dist/walk.js';
+import { jsRegistry } from '../dist/registry.js';
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function findConstant(result, name) {
+  return result.nodes.find(n => n.type === 'CONSTANT' && n.name === name);
+}
+
+function findAssignedFrom(result, srcId) {
+  return result.edges.filter(e => e.src === srcId && e.type === 'ASSIGNED_FROM');
+}
+
+function assertConstantWithLiteral(result, name) {
+  const constant = findConstant(result, name);
+  assert.ok(constant, `expected CONSTANT node named '${name}'`);
+
+  const edges = findAssignedFrom(result, constant.id);
+  assert.ok(edges.length >= 1,
+    `CONSTANT '${name}' should have at least one ASSIGNED_FROM edge, got ${edges.length}`);
+
+  const targetId = edges[0].dst;
+  const targetNode = result.nodes.find(n => n.id === targetId);
+  assert.ok(targetNode, `ASSIGNED_FROM target '${targetId}' should exist in nodes`);
+  assert.equal(targetNode.type, 'LITERAL',
+    `ASSIGNED_FROM target for '${name}' should be LITERAL, got '${targetNode.type}'`);
+}
+
+// ─── Individual literal types ────────────────────────────────────────
+
+describe('CONSTANT value source edges', () => {
+
+  it('const x = 42 -> CONSTANT named x + ASSIGNED_FROM -> LITERAL', async () => {
+    const result = await walkFile('const x = 42;', 'test.js', jsRegistry);
+    assertConstantWithLiteral(result, 'x');
+  });
+
+  it("const s = 'hello' -> CONSTANT named s + ASSIGNED_FROM -> LITERAL", async () => {
+    const result = await walkFile("const s = 'hello';", 'test.js', jsRegistry);
+    assertConstantWithLiteral(result, 's');
+  });
+
+  it('const b = true -> CONSTANT named b + ASSIGNED_FROM -> LITERAL', async () => {
+    const result = await walkFile('const b = true;', 'test.js', jsRegistry);
+    assertConstantWithLiteral(result, 'b');
+  });
+
+  it('const n = null -> CONSTANT named n + ASSIGNED_FROM -> LITERAL', async () => {
+    const result = await walkFile('const n = null;', 'test.js', jsRegistry);
+    assertConstantWithLiteral(result, 'n');
+  });
+
+  it('const r = /pat/g -> CONSTANT named r + ASSIGNED_FROM -> LITERAL', async () => {
+    const result = await walkFile('const r = /pat/g;', 'test.js', jsRegistry);
+    assertConstantWithLiteral(result, 'r');
+  });
+
+  it('const t = `tpl` -> CONSTANT named t + ASSIGNED_FROM -> LITERAL', async () => {
+    const result = await walkFile('const t = `tpl`;', 'test.js', jsRegistry);
+    assertConstantWithLiteral(result, 't');
+  });
+
+  it('const big = 42n -> CONSTANT named big + ASSIGNED_FROM -> LITERAL', async () => {
+    const result = await walkFile('const big = 42n;', 'test.js', jsRegistry);
+    assertConstantWithLiteral(result, 'big');
+  });
+
+  // ─── Negative cases ─────────────────────────────────────────────────
+
+  it('const x = new Foo() -> creates VARIABLE, not CONSTANT', async () => {
+    const result = await walkFile('const x = new Foo();', 'test.js', jsRegistry);
+    const constant = findConstant(result, 'x');
+    assert.equal(constant, undefined,
+      'new Foo() should not produce a CONSTANT node');
+
+    const variable = result.nodes.find(n => n.type === 'VARIABLE' && n.name === 'x');
+    assert.ok(variable, 'new Foo() should produce a VARIABLE node named x');
+  });
+
+  it('const x = foo() -> creates VARIABLE, not CONSTANT', async () => {
+    const result = await walkFile('const x = foo();', 'test.js', jsRegistry);
+    const constant = findConstant(result, 'x');
+    assert.equal(constant, undefined,
+      'foo() should not produce a CONSTANT node');
+
+    const variable = result.nodes.find(n => n.type === 'VARIABLE' && n.name === 'x');
+    assert.ok(variable, 'foo() should produce a VARIABLE node named x');
+  });
+
+  // ─── Batch invariant check ─────────────────────────────────────────
+
+  it('batch: all CONSTANT nodes in a multi-declaration file have ASSIGNED_FROM -> LITERAL', async () => {
+    const code = `
+      const num = 42;
+      const str = 'hello';
+      const bool = true;
+      const nil = null;
+      const undef = undefined;
+      const re = /abc/i;
+      const tpl = \`template\`;
+      const bigN = 100n;
+      const neg = -1;
+      const float = 3.14;
+      const zero = 0;
+      const empty = '';
+    `;
+    const result = await walkFile(code, 'test.js', jsRegistry);
+
+    // For every CONSTANT node, verify it has at least one outgoing ASSIGNED_FROM or DERIVES_FROM edge
+    const constants = result.nodes.filter(n => n.type === 'CONSTANT');
+    assert.ok(constants.length >= 10,
+      `expected at least 10 CONSTANT nodes, got ${constants.length}: ${constants.map(c => c.name).join(', ')}`);
+
+    const violations = constants.filter(c => {
+      const hasValueSource = result.edges.some(e =>
+        e.src === c.id && (e.type === 'ASSIGNED_FROM' || e.type === 'DERIVES_FROM')
+      );
+      return !hasValueSource;
+    });
+    assert.equal(violations.length, 0,
+      `Violations: ${violations.map(v => v.name).join(', ')}`);
+
+    // Additionally verify that every ASSIGNED_FROM target is a LITERAL
+    for (const c of constants) {
+      const assignedEdges = result.edges.filter(
+        e => e.src === c.id && e.type === 'ASSIGNED_FROM'
+      );
+      for (const edge of assignedEdges) {
+        const target = result.nodes.find(n => n.id === edge.dst);
+        assert.ok(target, `ASSIGNED_FROM target '${edge.dst}' should exist`);
+        assert.equal(target.type, 'LITERAL',
+          `ASSIGNED_FROM target for CONSTANT '${c.name}' should be LITERAL, got '${target.type}'`);
+      }
+    }
+  });
+});

--- a/packages/grafema-orchestrator/src/main.rs
+++ b/packages/grafema-orchestrator/src/main.rs
@@ -298,10 +298,14 @@ async fn commit_resolve_output(
     plugin::validate_plugin_output(output)?;
     plugin::stamp_metadata(output, name, generation);
     tag_virtual_nodes(output, name);
+    // Only include synthetic virtual files in changed_files — real source
+    // files must NOT be listed or commit_batch will tombstone all analysis
+    // nodes for those files before adding only the resolution nodes.
     let files: Vec<String> = output
         .nodes
         .iter()
         .filter_map(|n| n.file.clone())
+        .filter(|f| f.starts_with("__grafema_virtual/") || f.starts_with("<"))
         .collect::<HashSet<_>>()
         .into_iter()
         .collect();

--- a/packages/grafema-resolve/src/ImportResolution.hs
+++ b/packages/grafema-resolve/src/ImportResolution.hs
@@ -133,8 +133,8 @@ nodeToExportEntries node
   -- EXPORT node with name "named": skip (container node, children carry info)
   | gnType node == "EXPORT" = []
 
-  -- Directly exported declarations (FUNCTION, VARIABLE, CONSTANT, CLASS, INTERFACE, TYPE_ALIAS, ENUM)
-  | gnExported node && gnType node `elem` ["FUNCTION", "VARIABLE", "CONSTANT", "CLASS", "INTERFACE", "TYPE_ALIAS", "ENUM"] =
+  -- Directly exported declarations (FUNCTION, VARIABLE, CONSTANT, CLASS, INTERFACE, TYPE_ALIAS, ENUM, NAMESPACE)
+  | gnExported node && gnType node `elem` ["FUNCTION", "VARIABLE", "CONSTANT", "CLASS", "INTERFACE", "TYPE_ALIAS", "ENUM", "NAMESPACE"] =
       [(gnFile node, [ExportEntry (gnName node) (gnName node) (gnId node) (gnFile node) Nothing])]
 
   | otherwise = []
@@ -249,7 +249,9 @@ makeCandidates resolved =
       withExt = [resolved <> ext | ext <- extensions]
       -- Try as directory with index file
       indexFiles = [resolved <> "/index" <> ext | ext <- extensions]
-  in exact ++ swapped ++ withExt ++ indexFiles
+      -- .d.ts as last resort (type-declaration-only modules)
+      dtsExt = [resolved <> ".d.ts", resolved <> "/index.d.ts"]
+  in exact ++ swapped ++ withExt ++ indexFiles ++ dtsExt
 
 -- | If the path ends with a known extension, replace it with the target extension.
 -- Returns empty list if the path doesn't end with a known extension or the
@@ -257,7 +259,7 @@ makeCandidates resolved =
 swapExtension :: Text -> Text -> [Text]
 swapExtension path newExt =
   [ stripped <> newExt
-  | ext <- [".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"]
+  | ext <- [".d.ts", ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"]
   , ext `T.isSuffixOf` path
   , let stripped = T.dropEnd (T.length ext) path
   , stripped <> newExt /= path  -- skip if same as original
@@ -266,7 +268,7 @@ swapExtension path newExt =
 -- | Check if a path already has a known JS/TS extension.
 hasKnownExtension :: Text -> Bool
 hasKnownExtension p = any (`T.isSuffixOf` p)
-  [".js", ".ts", ".tsx", ".jsx", ".mjs", ".cjs", ".mts", ".cts"]
+  [".d.ts", ".js", ".ts", ".tsx", ".jsx", ".mjs", ".cjs", ".mts", ".cts"]
 
 -- ---------------------------------------------------------------------------
 -- Import resolution
@@ -375,8 +377,10 @@ handleExportEntry exportIndex wsMap visited depth node entry =
           mResolvedFile = resolveModulePath exportFile reExportSource exportIndex wsMap
       in case mResolvedFile of
         Nothing -> do
-          hPutStrLn stderr $ "Warning: cannot resolve re-export source '"
-            ++ T.unpack reExportSource ++ "'"
+          if isRelativeSpecifier reExportSource || Map.member reExportSource wsMap || findWorkspacePrefix reExportSource wsMap /= Nothing
+            then hPutStrLn stderr $ "Warning: cannot resolve re-export source '"
+                   ++ T.unpack reExportSource ++ "'"
+            else return ()
           return []
         Just resolvedFile ->
           resolveFromFile exportIndex wsMap visited (depth + 1) node resolvedFile (eeLocalName entry)

--- a/packages/grafema-resolve/test/Spec.hs
+++ b/packages/grafema-resolve/test/Spec.hs
@@ -12,6 +12,7 @@ import qualified PropertyAccess
 import qualified SameFileCalls
 import qualified JsThisMethodCalls
 import qualified ClassInheritance
+import qualified ImportResolution
 
 -- ---------------------------------------------------------------------------
 -- Test helpers
@@ -89,6 +90,12 @@ mkExportedFunction file name =
 mkExportedVariable :: Text -> Text -> GraphNode
 mkExportedVariable file name =
   (mkNode (file <> "->VARIABLE->" <> name) "VARIABLE" name file Map.empty)
+    { gnExported = True }
+
+-- | Create an exported NAMESPACE node.
+mkExportedNamespace :: Text -> Text -> GraphNode
+mkExportedNamespace file name =
+  (mkNode (file <> "->NAMESPACE->" <> name) "NAMESPACE" name file Map.empty)
     { gnExported = True }
 
 -- | Extract edges from plugin commands.
@@ -691,6 +698,67 @@ testCrossFileExtends =
     _ -> Fail $ "Expected 1 cross-file EXTENDS edge Dog→Animal, got: " ++ show edges
 
 -- ---------------------------------------------------------------------------
+-- ImportResolution unit tests
+-- ---------------------------------------------------------------------------
+
+-- | Exported NAMESPACE node appears in export index
+testNamespaceInExportIndex :: TestResult
+testNamespaceInExportIndex =
+  let schemasFile = "src/vs/base/common/network.ts"
+      nsNode = mkExportedNamespace schemasFile "Schemas"
+      idx = ImportResolution.buildExportIndex [nsNode]
+  in case Map.lookup schemasFile idx of
+    Just entries | any (\e -> ImportResolution.eeName e == "Schemas") entries -> Pass
+    Just entries -> Fail $ "Schemas not in entries: " ++ show (map ImportResolution.eeName entries)
+    Nothing -> Fail "File not found in export index"
+
+-- | Exported NAMESPACE resolves named import { Schemas } from './network'
+testNamespaceNamedImportResolves :: IO TestResult
+testNamespaceNamedImportResolves = do
+  let schemasFile = "src/vs/base/common/network.ts"
+      consumerFile = "src/vs/base/common/opener.ts"
+      nodes =
+        [ mkNamedImportBinding consumerFile "Schemas" "Schemas" "./network"
+        , mkExportedNamespace schemasFile "Schemas"
+        ]
+  cmds <- ImportResolution.resolveAll nodes
+  let edges = filter (\e -> geType e == "IMPORTS_FROM") (extractEdges cmds)
+  return $ case edges of
+    [e] | geTarget e == schemasFile <> "->NAMESPACE->Schemas" -> Pass
+    es -> Fail $ "Expected 1 IMPORTS_FROM edge to NAMESPACE, got: " ++ show es
+
+-- | ESM .js import resolves to .ts file (TS convention: import './foo.js' → foo.ts)
+testJsToTsResolution :: IO TestResult
+testJsToTsResolution = do
+  let targetFile = "src/vs/base/node/pfs.ts"
+      importerFile = "src/vs/platform/extensionManagement/node/extensionManagementService.ts"
+      nodes =
+        [ mkNamedImportBinding importerFile "Promises" "Promises" "../../../base/node/pfs.js"
+        , mkExportedVariable targetFile "Promises"
+        ]
+  cmds <- ImportResolution.resolveAll nodes
+  let edges = filter (\e -> geType e == "IMPORTS_FROM") (extractEdges cmds)
+  return $ case edges of
+    [e] | geTarget e == targetFile <> "->VARIABLE->Promises" -> Pass
+    es -> Fail $ "Expected 1 IMPORTS_FROM edge via .js→.ts swap, got: " ++ show es
+
+-- | .d.ts-only module resolves import (e.g., extensions/git/src/api/git.d.ts)
+testDtsOnlyModuleResolves :: IO TestResult
+testDtsOnlyModuleResolves = do
+  let dtsFile = "extensions/git/src/api/git.d.ts"
+      consumerFile = "extensions/git/src/api/consumer.ts"
+      nodes =
+        [ mkNamedImportBinding consumerFile "GitAPI" "GitAPI" "./git"
+        , (mkNode (dtsFile <> "->INTERFACE->GitAPI") "INTERFACE" "GitAPI" dtsFile Map.empty)
+            { gnExported = True }
+        ]
+  cmds <- ImportResolution.resolveAll nodes
+  let edges = filter (\e -> geType e == "IMPORTS_FROM") (extractEdges cmds)
+  return $ case edges of
+    [e] | geTarget e == dtsFile <> "->INTERFACE->GitAPI" -> Pass
+    es -> Fail $ "Expected 1 IMPORTS_FROM edge from .d.ts module, got: " ++ show es
+
+-- ---------------------------------------------------------------------------
 -- Main
 -- ---------------------------------------------------------------------------
 
@@ -741,7 +809,15 @@ main = do
     , runTest "unknown superClass produces no edge" testUnknownSuperClass
     , runTest "cross-file inheritance via import creates EXTENDS edge" testCrossFileExtends
     ]
-  let allResults = paResults ++ sfcResults ++ jsResults ++ ciResults
+  putStrLn ""
+  putStrLn "ImportResolution unit tests:"
+  irResults <- sequence
+    [ runTest "exported NAMESPACE in export index" testNamespaceInExportIndex
+    , runTestIO "NAMESPACE resolves named import" testNamespaceNamedImportResolves
+    , runTestIO ".js ESM import resolves to .ts file" testJsToTsResolution
+    , runTestIO ".d.ts-only module resolves import" testDtsOnlyModuleResolves
+    ]
+  let allResults = paResults ++ sfcResults ++ jsResults ++ ciResults ++ irResults
       total = length allResults
       passed = length (filter id allResults)
   putStrLn $ "\n" ++ show passed ++ "/" ++ show total ++ " tests passed"

--- a/packages/rfdb-server/src/storage_v2/compaction/coordinator.rs
+++ b/packages/rfdb-server/src/storage_v2/compaction/coordinator.rs
@@ -11,6 +11,8 @@
 
 use std::io::Cursor;
 
+use rayon::prelude::*;
+
 use crate::error::Result;
 use crate::storage_v2::compaction::merge::{merge_edge_segments, merge_node_segments};
 use crate::storage_v2::compaction::types::CompactionConfig;
@@ -75,16 +77,34 @@ pub struct ShardCompactionResult {
 pub fn compact_shard(shard: &Shard) -> Result<ShardCompactionResult> {
     let tombstones = shard.tombstones();
 
-    // Count L0 segments being merged
     let l0_segments_merged =
         (shard.l0_node_segment_count() + shard.l0_edge_segment_count()) as u32;
 
     let tombstones_before =
         (tombstones.node_count() + tombstones.edge_count()) as u64;
 
-    // ── Merge Nodes ─────────────────────────────────────────────────
+    // Merge nodes and edges in parallel — they read different segment
+    // types from the same shard and produce independent results.
+    let (node_result, edge_result) = rayon::join(
+        || merge_and_write_nodes(shard),
+        || merge_and_write_edges(shard),
+    );
 
-    // Collect segment references: L0 newest-first, then L1 (oldest)
+    let (node_segment_bytes, node_meta) = node_result?;
+    let (edge_segment_bytes, edge_meta) = edge_result?;
+
+    Ok(ShardCompactionResult {
+        node_segment_bytes,
+        node_meta,
+        edge_segment_bytes,
+        edge_meta,
+        l0_segments_merged,
+        tombstones_removed: tombstones_before,
+    })
+}
+
+fn merge_and_write_nodes(shard: &Shard) -> Result<(Option<Vec<u8>>, Option<SegmentMeta>)> {
+    let tombstones = shard.tombstones();
     let l0_node_segs: Vec<&NodeSegmentV2> = shard
         .l0_node_segments()
         .iter()
@@ -96,22 +116,22 @@ pub fn compact_shard(shard: &Shard) -> Result<ShardCompactionResult> {
         all_node_segs.push(l1);
     }
 
-    let merged_nodes = merge_node_segments(&all_node_segs, tombstones);
+    let merged = merge_node_segments(&all_node_segs, tombstones);
+    if merged.is_empty() {
+        return Ok((None, None));
+    }
 
-    let (node_segment_bytes, node_meta) = if merged_nodes.is_empty() {
-        (None, None)
-    } else {
-        let mut writer = NodeSegmentWriter::new();
-        for record in merged_nodes {
-            writer.add(record);
-        }
-        let mut cursor = Cursor::new(Vec::new());
-        let meta = writer.finish(&mut cursor)?;
-        (Some(cursor.into_inner()), Some(meta))
-    };
+    let mut writer = NodeSegmentWriter::new();
+    for record in merged {
+        writer.add(record);
+    }
+    let mut cursor = Cursor::new(Vec::new());
+    let meta = writer.finish(&mut cursor)?;
+    Ok((Some(cursor.into_inner()), Some(meta)))
+}
 
-    // ── Merge Edges ─────────────────────────────────────────────────
-
+fn merge_and_write_edges(shard: &Shard) -> Result<(Option<Vec<u8>>, Option<SegmentMeta>)> {
+    let tombstones = shard.tombstones();
     let l0_edge_segs: Vec<&EdgeSegmentV2> = shard
         .l0_edge_segments()
         .iter()
@@ -123,28 +143,18 @@ pub fn compact_shard(shard: &Shard) -> Result<ShardCompactionResult> {
         all_edge_segs.push(l1);
     }
 
-    let merged_edges = merge_edge_segments(&all_edge_segs, tombstones);
+    let merged = merge_edge_segments(&all_edge_segs, tombstones);
+    if merged.is_empty() {
+        return Ok((None, None));
+    }
 
-    let (edge_segment_bytes, edge_meta) = if merged_edges.is_empty() {
-        (None, None)
-    } else {
-        let mut writer = EdgeSegmentWriter::new();
-        for record in merged_edges {
-            writer.add(record);
-        }
-        let mut cursor = Cursor::new(Vec::new());
-        let meta = writer.finish(&mut cursor)?;
-        (Some(cursor.into_inner()), Some(meta))
-    };
-
-    Ok(ShardCompactionResult {
-        node_segment_bytes,
-        node_meta,
-        edge_segment_bytes,
-        edge_meta,
-        l0_segments_merged,
-        tombstones_removed: tombstones_before,
-    })
+    let mut writer = EdgeSegmentWriter::new();
+    for record in merged {
+        writer.add(record);
+    }
+    let mut cursor = Cursor::new(Vec::new());
+    let meta = writer.finish(&mut cursor)?;
+    Ok((Some(cursor.into_inner()), Some(meta)))
 }
 
 /// Build a SegmentDescriptor from compaction metadata.

--- a/packages/rfdb-server/src/storage_v2/compaction/coordinator.rs
+++ b/packages/rfdb-server/src/storage_v2/compaction/coordinator.rs
@@ -11,8 +11,6 @@
 
 use std::io::Cursor;
 
-use rayon::prelude::*;
-
 use crate::error::Result;
 use crate::storage_v2::compaction::merge::{merge_edge_segments, merge_node_segments};
 use crate::storage_v2::compaction::types::CompactionConfig;

--- a/packages/rfdb-server/src/storage_v2/resource.rs
+++ b/packages/rfdb-server/src/storage_v2/resource.rs
@@ -94,7 +94,7 @@ impl TuningProfile {
     /// - `segment_threshold`: RAM < 4 GB -> 2, < 16 GB -> 4, else 8.
     /// - `write_buffer_byte_limit`: `clamp(available * 0.02, 10 MB, 100 MB)`.
     /// - `write_buffer_node_limit`: `buffer_bytes / 220`.
-    /// - `compaction_threads`: RAM < 4 GB -> 1, else `clamp(cpu / 2, 1, 4)`.
+    /// - `compaction_threads`: RAM < 4 GB -> 1, else `cpu / 2` (at least 1).
     pub fn from_resources(res: &SystemResources) -> Self {
         let total_gb = res.total_memory_bytes as f64 / GB as f64;
 
@@ -122,11 +122,11 @@ impl TuningProfile {
         // Write buffer node limit
         let write_buffer_node_limit = write_buffer_byte_limit / BYTES_PER_NODE;
 
-        // Compaction threads
+        // Compaction threads: half of logical CPUs, floored at 1
         let compaction_threads = if total_gb < 4.0 {
             1
         } else {
-            (res.cpu_count / 2).clamp(1, 4)
+            (res.cpu_count / 2).max(1)
         };
 
         Self {
@@ -213,13 +213,13 @@ mod tests {
 
     #[test]
     fn test_tuning_profile_high_memory() {
-        // 64 GB RAM, 16 CPUs -> shard=16, threshold=8, threads=4 (capped)
+        // 64 GB RAM, 16 CPUs -> shard=16, threshold=8, threads=8
         let res = make_resources(64.0, 32.0, 16);
         let profile = TuningProfile::from_resources(&res);
 
         assert_eq!(profile.shard_count, 16);
         assert_eq!(profile.segment_threshold, 8);
-        assert_eq!(profile.compaction_threads, 4);
+        assert_eq!(profile.compaction_threads, 8);
     }
 
     #[test]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,17 +95,17 @@ importers:
         version: 2.8.2
     optionalDependencies:
       '@grafema/grafema-darwin-arm64':
-        specifier: 0.3.28
-        version: 0.3.28
+        specifier: 0.3.29
+        version: 0.3.29
       '@grafema/grafema-darwin-x64':
-        specifier: 0.3.28
-        version: 0.3.28
+        specifier: 0.3.29
+        version: 0.3.29
       '@grafema/grafema-linux-arm64':
-        specifier: 0.3.28
-        version: 0.3.28
+        specifier: 0.3.29
+        version: 0.3.29
       '@grafema/grafema-linux-x64':
-        specifier: 0.3.28
-        version: 0.3.28
+        specifier: 0.3.29
+        version: 0.3.29
     devDependencies:
       '@types/node':
         specifier: ^25.0.8
@@ -166,17 +166,17 @@ importers:
         version: 2.8.2
     optionalDependencies:
       '@grafema/grafema-darwin-arm64':
-        specifier: 0.3.28
-        version: 0.3.28
+        specifier: 0.3.29
+        version: 0.3.29
       '@grafema/grafema-darwin-x64':
-        specifier: 0.3.28
-        version: 0.3.28
+        specifier: 0.3.29
+        version: 0.3.29
       '@grafema/grafema-linux-arm64':
-        specifier: 0.3.28
-        version: 0.3.28
+        specifier: 0.3.29
+        version: 0.3.29
       '@grafema/grafema-linux-x64':
-        specifier: 0.3.28
-        version: 0.3.28
+        specifier: 0.3.29
+        version: 0.3.29
     devDependencies:
       '@types/node':
         specifier: ^25.0.8
@@ -285,17 +285,17 @@ importers:
         version: 2.8.2
     optionalDependencies:
       '@grafema/grafema-darwin-arm64':
-        specifier: 0.3.16
-        version: 0.3.16
+        specifier: 0.3.29
+        version: 0.3.29
       '@grafema/grafema-darwin-x64':
-        specifier: 0.3.16
-        version: 0.3.16
+        specifier: 0.3.29
+        version: 0.3.29
       '@grafema/grafema-linux-arm64':
-        specifier: 0.3.16
-        version: 0.3.16
+        specifier: 0.3.29
+        version: 0.3.29
       '@grafema/grafema-linux-x64':
-        specifier: 0.3.16
-        version: 0.3.16
+        specifier: 0.3.29
+        version: 0.3.29
     devDependencies:
       '@types/node':
         specifier: ^25.0.8
@@ -994,50 +994,26 @@ packages:
   '@fastify/busboy@3.2.0':
     resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
 
-  '@grafema/grafema-darwin-arm64@0.3.16':
-    resolution: {integrity: sha512-QfVUEaqgncxPXvmWPlhtAShnGHg5FLrXvGjdypxrLq8tY0gaNEotU67hvqTugF/DCv6gBu8Exw7VM8pyRzOutA==}
+  '@grafema/grafema-darwin-arm64@0.3.29':
+    resolution: {integrity: sha512-0pxgti5m5ytYAVDAxcJuiJ2LNC3BFh6ytd9mqstai54Z6tVcVLsPW0GvzIqnHxnSHV9j0BdeOLnYee/tGOAU4w==}
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@grafema/grafema-darwin-arm64@0.3.28':
-    resolution: {integrity: sha512-D1Wp7l8iwMJA66a9ZS0Z8LtEjH0bT3QGVkWWB68ZxgTjr9ZWRRlS0Sc42nP6PT389bqlJqiYcolblBa4/kEbZw==}
-    engines: {node: '>= 18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@grafema/grafema-darwin-x64@0.3.16':
-    resolution: {integrity: sha512-AqlKKlM6O8S3pHLTth+Ox+UkryC8OKxZuTromPm/mEocOpAS6b8jF88C1pwygSM+/9+DFkjWwWKDSai5ASmqpQ==}
+  '@grafema/grafema-darwin-x64@0.3.29':
+    resolution: {integrity: sha512-Yovcd8dWlurL56Ux2iOqrefSgXjGniwpc+KY86JBlq2oKSWvTPp9ZdgPZuJNc0eEH8Mw3dHbuP9qlwLx+D8v3w==}
     engines: {node: '>= 18'}
     cpu: [x64]
     os: [darwin]
 
-  '@grafema/grafema-darwin-x64@0.3.28':
-    resolution: {integrity: sha512-rK/RSZb2Z4SVx9YCFtJEfMATlav3+i1ht3HBLeh7bUt2qJm8jvK2Rb9xRj7hz8ycd2AarkrRplLygr9dF3SUwQ==}
-    engines: {node: '>= 18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@grafema/grafema-linux-arm64@0.3.16':
-    resolution: {integrity: sha512-FZ8GztKxTJwzof/ZDn7LKEl6U20jNlzAvYyQbSrsQfZMO1JZpxVtfZM/7bOZ308ukgGvzcxNJeb4K9M4X+tVSA==}
+  '@grafema/grafema-linux-arm64@0.3.29':
+    resolution: {integrity: sha512-UJQbAEpRq5LIwaUntHy2+VF3HCLaTu1OMaHz9ufJQszJsHPLC/nXWhdgwo5YS8vowecM21bb+X7S+LbFFVpZOA==}
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [linux]
 
-  '@grafema/grafema-linux-arm64@0.3.28':
-    resolution: {integrity: sha512-e3gnrf8auMZDd/RGs6op6ZEdT9gStUibU8gnqnJVycaUMxTIx4Rm5pXJ0jo0okD2DxYTwAvIc9/1ZB5bQEqQKg==}
-    engines: {node: '>= 18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@grafema/grafema-linux-x64@0.3.16':
-    resolution: {integrity: sha512-bbx7rNTWiUpWyL/6XbvMDI236p5n9UCuK+Ww46z1lrnXlwWWvvNFeilDvVZL/vFJ4cJiY8oj4/Jz0/sk+etfuQ==}
-    engines: {node: '>= 18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@grafema/grafema-linux-x64@0.3.28':
-    resolution: {integrity: sha512-OSxmkFKTFFN2yA8Lv8BwqKd3mWzSrq+cfzq9bHKTVzv7gk8qC2Nqd5Obx4WdDP3AM/jI+LLuEjXO20E8fBgEmg==}
+  '@grafema/grafema-linux-x64@0.3.29':
+    resolution: {integrity: sha512-hvRWU7r3GUpEyZX3H71QAv78xXJh8q7V1i+HkYoUUNVDsn3kV3dmvroiBWf7ds/z1bGlQdu5lUD79jwVF1kJnQ==}
     engines: {node: '>= 18'}
     cpu: [x64]
     os: [linux]
@@ -3020,28 +2996,16 @@ snapshots:
 
   '@fastify/busboy@3.2.0': {}
 
-  '@grafema/grafema-darwin-arm64@0.3.16':
+  '@grafema/grafema-darwin-arm64@0.3.29':
     optional: true
 
-  '@grafema/grafema-darwin-arm64@0.3.28':
+  '@grafema/grafema-darwin-x64@0.3.29':
     optional: true
 
-  '@grafema/grafema-darwin-x64@0.3.16':
+  '@grafema/grafema-linux-arm64@0.3.29':
     optional: true
 
-  '@grafema/grafema-darwin-x64@0.3.28':
-    optional: true
-
-  '@grafema/grafema-linux-arm64@0.3.16':
-    optional: true
-
-  '@grafema/grafema-linux-arm64@0.3.28':
-    optional: true
-
-  '@grafema/grafema-linux-x64@0.3.16':
-    optional: true
-
-  '@grafema/grafema-linux-x64@0.3.28':
+  '@grafema/grafema-linux-x64@0.3.29':
     optional: true
 
   '@graphql-tools/executor@1.5.1(graphql@16.12.0)':

--- a/test/fixtures/rust-ffi/rust-engine/src/lib.rs
+++ b/test/fixtures/rust-ffi/rust-engine/src/lib.rs
@@ -2,6 +2,11 @@
 
 use napi_derive::napi;
 
+pub const MAX_NODES: usize = 1024;
+const MAGIC_HEADER: &str = "GRFM";
+pub const VERSION: u32 = 2;
+const DOUBLE_MAX: usize = MAX_NODES * 2;
+
 #[napi]
 pub struct GraphEngine {
     nodes: Vec<String>,


### PR DESCRIPTION
## Summary

- **fix(resolve):** NAMESPACE exports now resolvable (was missing from export index — 1941 warnings on VSCode); .d.ts-only modules resolve; external re-export warning noise silenced
- **perf(rfdb):** Compaction thread cap lifted (was hardcoded max 4); node/edge merge parallelized within shard via rayon::join
- **fix(orchestrator):** Resolution commits no longer wipe analysis nodes for god-files — `commit_resolve_output` now filters `changed_files` to synthetic paths only (same REG-1091 pattern)

## Test plan

- [x] 34/34 grafema-resolve Haskell tests (4 new: NAMESPACE export index, NAMESPACE import resolution, .js→.ts swap, .d.ts resolution)
- [x] 28/28 RFDB compaction tests (including parallel correctness)
- [x] 8/8 resource tuning tests (updated for uncapped thread count)
- [x] 21/21 MCP regression tests + ESLint
- [x] Orchestrator `cargo check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)