### PR TITLE
fix(util): parse v2 semantic IDs whose in: namedParent contains "->"

### DIFF
--- a/packages/util/src/core/SemanticId.ts
+++ b/packages/util/src/core/SemanticId.ts
@@ -354,10 +354,6 @@ export function parseSemanticIdV2(id: string): ParsedSemanticIdV2 | null {
   const type = id.slice(firstArrow + 2, secondArrow);
   let rest = id.slice(secondArrow + 2);
 
-  // Check this isn't a v1 ID (v1 has 4+ parts, meaning rest contains '->')
-  // v2 names don't contain '->' in practice
-  if (rest.includes('->')) return null;
-
   // Parse counter suffix: #N (only at the very end, after brackets)
   let counter: number | undefined;
   const counterMatch = rest.match(/#(\d+)$/);
@@ -366,14 +362,26 @@ export function parseSemanticIdV2(id: string): ParsedSemanticIdV2 | null {
     rest = rest.slice(0, -counterMatch[0].length);
   }
 
+  // Locate the optional bracket payload: [in:namedParent,h:xxxx].
+  const bracketStart = rest.indexOf('[');
+  const bracketEnd = rest.lastIndexOf(']');
+  const hasBracket = bracketStart !== -1 && bracketEnd === rest.length - 1;
+
+  // Reject genuine v1 IDs (file->scope->TYPE->name): they carry extra '->'
+  // delimiters in the NAME region. Only the name region is inspected — the v2
+  // `in:` namedParent value is opaque and MAY legitimately contain '->' (the
+  // native Rust analyzer stores a full `file->FUNCTION->name` parent id there,
+  // see grafema-orchestrator/src/rust_analyzer.rs enclosing_fn). The old guard
+  // checked the whole remainder including the bracket and false-rejected these.
+  const nameRegion = hasBracket ? rest.slice(0, bracketStart) : rest;
+  if (nameRegion.includes('->')) return null;
+
   // Parse bracket content: [in:parent,h:xxxx]
   let namedParent: string | undefined;
   let contentHash: string | undefined;
   let name = rest;
 
-  const bracketStart = rest.indexOf('[');
-  const bracketEnd = rest.lastIndexOf(']');
-  if (bracketStart !== -1 && bracketEnd === rest.length - 1) {
+  if (hasBracket) {
     name = rest.slice(0, bracketStart);
     const bracketContent = rest.slice(bracketStart + 1, bracketEnd);
 

--- a/test/unit/SemanticIdV2NestedParent.test.js
+++ b/test/unit/SemanticIdV2NestedParent.test.js
@@ -1,0 +1,81 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { parseSemanticIdV2, computeSemanticIdV2 } from '@grafema/util';
+
+/**
+ * Regression: parseSemanticIdV2 must accept v2 IDs whose `in:` namedParent value
+ * itself contains '->'.
+ *
+ * The native Rust analyzer (packages/grafema-orchestrator/src/rust_analyzer.rs)
+ * stores the FULL enclosing-function semantic ID in the `in:` bracket
+ * (ctx.enclosing_fn = a `file->FUNCTION->name` node id), so every nested CALL /
+ * REFERENCE / PROPERTY_ACCESS / LITERAL node id looks like:
+ *
+ *   src/lib.rs->CALL->target_fn[in:src/lib.rs->FUNCTION->caller_fn,h:68e1]
+ *
+ * The old v1-rejection guard (`if (rest.includes('->')) return null`) inspected
+ * the ENTIRE remainder including the bracket content, so it false-rejected these
+ * legitimate v2 IDs and returned null — silently disabling every downstream
+ * consumer (matchesScope / extractScopeContext / FederatedRouter fallback /
+ * trace scope filter) for nested native-analyzer nodes.
+ *
+ * The guard must only reject a v1 NAME region (file->scope->TYPE->name); the v2
+ * `in:` value is opaque and may contain '->'.
+ */
+describe('parseSemanticIdV2 — namedParent containing "->" (native Rust analyzer shape)', () => {
+  it('parses a nested CALL whose in: value is a full parent semantic ID', () => {
+    const id = 'src/lib.rs->CALL->target_fn[in:src/lib.rs->FUNCTION->caller_fn,h:68e1]';
+    const parsed = parseSemanticIdV2(id);
+    assert.ok(parsed, 'expected a parse result, got null');
+    assert.equal(parsed.file, 'src/lib.rs');
+    assert.equal(parsed.type, 'CALL');
+    assert.equal(parsed.name, 'target_fn');
+    assert.equal(parsed.namedParent, 'src/lib.rs->FUNCTION->caller_fn');
+    assert.equal(parsed.contentHash, '68e1');
+  });
+
+  it('parses the grafema:// URI form of the same nested CALL', () => {
+    // Fragment encodes '->' as '-%3E', '[' as '%5B', ']' as '%5D'.
+    const uri =
+      'grafema://localhost/grafema/src/lib.rs#CALL-%3Etarget_fn%5Bin:src/lib.rs-%3EFUNCTION-%3Ecaller_fn,h:68e1%5D';
+    const parsed = parseSemanticIdV2(uri);
+    assert.ok(parsed, 'expected a parse result for URI form, got null');
+    assert.equal(parsed.file, 'src/lib.rs');
+    assert.equal(parsed.type, 'CALL');
+    assert.equal(parsed.name, 'target_fn');
+    assert.equal(parsed.namedParent, 'src/lib.rs->FUNCTION->caller_fn');
+    assert.equal(parsed.contentHash, '68e1');
+  });
+
+  it('parses a nested CALL with a trailing counter suffix', () => {
+    const id = 'src/lib.rs->CALL->target_fn[in:src/lib.rs->FUNCTION->caller_fn,h:68e1]#2';
+    const parsed = parseSemanticIdV2(id);
+    assert.ok(parsed, 'expected a parse result, got null');
+    assert.equal(parsed.name, 'target_fn');
+    assert.equal(parsed.namedParent, 'src/lib.rs->FUNCTION->caller_fn');
+    assert.equal(parsed.contentHash, '68e1');
+    assert.equal(parsed.counter, 2);
+  });
+
+  it('round-trips computeSemanticIdV2 with a full-path namedParent', () => {
+    const parent = 'src/lib.rs->FUNCTION->caller_fn';
+    const id = computeSemanticIdV2('CALL', 'target_fn', 'src/lib.rs', parent, 'abcd');
+    const parsed = parseSemanticIdV2(id);
+    assert.ok(parsed, 'expected encode→parse to round-trip, got null');
+    assert.equal(parsed.namedParent, parent);
+    assert.equal(parsed.name, 'target_fn');
+  });
+
+  it('still rejects genuine v1 IDs (extra "->" in the NAME region)', () => {
+    // v1 shape: file->scope->TYPE->name — the remainder name region has '->'.
+    assert.equal(parseSemanticIdV2('src/lib.rs->myScope->FUNCTION->foo'), null);
+    assert.equal(parseSemanticIdV2('src/lib.rs->s1->s2->CALL->foo'), null);
+  });
+
+  it('preserves existing bare-name in: behavior', () => {
+    const parsed = parseSemanticIdV2('src/app.js->CALL->foo[in:bar]');
+    assert.ok(parsed);
+    assert.equal(parsed.namedParent, 'bar');
+    assert.equal(parsed.name, 'foo');
+  });
+});


### PR DESCRIPTION
## Problem

`parseSemanticIdV2` (`packages/util/src/core/SemanticId.ts`) **silently returns `null`** for every v2 semantic ID whose `in:` namedParent value contains `->`.

The v1-rejection guard inspected the **entire** remainder, including the bracket payload:

```ts
let rest = id.slice(secondArrow + 2);   // e.g. target_fn[in:src/lib.rs->FUNCTION->caller_fn,h:68e1]
if (rest.includes('->')) return null;   // ← false-rejects: the '->' is inside in:, not the name
```

The **native Rust analyzer** stores the *full enclosing-function semantic ID* in `in:` — `ctx.enclosing_fn` is a `file->FUNCTION->name` node id (`packages/grafema-orchestrator/src/rust_analyzer.rs:92,528,571`), threaded into every nested `CALL` / `REFERENCE` / `PROPERTY_ACCESS` / `LITERAL` id (`rust_analyzer.rs:1136-1180,1295,1335`). So a call nested in a function produces:

```
src/lib.rs->CALL->target_fn[in:src/lib.rs->FUNCTION->caller_fn,h:68e1]
```

`rest.includes('->')` is `true` → the parser returns `null`, silently disabling every downstream consumer for these nodes:

- `matchesScope` (`packages/cli/src/commands/query.ts:439`) — file-scope filtering
- `extractScopeContext` (`query.ts:520`)
- `trace` scope filter (`packages/cli/src/commands/trace.ts:246`)
- the `FederatedRouter` URI fallback (which delegates to `parseSemanticIdV2`)

## Spec

- **Invariant restored:** the v2 parser must decode any ID the v2 encoder can produce. **Given** a v2 ID `file->TYPE->name[in:P,h:H]#N` where the namedParent `P` itself contains `->`, **when** parsed, **then** it returns `{file, type, name, namedParent: P, contentHash: H, counter: N}`. **Given** a genuine v1 ID (`file->scope->TYPE->name`, extra `->` in the **name region**), **then** it still returns `null`.
- **Mechanism:** strip the `#N` counter, locate the optional `[...]` bracket once, and run the v1-rejection guard against the **name region only** (`rest` before the bracket). The `in:` value is opaque and may legitimately contain `->`.
- **Blast radius:** the four consumers above previously got `null` for nested native-analyzer ids (then fell through to a v1 parse that also failed) → now they parse. Strictly improving; no JS/TS-analyzer ids change (those use bare `in:` names). The URI parser is fixed transitively (it delegates to `parseSemanticIdV2`).

## Before / After (live, same compiled module)

```
# BEFORE
compact  -> null
uri      -> null
bareName -> {"file":"src/app.js","type":"CALL","name":"foo","namedParent":"bar"}

# AFTER
compact  -> {"file":"src/lib.rs","type":"CALL","name":"target_fn","namedParent":"src/lib.rs->FUNCTION->caller_fn","contentHash":"68e1"}
uri      -> {"file":"src/lib.rs","type":"CALL","name":"target_fn","namedParent":"src/lib.rs->FUNCTION->caller_fn","contentHash":"68e1"}
counter  -> {... ,"contentHash":"68e1","counter":2}
bareName -> {"file":"src/app.js","type":"CALL","name":"foo","namedParent":"bar"}
v1 rej   -> null      # src/lib.rs->myScope->FUNCTION->foo
v1 rej2  -> null      # src/lib.rs->s1->s2->CALL->foo
```

## Tests

New `test/unit/SemanticIdV2NestedParent.test.js` (6 cases): compact nested CALL, `grafema://` URI form, trailing counter, `computeSemanticIdV2` round-trip, v1 rejection preserved, bare-name `in:` regression. The compact + URI cases are red-for-the-right-reason on HEAD (assert a parse, get `null`).

## Adversarial review

- **Round A — correctness:** edge cases verified live — empty input (`null`), bracket-without-`in:`, counter-without-bracket, malformed/unclosed bracket (`hasBracket` guards it, behavior unchanged), and `->` in the name region with a trailing bracket (still rejected). Counter is stripped before bracket detection so `bracketEnd === rest.length - 1` holds.
- **Round B — structural:** file is **431 lines** (< 500). Change is localized to one function and **removes** duplication — `bracketStart`/`bracketEnd` are now computed once and shared by the guard and the bracket parse.
- **Round C — class-not-instance:** the only over-aggressive `.includes('->')` guard in `packages/util/src` + `packages/cli/src` is the one fixed (grep-verified); the URI parser delegates to `parseSemanticIdV2` so the class is closed transitively.

## Verification (actual)

- `pnpm build` — exit 0
- `./scripts/test.sh SemanticIdV2NestedParent.test.js` — **6/6 pass**
- `./scripts/test.sh` (full) — **688/688 pass**, 0 fail (incl. existing `GrafemaUri` + `RFDBServerBackend.semanticId` — no regression)
- `pnpm typecheck` — exit 0
- `pnpm lint` — exit 0

## Follow-up (out of scope — needs an owner decision)

The native Rust analyzer stores a **full parent path** in `in:` (`src/lib.rs->FUNCTION->caller_fn`) whereas the v2 spec examples (`SemanticId.ts:76`, analyzer tests) use a **bare name** (`in:bar`). With the parser fixed, `extractScopeContext` now surfaces that full path verbatim (e.g. `inside src/lib.rs->FUNCTION->caller_fn`) for Rust nodes — previously it showed nothing. The parser fix is correct regardless; whether the analyzer should emit a bare name (or consumers should shorten it) is a separate analyzer/spec decision. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ra7ENb5ArZ7Vp8fyKbQss1)_