### PR TITLE
fix(orchestrator): index exported `namespace` declarations (REG-1139)

### DIFF
--- a/packages/grafema-orchestrator/src/plugin.rs
+++ b/packages/grafema-orchestrator/src/plugin.rs
@@ -982,7 +982,7 @@ pub async fn clear_context_on_workers(
 /// Index-worthy node types: these form the export index for cross-file resolution.
 const INDEX_NODE_TYPES: &[&str] = &[
     "EXPORT_BINDING", "EXPORT", "MODULE",
-    "FUNCTION", "VARIABLE", "CONSTANT", "CLASS", "INTERFACE", "TYPE_ALIAS", "ENUM",
+    "FUNCTION", "VARIABLE", "CONSTANT", "CLASS", "INTERFACE", "TYPE_ALIAS", "ENUM", "NAMESPACE",
 ];
 
 /// Per-file resolve: builds an export index on the worker, then resolves each
@@ -1032,7 +1032,7 @@ pub async fn resolve_per_file(
             // For declarations, only include exported ones in the index.
             // Note: JS analyzer's `exported` flag may be false for `export function foo()`
             // due to OXC AST walking order. We also check the file's exports list below.
-            if matches!(*node_type, "FUNCTION" | "VARIABLE" | "CONSTANT" | "CLASS" | "INTERFACE" | "TYPE_ALIAS" | "ENUM") {
+            if matches!(*node_type, "FUNCTION" | "VARIABLE" | "CONSTANT" | "CLASS" | "INTERFACE" | "TYPE_ALIAS" | "ENUM" | "NAMESPACE") {
                 if !node.exported {
                     continue;
                 }
@@ -1547,5 +1547,27 @@ mod tests {
             serde_json::from_str(output.nodes[0].metadata.as_ref().unwrap()).unwrap();
         assert_eq!(meta["_source"], "plugin-x");
         assert_eq!(meta["_generation"], 1);
+    }
+
+    /// Regression for REG-1139: every exported-declaration node type that the
+    /// grafema-resolve export index recognizes (see `nodeToExportEntries` /
+    /// `gnExported` arm in `packages/grafema-resolve/src/ImportResolution.hs`)
+    /// MUST also be queried by the orchestrator and sent to `build-index` — else
+    /// those exports are dark in the index and imports of them fail with
+    /// "no matching export" (e.g. `export namespace X {}`).
+    #[test]
+    fn index_node_types_cover_exported_declarations() {
+        // Mirrors grafema-resolve ImportResolution.hs `gnExported` export arm.
+        let resolver_exported_decl_types = [
+            "FUNCTION", "VARIABLE", "CONSTANT", "CLASS", "INTERFACE", "TYPE_ALIAS", "ENUM",
+            "NAMESPACE",
+        ];
+        for t in resolver_exported_decl_types {
+            assert!(
+                INDEX_NODE_TYPES.contains(&t),
+                "INDEX_NODE_TYPES is missing exported-declaration type {t:?} that the \
+                 resolver indexes — its exports become unresolvable (REG-1139)"
+            );
+        }
     }
 }


### PR DESCRIPTION
Fixes **REG-1139**.

## Problem

`export namespace X { ... }` produces **"no matching export 'X'"** warnings (~1941 on microsoft/vscode; `export namespace ` occurs 660× in vscode `src/`+`extensions/`) and the imported namespace never gets an `IMPORTS_FROM` edge — namespaced API surface is dark in the graph.

## Root cause (grounded with live queries)

The per-file resolver builds its export index only from the node types in `INDEX_NODE_TYPES` (`packages/grafema-orchestrator/src/plugin.rs`), which the orchestrator queries and sends to the worker's `build-index` step. **That list was missing `NAMESPACE`** — even though:

- the JS analyzer **does** emit a `NAMESPACE` node with `exported=true` (live query: `NAMESPACE Shapes exported=true`), and
- the resolver's index builder **already handles** `NAMESPACE` (`grafema-resolve/src/ImportResolution.hs` `nodeToExportEntries`, the `gnExported` arm lists `NAMESPACE`).

So the orchestrator and resolver lists were out of sync; the namespace node was never sent to build-index → the export index lacked `Shapes` → the import binding didn't resolve.

## SPEC

- **Invariant restored:** every exported-declaration node type the resolver indexes must also be queried + sent to build-index by the orchestrator, else those exports are dark.
- **Acceptance (BDD):** *Given* `export namespace Shapes {}` in `ns.ts` and `import { Shapes } from './ns'` in `use.ts`, *When* analyzed, *Then* the `Shapes` `IMPORT_BINDING` has an `IMPORTS_FROM` edge to the `NAMESPACE` node and no "no matching export" warning is emitted.
- **Blast radius:** `INDEX_NODE_TYPES` feeds only `resolve_per_file`; adding a type is additive (the resolver already filters by `gnExported`).

## Fix

Add `"NAMESPACE"` to `INDEX_NODE_TYPES` and to the exported-only filter in `resolve_per_file` (consistent with the other 7 exported-declaration types). The resolver needs no change.

## BEFORE / AFTER (live pipeline, rebuilt orchestrator)

```
BEFORE: Warning: no matching export 'Shapes' in src/ns.ts
        Shapes IMPORT_BINDING  IMPORTS_FROM -> []        (unresolved)
AFTER:  (no warning)
        Shapes IMPORT_BINDING  IMPORTS_FROM -> [NAMESPACE->Shapes]   RESOLVES=true
        JS resolution edges 5 -> 6
```

## TDD

`index_node_types_cover_exported_declarations` (new unit test) asserts `INDEX_NODE_TYPES` covers every exported-declaration type the resolver indexes — RED before the fix (`missing "NAMESPACE"`), GREEN after. Guards future drift between the orchestrator and `ImportResolution.hs`.

## Gate

```
cargo test --lib plugin::tests          → 17 passed, 0 failed
cargo test --lib (full orchestrator)    → 408 passed, 0 failed
rustfmt --check src/plugin.rs           → my hunks clean (file has pre-existing drift elsewhere, untouched)
cargo clippy                            → only a PRE-EXISTING "collapsible if" at the filter line
                                          (nested if structure unchanged — I only added a match arm)
pre-commit hook (eslint + JS tests)     → 21 passed, 0 failed
```

## Adversarial review

- **Round A (correctness):** the resolver already gates on `gnExported`, so adding NAMESPACE to the orchestrator query + exported filter only surfaces *exported* namespaces; non-exported `namespace` decls are still excluded (both by the new filter and the resolver). Verified the `exported=true` flag is set on the live node. ✅
- **Round B (structural):** 1-line addition to a named constant + a parallel filter; no god-file growth; regression test documents the cross-package invariant. ✅
- **Round C (class-not-instance):** searched for sibling node-type lists. `CONTEXT_NODE_TYPES` (plugin.rs:656) **also** omits NAMESPACE — but it is used only by `stream_resolve_nodes_to_workers`, which has **no callers** (dead code today). Filed as a follow-up note rather than scope-crept: if that broadcast path is reactivated it needs the same addition. ✅

## Sibling issues / follow-ups
- `CONTEXT_NODE_TYPES` latent gap (dead code today) — see Round C.
- Pre-existing clippy "collapsible if" at the exported-filter (not introduced here).

Leaving merge to a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)