### PR TITLE
test(git-ingest): make fixture commits hermetic under global commit signing

### DIFF
--- a/test/unit/GitFixtureSigningHermeticity.test.js
+++ b/test/unit/GitFixtureSigningHermeticity.test.js
@@ -1,0 +1,72 @@
+/**
+ * Regression guard (class-not-instance): every test suite that creates a
+ * throwaway git repo and runs `git commit` in a fixture must disable commit
+ * signing locally (`git config commit.gpgsign false`), so the fixture commits
+ * never invoke the host's gpg/ssh signing program.
+ *
+ * Why this matters:
+ *   - A host with a global `commit.gpgsign=true` (GitHub Verified-badge setups,
+ *     managed CI, the remote-execution environment whose ssh signing program
+ *     returns HTTP 400 for synthetic identities like `alice@test.com`) makes
+ *     EVERY fixture `git commit` fail with "fatal: failed to write commit
+ *     object". In `GitIngest.test.js` this cascaded to 7 failures (2 commit
+ *     errors + 5 cancelled subtests) even though the code under test is
+ *     correct — a pure environment-leak / non-hermeticity bug.
+ *   - The fix is to set `commit.gpgsign false` in the repo's local config
+ *     right after `git init`. This guard encodes that invariant structurally
+ *     so a future fixture cannot silently reintroduce the leak on a host where
+ *     signing happens to be off (where the bug is invisible).
+ *
+ * The discriminating behavior (the suite goes green under global signing) is
+ * proven by running `GitIngest.test.js` itself on a signing-enabled host.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEST_ROOT = join(__dirname, '..');
+
+// Detect a fixture that actually creates commits: an execSync (or similar)
+// invocation of `git commit ...`. Assembled from parts so this guard file does
+// not match its own scan even before the self-skip below.
+const COMMIT_NEEDLE = 'git ' + 'commit';
+const SIGNING_DISABLE_NEEDLE = 'commit.gpgsign false';
+
+/** Recursively collect every *.test.js / *.test.ts file under test/. */
+function collectTestFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...collectTestFiles(full));
+    } else if (/\.test\.(js|ts)$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+test('test fixtures that run `git commit` disable commit signing locally', () => {
+  const selfPath = fileURLToPath(import.meta.url);
+  const offenders = [];
+  for (const file of collectTestFiles(TEST_ROOT)) {
+    if (file === selfPath) continue; // this guard names the pattern in prose
+    const src = readFileSync(file, 'utf8');
+    if (src.includes(COMMIT_NEEDLE) && !src.includes(SIGNING_DISABLE_NEEDLE)) {
+      offenders.push(
+        `${file} runs \`git commit\` in a fixture but never sets ` +
+          '`commit.gpgsign false` — it will fail on hosts with global commit signing.',
+      );
+    }
+  }
+  assert.deepStrictEqual(
+    offenders,
+    [],
+    'git-fixture tests must disable commit signing locally for hermeticity:\n' +
+      offenders.join('\n'),
+  );
+});

--- a/test/unit/GitIngest.test.js
+++ b/test/unit/GitIngest.test.js
@@ -200,6 +200,11 @@ describe('GitIngest', () => {
 
     // Create a test git repo with some commits
     execSync('git init', { cwd: repoDir });
+    // Hermeticity: disable commit signing locally so the fixture commits below
+    // never invoke the host's gpg/ssh signing program. Hosts with a global
+    // `commit.gpgsign=true` (Verified-badge / managed CI setups) would
+    // otherwise fail every `git commit` for these synthetic identities.
+    execSync('git config commit.gpgsign false', { cwd: repoDir });
     execSync('git config user.email "alice@test.com"', { cwd: repoDir });
     execSync('git config user.name "Alice"', { cwd: repoDir });
 
@@ -697,6 +702,9 @@ describe('GitIngest → KnowledgeBase → query round-trip', () => {
 
     // Create test repo with 2 authors
     execSync('git init', { cwd: repoDir });
+    // Hermeticity: disable commit signing locally (see note in the GitIngest
+    // suite above) so fixture commits do not depend on the host signing config.
+    execSync('git config commit.gpgsign false', { cwd: repoDir });
     execSync('git config user.email "alice@test.com"', { cwd: repoDir });
     execSync('git config user.name "Alice"', { cwd: repoDir });
 


### PR DESCRIPTION
## Problem

`test/unit/GitIngest.test.js` creates throwaway git repos in two `before` hooks (`git init` → `git config user.*` → `git commit`) **without disabling local commit signing**. On any host with a global `commit.gpgsign=true` — GitHub Verified-badge setups, managed CI, and the remote-execution environment whose ssh signing program returns HTTP `400` for synthetic identities like `alice@test.com` — every fixture commit fails:

```
Error: signing failed: ... signing server returned status 400
fatal: failed to write commit object
```

This is a pure non-hermeticity / environment-leak bug: the code under test is correct, but the fixtures depend on host signing config.

## SPEC

- **Invariant restored**: GitIngest fixtures are hermetic — they never invoke the host's gpg/ssh signing program, so the suite result depends only on the code under test.
- **Acceptance (BDD)**: *Given* a host with global `commit.gpgsign=true` and a signing program that rejects synthetic identities, *When* the GitIngest suite runs, *Then* all fixture commits succeed and the suite is green.
- **Blast radius**: test-only. Repo-wide scan (`git commit` over `**/*.{js,ts,mjs,cjs}`) shows `GitIngest.test.js` is the **only** file that commits in a fixture — the class is fully contained. The other `git init` string hits are literals in suggestion-message assertions (`DiagnosticReporter`/`GrafemaError`), not git operations.

## Fix

Set `commit.gpgsign false` in the repo-local config right after `git init` in both committing `before` hooks. Format-agnostic (works regardless of `gpg.format`), local-only (does not touch global/host config).

Add `test/unit/GitFixtureSigningHermeticity.test.js` — a class-not-instance regression guard (mirrors the existing `RfdbBinaryResolutionSiblings.test.js` idiom): any test file that runs `git commit` in a fixture must also disable commit signing locally, so the leak cannot be silently reintroduced on a host where signing happens to be off (where the bug is invisible).

## Before / After (actual outputs, this signing-enabled env)

Direct repro:
```
$ cd /tmp/repro && git init -q && git config user.email alice@test.com && echo x>f && git add . && git commit -m initial
Error: signing failed: ... signing server returned status 400 (140-byte body)
fatal: failed to write commit object   # EXIT=128
```

Suite, before:
```
# tests 29 ... # pass 24 # fail 0 # cancelled 5
7 test(s) failed
  FAIL: GitIngest — Command failed: git commit -m "initial commit"
  FAIL: GitIngest → KnowledgeBase → query round-trip — Command failed: git commit -m "init"
  FAIL: full ingest writes YAML files (cancelled)  [+4 cancelled]
```

Suite, after:
```
# tests 29 # pass 29 # fail 0 # cancelled 0
ALL TESTS PASSED
```

## Adversarial review

- **Round A (correctness)**: signing disabled before any commit runs; local-only config; format-agnostic (covers ssh and gpg). The third `git init` (empty-repo test) performs no commit, so it never signs — left untouched intentionally (minimal change).
- **Round B (fragility)**: change is +8 lines of config + comments in an existing 754-line test file; no new coupling. The guard hardens against silent reintroduction.
- **Round C (class-not-instance + gate)**: repo-wide scan confirms `GitIngest.test.js` is the only committing fixture; guard enforces the invariant across all current and future test files. Guard verified red-for-the-right-reason (a temporary offending fixture made it fail with the exact offender message; removed). Full gate: `pnpm build` ✓, full unit suite **682/682** ✓, `pnpm typecheck` ✓, `pnpm lint` ✓.

## Follow-ups

None — the class is contained; no sibling latent instances found.

https://claude.ai/code/session_01BddFi8aFNRCgkeZ3kamATk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BddFi8aFNRCgkeZ3kamATk)_