### PR TITLE
test(mcp): assert every advertised tool has a dispatch handler (REG-1144)

### DIFF
--- a/packages/mcp/test/regressions.test.ts
+++ b/packages/mcp/test/regressions.test.ts
@@ -14,7 +14,7 @@ import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { FileOverview } from '@grafema/util';
 import type { GraphBackend } from '@grafema/types';
 import { findProjectRoot } from '../src/state.js';
@@ -571,5 +571,34 @@ describe('REG-652 — findProjectRoot workspace auto-detection', () => {
     const sub = join(inner, 'src');
     mkdirSync(sub);
     assert.strictEqual(findProjectRoot(sub), inner);
+  });
+});
+
+// ============================================================================
+// REG-1144 — no advertised-but-dead MCP tools
+//
+// Every tool advertised in TOOLS (returned by ListTools) must have a matching
+// `case '<name>':` dispatch arm in server.ts, or calling it falls through to
+// the switch default and returns errorResult("Unknown tool: <name>") — an
+// advertised-but-dead trust hole for agents.
+// ============================================================================
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { TOOLS } from '../src/definitions/index.js';
+
+describe('REG-1144 — advertised tools all have dispatch handlers', () => {
+  it('no advertised tool is missing a server.ts case handler', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const serverSrc = readFileSync(join(here, '..', 'src', 'server.ts'), 'utf8');
+    const handled = new Set(
+      [...serverSrc.matchAll(/case '([a-z_]+)':/g)].map((m) => m[1]),
+    );
+    const dead = TOOLS.map((t) => t.name).filter((n) => !handled.has(n));
+    assert.deepStrictEqual(
+      dead,
+      [],
+      `advertised tools with no dispatch handler (would return "Unknown tool"): ${dead.join(', ')}`,
+    );
   });
 });

--- a/packages/mcp/test/regressions.test.ts
+++ b/packages/mcp/test/regressions.test.ts
@@ -591,8 +591,11 @@ describe('REG-1144 — advertised tools all have dispatch handlers', () => {
   it('no advertised tool is missing a server.ts case handler', () => {
     const here = dirname(fileURLToPath(import.meta.url));
     const serverSrc = readFileSync(join(here, '..', 'src', 'server.ts'), 'utf8');
+    // Anchor to line start (after indentation) so commented-out arms like
+    // `// case 'git_churn':` are NOT counted as handled — otherwise the test
+    // would silently pass on the exact REG-1144 pattern it guards against.
     const handled = new Set(
-      [...serverSrc.matchAll(/case '([a-z_]+)':/g)].map((m) => m[1]),
+      [...serverSrc.matchAll(/^\s*case '([a-z_]+)':/gm)].map((m) => m[1]),
     );
     const dead = TOOLS.map((t) => t.name).filter((n) => !handled.has(n));
     assert.deepStrictEqual(


### PR DESCRIPTION
Addresses **REG-1144** deliverable #3 (the regression invariant). Adds the guard; does not change behavior.

## Context (grounded on HEAD)

REG-1144 reported `git_churn`/`git_cochange`/`git_ownership`/`git_archaeology` as "advertised in the MCP tool surface but dead". On current HEAD that **does not reproduce** — those tools are commented out in BOTH the definitions and the `server.ts` dispatch, so the live advertised `TOOLS` array (49 tools) contains no `git_*`. Option B (delist) is effectively already done; option A (revive as a git-enrichment feature) remains as a feature decision (see issue thread).

What IS worth shipping now is REG-1144's third deliverable: a regression guard so a tool can never be advertised without a handler.

## SPEC

- **Invariant:** every name in the exported `TOOLS` array (what `ListTools` returns) must have a matching `case '<name>':` arm in `server.ts`; otherwise calling it falls through the switch `default` → `errorResult("Unknown tool: <name>")` — an advertised-but-dead trust hole for agents.
- **Acceptance:** a unit test enumerating `TOOLS` and asserting each name is dispatched. Passes today; fails loudly if a future tool is advertised without wiring.

## Change

`packages/mcp/test/regressions.test.ts` — new test "advertised tools all have dispatch handlers": imports the real `TOOLS`, extracts the `case '...'` labels from `server.ts`, asserts the set difference is empty.

## Verify (actual output)

```
node --import tsx --test test/regressions.test.ts
  ✔ REG-1144 — advertised tools all have dispatch handlers › no advertised tool is missing a server.ts case handler
# pass 22  # fail 0
```

Authoritative check note: I confirmed the advertised set via the exported `TOOLS` (49 tools) — NOT a grep over definition files, which over-counts commented-out defs and nested schema-property `name:` fields (that mistake briefly produced a false "5 knowledge tools are dead" reading; the test importing real `TOOLS` refuted it).

## Gate / blast radius

- Test-only change; no production code touched. No behavior change.
- Full `packages/mcp` suite: my test + 64 others pass; **2 PRE-EXISTING failures unrelated to this change** — `query-graph-count.test.ts` (`mock.module is not a function`, Node test-API mismatch) and `tools-onboarding.test.ts` (imports a non-built `dist/handlers.js` path). Proven pre-existing by stashing this change and re-running (both still fail).

## Follow-ups (not in this PR)
- REG-1144 option A (revive the git temporal/behavioral tools) — feature, owner decision.
- Old file-based knowledge layer left orphaned code (`handlers/knowledge-handlers.ts`, commented defs) + CLAUDE.md still references `query_knowledge`/`query_decisions`; if retired for Enox, that wants a docs/dead-code tidy (separate low-pri issue).

Leaving merge to a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)