### PR TITLE
docs(changelog): record merged fix #277 (REG-1139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - fix(coverage): exclude skipped/failed files from the analyzed count — oversized files that the orchestrator silently skips are reclassified from "analyzed" into a new "Failed" bucket, so `grafema coverage` reports an accurate (no longer inflated) percentage (REG-1140, #276)
 - fix(rfdb): correct token fuzzy-search Jaccard scores by unifying the tokenizer — removes the phantom whole-string token that inflated the union denominator and distorted `find_nodes` fuzzy-fallback ranking (#275)
 - fix(rust-analyzer): unwrap `Box`/`Rc`/`Arc` receiver types so `Box<dyn Trait>` resolves to the inner trait, restoring dyn-dispatch CALLS edges that were previously dropped (#273)
+- fix(orchestrator): index exported `namespace` declarations so `export namespace X {}` resolves cross-file and gets an IMPORTS_FROM edge — keeps `INDEX_NODE_TYPES` in sync with the resolver's exported-declaration list (REG-1139, #277)
 
 ## [0.3.23] - 2026-04-01
 


### PR DESCRIPTION
Adds an `[Unreleased]` > Bug Fixes entry for #277 (merged into `main`):

- orchestrator: index exported `namespace` declarations so `export namespace X {}` resolves cross-file and gets an IMPORTS_FROM edge (REG-1139)

Documentation-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)