### PR TITLE
test(harness): resolve rfdb-server via canonical findRfdbBinary (honor GRAFEMA_RFDB_SERVER)

### DIFF
--- a/test/helpers/TestRFDB.js
+++ b/test/helpers/TestRFDB.js
@@ -11,8 +11,8 @@
  */
 
 import { RFDBClient } from '../../packages/rfdb/dist/client.js';
-import { RFDBServerBackend } from '@grafema/util';
-import { join, dirname } from 'node:path';
+import { RFDBServerBackend, findRfdbBinary } from '@grafema/util';
+import { dirname } from 'node:path';
 import { existsSync, rmSync, mkdirSync } from 'node:fs';
 import { spawn } from 'node:child_process';
 import { setTimeout as sleep } from 'node:timers/promises';
@@ -127,7 +127,8 @@ async function _startSharedServer() {
   const binaryPath = _findServerBinary();
   if (!binaryPath) {
     throw new Error(
-      'RFDB server binary not found. Run: cargo build --release -p rfdb-server'
+      'RFDB server binary not found. Set GRAFEMA_RFDB_SERVER, run `npm install`, ' +
+        'or build from source: cd packages/rfdb-server && cargo build --release'
     );
   }
 
@@ -169,19 +170,18 @@ async function _startSharedServer() {
   };
 }
 
-function _findServerBinary() {
-  const candidates = [
-    join(process.cwd(), 'packages/rfdb-server/target/release/rfdb-server'),
-    join(process.cwd(), 'packages/rfdb-server/target/debug/rfdb-server'),
-  ];
-
-  for (const path of candidates) {
-    if (existsSync(path)) {
-      return path;
-    }
-  }
-
-  return null;
+/**
+ * Resolve the rfdb-server binary using the same canonical resolver as
+ * production code (`findRfdbBinary` from `@grafema/util`). This honors the
+ * documented `GRAFEMA_RFDB_SERVER` override, the platform npm package, the
+ * monorepo `cargo` build dirs, `PATH`, and `~/.grafema/bin` — keeping the test
+ * harness in lockstep with how the server is actually located at runtime
+ * instead of duplicating a narrower, divergent lookup (RFD-40).
+ *
+ * @returns {string | null} Absolute path to the binary, or null if not found.
+ */
+export function _findServerBinary() {
+  return findRfdbBinary();
 }
 
 // ===========================================================================

--- a/test/unit/TestRFDBBinaryResolution.test.js
+++ b/test/unit/TestRFDBBinaryResolution.test.js
@@ -1,0 +1,60 @@
+/**
+ * Regression: the test harness must resolve the rfdb-server binary the same way
+ * production code does — via the canonical `findRfdbBinary` resolver in
+ * `@grafema/util` — instead of a hardcoded `target/{release,debug}` list.
+ *
+ * Why this matters:
+ *   - `GRAFEMA_RFDB_SERVER` is the documented override (README "Environment
+ *     variables" table) and is honored by every production resolver
+ *     (`findRfdbBinary`, `packages/grafema/src/binaries.ts`, the VS Code client,
+ *     and `grafema doctor`). A contributor who points it at a locally-built
+ *     binary, or who relies on the npm-distributed binary, could not run the
+ *     test suite because `TestRFDB._findServerBinary()` ignored all of those
+ *     locations and only checked two `cargo`-build paths.
+ *   - Archived task RFD-40 already fixed this exact "hardcoded resolution that
+ *     ignores GRAFEMA_RFDB_SERVER" DRY violation in the CLI server command; the
+ *     test helper was the last remaining sibling instance.
+ *
+ * This test asserts the documented override wins, which is the discriminating
+ * behavior between the old hardcoded list (env var ignored) and delegation to
+ * the canonical resolver (env var honored, checked before monorepo build dirs).
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { getPlatformDir } from '@grafema/util';
+
+import { _findServerBinary } from '../helpers/TestRFDB.js';
+
+test('TestRFDB._findServerBinary honors the documented GRAFEMA_RFDB_SERVER override', (t) => {
+  // Use a real, existing binary as the override target. The committed prebuilt
+  // binary for the current platform is the most honest choice (it exists in a
+  // fresh clone). Skip on platforms that ship no prebuilt binary.
+  const override = join(
+    process.cwd(),
+    'packages/rfdb-server/prebuilt',
+    getPlatformDir(),
+    'rfdb-server',
+  );
+  if (!existsSync(override)) {
+    t.skip(`no committed prebuilt rfdb-server for ${getPlatformDir()}`);
+    return;
+  }
+
+  const original = process.env.GRAFEMA_RFDB_SERVER;
+  process.env.GRAFEMA_RFDB_SERVER = override;
+  try {
+    assert.strictEqual(
+      _findServerBinary(),
+      override,
+      'test helper must delegate to the canonical findRfdbBinary resolver and ' +
+        'honor the documented GRAFEMA_RFDB_SERVER override',
+    );
+  } finally {
+    if (original === undefined) delete process.env.GRAFEMA_RFDB_SERVER;
+    else process.env.GRAFEMA_RFDB_SERVER = original;
+  }
+});


### PR DESCRIPTION
## Summary

The unit-test harness `test/helpers/TestRFDB.js` resolved the `rfdb-server`
binary with a **hardcoded two-path list** — `packages/rfdb-server/target/{release,debug}/rfdb-server` —
ignoring the documented `GRAFEMA_RFDB_SERVER` override and every other location
the production resolver honors. This is the last sibling of a DRY violation the
project already fixed elsewhere.

## Spec

**Invariant restored:** the test harness locates `rfdb-server` exactly as
runtime does — through the single canonical resolver `findRfdbBinary`
(`@grafema/util`) — so the documented `GRAFEMA_RFDB_SERVER` contract holds in
tests too.

**Acceptance (BDD):**
- *Given* `GRAFEMA_RFDB_SERVER` points at a valid `rfdb-server` binary
- *When* the test harness resolves the server binary
- *Then* it returns that path (the documented override wins), instead of
  silently ignoring the env var and falling back to a `cargo` build dir.

## Why this matters (evidence)

- `GRAFEMA_RFDB_SERVER` is documented in `README.md:220` ("Path to RFDB server
  binary") and honored by every production resolver: `findRfdbBinary`
  (`packages/util/src/utils/findRfdbBinary.ts:42`), `packages/grafema/src/binaries.ts:32`,
  the VS Code client (`packages/vscode/src/grafemaClient.ts:363`), and
  `grafema doctor` (`packages/cli/src/commands/doctor/checks.ts:62`).
- The harness honored **none** of it — only the two `cargo` build dirs. A
  contributor who points `GRAFEMA_RFDB_SERVER` at a local build, or relies on
  the npm-distributed binary, could not run the suite even with a working
  server present (124 unit tests depend on this helper).
- Archived task **RFD-40** explicitly flagged this exact pattern as a
  *"DRY violation — it ignores `GRAFEMA_RFDB_SERVER` env var"* and fixed it in
  the CLI server command. The test harness was the remaining instance of the
  same class.

## Change

`_findServerBinary()` now delegates to `findRfdbBinary()` from `@grafema/util`
(env var → platform npm package → monorepo `cargo` dirs → `PATH` →
`~/.grafema/bin` → `~/.local/bin` → legacy `@grafema/rfdb` prebuilt). The
not-found error message is updated to reflect the broader resolution
(matching `grafema doctor` guidance). `+16 / −16`, one file.

## Before / After (actual output)

**RED — env var ignored (before fix):**
```
$ GRAFEMA_RFDB_SERVER=.../prebuilt/linux-x64/rfdb-server  node --test test/unit/TestRFDBBinaryResolution.test.js
not ok 1 - TestRFDB._findServerBinary honors the documented GRAFEMA_RFDB_SERVER override
    + actual:   '.../packages/rfdb-server/target/release/rfdb-server'
    - expected: '.../packages/rfdb-server/prebuilt/linux-x64/rfdb-server'
```

**GREEN — after fix:**
```
ok 1 - TestRFDB._findServerBinary honors the documented GRAFEMA_RFDB_SERVER override
# tests 1 # pass 1 # fail 0
```

**End-to-end — real RFDB suite using a binary supplied *only* via the env var**
(with `target/` removed, so `findRfdbBinary()` → `null` without the override):
```
$ # target/ moved aside; findRfdbBinary() -> null
$ GRAFEMA_RFDB_SERVER=.../prebuilt/linux-x64/rfdb-server  node --test test/unit/specedContractEnricher.test.js
# tests 6 # pass 6 # fail 0
```
Before the fix these 6 tests threw `RFDB server binary not found`.

## Adversarial review

- **Round A — correctness.** Env override precedence verified. A non-existent
  `GRAFEMA_RFDB_SERVER` path is rejected by `findRfdbBinary`'s `existsSync`
  guard and resolution falls through (same as the old `existsSync` candidates);
  no match still returns `null` → caller throws the improved error. `target/
  {release,debug}` remain in the resolver (paths 4–5), so existing `cargo`-build
  workflows are unaffected.
- **Round B — structural.** Removes a divergent duplicate resolver in favor of
  the single source of truth; net fragility reduced. File stays well under 500
  lines.
- **Round C — class, not instance.** Searched the tree for the same hardcoded
  pattern. Remaining siblings live in **opt-in** suites not run by the default
  `pnpm test` gate (see follow-ups). The `cli/server.ts` and
  `rfdb-server/scripts/postinstall.js` hits are help-text strings, not
  resolution logic.

## Full gate (actual)

- `./scripts/test.sh` — new test passes; **no new failures**. The only reds are
  7 pre-existing `GitIngest` cases failing on the unrelated `commit.gpgsign`
  hermeticity issue (present at baseline before this change; a fix already
  exists, unmerged, on branch `claude/vigilant-lamport-Y5PfG` / commit
  `e303862` — flagged for the owner, not duplicated here).
- `pnpm typecheck` — clean. `pnpm lint` — clean. `eslint` on the two changed
  test files — clean.

## Blast radius

One test-only helper, used by ~124 unit tests via `getSharedServer()`. No
production code touched; production binary resolution is unchanged.

## Follow-ups (same class, separate opt-in suites — not verified in this env)

- [ ] `test/integration/rfdb-federation.test.js:23-24` — identical 2-path list
- [ ] `test/integration/rfdb-websocket.test.ts:39` — hardcoded `target/debug`
- [ ] `test/scenarios/rfdb-client.test.js:25` — hardcoded `target/debug`
- [ ] `test/scenarios/rfdb-request-id.test.js:28` — hardcoded `target/debug`

https://claude.ai/code/session_013sksBwku2oCKfTAkTBQ4eq

---
_Generated by [Claude Code](https://claude.ai/code/session_013sksBwku2oCKfTAkTBQ4eq)_