### PR TITLE
fix(cli): `file`/`explain` find the file under a symlinked project root

### DIFF
--- a/packages/cli/src/commands/explain.ts
+++ b/packages/cli/src/commands/explain.ts
@@ -45,7 +45,15 @@ If a file shows NOT_ANALYZED:
   - Check if file is excluded in config
 `)
   .action(async (file: string, options: ExplainOptions) => {
-    const projectPath = resolve(options.project);
+    // realpath the project root so it shares a base with the realpath'd file
+    // path computed below; otherwise relative() breaks when the root is a
+    // symlink (e.g. macOS /tmp -> /private/tmp), and the file reads NOT_ANALYZED.
+    let projectPath = resolve(options.project);
+    try {
+      projectPath = realpathSync(projectPath);
+    } catch {
+      // Project dir missing — leave resolved; the dbPath check below reports it.
+    }
     const grafemaDir = join(projectPath, '.grafema');
     const dbPath = join(grafemaDir, 'graph.rfdb');
 

--- a/packages/cli/src/commands/file.ts
+++ b/packages/cli/src/commands/file.ts
@@ -50,7 +50,15 @@ Output shows:
 Use 'grafema context <id>' to dive deeper into any specific entity.
 `)
   .action(async (file: string, options: FileOptions) => {
-    const projectPath = resolve(options.project);
+    // realpath the project root so it shares a base with the realpath'd file
+    // path computed below; otherwise relative() breaks when the root is a
+    // symlink (e.g. macOS /tmp -> /private/tmp), and the file reads NOT_ANALYZED.
+    let projectPath = resolve(options.project);
+    try {
+      projectPath = realpathSync(projectPath);
+    } catch {
+      // Project dir missing — leave resolved; the dbPath check below reports it.
+    }
     const grafemaDir = join(projectPath, '.grafema');
     const dbPath = join(grafemaDir, 'graph.rfdb');
 

--- a/packages/cli/test/file-explain-symlinked-root.test.ts
+++ b/packages/cli/test/file-explain-symlinked-root.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for `grafema file` / `grafema explain` under a SYMLINKED project root.
+ *
+ * Bug (found by dogfooding): both commands realpath the resolved FILE path
+ * (`absoluteFilePath = realpathSync(resolvedPath)`) but compute the project-
+ * relative path against a NON-realpath'd `projectPath = resolve(options.project)`.
+ * When the project root is a symlink (e.g. macOS `/tmp` -> `/private/tmp`, `/var`,
+ * a symlinked checkout), `relative(projectPath, absoluteFilePath)` crosses the
+ * symlink and yields a wrong path (`../../private/...`), so the MODULE node is
+ * never matched and the command reports `NOT_ANALYZED` for an analyzed file.
+ *
+ * This test reproduces it deterministically on any platform via an explicit
+ * symlink to the (realpath'd) project dir. Red before the fix, green after.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, realpathSync, symlinkSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, dirname } from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliPath = join(__dirname, '../dist/cli.js');
+
+function runCli(args: string[]): { stdout: string; stderr: string; status: number | null } {
+  const r = spawnSync('node', [cliPath, ...args], { encoding: 'utf-8', env: { ...process.env, NO_COLOR: '1' } });
+  return { stdout: r.stdout || '', stderr: r.stderr || '', status: r.status };
+}
+
+describe('grafema file/explain: symlinked project root', { timeout: 90000 }, () => {
+  let realRoot: string;   // the real (realpath'd) project directory
+  let linkRoot: string;   // a symlink pointing at realRoot
+
+  before(() => {
+    // realpath the temp base so `realRoot` is the canonical path.
+    const base = realpathSync(mkdtempSync(join(tmpdir(), 'gfm-sym-')));
+    realRoot = join(base, 'proj');
+    mkdirSync(join(realRoot, 'src'), { recursive: true });
+    writeFileSync(join(realRoot, 'package.json'),
+      JSON.stringify({ name: 'sym-test', version: '1.0.0', main: 'src/main.js' }));
+    writeFileSync(join(realRoot, 'grafema.config.yaml'), 'root: "."\ninclude: ["src/**/*.js"]\nexclude: []\n');
+    writeFileSync(join(realRoot, 'src', 'main.js'), 'export function run() {\n  return 42;\n}\n');
+
+    const analyze = spawnSync('node', [cliPath, 'analyze', '.', '--clear'],
+      { cwd: realRoot, encoding: 'utf-8', env: { ...process.env, NO_COLOR: '1' } });
+    assert.strictEqual(analyze.status, 0, `analyze failed: ${analyze.stderr}`);
+
+    // A symlink pointing at the real project root. Passing this as --project
+    // gives a non-realpath'd projectPath that triggers the bug.
+    linkRoot = join(base, 'link');
+    symlinkSync(realRoot, linkRoot);
+  });
+
+  after(() => {
+    runCli(['server', 'stop', '--project', realRoot]);
+    const base = realRoot && dirname(realRoot);
+    if (base) rmSync(base, { recursive: true, force: true });
+  });
+
+  it('`file` reports ANALYZED via a symlinked project root', () => {
+    const out = runCli(['file', 'src/main.js', '--project', linkRoot]).stdout;
+    assert.ok(!/NOT_ANALYZED/.test(out), `file should not report NOT_ANALYZED via symlinked root:\n${out}`);
+    assert.match(out, /\brun\b/, `file should list the analyzed function 'run':\n${out}`);
+  });
+
+  it('`explain` finds the analyzed file via a symlinked project root', () => {
+    const out = runCli(['explain', 'src/main.js', '--project', linkRoot]).stdout;
+    assert.ok(
+      !/not been analyzed|No nodes found|NOT_ANALYZED/i.test(out),
+      `explain should find the analyzed file via symlinked root:\n${out}`
+    );
+    assert.match(out, /\brun\b/, `explain should mention the analyzed function 'run':\n${out}`);
+  });
+});


### PR DESCRIPTION
## Problem (found while dogfooding)

`grafema file <f>` and `grafema explain <f>` report **`NOT_ANALYZED`** for a file that *was* analyzed, when the **project root is a symlink** — e.g. `--project` pointing at a symlinked checkout, or a root under macOS `/tmp`→`/private/tmp` / `/var`→`/private/var`.

## Root cause

Both commands realpath the resolved **file** path but compute the project-relative path against a **non-realpath'd** `projectPath`:
```ts
const projectPath = resolve(options.project);            // NOT realpath'd
…
const absoluteFilePath = realpathSync(resolvedPath);     // realpath'd
const relativeFilePath = relative(projectPath, absoluteFilePath);  // mismatched base
```
When the root is a symlink, `relative()` crosses the link → a wrong path like `../../private/tmp/proj/src/main.js`. `FileOverview.findModuleNode` matches MODULE nodes with an exact `node.file === filePath` (`packages/util/src/core/FileOverview.ts:211-213`), so it never matches → `NOT_ANALYZED`.

`explain.ts:80` even carries a comment *"Use realpath to match how graph stores paths (handles symlinks like /tmp -> /private/tmp on macOS)"* — it realpath'd the **file** but missed the **project root**. This fix completes that intent.

## Fix

Realpath `projectPath` so `relative()` uses the same base (defensive `try/catch` keeps the existing "No graph database found" UX if the dir is missing). No-op for non-symlinked roots.

```ts
let projectPath = resolve(options.project);
try { projectPath = realpathSync(projectPath); } catch { /* dbPath check reports a missing dir */ }
```

## Spec
- **Given** an analyzed project whose root is reached via a symlink, **when** `grafema file src/main.js --project <symlink>` (or `explain`), **then** the file resolves to its MODULE node (not `NOT_ANALYZED`).

## Before / After (deterministic, explicit symlink)
```
# Before — file/explain via a symlink to the project root:
Status: NOT_ANALYZED
# After:
Module: src/main.js
Functions:
  run()  (line 1)
```

## Tests / verification (actual outputs)
New `packages/cli/test/file-explain-symlinked-root.test.ts`: analyze a real project, then run `file` and `explain` via an **explicit symlink** to its root.
```
# Before fix:  not ok 1 / not ok 2  (Status: NOT_ANALYZED)   # red for the right reason
# After fix:   # tests 2  # pass 2  # fail 0
```
`pnpm --filter @grafema/cli build` (tsc) clean; `eslint` on both files 0 errors; fresh non-symlinked + plain `/tmp` analyze still resolve correctly (no regression).

## Adversarial review
- **A (correctness):** non-symlinked root → `realpathSync` is identity → unchanged; missing dir → `try/catch` falls back, existing error UX preserved; the absolute-file-arg branch (`relative(projectPath, file)`) is fixed by the same change.
- **B (structural):** `file.ts` and `explain.ts` now share an identical 8-line block (pre-existing duplication — `file.ts` says "same path resolution as explain"); a shared `resolveProjectRoot()` helper is a reasonable follow-up.
- **C (class):** `file` + `explain` are the only commands doing realpath-file + `relative(projectPath, …)` (`who`/`impact` use `relative` on already-relative stored node paths; `tldr` has no realpath path-mapping). Both fixed; class closed.

## Note
- Surfaced while dogfooding the `file` command on the live local pipeline; reproduced deterministically via an explicit symlink (independent of the macOS `/tmp` symlink, so the test holds on any platform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)