### PR TITLE
fix(cypher): route only real aggregates through HashAggregate (RFD-70 follow-up)

### DIFF
--- a/packages/rfdb-server/src/cypher/aggregate.rs
+++ b/packages/rfdb-server/src/cypher/aggregate.rs
@@ -17,6 +17,19 @@ use super::values::CypherValue;
 use super::CypherError;
 use std::cmp::Ordering;
 
+/// Is `name` (any case) one of the aggregate functions the executor implements?
+///
+/// This is the single source of truth for "aggregate vs scalar" — it MUST stay
+/// in sync with the accepted set in [`AggAcc::new`]. The planner uses it to route
+/// only aggregate calls through `HashAggregate` (and to reject unknown functions),
+/// so a scalar function in `RETURN` is never silently treated as an aggregate.
+pub fn is_aggregate_function(name: &str) -> bool {
+    matches!(
+        name.to_uppercase().as_str(),
+        "COUNT" | "SUM" | "AVG" | "MIN" | "MAX"
+    )
+}
+
 /// Per-aggregate, per-group accumulator state.
 ///
 /// Constructed once per group from the aggregate's function name, updated for

--- a/packages/rfdb-server/src/cypher/planner.rs
+++ b/packages/rfdb-server/src/cypher/planner.rs
@@ -9,6 +9,7 @@
 //! 4. Without aggregates: `Sort` → `Project` → `Limit`
 //!    With aggregates: `HashAggregate` → `Sort` → `Limit`
 
+use crate::cypher::aggregate::is_aggregate_function;
 use crate::cypher::ast::*;
 use crate::cypher::executor::*;
 use crate::cypher::CypherError;
@@ -115,11 +116,30 @@ pub fn plan<'a>(
     //   HashAggregate already produces named columns, so Sort works on those.
     //   No separate Project is needed after HashAggregate.
 
+    // Reject non-aggregate functions in RETURN. The executor implements only
+    // aggregate functions (COUNT/SUM/AVG/MIN/MAX); a scalar function such as
+    // toUpper(...) must fail loudly here rather than be silently routed through
+    // HashAggregate (which would mislabel it as an aggregate) or projected to
+    // NULL. Scalar-function support is a separate feature.
+    for item in &query.return_clause.items {
+        if let Expr::FunctionCall(name, _) = &item.expr {
+            if !is_aggregate_function(name) {
+                return Err(CypherError::Plan(format!(
+                    "Unsupported function '{}' in RETURN (supported: COUNT, SUM, AVG, MIN, MAX)",
+                    name
+                )));
+            }
+        }
+    }
+
     let has_aggregates = query
         .return_clause
         .items
         .iter()
-        .any(|item| matches!(item.expr, Expr::FunctionCall(_, _)));
+        .any(|item| match &item.expr {
+            Expr::FunctionCall(name, _) => is_aggregate_function(name),
+            _ => false,
+        });
 
     if has_aggregates {
         let (group_keys, aggregates) = split_return_items(&query.return_clause);

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -2403,4 +2403,60 @@ mod integration_tests {
             result
         );
     }
+
+    // ── Aggregate-vs-scalar function routing (RFD-70 follow-up) ─────────
+
+    #[test]
+    fn scalar_function_in_return_rejected_not_mislabeled_aggregate() {
+        // A non-aggregate function in RETURN must be rejected as an unsupported
+        // FUNCTION — never silently routed through aggregation nor mislabeled as
+        // an "aggregate". Only COUNT/SUM/AVG/MIN/MAX are aggregates.
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN toUpper(n.name)",
+            EvalLimits::none(),
+        );
+        assert!(result.is_err(), "expected an error for unsupported scalar function");
+        let msg = format!("{:?}", result.unwrap_err()).to_lowercase();
+        assert!(
+            !msg.contains("aggregate"),
+            "scalar function must not be reported as an aggregate; got: {}",
+            msg
+        );
+        assert!(
+            msg.contains("toupper") || msg.contains("function"),
+            "error should name the unsupported function; got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn mixed_scalar_and_column_not_misaggregated() {
+        // `RETURN n.file, toUpper(n.name)` must NOT be planned as GROUP BY n.file
+        // with toUpper treated as an aggregate; it's rejected as unsupported.
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.file, toUpper(n.name)",
+            EvalLimits::none(),
+        );
+        assert!(result.is_err());
+        let msg = format!("{:?}", result.unwrap_err()).to_lowercase();
+        assert!(!msg.contains("aggregate"), "got: {}", msg);
+    }
+
+    #[test]
+    fn real_aggregates_still_work_after_scalar_split() {
+        // Regression: real aggregates + grouping unaffected by the scalar split.
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (f:FUNCTION)-[:CALLS]->(g) RETURN f.name, COUNT(g) AS calls",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        assert_eq!(result.columns, vec!["f.name", "calls"]);
+        assert!(result.row_count >= 1);
+    }
 }


### PR DESCRIPTION
Follow-up to **RFD-70** (PR #274), which flagged that the cypher planner treats *every* `RETURN` function call as an aggregate.

## Problem

`planner.rs` set `has_aggregates = query.return_clause.items.any(|i| matches!(i.expr, FunctionCall(_,_)))` and `split_return_items` routed **all** function calls into `HashAggregate`. Consequences:

- `RETURN toUpper(n.name)` surfaced the misleading error **"Unsupported aggregate function: TOUPPER"** (a scalar function reported as an aggregate, at execution time).
- `RETURN n.file, toUpper(n.name)` was conceptually planned as **GROUP BY n.file with toUpper as an aggregate**. No scalar functions are implemented today (so it errors), but once they are, this misrouting would silently produce **wrong grouping**.

## SPEC

- **Invariant:** only `COUNT`/`SUM`/`AVG`/`MIN`/`MAX` are aggregates and route through `HashAggregate`. Any other function in `RETURN` is an unsupported *scalar* function and must fail loudly — never be silently treated as an aggregate or projected to `NULL` (consistent with RFD-70's "no silent wrong data").
- **Acceptance (BDD):**
  - *Given* `RETURN toUpper(n.name)`, *Then* a plan-time error naming the **function** (not "aggregate").
  - *Given* `RETURN n.file, toUpper(n.name)`, *Then* rejected (not mis-aggregated).
  - *Given* `RETURN f.name, COUNT(g)`, *Then* grouping/aggregation still works.
- **Blast radius:** `plan()` only; `split_return_items` now only ever sees real aggregates (validation runs first); `eval_expr`'s NULL fallback for non-aggregate functions is no longer reachable for top-level `RETURN` items.

## Change

- New single source of truth `aggregate::is_aggregate_function(name)` (COUNT/SUM/AVG/MIN/MAX), documented to stay in sync with `AggAcc::new`.
- `has_aggregates` uses it.
- `plan()` rejects any non-aggregate `RETURN` function with `CypherError::Plan("Unsupported function '<name>' in RETURN (supported: COUNT, SUM, AVG, MIN, MAX)")`.

## BEFORE / AFTER (test output)

```
BEFORE: RETURN toUpper(n.name)  ->  Execution("unsupported aggregate function: toupper")   # mislabeled
AFTER:  RETURN toUpper(n.name)  ->  Plan("Unsupported function 'toUpper' in RETURN ...")     # honest, plan-time
```

## Gate (actual)

```
cargo test --lib cypher::      → 120 passed, 0 failed (3 new: red→green)
cargo test --lib (full crate)  → 859 passed, 0 failed
cargo clippy                   → clean at changed lines
rustfmt --check                → changed hunks clean (planner.rs has pre-existing drift elsewhere, untouched)
pre-commit (eslint + JS tests) → 22 passed, 0 failed
```

## Adversarial review
- **A (correctness):** `COUNT`/lowercase `count` still route as aggregates (`is_aggregate_function` upper-cases, matching the prior `to_uppercase()`); empty RETURN / no functions → normal path; real aggregates + grouping unaffected (regression test). ✅
- **B (structural):** one shared predicate instead of duplicated `matches!` logic; no god-file growth. ✅
- **C (class-not-instance):** the only other "FunctionCall ⇒ aggregate" assumptions are `split_return_items` (now safe behind validation) and `eval_expr`'s NULL fallback (now unreachable for top-level RETURN). ✅

## Follow-ups (not in scope)
- Implement common scalar functions (`toUpper`/`toLower`/`length`/`trim`/…) in `eval_expr` so these queries return values instead of erroring.
- Nested scalar calls inside expressions (e.g. `RETURN n.a + toUpper(n.b)`) still evaluate to `NULL` (pre-existing; the top-level validation doesn't recurse).

Leaving merge to a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)