### PR TITLE
fix(orchestrator): surface silently-ignored --resolve-jobs / --jobs (no more silent no-op)

### DIFF
--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -20,7 +20,7 @@ export const analyzeCommand = new Command('analyze')
   .option('--log-level <level>', 'Set log level (silent, errors, warnings, info, debug)')
   .option('--log-file <path>', 'Write all log output to a file')
   .option('--strict', 'Enable strict mode (fail on unresolved references)')
-  .option('--resolve-jobs <number>', 'Number of parallel resolve workers (default: auto based on CPU and memory)')
+  .option('--resolve-jobs <number>', 'Requested resolve-worker count (resolution currently runs single-worker; a value other than 1 has no effect — a notice is printed)')
   .option('--no-auto-start', 'Do not auto-start RFDB server (require manual start)')
   .option('--quickstart', 'Auto-initialize if no config exists (scan project, generate config)')
   .addHelpText('after', `

--- a/packages/cli/src/commands/resolve.ts
+++ b/packages/cli/src/commands/resolve.ts
@@ -16,7 +16,7 @@ export const resolveCommand = new Command('resolve')
   .option('--debug', 'Enable debug mode')
   .option('--log-level <level>', 'Set log level (silent, errors, warnings, info, debug)')
   .option('--log-file <path>', 'Write all log output to a file')
-  .option('-j, --jobs <number>', 'Number of parallel resolve workers (default: auto)')
+  .option('-j, --jobs <number>', 'Requested resolve-worker count (resolution currently runs single-worker; a value other than 1 has no effect — a notice is printed)')
   .option('--no-auto-start', 'Do not auto-start RFDB server (require manual start)')
   .addHelpText('after', `
 Examples:

--- a/packages/grafema-orchestrator/src/main.rs
+++ b/packages/grafema-orchestrator/src/main.rs
@@ -50,7 +50,9 @@ enum Commands {
         #[arg(long)]
         force: bool,
 
-        /// Number of parallel resolve workers (overrides auto-detection)
+        /// Requested resolve-worker count. NOTE: resolution currently runs
+        /// single-worker (per-file streaming); a value other than 1 has no
+        /// effect and a notice is printed.
         #[arg(long)]
         resolve_jobs: Option<usize>,
     },
@@ -62,7 +64,9 @@ enum Commands {
         /// Path to RFDB unix socket
         #[arg(short, long)]
         socket: Option<PathBuf>,
-        /// Number of parallel resolve workers (default: auto based on CPU count)
+        /// Requested resolve-worker count. NOTE: resolution currently runs
+        /// single-worker (per-file streaming); a value other than 1 has no
+        /// effect and a notice is printed.
         #[arg(short, long)]
         jobs: Option<usize>,
     },
@@ -181,6 +185,23 @@ fn resolve_worker_count() -> usize {
         );
     }
     count
+}
+
+/// Build a user-facing notice when an explicit resolve-worker count is requested
+/// that the orchestrator cannot honor. Resolution currently runs single-worker
+/// (per-file streaming), so any request other than 1 worker is a no-op today.
+/// Surfacing it stops `--resolve-jobs` / `--jobs` from being silently ignored and
+/// misleading the user about its effect (REG-563: surface silent skips).
+///
+/// Returns `Some(message)` when `requested` is `Some(n)` with `n != 1`, else `None`.
+fn resolve_jobs_notice(flag: &str, requested: Option<usize>) -> Option<String> {
+    match requested {
+        Some(n) if n != 1 => Some(format!(
+            "{flag}={n} has no effect: resolution currently runs single-worker \
+             (per-file streaming); proceeding with 1 worker."
+        )),
+        _ => None,
+    }
 }
 
 /// Detect available system memory in GB.
@@ -347,8 +368,11 @@ async fn main() -> Result<()> {
             socket,
             jobs,
             force,
-            resolve_jobs: _resolve_jobs,
+            resolve_jobs,
         } => {
+            if let Some(msg) = resolve_jobs_notice("--resolve-jobs", resolve_jobs) {
+                tracing::warn!("{msg}");
+            }
             let cfg = config::load(&config_path)?.with_defaults();
 
             // Resolve RFDB socket path: CLI flag > config > default
@@ -1893,8 +1917,11 @@ async fn main() -> Result<()> {
         Commands::Resolve {
             config: config_path,
             socket,
-            jobs: _jobs,
+            jobs,
         } => {
+            if let Some(msg) = resolve_jobs_notice("--jobs", jobs) {
+                tracing::warn!("{msg}");
+            }
             let cfg = config::load(&config_path)?.with_defaults();
 
             // Resolve RFDB socket path: CLI flag > config > default
@@ -2895,5 +2922,27 @@ mod tests {
     #[test]
     fn test_parse_git_remote_invalid() {
         assert_eq!(parse_git_remote_authority("not-a-url"), None);
+    }
+
+    #[test]
+    fn resolve_jobs_notice_silent_for_default_and_single_worker() {
+        // Unset or exactly 1 worker matches reality → no notice (no false alarm).
+        assert!(resolve_jobs_notice("--resolve-jobs", None).is_none());
+        assert!(resolve_jobs_notice("--resolve-jobs", Some(1)).is_none());
+    }
+
+    #[test]
+    fn resolve_jobs_notice_surfaces_unhonored_request() {
+        // n > 1 is silently a no-op today → must be surfaced, naming the flag,
+        // the requested value, and that it runs single-worker.
+        let msg = resolve_jobs_notice("--resolve-jobs", Some(8)).expect("n>1 surfaced");
+        assert!(msg.contains("--resolve-jobs"), "names the flag: {msg}");
+        assert!(msg.contains('8'), "echoes the requested value: {msg}");
+        assert!(msg.contains("single-worker"), "states actual behavior: {msg}");
+
+        // 0 is also a non-unit request → surfaced, not silently swallowed.
+        assert!(resolve_jobs_notice("--jobs", Some(0)).is_some());
+        // The flag name is threaded through (resolve subcommand uses --jobs).
+        assert!(resolve_jobs_notice("--jobs", Some(4)).unwrap().contains("--jobs"));
     }
 }


### PR DESCRIPTION
## Problem

`--resolve-jobs` (on `analyze`) and `--jobs` (on `resolve`) are exposed end-to-end and **documented as "Number of parallel resolve workers (default: auto based on CPU and memory)"**, but the orchestrator **silently discards them**:

- `packages/cli/src/commands/analyze.ts:23` defines `--resolve-jobs`; `analyzeAction.ts:361` passes it to the binary; `docs/cli-reference.md` advertises it.
- The orchestrator parses then drops it: `main.rs:350` `resolve_jobs: _resolve_jobs`, and `main.rs:1896` `jobs: _jobs`. Resolution runs **single-worker** (per-file streaming); there is no auto-detection and the flag has **no effect**.

A user running `grafema analyze --resolve-jobs 8` expecting parallelism gets one worker and **no warning** — a confidently-wrong, user-facing no-op. This is exactly the "surface all silent skips" gap tracked in REG-563.

(Root cause = **defect (3)** of the Enox node *"Grafema JS-resolve wedge … three independent defects in grafema-orchestrator/src"*; defect (1) was fixed in #286.)

## Spec

- **Invariant:** the orchestrator must not silently ignore an explicit resolve-worker request. **Given** `--resolve-jobs N` / `--jobs N` with `N != 1`, **when** the command runs, **then** it prints a clear notice that resolution is single-worker and the flag has no effect, and proceeds with 1 worker. **Given** the flag is unset or `N == 1`, **then** no notice (no false alarm).
- **Class, not instance:** fixed **both** discarded flags. The `analyze --jobs` flag (analysis-phase workers, `main.rs:369/428/744`) is genuinely consumed — not part of this defect.
- **Blast radius:** orchestrator `Commands::Analyze` + `Commands::Resolve` arms; cli `.option()` help text for the two flags. No behavior change beyond the new warning; the dead `resolve_worker_count()` is intentionally left intact (kept for future multi-worker resolve — out of scope).

## Change

- Add pure `resolve_jobs_notice(flag, requested) -> Option<String>` (returns a message iff `requested == Some(n)` with `n != 1`).
- Emit it via `tracing::warn!` in both arms, before any work.
- Make the two `#[arg]` help docs and the two cli `.option()` descriptions honest (string-only edits).

## Before / After (actual output)

```
$ grafema-orchestrator analyze --config … --resolve-jobs 8
WARN grafema_orchestrator: --resolve-jobs=8 has no effect: resolution currently runs single-worker (per-file streaming); proceeding with 1 worker.

$ grafema-orchestrator resolve  --config … --jobs 4
WARN grafema_orchestrator: --jobs=4 has no effect: resolution currently runs single-worker (per-file streaming); proceeding with 1 worker.

$ grafema-orchestrator analyze --config … --resolve-jobs 1      # matches reality
(no notice)
```
Visible at the default log level (no `RUST_LOG` needed) — same mechanism as the existing oversized-file skip warnings.

## Verification

- `cargo build` — clean (only a pre-existing unrelated `unused_assignments` warning).
- `cargo test` — `414` lib + `6` bin (incl. 2 new `resolve_jobs_notice` tests) + `14` integration (1 pre-existing ignore) all pass.
- `cargo clippy --bin grafema-orchestrator` — **0 errors**, none cite the new code.
- TS: 2 description-string edits, `npx eslint` clean, type-neutral (string literals in existing `.option()` positions).
- **Pre-existing failure proven, not mine:** `cargo test --doc` fails on `src/profiler.rs` doctest (line 9, `Profiler` not imported). Reproduced on clean HEAD with this change stashed — unrelated to this PR (see follow-ups).

## Adversarial review

- **Round A (correctness):** `None`→none, `Some(1)`→none, `Some(0)`→surfaced (non-unit, not silently swallowed), `Some(>1)`→surfaced; flag name threaded through; large `usize` formats fine. All in `resolve_jobs_notice_*` tests.
- **Round B (structural):** `main.rs` is a pre-existing god-file; additions are one small pure fn + two 3-line call sites sharing it (single source, no duplication).
- **Round C (class):** both discarded resolve-worker flags fixed; `analyze --jobs` verified as legitimately used (not a defect).

## Follow-ups (not in this PR)
- Fix the broken `src/profiler.rs` doctest (`Profiler` unimported) — pre-existing `cargo test --doc` red.
- Defect (2) of the same Enox node: no progress-telemetry profiler event in the resolve loop (blocked behind #286 which restructures `resolve_per_file`).
- If/when multi-worker resolve lands (memory-gated, ~5GB/worker), wire `resolve_jobs` to `resolve_worker_count()` and drop the notice.

Related: #286 (defect 1, durability), REG-563 (surface silent skips), REG-1138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)