### PR TITLE
fix(cli): `who` attributes calls to the enclosing function, not <anonymous>

### DIFF
--- a/packages/cli/src/commands/who.ts
+++ b/packages/cli/src/commands/who.ts
@@ -11,7 +11,7 @@
 import { Command } from 'commander';
 import { resolve, join, isAbsolute, relative } from 'path';
 import { existsSync } from 'fs';
-import { RFDBServerBackend } from '@grafema/util';
+import { RFDBServerBackend, parseSemanticIdV2 } from '@grafema/util';
 import { exitWithError } from '../utils/errorFormatter.js';
 import { Spinner } from '../utils/spinner.js';
 
@@ -88,17 +88,12 @@ Examples:
         const edges = await backend.getOutgoingEdges(node.id, ['CALLS']);
         const resolved = edges.length > 0;
 
-        // Extract caller name from semantic ID
-        // Format: "file->SCOPE->TYPE->name" — parent scope is the caller
-        const idParts = node.id.split('->');
-        let callerName = '<anonymous>';
-        // Walk up the scope chain to find a FUNCTION or METHOD parent
-        for (let i = idParts.length - 3; i >= 1; i--) {
-          if (idParts[i] === 'FUNCTION' || idParts[i] === 'METHOD') {
-            callerName = idParts[i + 1] || callerName;
-            break;
-          }
-        }
+        // Extract the enclosing function/method from the v2 semantic ID's
+        // `[in:<parent>]` annotation, e.g. `…#CALL->helper[in:caller,h:5e14]`
+        // (parseSemanticIdV2 also decodes the `grafema://` URI form). The old
+        // `->`-split walk targeted the v1 id shape and never matched v2 ids, so
+        // every caller printed as `<anonymous>`.
+        const callerName = parseSemanticIdV2(node.id)?.namedParent || '<anonymous>';
 
         const file = node.file || '';
 
@@ -127,7 +122,10 @@ Examples:
       }
 
       if (funcNode) {
-        const incomingEdges = await backend.getIncomingEdges(funcNode.id, ['CALLS', 'READS_FROM', 'IMPORTS_FROM']);
+        // CALLS / READS_FROM are real uses-as-caller. IMPORTS_FROM is an import,
+        // not a caller — importers are reported separately (Strategy 3, labelled
+        // "imports …"); including them here mislabelled the import as a bare caller.
+        const incomingEdges = await backend.getIncomingEdges(funcNode.id, ['CALLS', 'READS_FROM']);
         for (const edge of incomingEdges) {
           const srcNode = await backend.getNode(edge.src);
           if (!srcNode) continue;

--- a/packages/cli/test/who-caller-attribution.test.ts
+++ b/packages/cli/test/who-caller-attribution.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for `grafema who` caller attribution.
+ *
+ * Two bugs (found by dogfooding, fixed together):
+ *
+ * 1. `<anonymous>` caller — `who.ts` extracted the enclosing function from the
+ *    CALL node's semantic ID by splitting on `->` and looking for a `FUNCTION`/
+ *    `METHOD` segment (the OLD v1 id shape). Current ids are v2 URIs of the form
+ *    `grafema://…/file#CALL->name[in:enclosingFn,h:xxxx]`, so the walk never
+ *    matched and every caller printed as `<anonymous>`. Fixed by parsing the v2
+ *    `[in:…]` annotation via `parseSemanticIdV2`.
+ *
+ * 2. import-as-caller — Strategy 2 listed `IMPORTS_FROM` incoming edges as
+ *    callers, so the `import { helper }` line was reported as a bare caller
+ *    named `helper`. Imports are uses, not callers; they are reported separately
+ *    (Strategy 3, labelled `imports …`), so `IMPORTS_FROM` was dropped here.
+ *
+ * Pattern matches impact-polymorphic-callers.test.ts (real analyze, assert stdout).
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, dirname } from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const cliPath = join(__dirname, '../dist/cli.js');
+
+function runCli(args: string[], cwd: string): { stdout: string; stderr: string; status: number | null } {
+  const result = spawnSync('node', [cliPath, ...args], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, NO_COLOR: '1' },
+  });
+  return { stdout: result.stdout || '', stderr: result.stderr || '', status: result.status };
+}
+
+describe('grafema who: caller attribution', { timeout: 60000 }, () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'gfm-who-'));
+    const srcDir = join(tempDir, 'src');
+    mkdirSync(srcDir);
+    writeFileSync(join(tempDir, 'package.json'),
+      JSON.stringify({ name: 'who-test', version: '1.0.0', main: 'src/main.js' }));
+    writeFileSync(join(srcDir, 'lib.js'), `export function helper(x) {\n  return x * 2;\n}\n`);
+    writeFileSync(join(srcDir, 'main.js'),
+      `import { helper } from './lib.js';\n\nfunction caller() {\n  return helper(21);\n}\n\nexport function topLevel() {\n  return caller();\n}\n`);
+
+    const init = runCli(['init'], tempDir);
+    assert.strictEqual(init.status, 0, `init failed: ${init.stderr}`);
+    const analyze = runCli(['analyze'], tempDir);
+    assert.strictEqual(analyze.status, 0, `analyze failed: ${analyze.stderr}`);
+  });
+
+  afterEach(() => {
+    if (tempDir && existsSync(tempDir)) {
+      runCli(['server', 'stop'], tempDir);
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('attributes a call to its enclosing named function, not <anonymous>', () => {
+    // helper() is called inside function caller() at main.js:4
+    const out = runCli(['who', 'helper'], tempDir).stdout;
+    assert.match(out, /\bcaller\b/, `who helper should name the enclosing function 'caller':\n${out}`);
+    // The helper call site must NOT be reported as <anonymous>.
+    assert.ok(
+      !/main\.js:4\s+<anonymous>/.test(out),
+      `helper's call site should be attributed to 'caller', not <anonymous>:\n${out}`
+    );
+  });
+
+  it('attributes a nested named caller (topLevel calls caller)', () => {
+    // caller() is called inside function topLevel() at main.js:8
+    const out = runCli(['who', 'caller'], tempDir).stdout;
+    assert.match(out, /\btopLevel\b/, `who caller should name the enclosing function 'topLevel':\n${out}`);
+    assert.ok(
+      !/main\.js:8\s+<anonymous>/.test(out),
+      `caller's call site should be attributed to 'topLevel', not <anonymous>:\n${out}`
+    );
+  });
+
+  it('does not report the import statement as a bare caller of the symbol', () => {
+    // `import { helper }` at main.js:1 is a use, not a caller. If listed at all
+    // it must be labelled as an import (Strategy 3), never as a plain caller.
+    const out = runCli(['who', 'helper'], tempDir).stdout;
+    assert.ok(
+      !/main\.js:1\s+helper\b/.test(out),
+      `the import line should not be reported as a bare caller named 'helper':\n${out}`
+    );
+  });
+});


### PR DESCRIPTION
## Problem (found by dogfooding the live graph)

`grafema who <symbol>` — a core AI-facing command ("who uses this?") — printed **every caller as `<anonymous>`** and listed **import statements as bare callers**.

Live repro (2-file fixture, fresh `grafema analyze`):
```
$ grafema who helper
helper — 2 callers
  src/main.js:4   <anonymous>   [resolved]     ← call is inside function caller()
  src/main.js:1   helper        [resolved]     ← this is the `import { helper }` line
```

## Root cause

Two bugs in `packages/cli/src/commands/who.ts`:

1. **`<anonymous>` caller** — Strategy 1 derived the enclosing function by splitting the CALL node's semantic id on `->` and scanning for a `FUNCTION`/`METHOD` segment (the **v1** id shape, who.ts:91-101). Current ids are **v2 URIs**:
   ```
   grafema://localhost/p/src/main.js#CALL->helper[in:caller,h:5e14]
   ```
   The enclosing function is the `[in:…]` annotation, so the `->`-walk never matched → always `<anonymous>`.

2. **import-as-caller** — Strategy 2 included `IMPORTS_FROM` among the "caller" edge types (who.ts:130), so `import { helper }` was reported as a bare caller named `helper`. An import is a *use*, not a caller, and is already reported separately by Strategy 3 (labelled `imports …`).

## Fix

1. Use the canonical `parseSemanticIdV2(node.id)?.namedParent` (from `@grafema/util`, SemanticId.ts:283) — it parses the `[in:parent]` annotation and decodes the `grafema://` URI form. Null-safe → top-level calls correctly fall back to `<anonymous>`.
2. Drop `IMPORTS_FROM` from Strategy 2's incoming-edge types (`['CALLS','READS_FROM']`); imports stay handled by Strategy 3.

Doc-comment-only context added; **no analyzer/graph change** — the `[in:caller]` data was already in the id.

## Spec

- **Given** a call inside `function caller()`, **when** `who helper`, **then** the caller is `caller`.
- **Given** `import { helper }`, **when** `who helper`, **then** it is labelled `imports helper`, not a bare caller.

## Before / After (actual live output)

```
# Before
$ grafema who helper
  src/main.js:4   <anonymous>      [resolved]
  src/main.js:1   helper           [resolved]
$ grafema who caller
  src/main.js:8   <anonymous>      [resolved]

# After
$ grafema who helper
  src/main.js:4   caller           [resolved]
  src/main.js:1   imports helper   [resolved]
$ grafema who caller
  src/main.js:8   topLevel         [resolved]
```

## Tests / verification (actual outputs)

New behavioral test `packages/cli/test/who-caller-attribution.test.ts` (analyze a fixture → run `who` → assert), mirroring `impact-polymorphic-callers.test.ts`:
```
# Before fix:  not ok (shows <anonymous>)   # red for the right reason
# After fix:   # tests 3  # pass 3  # fail 0
```
`pnpm --filter @grafema/cli build` (tsc) clean; `eslint who.ts` 0 errors.

## Adversarial review
- **A (correctness):** `parseSemanticIdV2` is null-safe → top-level calls (no `[in:]`) → `<anonymous>` (correct); methods/nested functions covered by `namedParent`.
- **B (structural):** minimal; replaces a hand-rolled parser with the canonical one; who.ts stays 215 lines.
- **C (class):** the v1 id-string parse was **unique to who.ts**; `impact`/`context` resolve callers via graph `node.type`, not id parsing — no siblings.

## Notes / follow-ups (out of scope)
- The cli command tests in `packages/cli/test/` (incl. this one and `impact-*`) are **not in CI's path** (`test:coverage` runs only `test/unit/*.test.js`) — pre-existing coverage gap.
- `impact-polymorphic-callers.test.ts` / `impact-class.test.ts` call `analyze --auto-start`, but `--auto-start` is no longer a valid flag (only `--no-auto-start`; auto-start is default) — those tests' `analyze` step fails in `beforeEach`. Pre-existing, unrelated; worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)