### PR TITLE
test(rfdb): resolve server binary via findRfdbBinary in 4 opt-in suites

### DIFF
--- a/test/integration/rfdb-federation.test.js
+++ b/test/integration/rfdb-federation.test.js
@@ -15,18 +15,16 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { realpathSync } from 'node:fs';
 import { RFDBClient } from '../../packages/rfdb/dist/client.js';
 import { ShardDiscovery } from '../../packages/util/dist/federation/ShardDiscovery.js';
+import { findRfdbBinary } from '@grafema/util';
 
 // ── Helpers ─────────────────────────────────────────────────────
 
+// Resolve rfdb-server via the canonical production resolver so the suite
+// honors GRAFEMA_RFDB_SERVER, the platform npm package, PATH, ~/.grafema/bin,
+// etc. — not just the two monorepo `cargo`-build paths. See
+// test/unit/RfdbBinaryResolutionSiblings.test.js for the rationale.
 function findServerBinary() {
-  const candidates = [
-    join(process.cwd(), 'packages/rfdb-server/target/release/rfdb-server'),
-    join(process.cwd(), 'packages/rfdb-server/target/debug/rfdb-server'),
-  ];
-  for (const path of candidates) {
-    if (existsSync(path)) return path;
-  }
-  return null;
+  return findRfdbBinary();
 }
 
 async function startFederatedServer(name, dbDir, socketPath, rootPath) {

--- a/test/integration/rfdb-websocket.test.ts
+++ b/test/integration/rfdb-websocket.test.ts
@@ -26,6 +26,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 import { setTimeout as sleep } from 'node:timers/promises';
+import { findRfdbBinary } from '@grafema/util';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -36,14 +37,16 @@ const TEST_WS_URL = `ws://127.0.0.1:${TEST_WS_PORT}`;
 const testDir = mkdtempSync(join(tmpdir(), 'rfdb-ws-'));
 const TEST_DB_PATH = join(testDir, 'graph.rfdb');
 const TEST_SOCKET_PATH = join(testDir, 'rfdb.sock');
-const SERVER_BINARY = join(__dirname, '../../packages/rfdb-server/target/debug/rfdb-server');
+// Resolve via the canonical production resolver (honors GRAFEMA_RFDB_SERVER,
+// the platform npm package, PATH, ~/.grafema/bin, etc.).
+const SERVER_BINARY = findRfdbBinary();
 
 /**
  * Check if rfdb-server binary exists and supports --ws-port.
  * If not, skip these tests.
  */
 function canRunTests(): boolean {
-  return existsSync(SERVER_BINARY);
+  return SERVER_BINARY !== null;
 }
 
 // =============================================================================
@@ -59,7 +62,8 @@ describe('RFDB WebSocket Integration', { skip: !canRunTests() ? 'rfdb-server bin
 
   before(async () => {
     // Start server with both Unix socket and WebSocket
-    serverProcess = spawn(SERVER_BINARY, [
+    // Non-null: the suite is skipped via canRunTests() when SERVER_BINARY is null.
+    serverProcess = spawn(SERVER_BINARY as string, [
       TEST_DB_PATH,
       '--socket', TEST_SOCKET_PATH,
       '--ws-port', TEST_WS_PORT.toString(),

--- a/test/scenarios/rfdb-client.test.js
+++ b/test/scenarios/rfdb-client.test.js
@@ -14,7 +14,7 @@ import { dirname } from 'path';
 import { tmpdir } from 'os';
 import { setTimeout as sleep } from 'timers/promises';
 
-import { RFDBClient } from '@grafema/util';
+import { RFDBClient, findRfdbBinary } from '@grafema/util';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -22,22 +22,27 @@ const __dirname = dirname(__filename);
 const testDir = mkdtempSync(join(tmpdir(), 'rfdb-client-'));
 const TEST_DB_PATH = join(testDir, 'graph.rfdb');
 const TEST_SOCKET_PATH = join(testDir, 'rfdb.sock');
-const SERVER_BINARY = join(__dirname, '../../packages/rfdb-server/target/debug/rfdb-server');
+// Resolve via the canonical production resolver (honors GRAFEMA_RFDB_SERVER,
+// the platform npm package, PATH, ~/.grafema/bin, etc.). Re-resolved after a
+// build fallback below.
+let SERVER_BINARY = findRfdbBinary();
 
 describe('RFDB Client-Server', () => {
   let serverProcess = null;
   let client = null;
 
   before(async () => {
-    // Check if server binary exists
-    if (!existsSync(SERVER_BINARY)) {
+    // Build a development binary only if none was resolved anywhere.
+    if (!SERVER_BINARY) {
       console.log('Building rfdb-server...');
       const { execSync } = await import('child_process');
       execSync('cargo build --bin rfdb-server', {
         cwd: join(__dirname, '../../packages/rfdb-server'),
         stdio: 'inherit'
       });
+      SERVER_BINARY = findRfdbBinary();
     }
+    if (!SERVER_BINARY) throw new Error('rfdb-server binary not found');
 
     // Start server
     console.log('Starting rfdb-server...');

--- a/test/scenarios/rfdb-request-id.test.js
+++ b/test/scenarios/rfdb-request-id.test.js
@@ -17,7 +17,7 @@ import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const { encode, decode } = require('../../packages/rfdb/node_modules/@msgpack/msgpack');
 
-import { RFDBClient } from '@grafema/util';
+import { RFDBClient, findRfdbBinary } from '@grafema/util';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -25,20 +25,25 @@ const __dirname = dirname(__filename);
 const testDir = mkdtempSync(join(tmpdir(), 'rfdb-reqid-'));
 const TEST_DB_PATH = join(testDir, 'graph.rfdb');
 const TEST_SOCKET_PATH = join(testDir, 'rfdb.sock');
-const SERVER_BINARY = join(__dirname, '../../packages/rfdb-server/target/debug/rfdb-server');
+// Resolve via the canonical production resolver (honors GRAFEMA_RFDB_SERVER,
+// the platform npm package, PATH, ~/.grafema/bin, etc.). Re-resolved after a
+// build fallback below.
+let SERVER_BINARY = findRfdbBinary();
 
 describe('RFDB Request IDs (RFD-3)', () => {
   let serverProcess = null;
   let client = null;
 
   before(async () => {
-    if (!existsSync(SERVER_BINARY)) {
+    if (!SERVER_BINARY) {
       const { execSync } = await import('child_process');
       execSync('cargo build --bin rfdb-server', {
         cwd: join(__dirname, '../../packages/rfdb-server'),
         stdio: 'inherit'
       });
+      SERVER_BINARY = findRfdbBinary();
     }
+    if (!SERVER_BINARY) throw new Error('rfdb-server binary not found');
 
     serverProcess = spawn(SERVER_BINARY, [TEST_DB_PATH, '--socket', TEST_SOCKET_PATH], {
       stdio: ['ignore', 'pipe', 'pipe']

--- a/test/unit/RfdbBinaryResolutionSiblings.test.js
+++ b/test/unit/RfdbBinaryResolutionSiblings.test.js
@@ -1,0 +1,97 @@
+/**
+ * Regression guard (class-not-instance): every test suite that needs the
+ * rfdb-server binary must resolve it through the canonical `findRfdbBinary`
+ * resolver in `@grafema/util`, NOT through a hardcoded
+ * `packages/rfdb-server/target/{release,debug}/rfdb-server` list.
+ *
+ * Why this matters:
+ *   - `GRAFEMA_RFDB_SERVER` is the documented override (README "Environment
+ *     variables" table) and is honored by every production resolver
+ *     (`findRfdbBinary`, the CLI `server` command, the VS Code client). A
+ *     hardcoded `target/{release,debug}` list ignores it, plus the platform
+ *     npm package, `PATH`, `~/.grafema/bin`, `~/.local/bin`, and the legacy
+ *     `@grafema/rfdb` prebuilt location — so a contributor who points the env
+ *     var at a locally-built binary, or relies on the npm-distributed binary,
+ *     cannot run these suites at all.
+ *   - PR #281 (RFD-40 follow-up) fixed this exact DRY violation in the shared
+ *     `test/helpers/TestRFDB.js` harness (covered by
+ *     `TestRFDBBinaryResolution.test.js`). The four opt-in suites listed below
+ *     were the last remaining sibling instances, filed as follow-ups.
+ *
+ * This test encodes the invariant structurally so a future suite cannot
+ * silently reintroduce the hardcoded list. The discriminating behavior of the
+ * fix (env override is honored) is proven separately by
+ * `TestRFDBBinaryResolution.test.js`, which exercises the live resolver.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEST_ROOT = join(__dirname, '..');
+
+// Assemble the forbidden needles from parts so THIS file does not match the
+// directory scan below.
+const SEG = 'rfdb-server/' + 'target/';
+const FORBIDDEN = [SEG + 'release' + '/rfdb-server', SEG + 'debug' + '/rfdb-server'];
+
+// Suites that spawn a real rfdb-server and therefore must use findRfdbBinary().
+const SUITES_NEEDING_RESOLVER = [
+  'integration/rfdb-federation.test.js',
+  'integration/rfdb-websocket.test.ts',
+  'scenarios/rfdb-client.test.js',
+  'scenarios/rfdb-request-id.test.js',
+];
+
+/** Recursively collect every *.test.js / *.test.ts file under test/. */
+function collectTestFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...collectTestFiles(full));
+    } else if (/\.test\.(js|ts)$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+test('no test file hardcodes the rfdb-server target/ binary path', () => {
+  const selfPath = fileURLToPath(import.meta.url);
+  const offenders = [];
+  for (const file of collectTestFiles(TEST_ROOT)) {
+    if (file === selfPath) continue; // this guard names the pattern in prose
+    const src = readFileSync(file, 'utf8');
+    for (const needle of FORBIDDEN) {
+      if (src.includes(needle)) {
+        offenders.push(`${file} contains hardcoded "${needle}"`);
+      }
+    }
+  }
+  assert.deepStrictEqual(
+    offenders,
+    [],
+    'test suites must resolve rfdb-server via findRfdbBinary() (from @grafema/util), ' +
+      'not a hardcoded target/{release,debug} path:\n' + offenders.join('\n'),
+  );
+});
+
+test('rfdb-server suites delegate resolution to findRfdbBinary', () => {
+  const missing = [];
+  for (const rel of SUITES_NEEDING_RESOLVER) {
+    const src = readFileSync(join(TEST_ROOT, rel), 'utf8');
+    if (!src.includes('findRfdbBinary')) {
+      missing.push(rel);
+    }
+  }
+  assert.deepStrictEqual(
+    missing,
+    [],
+    'these suites must import and use findRfdbBinary() from @grafema/util:\n' +
+      missing.join('\n'),
+  );
+});

--- a/test/unit/RfdbBinaryResolutionSiblings.test.js
+++ b/test/unit/RfdbBinaryResolutionSiblings.test.js
@@ -15,13 +15,13 @@
  *     cannot run these suites at all.
  *   - PR #281 (RFD-40 follow-up) fixed this exact DRY violation in the shared
  *     `test/helpers/TestRFDB.js` harness (covered by
- *     `TestRFDBBinaryResolution.test.js`). The four opt-in suites listed below
+ *     `FindRfdbBinary.test.js`). The four opt-in suites listed below
  *     were the last remaining sibling instances, filed as follow-ups.
  *
  * This test encodes the invariant structurally so a future suite cannot
  * silently reintroduce the hardcoded list. The discriminating behavior of the
  * fix (env override is honored) is proven separately by
- * `TestRFDBBinaryResolution.test.js`, which exercises the live resolver.
+ * `FindRfdbBinary.test.js`, which exercises the live resolver.
  */
 
 import test from 'node:test';


### PR DESCRIPTION
## Summary

Four opt-in test suites resolved the `rfdb-server` binary with a hardcoded
`packages/rfdb-server/target/{release,debug}/rfdb-server` list, ignoring the
documented `GRAFEMA_RFDB_SERVER` override and every other location the
production resolver `findRfdbBinary` (`@grafema/util`) honors (platform npm
package, `PATH`, `~/.grafema/bin`, `~/.local/bin`, legacy `@grafema/rfdb`
prebuilt). A contributor who points the env var at a locally-built binary, or
relies on the npm-distributed binary, could not run these suites.

This is the **last set of siblings** of the same DRY violation that PR #281
(RFD-40 follow-up) fixed in `test/helpers/TestRFDB.js`, explicitly filed as
follow-ups. CLI (`server.ts`, RFD-40) and `TestRFDB.js` (#281) were already
fixed; the VS Code client uses its own resolver that already honors the env
var. These four were the remainder.

Fixed files:
- `test/integration/rfdb-federation.test.js`
- `test/integration/rfdb-websocket.test.ts`
- `test/scenarios/rfdb-client.test.js`
- `test/scenarios/rfdb-request-id.test.js`

Each now delegates to `findRfdbBinary()`. The two scenario suites keep their
"build a dev binary if none is resolvable" fallback (re-resolving after the
build, with an explicit throw if still missing).

## Spec

- **Invariant restored:** test suites resolve the rfdb-server binary the same
  way production does — via the canonical `findRfdbBinary` resolver — so the
  documented `GRAFEMA_RFDB_SERVER` override (and the 6 other locations) is honored.
- **Acceptance (BDD):**
  - *Given* the rfdb-server binary exists only at a path named by
    `GRAFEMA_RFDB_SERVER` (nothing in `packages/rfdb-server/target/`),
  - *When* a suite that needs the binary starts,
  - *Then* it resolves and uses that binary instead of failing with
    "rfdb-server binary not found".
- **Blast radius:** only `test/` — no production code path touched. The four
  suites are opt-in (not part of `scripts/test.sh`'s `test/unit/*.test.js`
  gate). `findRfdbBinary`/`@grafema/util` unchanged.

## Red → Green test (in the unit gate)

Added `test/unit/RfdbBinaryResolutionSiblings.test.js` — a class-not-instance
regression guard that (a) scans **every** test file for the hardcoded
`target/{release,debug}/rfdb-server` literal and (b) asserts the four suites
reference `findRfdbBinary`. It fails RED before the fix and guards against any
future suite reintroducing the hardcoded path.

```
# before fix
not ok 1 - no test file hardcodes the rfdb-server target/ binary path
    rfdb-federation.test.js contains hardcoded "rfdb-server/target/release/rfdb-server"
    rfdb-federation.test.js contains hardcoded "rfdb-server/target/debug/rfdb-server"
    rfdb-websocket.test.ts  contains hardcoded "rfdb-server/target/debug/rfdb-server"
    rfdb-client.test.js     contains hardcoded "rfdb-server/target/debug/rfdb-server"
    rfdb-request-id.test.js contains hardcoded "rfdb-server/target/debug/rfdb-server"
not ok 2 - rfdb-server suites delegate resolution to findRfdbBinary

# after fix
ok 1 - no test file hardcodes the rfdb-server target/ binary path
ok 2 - rfdb-server suites delegate resolution to findRfdbBinary
```

The behavioral discriminator (env override is honored) is also exercised
end-to-end below and by the existing `TestRFDBBinaryResolution.test.js`.

## Before / After evidence (behavioral, end-to-end)

Binary supplied **only** via `GRAFEMA_RFDB_SERVER`; `packages/rfdb-server/target/`
contains no binary. `rfdb-federation.test.js` has no build fallback, so it
cleanly throws when resolution fails — the sharpest discriminator.

```
# BEFORE (original hardcoded resolution) — env var ignored
$ GRAFEMA_RFDB_SERVER=<prebuilt> node --test test/integration/rfdb-federation.test.js
  error: 'rfdb-server binary not found'      # before hook throws, all subtests cancelled

# AFTER (findRfdbBinary resolution) — env var honored
$ GRAFEMA_RFDB_SERVER=<prebuilt> node --test test/integration/rfdb-federation.test.js
target/release present? no (binary supplied ONLY via env)
# tests 9
# pass 9
# fail 0
```

Other suites with the fix (binary resolvable):
```
rfdb-client + rfdb-request-id : # tests 11 / # pass 11 / # fail 0
rfdb-websocket                : # tests 28 / # pass 28 / # fail 0
```

## Full gate

```
pnpm install --no-frozen-lockfile   OK
pnpm build                          OK (BUILD_EXIT=0)
./scripts/test.sh                   676 pass; new guard ok 32, ok 33
pnpm typecheck                      OK (exit 0)
pnpm lint                           OK (exit 0)
```

The only `scripts/test.sh` failures are 7 pre-existing `GitIngest.test.js`
fixtures, caused by this environment's global `commit.gpgsign=true` + a signing
server returning 400 for synthetic identities (every fixture `git commit`
fails). Reproduced on a throwaway repo independent of this branch; this diff
touches zero GitIngest files. A fix for that hermeticity issue exists on a
separate branch and is out of scope here.

## Adversarial review

- **Round A — correctness:** `findRfdbBinary()` may return `null`; handled in
  every file (federation throws "binary not found"; scenario suites build then
  re-resolve and throw if still missing; websocket skips via `canRunTests()`,
  with a `SERVER_BINARY as string` at the guarded spawn site). The guard
  excludes itself and assembles the forbidden needle from parts so it cannot
  self-match.
- **Round B — structural fragility:** the change removes duplication in favor of
  a single production resolver; the new scan covers all current + future test
  files, so a reintroduced hardcode is caught in the gate. All files < 500 lines.
- **Round C — class-not-instance:** repo-wide search confirms these four were the
  complete remaining set of hardcoded-path siblings. The websocket
  `canRunTests()` now activates when any binary resolves (previously only with a
  `target/debug` build) — verified the suite passes 28/28 once activated, so
  this widens coverage rather than enabling a broken suite. No analysis-pipeline
  invariant touched (test-only change).

## Follow-ups

None required. The regression guard covers the class; no further siblings exist.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vm5PH63ubebxWvUzDsbK1Z)_