### PR TITLE
fix(coverage): exclude skipped/failed files from analyzed count (REG-1140)

### DIFF
--- a/packages/cli/src/commands/coverage.ts
+++ b/packages/cli/src/commands/coverage.ts
@@ -68,8 +68,31 @@ function printCoverageReport(result: CoverageResult, verbose: boolean): void {
   console.log('File breakdown:');
   console.log(`  Total files:     ${result.total}`);
   console.log(`  Analyzed:        ${result.analyzed.count} (${result.percentages.analyzed}%) - in graph`);
+  if (result.failed.count > 0) {
+    console.log(`  Failed:          ${result.failed.count} (${result.percentages.failed}%) - skipped/failed during analysis`);
+  }
   console.log(`  Unsupported:     ${result.unsupported.count} (${result.percentages.unsupported}%) - no indexer available`);
   console.log(`  Unreachable:     ${result.unreachable.count} (${result.percentages.unreachable}%) - not imported from entrypoints`);
+
+  // Failed files breakdown (skipped/failed during analysis)
+  if (result.failed.count > 0) {
+    console.log('');
+    console.log('Failed files by reason:');
+    const sortedCategories = Object.entries(result.failed.byCategory)
+      .sort((a, b) => b[1].length - a[1].length);
+
+    for (const [category, files] of sortedCategories) {
+      console.log(`  ${category}: ${files.length} files`);
+      if (verbose) {
+        for (const file of files.slice(0, 10)) {
+          console.log(`    - ${file}`);
+        }
+        if (files.length > 10) {
+          console.log(`    ... and ${files.length - 10} more`);
+        }
+      }
+    }
+  }
 
   // Unsupported files breakdown
   if (result.unsupported.count > 0) {

--- a/packages/mcp/src/handlers/coverage-handlers.ts
+++ b/packages/mcp/src/handlers/coverage-handlers.ts
@@ -31,8 +31,18 @@ export async function handleGetCoverage(args: GetCoverageArgs): Promise<ToolResu
     output += `File breakdown:\n`;
     output += `  Total files:     ${result.total}\n`;
     output += `  Analyzed:        ${result.analyzed.count} (${result.percentages.analyzed}%) - in graph\n`;
+    if (result.failed.count > 0) {
+      output += `  Failed:          ${result.failed.count} (${result.percentages.failed}%) - skipped/failed during analysis\n`;
+    }
     output += `  Unsupported:     ${result.unsupported.count} (${result.percentages.unsupported}%) - no indexer available\n`;
     output += `  Unreachable:     ${result.unreachable.count} (${result.percentages.unreachable}%) - not imported from entrypoints\n`;
+
+    if (result.failed.count > 0) {
+      output += `\nFailed files by reason:\n`;
+      for (const [category, files] of Object.entries(result.failed.byCategory)) {
+        output += `  ${category}: ${files.length} files\n`;
+      }
+    }
 
     if (result.unsupported.count > 0) {
       output += `\nUnsupported files by extension:\n`;

--- a/packages/util/src/core/CoverageAnalyzer.ts
+++ b/packages/util/src/core/CoverageAnalyzer.ts
@@ -24,6 +24,20 @@ const RUST_SUPPORTED = ['.rs'];
 const SUPPORTED_EXTENSIONS = new Set([...JS_SUPPORTED, ...RUST_SUPPORTED]);
 
 /**
+ * ISSUE node categories that mean the analyzer SKIPPED the file entirely, so it
+ * contributed zero real analysis even though a MODULE stub exists for it
+ * (the stub is created so file-scoped GC and graph queries still see the file).
+ *
+ * A file carrying one of these issues is reported as `failed`, not `analyzed`,
+ * so the coverage percentage reflects real analysis (REG-1140). These are the
+ * size-guard silent-skips emitted by the orchestrator
+ * (`grafema-orchestrator/src/analyzer.rs`); recoverable `parse_error`s are
+ * intentionally NOT here — oxc continues with a partial AST and still produces
+ * real nodes, so those files remain legitimately "analyzed".
+ */
+const SKIP_ISSUE_CATEGORIES = new Set(['oversized_source', 'oversized_ast']);
+
+/**
  * Known code file extensions (for scanning)
  * Files with these extensions are considered source code
  */
@@ -64,6 +78,16 @@ export interface CoverageResult {
     count: number;
     files: string[];
   };
+  /**
+   * Files that have a MODULE node but were skipped/failed during analysis
+   * (e.g. oversized god-files) so they produced no real analysis. Subtracted
+   * from `analyzed` so coverage is not inflated (REG-1140).
+   */
+  failed: {
+    count: number;
+    files: string[];
+    byCategory: Record<string, string[]>;
+  };
   unsupported: {
     count: number;
     byExtension: Record<string, string[]>;
@@ -75,6 +99,7 @@ export interface CoverageResult {
   };
   percentages: {
     analyzed: number;
+    failed: number;
     unsupported: number;
     unreachable: number;
   };
@@ -97,8 +122,29 @@ export class CoverageAnalyzer {
    */
   async analyze(): Promise<CoverageResult> {
     // Step 1: Get all MODULE nodes from the graph
-    const analyzedFiles = await this.getAnalyzedFiles();
+    const allModuleFiles = await this.getAnalyzedFiles();
+
+    // Step 1b: Identify files that have a MODULE node but were skipped/failed
+    // during analysis (oversized god-files etc.). These contribute zero real
+    // analysis and must not inflate the analyzed count (REG-1140).
+    const failedByFile = await this.getSkippedFiles();
+    const analyzedFiles: string[] = [];
+    const failedFiles: string[] = [];
+    const failedByCategory: Record<string, string[]> = {};
+    for (const file of allModuleFiles) {
+      const category = failedByFile.get(file);
+      if (category) {
+        failedFiles.push(file);
+        if (!failedByCategory[category]) {
+          failedByCategory[category] = [];
+        }
+        failedByCategory[category].push(file);
+      } else {
+        analyzedFiles.push(file);
+      }
+    }
     const analyzedSet = new Set(analyzedFiles);
+    const failedSet = new Set(failedFiles);
 
     // Step 2: Scan project for all code files
     const allCodeFiles = this.scanProjectFiles();
@@ -109,8 +155,8 @@ export class CoverageAnalyzer {
     const unreachableFiles: string[] = [];
 
     for (const file of allCodeFiles) {
-      if (analyzedSet.has(file)) {
-        continue; // Already analyzed
+      if (analyzedSet.has(file) || failedSet.has(file)) {
+        continue; // Already accounted for as analyzed or failed
       }
 
       const ext = extname(file).toLowerCase();
@@ -136,11 +182,16 @@ export class CoverageAnalyzer {
       .reduce((sum, files) => sum + files.length, 0);
     const unreachableCount = unreachableFiles.length;
     const analyzedCount = analyzedFiles.length;
-    const total = analyzedCount + unsupportedCount + unreachableCount;
+    const failedCount = failedFiles.length;
+    // `failed` files have MODULE nodes, so they were previously counted in
+    // `analyzed`; the total file population is unchanged — failed is carved out
+    // of analyzed, not added on top.
+    const total = analyzedCount + failedCount + unsupportedCount + unreachableCount;
 
     // Calculate percentages (handle division by zero)
     const percentages = {
       analyzed: total > 0 ? Math.round((analyzedCount / total) * 100) : 0,
+      failed: total > 0 ? Math.round((failedCount / total) * 100) : 0,
       unsupported: total > 0 ? Math.round((unsupportedCount / total) * 100) : 0,
       unreachable: total > 0 ? Math.round((unreachableCount / total) * 100) : 0,
     };
@@ -151,6 +202,11 @@ export class CoverageAnalyzer {
       analyzed: {
         count: analyzedCount,
         files: analyzedFiles,
+      },
+      failed: {
+        count: failedCount,
+        files: failedFiles,
+        byCategory: failedByCategory,
       },
       unsupported: {
         count: unsupportedCount,
@@ -183,6 +239,36 @@ export class CoverageAnalyzer {
     }
 
     return files;
+  }
+
+  /**
+   * Map of files the analyzer SKIPPED → the ISSUE category that flagged the skip.
+   *
+   * A skipped file still gets a MODULE stub (so it appears in {@link getAnalyzedFiles}),
+   * but it produced no real analysis. We detect skips via ISSUE nodes whose
+   * `category` is in {@link SKIP_ISSUE_CATEGORIES} (size-guard silent-skips). The
+   * returned paths are normalized to project-relative form to match the MODULE
+   * file paths from {@link getAnalyzedFiles}. Used to keep skipped files out of
+   * the analyzed count (REG-1140).
+   */
+  private async getSkippedFiles(): Promise<Map<string, string>> {
+    const skipped = new Map<string, string>();
+
+    for await (const node of this.graph.queryNodes({ type: 'ISSUE' })) {
+      const category = typeof node.category === 'string' ? node.category : '';
+      if (!SKIP_ISSUE_CATEGORIES.has(category) || !node.file) {
+        continue;
+      }
+      const relativePath = node.file.startsWith(this.projectPath)
+        ? relative(this.projectPath, node.file)
+        : node.file;
+      // First skip-category issue per file wins (a file is skipped once).
+      if (!skipped.has(relativePath)) {
+        skipped.set(relativePath, category);
+      }
+    }
+
+    return skipped;
   }
 
   /**

--- a/test/unit/core/CoverageAnalyzer.test.ts
+++ b/test/unit/core/CoverageAnalyzer.test.ts
@@ -519,4 +519,80 @@ describe('CoverageAnalyzer', () => {
       assert.ok(result.unreachable.byExtension['.rs']);
     });
   });
+
+  // ===========================================================================
+  // TESTS: Failed/skipped files excluded from analyzed (REG-1140)
+  // ===========================================================================
+
+  describe('Failed/skipped files (REG-1140)', () => {
+    it('reclassifies an oversized-skipped file from analyzed into failed', async () => {
+      mkdirSync(join(testDir, 'src'), { recursive: true });
+      writeFileSync(join(testDir, 'src', 'good.ts'), 'export const x = 1;');
+      writeFileSync(join(testDir, 'src', 'godfile.ts'), '// huge file');
+
+      // Both files have MODULE nodes (the analyzer creates a stub even when it
+      // skips the file), but godfile.ts also has an oversized_source ISSUE — it
+      // produced zero real analysis and must NOT count as analyzed.
+      const graph = new MockGraphBackend(['src/good.ts', 'src/godfile.ts']);
+      await graph.addNode({
+        id: 'issue:godfile',
+        type: 'ISSUE',
+        name: 'oversized_source: warning',
+        file: 'src/godfile.ts',
+        category: 'oversized_source',
+        severity: 'warning',
+        message: 'Source file too large: 2439 KB (limit: 1024 KB)',
+      });
+
+      const analyzer = new CoverageAnalyzer(graph as unknown as GraphBackend, testDir);
+      const result = await analyzer.analyze();
+
+      assert.strictEqual(result.failed.count, 1, 'godfile should be in failed bucket');
+      assert.ok(result.failed.files.includes('src/godfile.ts'));
+      assert.ok(result.failed.byCategory['oversized_source']?.includes('src/godfile.ts'));
+
+      assert.strictEqual(result.analyzed.count, 1, 'only good.ts is truly analyzed');
+      assert.ok(!result.analyzed.files.includes('src/godfile.ts'));
+
+      // total stays 2 (failed comes out of analyzed, not added on top)
+      assert.strictEqual(result.total, 2);
+      assert.strictEqual(result.percentages.analyzed, 50);
+      assert.strictEqual(result.percentages.failed, 50);
+    });
+
+    it('does NOT reclassify a file that only has a non-skip ISSUE (e.g. a smell)', async () => {
+      mkdirSync(join(testDir, 'src'), { recursive: true });
+      writeFileSync(join(testDir, 'src', 'good.ts'), 'export const x = 1;');
+
+      const graph = new MockGraphBackend(['src/good.ts']);
+      await graph.addNode({
+        id: 'issue:smell',
+        type: 'ISSUE',
+        name: 'complexity: info',
+        file: 'src/good.ts',
+        category: 'complexity',
+        severity: 'info',
+        message: 'Function too complex',
+      });
+
+      const analyzer = new CoverageAnalyzer(graph as unknown as GraphBackend, testDir);
+      const result = await analyzer.analyze();
+
+      assert.strictEqual(result.failed.count, 0, 'a smell must not mark the file failed');
+      assert.strictEqual(result.analyzed.count, 1);
+      assert.strictEqual(result.percentages.analyzed, 100);
+    });
+
+    it('keeps failed.count at 0 when there are no issues (backward compatible)', async () => {
+      mkdirSync(join(testDir, 'src'), { recursive: true });
+      writeFileSync(join(testDir, 'src', 'good.ts'), 'export const x = 1;');
+
+      const graph = new MockGraphBackend(['src/good.ts']) as unknown as GraphBackend;
+      const analyzer = new CoverageAnalyzer(graph, testDir);
+      const result = await analyzer.analyze();
+
+      assert.strictEqual(result.failed.count, 0);
+      assert.strictEqual(result.percentages.analyzed, 100);
+    });
+  });
 });


### PR DESCRIPTION
Fixes **REG-1140**.

## Problem

`grafema coverage` counts **every** MODULE node as "analyzed" (`CoverageAnalyzer.getAnalyzedFiles`). But the orchestrator creates a MODULE *stub* even for files it **skips** (e.g. oversized god-files past the 1 MB source guard). Those files contribute zero real analysis yet land in the numerator, inflating the reported coverage %.

## Live reproduction (Evidence-Rule grade)

Fixture: one valid file + a 2 439 KB `godfile.ts`. `grafema analyze` then `grafema coverage`:

```
WARN  Skipping oversized source file: Source file too large: 2439 KB (limit: 1024 KB) file=.../godfile.ts
INFO  Analysis complete nodes=17 errors=0          ← the skip is errors=0, not an error
coverage (--json): analyzed.count=4 [.../godfile.ts ...], percentages.analyzed=100
```

Live graph probe (`queryNodes`) of the skipped file — it has **both** a MODULE node and an ISSUE node:
```json
{ "type":"ISSUE", "file":"src/godfile.ts", "category":"oversized_source",
  "severity":"warning", "message":"Source file too large: 2439 KB (limit: 1024 KB)" }
```
So the failure signal is already in the graph the analyzer reads — no orchestrator change needed.

## SPEC

- **Invariant restored:** a file that produced no real analysis must not count as `analyzed`. Coverage % reflects real analysis.
- **Entities:** `CoverageAnalyzer` (`packages/util/src/core/CoverageAnalyzer.ts`), the CLI/MCP coverage renderers.
- **Acceptance (BDD):**
  - *Given* a file with a MODULE node and an `oversized_source` ISSUE, *When* coverage runs, *Then* it is reported under a new `failed` bucket, not `analyzed`.
  - *Given* a file with only a non-skip ISSUE (e.g. a `complexity` smell), *Then* it stays `analyzed`.
  - *Given* no issues, *Then* `failed.count == 0` (backward compatible).
- **Blast radius:** `CoverageResult` consumers are the CLI (`coverage.ts`) and MCP (`coverage-handlers.ts`) renderers (both updated) and the integration test (additive `typeof` checks — unaffected). New field is additive.

## Fix (TS-only)

`CoverageAnalyzer` detects files carrying a **skip-category** ISSUE node (`oversized_source` / `oversized_ast` — the size-guard silent-skips) and reclassifies them from `analyzed` into a new `failed` bucket. Total file population is unchanged (failed is carved out of analyzed). Recoverable `parse_error` files are **intentionally not** failed — oxc continues with a partial AST and produces real nodes, so they remain legitimately analyzed.

- `CoverageResult` gains `failed: {count, files, byCategory}` + `percentages.failed`
- new `getSkippedFiles()` queries ISSUE nodes via the existing `GraphBackend`
- CLI + MCP renderers surface the Failed bucket (count, %, by-reason breakdown)

## BEFORE / AFTER (live god-file graph, via tsx on source)

```
BEFORE: analyzed=4 [incl godfile.ts]            analyzed% 100
AFTER:  failed=1 ['src/godfile.ts'] byCategory={"oversized_source":[...]}
        analyzed=3 [good, broken, broken2]      analyzed% 75   failed% 25
        godfile in analyzed? false   godfile in failed? true
```
(The two `parse_error` files correctly stay analyzed — partial AST = real nodes.)

## Gate

```
./scripts/test.sh core/CoverageAnalyzer.test.ts   → 25 passed, 0 failed (3 new)
typecheck: @grafema/util  → no errors in changed files
           @grafema/cli   → 0 errors
           @grafema/mcp   → 0 errors
eslint (3 source files)   → 0 errors
pre-commit hook (eslint + JS tests) → 21 passed, 0 failed
```

Note: `pnpm --filter @grafema/util build` (tsc) fails on a **pre-existing, unrelated** error in `src/enrichers/compactionEnricher.ts` (`getEdgesByType` missing on `RFDBClient` — RFD-69 territory). Proven pre-existing by stashing this change and rebuilding on clean HEAD (`features`). Not introduced here.

## Adversarial review

- **Round A (correctness):** unit tests cover oversized→failed, non-skip ISSUE stays analyzed, no-issues backward-compat; total is preserved (failed carved out of analyzed, denominator unchanged); failed files are excluded from the unreachable fall-through via a `failedSet` guard. ✅
- **Round B (structural):** `CoverageAnalyzer.ts` stays well under 500 lines; the skip-category set is a single named constant, trivially extensible; both renderers (CLI + MCP) updated together. ✅
- **Round C (class-not-instance):** both `CoverageResult` display consumers (CLI + MCP) surface the new bucket; integration test only does additive `typeof` checks. ✅

## Sibling issues found (follow-ups, not scope-crept)

- **Worker-panic rollback** (the issue title's headline): a panic that *rolls back the commit* may leave **no** MODULE node at all (then it's counted as `unreachable`, not inflating analyzed) — a different mechanism from the verified oversized-skip. Needs its own live repro to confirm the in-graph signal; only `oversized_source`/`oversized_ast` are verified here.
- **REG-1138** (complex god-files producing 0 nodes that are NOT the size guard): if those emit a different ISSUE category, add it to `SKIP_ISSUE_CATEGORIES`.
- **Pre-existing**: `@grafema/util` tsc build is red on `compactionEnricher.ts` (`getEdgesByType`, RFD-69) — blocks `pnpm build` repo-wide; worth a tracking issue.

Leaving merge to a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)