### PR TITLE
fix(rust-analyzer): unwrap Box/Rc/Arc so dyn-trait receivers survive resolution

### DIFF
--- a/packages/grafema-orchestrator/src/rust_analyzer.rs
+++ b/packages/grafema-orchestrator/src/rust_analyzer.rs
@@ -1691,9 +1691,37 @@ fn path_to_string(path: &syn::Path) -> String {
         .join("::")
 }
 
+/// If `path` is a single-segment `Box<T>`, `Rc<T>`, or `Arc<T>` (optionally
+/// fully qualified, e.g. `std::boxed::Box<T>`), return the inner type `T`.
+///
+/// These are the canonical Deref-transparent owning smart pointers: a method
+/// call on a `Box<T>` / `Rc<T>` / `Arc<T>` receiver auto-derefs to `T`, and
+/// unsized trait objects (`dyn Trait`) can only exist behind such a pointer.
+/// Treating the inner type as the receiver type is therefore what method- and
+/// dyn-dispatch resolution needs. Other generic containers (`Vec`, `Option`,
+/// `RefCell`, …) are intentionally NOT unwrapped — a method on them belongs to
+/// the container, not the element.
+fn unwrap_smart_pointer(path: &syn::Path) -> Option<&syn::Type> {
+    let seg = path.segments.last()?;
+    if !matches!(seg.ident.to_string().as_str(), "Box" | "Rc" | "Arc") {
+        return None;
+    }
+    if let syn::PathArguments::AngleBracketed(args) = &seg.arguments {
+        for arg in &args.args {
+            if let syn::GenericArgument::Type(inner) = arg {
+                return Some(inner);
+            }
+        }
+    }
+    None
+}
+
 fn type_to_name(ty: &syn::Type) -> String {
     match ty {
-        syn::Type::Path(p) => path_to_string(&p.path),
+        syn::Type::Path(p) => match unwrap_smart_pointer(&p.path) {
+            Some(inner) => type_to_name(inner),
+            None => path_to_string(&p.path),
+        },
         syn::Type::Reference(r) => type_to_name(&r.elem),
         syn::Type::Paren(p) => type_to_name(&p.elem),
         syn::Type::Group(g) => type_to_name(&g.elem),
@@ -1794,6 +1822,56 @@ mod tests {
         assert_eq!(seg.metadata.get("typeAnnotation"), Some(&serde_json::json!("NodeSegmentV2")));
     }
 
+    // Trait objects in idiomatic Rust are unsized, so they always appear behind
+    // a pointer: `&dyn T`, `Box<dyn T>`, `Rc<dyn T>`, `Arc<dyn T>`. References are
+    // already peeled, but the Deref-transparent owning smart pointers must be
+    // unwrapped too, otherwise `Box<dyn Draw>` collapses to `"Box"` and the trait
+    // name needed for dyn-dispatch resolution is lost.
+    #[test]
+    fn test_type_annotation_box_dyn_trait() {
+        let fa = parse_and_analyze("fn render(x: Box<dyn Draw>) {}");
+        let x = fa.nodes.iter().find(|n| n.node_type == "PARAMETER" && n.name == "x").unwrap();
+        assert_eq!(x.metadata.get("typeAnnotation"), Some(&serde_json::json!("dyn Draw")));
+    }
+
+    #[test]
+    fn test_type_annotation_rc_dyn_trait() {
+        let fa = parse_and_analyze("fn render(x: Rc<dyn Shape>) {}");
+        let x = fa.nodes.iter().find(|n| n.node_type == "PARAMETER" && n.name == "x").unwrap();
+        assert_eq!(x.metadata.get("typeAnnotation"), Some(&serde_json::json!("dyn Shape")));
+    }
+
+    #[test]
+    fn test_type_annotation_arc_dyn_trait() {
+        let fa = parse_and_analyze("fn handle(x: Arc<dyn Handler>) {}");
+        let x = fa.nodes.iter().find(|n| n.node_type == "PARAMETER" && n.name == "x").unwrap();
+        assert_eq!(x.metadata.get("typeAnnotation"), Some(&serde_json::json!("dyn Handler")));
+    }
+
+    #[test]
+    fn test_type_annotation_fully_qualified_box_dyn_trait() {
+        let fa = parse_and_analyze("fn render(x: std::boxed::Box<dyn Draw>) {}");
+        let x = fa.nodes.iter().find(|n| n.node_type == "PARAMETER" && n.name == "x").unwrap();
+        assert_eq!(x.metadata.get("typeAnnotation"), Some(&serde_json::json!("dyn Draw")));
+    }
+
+    #[test]
+    fn test_type_annotation_box_concrete_type() {
+        // Box<Foo> derefs to Foo, so a method call on it resolves to Foo's impl.
+        let fa = parse_and_analyze("fn take(x: Box<Foo>) {}");
+        let x = fa.nodes.iter().find(|n| n.node_type == "PARAMETER" && n.name == "x").unwrap();
+        assert_eq!(x.metadata.get("typeAnnotation"), Some(&serde_json::json!("Foo")));
+    }
+
+    #[test]
+    fn test_type_annotation_vec_not_unwrapped() {
+        // Vec is NOT a Deref-transparent owning pointer: `v.push()` is a Vec method,
+        // not a method on the element type. Vec<String> must stay "Vec".
+        let fa = parse_and_analyze("fn take(v: Vec<String>) {}");
+        let v = fa.nodes.iter().find(|n| n.node_type == "PARAMETER" && n.name == "v").unwrap();
+        assert_eq!(v.metadata.get("typeAnnotation"), Some(&serde_json::json!("Vec")));
+    }
+
     #[test]
     fn test_struct_with_fields() {
         let fa = parse_and_analyze("pub struct Foo { pub bar: i32, baz: String }");
@@ -1813,8 +1891,9 @@ mod tests {
         let make_shard = fa.nodes.iter().find(|n| n.node_type == "FUNCTION" && n.name == "make_shard").unwrap();
         assert_eq!(make_shard.metadata.get("returnType"), Some(&serde_json::json!("Shard")));
 
+        // Box<Vec<u8>> derefs to Vec<u8>, so the receiver type is the inner Vec.
         let make_box = fa.nodes.iter().find(|n| n.node_type == "FUNCTION" && n.name == "make_box").unwrap();
-        assert_eq!(make_box.metadata.get("returnType"), Some(&serde_json::json!("Box")));
+        assert_eq!(make_box.metadata.get("returnType"), Some(&serde_json::json!("Vec")));
 
         let unit_fn = fa.nodes.iter().find(|n| n.node_type == "FUNCTION" && n.name == "unit_fn").unwrap();
         assert!(unit_fn.metadata.get("returnType").is_none());


### PR DESCRIPTION
## Summary

Rust trait objects are unsized, so they only ever appear behind a pointer: `&dyn T`, `Box<dyn T>`, `Rc<dyn T>`, `Arc<dyn T>`. The native Rust analyzer's `type_to_name` already peeled `&T` references, but routed every `Type::Path` straight through `path_to_string`, which **drops generic arguments**. So `Box<dyn Draw>` collapsed to the string `"Box"` — the trait name was discarded **in the analyzer**, before the resolver ever ran.

Downstream, the Haskell `rust-resolve` dyn-dispatch path only fires on a bare `dyn Trait` string (`packages/rust-resolve/src/RustCrossMethodCalls.hs:78-82`, test `Spec.hs:779`). A bare `dyn Trait` by value is *not even valid Rust* for a parameter — so the implemented path matched the near-impossible form and missed every idiomatic one. Result: smart-pointer trait objects silently produced **zero** `CALLS` edges — confidently-wrong 0-impact on dynamic dispatch.

No source issue (no open GitHub issue / Linear unavailable in env). Task was selected from a recorded Enox lead on dynamic-dispatch blindness; the originally-cited "ImplResolve never dispatched" blocker was verified **already fixed** (`rust-trait-resolve` exists and is wired at `main.rs:1173,2085`), so this PR addresses the *adjacent, still-live* root cause.

## Spec

- **Invariant restored:** a method/dyn-dispatch receiver typed as a Deref-transparent owning smart pointer resolves to the **inner** type, not to the pointer wrapper name.
- **Given** a Rust receiver typed `Box<dyn Draw>` / `Rc<dyn Shape>` / `Arc<dyn Handler>` (incl. fully-qualified `std::boxed::Box<dyn Draw>`),
  **When** the analyzer records its `typeAnnotation`,
  **Then** it stores `"dyn Draw"` (the inner trait object), which the existing resolver fans out to every `trait`-tagged implementer as `rust-dyn-dispatch` `CALLS` edges.
- **Also:** `Box<Foo>` → `"Foo"` (auto-Deref makes `Foo` the real method receiver). Non-Deref-transparent containers (`Vec`, `Option`, `RefCell`, …) are intentionally **not** unwrapped.

## Root cause / blast radius

`type_to_name` is the single chokepoint feeding receiver-type metadata. Call sites: `rust_analyzer.rs:538, 601, 716, 789, 836, 1204/1256` → parameter, variable, record-field, return-type, and impl-self annotations all benefit (class fix, not one instance).

## Before / After (actual outputs)

Red (before fix), new tests:
```
test result: FAILED. 4 passed; 5 failed; ...
  left: Some(String("Rc"))  right: Some(String("dyn Shape"))   # Box/Rc/Arc collapsed
```
Green (after fix), full analyzer module:
```
test result: ok. 44 passed; 0 failed; ...   # 6 new + updated make_box
```
Full orchestrator suite:
```
test result: ok. 413 passed; 0 failed; ...
```
Clippy on the crate: no warnings reference `rust_analyzer.rs` / `unwrap_smart_pointer` (all pre-existing, other files).

## Tests added

`Box<dyn Draw>`, `Rc<dyn Shape>`, `Arc<dyn Handler>`, fully-qualified `std::boxed::Box<dyn Draw>` → inner trait; `Box<Foo>` → `Foo`; `Vec<String>` → stays `Vec` (over-unwrap guard). Updated `test_function_return_type` (`Box<Vec<u8>>` → `"Vec"`; the old `"Box"` assertion just documented the lossy behavior).

## Adversarial review

- **A — correctness:** empty/no-arg `Box` → falls through to `"Box"`; lifetime-first `Box<'a, dyn T>` → loop skips the lifetime arg; nested `Arc<Mutex<T>>` → `"Mutex"` (correct under Deref); `Box<Box<T>>` → recurses to `T`; `Box<dyn Draw + Send>` → `"dyn Draw"`.
- **B — structural:** one small documented helper; no new file. (`rust_analyzer.rs` is a pre-existing ~1960-line god-file — not worsened; refactor out of scope.)
- **C — class/invariants:** fixed at the single chokepoint; no node/edge count change, only more accurate metadata strings for Box/Rc/Arc-wrapped types; analysis-pipeline invariants intact.

## Env note / follow-ups

- The consumer `rust-resolve` (Haskell) is **unchanged**; its existing `Spec.hs:779` test already covers the produced `"dyn Draw"` string. GHC/cabal were not available in this run env, so that package was not re-run; the contract it asserts is the exact string this fix now emits.
- Follow-up candidate (different class, not in scope): equivalent generic/pointer normalization for other languages' analyzers (e.g. Go `*T`).

Leave merge to a human — do not auto-merge.

https://claude.ai/code/session_01CbA7R9UJzBwPYWVHVuJMSS

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbA7R9UJzBwPYWVHVuJMSS)_