### PR TITLE
docs(changelog): record merged fix #286 (REG-1138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - fix(rust-analyzer): unwrap `Box`/`Rc`/`Arc` receiver types so `Box<dyn Trait>` resolves to the inner trait, restoring dyn-dispatch CALLS edges that were previously dropped (#273)
 - fix(orchestrator): index exported `namespace` declarations so `export namespace X {}` resolves cross-file and gets an IMPORTS_FROM edge — keeps `INDEX_NODE_TYPES` in sync with the resolver's exported-declaration list (REG-1139, #277)
 - fix(cypher): route only real aggregates (COUNT/SUM/AVG/MIN/MAX) through HashAggregate — a scalar function in `RETURN` (e.g. `toUpper(n.name)`) now fails loudly at plan time instead of being mislabeled as an aggregate and erroring at execution (RFD-70 follow-up, #282)
+- fix(orchestrator): checkpoint JS/TS resolve every 500 files instead of a single end-of-phase commit, so a crash or SIGTERM mid-resolve loses at most ~500 files of work rather than the entire (multi-hour on large monorepos) resolution phase (REG-1138, #286)
 
 ## [0.3.23] - 2026-04-01
 


### PR DESCRIPTION
Adds an `[Unreleased]` > Bug Fixes entry for #286 (mid-phase resolve checkpointing):

- orchestrator: checkpoint JS/TS resolve every 500 files so a mid-resolve crash/SIGTERM loses ≤500 files instead of the whole phase (REG-1138)

Documentation-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)