### PR TITLE
fix(rfdb): correct token fuzzy-search Jaccard scores; unify tokenizer

### DIFF
--- a/packages/rfdb-server/src/storage_v2/index/token.rs
+++ b/packages/rfdb-server/src/storage_v2/index/token.rs
@@ -1,8 +1,9 @@
 //! Token-based fuzzy name index for RFDB.
 //!
 //! When exact `find_nodes(name=...)` returns 0 results, this index enables
-//! fuzzy fallback: split names into tokens (CamelCase, snake_case, dots,
-//! hyphens), compute Jaccard similarity, and return ranked matches.
+//! fuzzy fallback: split names into tokens (CamelCase, snake_case, and any
+//! non-alphanumeric separator — dots, hyphens, whitespace, punctuation),
+//! compute Jaccard similarity, and return ranked matches.
 //!
 //! # Example
 //!
@@ -57,8 +58,15 @@ const TOKEN_INDEX_VERSION: u32 = 1;
 
 // ── Tokenizer ──────────────────────────────────────────────────────
 
-/// Split a name into lowercase tokens by CamelCase boundaries, underscores,
-/// hyphens, and dots. Single-character tokens and empty strings are filtered.
+/// Split a name into lowercase tokens by CamelCase boundaries and any
+/// non-alphanumeric separator (underscores, hyphens, dots, whitespace,
+/// punctuation). Single-character tokens and empty strings are filtered.
+///
+/// Because the separator set is "every non-alphanumeric character", this one
+/// tokenizer handles both code identifiers (CamelCase / snake_case) and
+/// natural-language knowledge-graph entity names ("RFDB V2 engine (storage)")
+/// without emitting a coarse whole-string token that would distort Jaccard
+/// scoring.
 ///
 /// # CamelCase rules
 ///
@@ -69,15 +77,18 @@ const TOKEN_INDEX_VERSION: u32 = 1;
 /// # Examples
 ///
 /// ```text
-/// "PtyHostHeartbeatService" -> ["pty", "host", "heartbeat", "service"]
-/// "get_user_by_id"          -> ["get", "user", "by", "id"]
-/// "HTTPClient"              -> ["http", "client"]
-/// "parseJSON"               -> ["parse", "json"]
-/// "XMLParser"               -> ["xml", "parser"]
-/// "getHTTPSUrl"             -> ["get", "https", "url"]
-/// "MyClass.method"          -> ["my", "class", "method"]
-/// "a"                       -> []  (single char filtered)
-/// ""                        -> []
+/// "PtyHostHeartbeatService"         -> ["pty", "host", "heartbeat", "service"]
+/// "get_user_by_id"                  -> ["get", "user", "by", "id"]
+/// "getUserById"                     -> ["get", "user", "by", "id"]
+/// "HTTPClient"                      -> ["http", "client"]
+/// "parseJSON"                       -> ["parse", "json"]
+/// "XMLParser"                       -> ["xml", "parser"]
+/// "getHTTPSUrl"                     -> ["get", "https", "url"]
+/// "MyClass.method"                  -> ["my", "class", "method"]
+/// "cross-domain knowledge transfer" -> ["cross", "domain", "knowledge", "transfer"]
+/// "RFDB V2 engine (storage)"        -> ["rfdb", "v2", "engine", "storage"]
+/// "a"                               -> []  (single char filtered)
+/// ""                                -> []
 /// ```
 pub fn tokenize_name(name: &str) -> Vec<String> {
     let mut raw_tokens: Vec<String> = Vec::new();
@@ -90,8 +101,10 @@ pub fn tokenize_name(name: &str) -> Vec<String> {
     while i < len {
         let c = chars[i];
 
-        // Separators: underscore, hyphen, dot
-        if c == '_' || c == '-' || c == '.' {
+        // Separators: any non-alphanumeric character (underscore, hyphen, dot,
+        // whitespace, punctuation). Keeps CamelCase splitting for the
+        // alphanumeric runs below.
+        if !c.is_alphanumeric() {
             if !current.is_empty() {
                 raw_tokens.push(std::mem::take(&mut current));
             }
@@ -158,22 +171,6 @@ pub fn tokenize_name(name: &str) -> Vec<String> {
         .into_iter()
         .map(|t| t.to_lowercase())
         .filter(|t| t.len() > 1)
-        .collect()
-}
-
-/// Split text into lowercase tokens by whitespace and punctuation.
-/// Handles natural language names (knowledge graph entities, sentences).
-/// Single-character and empty tokens are filtered.
-///
-/// ```text
-/// "cross-domain knowledge transfer" -> ["cross", "domain", "knowledge", "transfer"]
-/// "RFDB V2 engine (storage)"        -> ["rfdb", "v2", "engine", "storage"]
-/// ```
-pub fn tokenize_text(text: &str) -> Vec<String> {
-    text.split(|c: char| !c.is_alphanumeric())
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_lowercase())
-        .filter(|s| s.len() > 1)
         .collect()
 }
 
@@ -361,10 +358,7 @@ impl TokenIndex {
     /// 3. Compute Jaccard similarity for each candidate
     /// 4. Filter by `min_score`, sort descending, take top `k`
     pub fn search(&self, query: &str, k: usize, min_score: f32) -> Vec<TokenMatch> {
-        let mut query_tokens: HashSet<String> = tokenize_name(query).into_iter().collect();
-        for t in tokenize_text(query) {
-            query_tokens.insert(t);
-        }
+        let query_tokens: HashSet<String> = tokenize_name(query).into_iter().collect();
         if query_tokens.is_empty() {
             return Vec::new();
         }
@@ -383,10 +377,7 @@ impl TokenIndex {
         let mut matches: Vec<TokenMatch> = Vec::new();
         for idx in candidate_indices {
             let (node_id, ref name) = self.names[idx];
-            let mut name_tokens: HashSet<String> = tokenize_name(name).into_iter().collect();
-            for t in tokenize_text(name) {
-                name_tokens.insert(t);
-            }
+            let name_tokens: HashSet<String> = tokenize_name(name).into_iter().collect();
 
             let intersection = query_tokens.intersection(&name_tokens).count();
             let union = query_tokens.union(&name_tokens).count();
@@ -461,9 +452,6 @@ pub fn build_token_index(
 
     for (i, (_node_id, name)) in names.iter().enumerate() {
         for token in tokenize_name(name) {
-            token_to_indices.entry(token).or_default().push(i);
-        }
-        for token in tokenize_text(name) {
             token_to_indices.entry(token).or_default().push(i);
         }
     }
@@ -651,6 +639,30 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_tokenize_natural_language_whitespace() {
+        // Natural-language knowledge-graph entity names split on whitespace and
+        // punctuation, NOT into a coarse whole-string token (which would
+        // distort Jaccard scoring).
+        assert_eq!(
+            tokenize_name("cross-domain knowledge transfer"),
+            vec!["cross", "domain", "knowledge", "transfer"]
+        );
+        assert_eq!(
+            tokenize_name("RFDB V2 engine (storage)"),
+            vec!["rfdb", "v2", "engine", "storage"]
+        );
+    }
+
+    #[test]
+    fn test_tokenize_no_whole_string_token_for_identifier() {
+        // Regression guard: a CamelCase identifier must NOT yield the whole
+        // concatenated string as a token (the bug that broke Jaccard scoring).
+        let tokens = tokenize_name("getUserById");
+        assert_eq!(tokens, vec!["get", "user", "by", "id"]);
+        assert!(!tokens.contains(&"getuserbyid".to_string()));
+    }
+
     // ── Build + from_bytes Roundtrip ───────────────────────────────
 
     #[test]
@@ -746,6 +758,26 @@ mod tests {
         assert_eq!(results[0].name, "get_user_by_id");
         // Jaccard: tokens are identical sets -> 1.0
         assert!((results[0].score - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_search_natural_language() {
+        // The unified tokenizer also answers natural-language entity names:
+        // a whitespace-separated query matches a punctuation-separated name on
+        // their shared fine-grained tokens.
+        let records = vec![
+            make_node("cross-domain knowledge transfer"),
+            make_node("HTTPClient"),
+        ];
+
+        let bytes = build_token_index(&records, 0, 1).unwrap();
+        let index = TokenIndex::from_bytes(&bytes).unwrap();
+
+        let results = index.search("knowledge transfer", 10, 0.0);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "cross-domain knowledge transfer");
+        // Jaccard: {knowledge, transfer} / {cross, domain, knowledge, transfer} = 2/4 = 0.5
+        assert!((results[0].score - 0.5).abs() < f32::EPSILON);
     }
 
     #[test]

--- a/packages/rfdb-server/src/storage_v2/multi_shard.rs
+++ b/packages/rfdb-server/src/storage_v2/multi_shard.rs
@@ -34,7 +34,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::{GraphError, Result};
 use crate::storage_v2::compaction::{CompactionConfig, CompactionResult};
 use crate::storage_v2::index::{build_inverted_indexes, GlobalIndex, IndexEntry, InvertedIndex};
-use crate::storage_v2::index::token::{TokenIndex, TokenMatch, tokenize_name, tokenize_text};
+use crate::storage_v2::index::token::{TokenIndex, TokenMatch, tokenize_name};
 use crate::storage_v2::manifest::{ManifestStore, SegmentDescriptor};
 use crate::storage_v2::segment::{self, EdgeSegmentV2, NodeSegmentV2};
 use crate::storage_v2::shard::{Shard, ShardDiagnostics, TombstoneSet};
@@ -757,10 +757,7 @@ impl MultiShardStore {
     ) -> Vec<TokenMatch> {
         let mut all_matches: Vec<TokenMatch> = Vec::new();
         let mut seen_ids: HashSet<u128> = HashSet::new();
-        let mut query_tokens: HashSet<String> = tokenize_name(query).into_iter().collect();
-        for t in tokenize_text(query) {
-            query_tokens.insert(t);
-        }
+        let query_tokens: HashSet<String> = tokenize_name(query).into_iter().collect();
 
         // Search L1 token indexes on each shard
         for shard in &self.shards {
@@ -801,10 +798,7 @@ impl MultiShardStore {
                             continue;
                         }
                     }
-                    let mut name_tokens: HashSet<String> = tokenize_name(&record.name).into_iter().collect();
-                    for t in tokenize_text(&record.name) {
-                        name_tokens.insert(t);
-                    }
+                    let name_tokens: HashSet<String> = tokenize_name(&record.name).into_iter().collect();
                     if name_tokens.is_empty() {
                         continue;
                     }


### PR DESCRIPTION
## Problem

The token fuzzy-name index (`packages/rfdb-server/src/storage_v2/index/token.rs`) computed **wrong Jaccard similarity scores** for code identifiers. Two unit tests fail on clean HEAD:

```
$ cargo test --lib storage_v2::index::token::tests   # on HEAD 0ab3145
test_search_cross_convention ... FAILED   # token.rs:748  score != 1.0  (was 0.8)
test_search_fuzzy_heartbeat  ... FAILED   # token.rs:721  score != 0.5  (was 0.333)
test result: FAILED. 24 passed; 2 failed
```

(These are the two failures PR #274 flagged as "pre-existing".)

### Root cause — regression from `7c82382`

`search()` and `build_token_index()` **union two independent tokenizations**: `tokenize_name` (CamelCase / snake_case) **and** `tokenize_text` (whitespace / punctuation). For a code identifier with no separators, `tokenize_text` splits on non-alphanumeric only, so it emits the **whole concatenated string** as a single token:

- `getUserById` → `tokenize_name` = `{get,user,by,id}`, `tokenize_text` = `{getuserbyid}` → union `{get,user,by,id,getuserbyid}`
- `get_user_by_id` → union `{get,user,by,id}` (has `_` separators, no whole-string token)

The whole-string tokens **never intersect** (the query's `getuserbyid` ≠ the candidate's, and `ptyhostheartbeatservice` ≠ `heartbeatservice`) but **always inflate the Jaccard union**, so every score involving an unseparated identifier is distorted:

| query | candidate | expected | actual (HEAD) |
|---|---|---|---|
| `getUserById` | `get_user_by_id` | `4/4 = 1.0` | `4/5 = 0.8` |
| `PtyHostHeartbeatService` | `HeartbeatService` | `2/4 = 0.5` | `2/6 = 0.333` |

The same buggy union is **duplicated** in `multi_shard.rs` (the L0 write-buffer fallback path) — the class sibling.

## Spec

- **Invariant restored:** the fuzzy score reflects shared tokens / total distinct tokens, using **one consistent tokenization** for both the query and the candidate — no coarse whole-string token contaminating the set.
- **Acceptance (BDD):**
  - *Given* a node `get_user_by_id`, *When* `search("getUserById")`, *Then* score `1.0` (identical token sets).
  - *Given* nodes `HeartbeatService` / `PtyHostHeartbeatService`, *When* `search("PtyHostHeartbeatService")`, *Then* `HeartbeatService` scores `0.5` (Jaccard `2/4`).
  - *Given* a node `cross-domain knowledge transfer`, *When* `search("knowledge transfer")`, *Then* it matches with score `0.5` — the natural-language feature `7c82382` added still works through the unified tokenizer.
- **Blast radius:** `tokenize_name` is the single tokenizer feeding both the index build and scoring. Generalizing its separator set (`{_ - .}` → any non-alphanumeric) is safe for every existing `tokenize_name` test (none contain whitespace or punctuation beyond `_`/`.`). `tokenize_text` had no other consumers (`grep` confirms; not re-exported in `index/mod.rs`) and is removed. No graph/analyzer node or edge shape changes — only fuzzy-fallback ranking becomes correct.

## Fix

Collapse to **one correct tokenizer**:
1. Generalize `tokenize_name` to treat **any non-alphanumeric character** as a separator (dots, hyphens, whitespace, punctuation) while keeping CamelCase splitting. This handles natural-language entity names too (`"RFDB V2 engine (storage)"` → `[rfdb, v2, engine, storage]`) **without** a whole-string token.
2. Drop the `tokenize_text` union from all four sites: `token.rs` `search()` (query + candidate) and `build_token_index()`, plus `multi_shard.rs` L0 fallback (query + candidate).
3. Remove the now-redundant `tokenize_text` function and its import (no dead code).

## Before / After (actual outputs)

```
# BEFORE (clean HEAD)
test result: FAILED. 24 passed; 2 failed
  test_search_cross_convention  left: score   right: 1.0   # was 0.8
  test_search_fuzzy_heartbeat   assertion failed: (hb.score - 0.5).abs() < EPSILON  # was 0.333

# AFTER
$ cargo test --lib storage_v2::index::token::tests
test result: ok. 29 passed; 0 failed   # 2 restored + 3 new

$ cargo test --lib   # whole rfdb crate
test result: ok. 835 passed; 0 failed
```

## Tests added

- `test_search_natural_language` — locks in that NL search (`7c82382`'s feature) still works via the unified tokenizer.
- `test_tokenize_natural_language_whitespace` — NL names split on whitespace/punctuation, not into a whole-string token.
- `test_tokenize_no_whole_string_token_for_identifier` — regression guard: a CamelCase identifier must not yield the concatenated whole-string token.

## Gate

```
cargo test --lib   → 835 passed; 0 failed
cargo fmt --check  → token.rs & multi_shard.rs clean (pre-existing drift only in benches/, bin/)
cargo clippy --lib → no NEW warnings on either file
                     (token.rs:140/149/443 & multi_shard.rs:674/701/1038 are pre-existing,
                      in code this PR does not touch)
```

## Adversarial review

- **Round A (correctness):** empty / whitespace-only query → `[]` → empty results (guarded); single-char tokens filtered; all-separator names (`"___"`, `"()"`) → `[]` with no panic; `char::is_alphanumeric` is Unicode-aware so non-ASCII identifiers tokenize sanely; digits preserved (`get2ndItem` → `[get2nd, item]`). CamelCase index math untouched. ✅
- **Round B (structural):** the duplicated union pattern is gone from all four sites; both files shrank; growth in `token.rs` is test-only — no new god-file or hidden coupling. ✅
- **Round C (class-not-instance):** fixed the whole class (4 call-sites across 2 files), not one instance; `grep` confirms no remaining `tokenize_text` reference; no other consumer relied on the polluted scores (they were simply wrong). ✅

## Source / follow-ups

- No GitHub issue / Linear ticket (Linear not reachable in this environment); task selected from PR #274's "pre-existing failures" note and reproduced from clean HEAD.
- Pre-existing fmt drift in `benches/`/`bin/` and the pre-existing clippy lints noted above are out of scope (separate cleanup).

Leave merge to a human — do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRv6dLFCCa9i5zQkoVApDA)_