### PR TITLE
fix(rust): repair broken library doctests (green cargo test --doc)

### DIFF
--- a/packages/grafema-orchestrator/src/profiler.rs
+++ b/packages/grafema-orchestrator/src/profiler.rs
@@ -7,10 +7,15 @@
 //!
 //! Usage:
 //! ```no_run
+//! use grafema_orchestrator::profiler::Profiler;
+//!
+//! # fn main() -> std::io::Result<()> {
 //! let profiler = Profiler::new(".grafema/analysis-profile.jsonl")?;
 //! profiler.event("phase_start", &[("phase", "js_analysis"), ("files", "204")]);
 //! // ... do work ...
 //! profiler.event("phase_end", &[("phase", "js_analysis"), ("nodes", "45000")]);
+//! # Ok(())
+//! # }
 //! ```
 
 use std::fs::{File, OpenOptions};

--- a/packages/rfdb-server/src/container_hierarchy.rs
+++ b/packages/rfdb-server/src/container_hierarchy.rs
@@ -6,7 +6,7 @@
 //!
 //! # Example
 //!
-//! ```
+//! ```no_run
 //! use rfdb::container_hierarchy::{HierarchyLevel, ContainerRule, ContainerTree};
 //!
 //! let hierarchy = vec![
@@ -18,8 +18,9 @@
 //!     ])),
 //! ];
 //!
-//! let tree = ContainerTree::build(&hierarchy, &nodes, &edges);
-//! let region = tree.sa_region(node_idx);
+//! // `nodes` / `edges` come from your graph; empty slices here for illustration.
+//! let tree = ContainerTree::build(&hierarchy, &[], &[]);
+//! let _region = tree.sa_region(0);
 //! ```
 
 use std::collections::HashMap;


### PR DESCRIPTION
## Problem

`cargo test --doc` was **red in both Rust crates** — two library doc examples failed to compile:

- `packages/grafema-orchestrator/src/profiler.rs:9` — `error[E0433]: cannot find type \`Profiler\`` (example used `Profiler` without importing it, and `?` outside a `Result` fn).
- `packages/rfdb-server/src/container_hierarchy.rs:9` — `error[E0425]: cannot find value \`nodes\`/\`edges\`/\`node_idx\`` (the example referenced variables it never defined).

**Severity: low.** CI (`.github/workflows/ci.yml`) runs only the JS/TS suite (`pnpm test:coverage`), so Rust doctests are not CI-gated. But these snippets are the project's **AI-facing API examples** (CLAUDE.md: "Every function must be documented for LLM-based agents") — a non-compiling example misleads any agent or human who copies it, and `cargo test --doc` should be green for anyone running Rust tests locally.

## Fix

- **profiler.rs:** add `use grafema_orchestrator::profiler::Profiler;` and wrap in a hidden `# fn main() -> std::io::Result<()> { … # Ok(()) # }` so `?` has a `Result` context. Kept `no_run`.
- **container_hierarchy.rs:** pass empty slices and index `0` (`ContainerTree::build(&hierarchy, &[], &[])`, `sa_region(0)`), and mark the fence `no_run` (illustrative example — compile-checked, not executed, so no panic risk from empty inputs). The signature is `build(&[HierarchyLevel], &[NodeRef], &[EdgeRef])`, so `&[]` coerces without naming the element types.

Doc-comment-only changes; **no executable code touched.**

## Before / After (actual `cargo test --doc`)

Before (clean HEAD):
```
test src/profiler.rs - profiler (line 9) - compile ... FAILED        # E0433
test src/container_hierarchy.rs - container_hierarchy (line 9) ... FAILED   # E0425
```
After:
```
# grafema-orchestrator
test src/profiler.rs - profiler (line 9) - compile ... ok
test result: ok. 1 passed; 0 failed; 0 ignored

# rfdb-server
test src/container_hierarchy.rs - container_hierarchy (line 9) - compile ... ok
test result: ok. 11 passed; 0 failed; 3 ignored
```

## Adversarial review

- **Round A (correctness):** both examples compile; imports/types resolve; `?` has a `Result` context; `no_run` avoids executing illustrative code. Verified by the passing doctest runs above.
- **Round B (structural):** doc-comment-only; zero impact on compiled code or the JS workspace.
- **Round C (class):** the repo has exactly two Rust crates (`grafema-orchestrator`, `rfdb-server`); I ran `cargo test --doc` across **both** and across every other Rust crate (none) — these were the only two broken doctests. The class is fully closed.

Discovered while verifying #287 (the profiler doctest reproduced on clean HEAD there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)