### PR TITLE
test(cli): drop removed `--auto-start` flag from analyze invocations

### DIFF
--- a/packages/cli/test/context-class.test.ts
+++ b/packages/cli/test/context-class.test.ts
@@ -136,7 +136,7 @@ module.exports = { getUser };
     const initResult = runCli(['init'], tempDir);
     assert.strictEqual(initResult.status, 0, `init failed: ${initResult.stderr}`);
 
-    const analyzeResult = runCli(['analyze', '--auto-start'], tempDir);
+    const analyzeResult = runCli(['analyze'], tempDir);
     assert.strictEqual(analyzeResult.status, 0, `analyze failed: ${analyzeResult.stderr}`);
   });
 
@@ -279,7 +279,7 @@ module.exports = { SimpleClass };
     const initResult = runCli(['init'], tempDir);
     assert.strictEqual(initResult.status, 0, `init failed: ${initResult.stderr}`);
 
-    const analyzeResult = runCli(['analyze', '--auto-start'], tempDir);
+    const analyzeResult = runCli(['analyze'], tempDir);
     assert.strictEqual(analyzeResult.status, 0, `analyze failed: ${analyzeResult.stderr}`);
   });
 

--- a/packages/cli/test/explain-command.test.ts
+++ b/packages/cli/test/explain-command.test.ts
@@ -115,7 +115,7 @@ module.exports = { fetchData, processData, DataService };
     const initResult = runCli(['init'], tempDir);
     assert.strictEqual(initResult.status, 0, `init failed: ${initResult.stderr}`);
 
-    const analyzeResult = runCli(['analyze', '--auto-start'], tempDir);
+    const analyzeResult = runCli(['analyze'], tempDir);
     assert.strictEqual(analyzeResult.status, 0, `analyze failed: ${analyzeResult.stderr}`);
   }
 
@@ -438,7 +438,7 @@ module.exports = { fetchData, processData, DataService };
       );
 
       runCli(['init'], tempDir);
-      runCli(['analyze', '--auto-start'], tempDir);
+      runCli(['analyze'], tempDir);
 
       const result = runCli(['explain', 'src/constants.js'], tempDir);
 

--- a/packages/cli/test/explore.test.ts
+++ b/packages/cli/test/explore.test.ts
@@ -145,7 +145,7 @@ export function orphanFunction() {
     const initResult = runCli(['init'], tempDir);
     assert.strictEqual(initResult.status, 0, `init failed: ${initResult.stderr}`);
 
-    const analyzeResult = runCli(['analyze', '--auto-start'], tempDir);
+    const analyzeResult = runCli(['analyze'], tempDir);
     assert.strictEqual(analyzeResult.status, 0, `analyze failed: ${analyzeResult.stderr}`);
   }
 

--- a/packages/cli/test/impact-class.test.ts
+++ b/packages/cli/test/impact-class.test.ts
@@ -176,7 +176,7 @@ module.exports = { handleGetRequest, handleCreateRequest };
     const initResult = runCli(['init'], tempDir);
     assert.strictEqual(initResult.status, 0, `init failed: ${initResult.stderr}`);
 
-    const analyzeResult = runCli(['analyze', '--auto-start'], tempDir);
+    const analyzeResult = runCli(['analyze'], tempDir);
     assert.strictEqual(analyzeResult.status, 0, `analyze failed: ${analyzeResult.stderr}`);
   }
 
@@ -391,7 +391,7 @@ module.exports = { UnusedClass };
       const initResult = runCli(['init'], tempDir);
       assert.strictEqual(initResult.status, 0, `init failed: ${initResult.stderr}`);
 
-      const analyzeResult = runCli(['analyze', '--auto-start'], tempDir);
+      const analyzeResult = runCli(['analyze'], tempDir);
       assert.strictEqual(analyzeResult.status, 0, `analyze failed: ${analyzeResult.stderr}`);
 
       const result = runCli(['impact', 'class UnusedClass'], tempDir);
@@ -447,7 +447,7 @@ module.exports = { InternalClass };
       const initResult = runCli(['init'], tempDir);
       assert.strictEqual(initResult.status, 0, `init failed: ${initResult.stderr}`);
 
-      const analyzeResult = runCli(['analyze', '--auto-start'], tempDir);
+      const analyzeResult = runCli(['analyze'], tempDir);
       assert.strictEqual(analyzeResult.status, 0, `analyze failed: ${analyzeResult.stderr}`);
 
       const result = runCli(['impact', 'class InternalClass'], tempDir);
@@ -486,7 +486,7 @@ module.exports = { dummy };
       const initResult = runCli(['init'], tempDir);
       assert.strictEqual(initResult.status, 0, `init failed: ${initResult.stderr}`);
 
-      const analyzeResult = runCli(['analyze', '--auto-start'], tempDir);
+      const analyzeResult = runCli(['analyze'], tempDir);
       assert.strictEqual(analyzeResult.status, 0, `analyze failed: ${analyzeResult.stderr}`);
 
       const result = runCli(['impact', 'class NonExistentClass'], tempDir);

--- a/packages/cli/test/impact-polymorphic-callers.test.ts
+++ b/packages/cli/test/impact-polymorphic-callers.test.ts
@@ -63,7 +63,7 @@ function initAndAnalyze(tempDir: string): void {
   const initResult = runCli(['init'], tempDir);
   assert.strictEqual(initResult.status, 0, `init failed: ${initResult.stderr}`);
 
-  const analyzeResult = runCli(['analyze', '--auto-start'], tempDir);
+  const analyzeResult = runCli(['analyze'], tempDir);
   assert.strictEqual(analyzeResult.status, 0, `analyze failed: ${analyzeResult.stderr}`);
 }
 

--- a/packages/cli/test/ls-command.test.ts
+++ b/packages/cli/test/ls-command.test.ts
@@ -85,7 +85,7 @@ module.exports = { hello, world, greet, MyClass };
     const initResult = runCli(['init'], tempDir);
     assert.strictEqual(initResult.status, 0, `init failed: ${initResult.stderr}`);
 
-    const analyzeResult = runCli(['analyze', '--auto-start'], tempDir);
+    const analyzeResult = runCli(['analyze'], tempDir);
     assert.strictEqual(analyzeResult.status, 0, `analyze failed: ${analyzeResult.stderr}`);
   }
 

--- a/packages/cli/test/query-http-requests.test.ts
+++ b/packages/cli/test/query-http-requests.test.ts
@@ -118,7 +118,7 @@ module.exports = { fetchUsers, createUser, getInvitations, sendInvitation, fetch
     const initResult = runCli(['init'], tempDir);
     assert.strictEqual(initResult.status, 0, `init failed: ${initResult.stderr}`);
 
-    const analyzeResult = runCli(['analyze', '--auto-start'], tempDir);
+    const analyzeResult = runCli(['analyze'], tempDir);
     assert.strictEqual(analyzeResult.status, 0, `analyze failed: ${analyzeResult.stderr}`);
   }
 

--- a/packages/cli/test/query-http-routes.test.ts
+++ b/packages/cli/test/query-http-routes.test.ts
@@ -123,7 +123,7 @@ module.exports = { app, postMessage, getMessage };
     const initResult = runCli(['init'], tempDir);
     assert.strictEqual(initResult.status, 0, `init failed: ${initResult.stderr}`);
 
-    const analyzeResult = runCli(['analyze', '--auto-start'], tempDir);
+    const analyzeResult = runCli(['analyze'], tempDir);
     assert.strictEqual(analyzeResult.status, 0, `analyze failed: ${analyzeResult.stderr}`);
   }
 

--- a/packages/cli/test/query-natural-language.test.ts
+++ b/packages/cli/test/query-natural-language.test.ts
@@ -604,7 +604,7 @@ module.exports = { fetchData, processData, UserService };
     const initResult = runCli(['init'], tempDir);
     assert.strictEqual(initResult.status, 0, `init failed: ${initResult.stderr}`);
 
-    const analyzeResult = runCli(['analyze', '--auto-start'], tempDir);
+    const analyzeResult = runCli(['analyze'], tempDir);
     assert.strictEqual(analyzeResult.status, 0, `analyze failed: ${analyzeResult.stderr}`);
   }
 
@@ -653,7 +653,7 @@ module.exports = { testProcessItem };
     const initResult = runCli(['init'], tempDir);
     assert.strictEqual(initResult.status, 0, `init failed: ${initResult.stderr}`);
 
-    const analyzeResult = runCli(['analyze', '--auto-start'], tempDir);
+    const analyzeResult = runCli(['analyze'], tempDir);
     assert.strictEqual(analyzeResult.status, 0, `analyze failed: ${analyzeResult.stderr}`);
   }
 
@@ -687,7 +687,7 @@ module.exports = { signin, authenticate };
     const initResult = runCli(['init'], tempDir);
     assert.strictEqual(initResult.status, 0, `init failed: ${initResult.stderr}`);
 
-    const analyzeResult = runCli(['analyze', '--auto-start'], tempDir);
+    const analyzeResult = runCli(['analyze'], tempDir);
     assert.strictEqual(analyzeResult.status, 0, `analyze failed: ${analyzeResult.stderr}`);
   }
 

--- a/packages/cli/test/query-type-flag.test.ts
+++ b/packages/cli/test/query-type-flag.test.ts
@@ -86,7 +86,7 @@ module.exports = { functionRoute, RouteClass, fetchUsers };
     const initResult = runCli(['init'], tempDir);
     assert.strictEqual(initResult.status, 0, `init failed: ${initResult.stderr}`);
 
-    const analyzeResult = runCli(['analyze', '--auto-start'], tempDir);
+    const analyzeResult = runCli(['analyze'], tempDir);
     assert.strictEqual(analyzeResult.status, 0, `analyze failed: ${analyzeResult.stderr}`);
   }
 

--- a/packages/cli/test/types-command.test.ts
+++ b/packages/cli/test/types-command.test.ts
@@ -85,7 +85,7 @@ module.exports = { hello, world, MyClass, config };
     const initResult = runCli(['init'], tempDir);
     assert.strictEqual(initResult.status, 0, `init failed: ${initResult.stderr}`);
 
-    const analyzeResult = runCli(['analyze', '--auto-start'], tempDir);
+    const analyzeResult = runCli(['analyze'], tempDir);
     assert.strictEqual(analyzeResult.status, 0, `analyze failed: ${analyzeResult.stderr}`);
   }
 

--- a/test/integration/semantic-id-stability.test.js
+++ b/test/integration/semantic-id-stability.test.js
@@ -10,7 +10,8 @@
  * 3. grafema analyze --clear again (no code changes) → collect all node IDs
  * 4. Assert: all IDs identical between runs
  *
- * Requirements: RFDB server running (or use --auto-start), grafema-orchestrator binary.
+ * Requirements: grafema-orchestrator binary. The RFDB server is auto-started
+ * by `grafema analyze` by default (pass --no-auto-start to require a manual server).
  * This is an integration test — not run in CI by default.
  */
 
@@ -138,7 +139,7 @@ export function buildUrl(base, path) {
 
   it('should produce identical node IDs on re-analysis of unchanged code', () => {
     // First analysis
-    execSync(`node "${cliPath}" analyze --auto-start`, {
+    execSync(`node "${cliPath}" analyze`, {
       cwd: tempDir,
       stdio: 'pipe',
       timeout: 120000,
@@ -148,7 +149,7 @@ export function buildUrl(base, path) {
     assert.ok(idsFirstRun.length > 0, `First run should produce nodes, got ${idsFirstRun.length}`);
 
     // Second analysis — clear and re-analyze same code
-    execSync(`node "${cliPath}" analyze --clear --auto-start`, {
+    execSync(`node "${cliPath}" analyze --clear`, {
       cwd: tempDir,
       stdio: 'pipe',
       timeout: 120000,

--- a/test/unit/AnalyzeAutoStartFlag.test.js
+++ b/test/unit/AnalyzeAutoStartFlag.test.js
@@ -1,0 +1,92 @@
+/**
+ * Regression guard (class-not-instance): no test suite may invoke
+ * `grafema analyze` with the `--auto-start` flag, because the `analyze` command
+ * no longer defines it.
+ *
+ * Why this matters:
+ *   - `analyze` historically had an opt-in `--auto-start` flag (REG-435). It
+ *     was later changed so auto-start is the DEFAULT and only the negation
+ *     `--no-auto-start` remains (see `packages/cli/src/commands/analyze.ts`).
+ *   - Commander rejects unknown options, so `grafema analyze --auto-start`
+ *     exits 1 with `error: unknown option '--auto-start'` BEFORE any analysis
+ *     or server work runs. Every `beforeEach` that did
+ *     `runCli(['analyze', '--auto-start'], ...)` therefore failed its
+ *     `assert.strictEqual(status, 0)` setup step unconditionally, in every
+ *     environment — silently disabling ~11 CLI command-test files plus the
+ *     `semantic-id-stability` integration test. (These package/integration
+ *     suites are not in CI's `test/unit/*.test.js` coverage path, so the
+ *     breakage went unnoticed.)
+ *   - The fix dropped the redundant flag from those suites (auto-start is the
+ *     default, so the flag was a pure no-op even when it had existed). This
+ *     guard encodes the invariant structurally so a future suite cannot
+ *     silently reintroduce the dead flag.
+ *
+ * Premise check below: if `analyze` ever re-introduces a real `--auto-start`
+ * option, the ban auto-relaxes (the flag becomes valid again).
+ *
+ * Note `--auto-start` is NOT a substring of the valid `--no-auto-start` (the
+ * leading `--` sits before `no`), so a literal scan does not false-match it.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..');
+
+// Assemble the flag from parts so THIS guard file does not match its own scan.
+const FLAG = '--auto' + '-start';
+const ANALYZE_CMD_SRC = join(REPO_ROOT, 'packages/cli/src/commands/analyze.ts');
+
+/** Whether the `analyze` command currently defines `--auto-start` as an option. */
+function analyzeDefinesAutoStart() {
+  const src = readFileSync(ANALYZE_CMD_SRC, 'utf8');
+  // A commander option is registered via `.option('--auto-start', ...)`.
+  return src.includes(`.option('${FLAG}'`) || src.includes(`.option("${FLAG}"`);
+}
+
+/** Recursively collect every *.test.js / *.test.ts file, skipping vendored/build dirs. */
+function collectTestFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === 'dist' || entry === '.git') continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...collectTestFiles(full));
+    } else if (/\.test\.(js|ts)$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+test('no test suite invokes `grafema analyze` with the removed `--auto-start` flag', () => {
+  if (analyzeDefinesAutoStart()) {
+    // The flag is a real option again — nothing to ban.
+    return;
+  }
+
+  const selfPath = fileURLToPath(import.meta.url);
+  const offenders = [];
+  for (const file of collectTestFiles(REPO_ROOT)) {
+    if (file === selfPath) continue; // this guard names the flag in prose
+    const src = readFileSync(file, 'utf8');
+    if (src.includes(FLAG)) {
+      offenders.push(
+        `${file} passes the removed \`${FLAG}\` flag to \`grafema analyze\` — ` +
+          'commander rejects it as an unknown option (exit 1), failing setup. ' +
+          'Auto-start is the default; drop the flag.',
+      );
+    }
+  }
+
+  assert.deepStrictEqual(
+    offenders,
+    [],
+    'test suites must not pass the removed `--auto-start` flag to `grafema analyze`:\n' +
+      offenders.join('\n'),
+  );
+});


### PR DESCRIPTION
## Problem (concrete repro)

`grafema analyze` historically had an opt-in `--auto-start` flag (REG-435; see `_archive/tasks/REG-435/002-don-plan.md:185` — `.option('--auto-start', 'Auto-start RFDB server if not running')`). It was later changed so **auto-start is the default** and only the negation `--no-auto-start` remains (`packages/cli/src/commands/analyze.ts:24`). The test suites were never updated.

Commander rejects unknown options, so the flag fails at parse time, **before** any analysis/server work:

```
$ node packages/cli/dist/cli.js analyze --auto-start <dir>
error: unknown option '--auto-start'
(Did you mean --no-auto-start?)
# exit 1
```

Every affected test did `runCli(['analyze', '--auto-start'], ...)` followed by `assert.strictEqual(status, 0, ...)`, so the **`beforeEach` setup failed unconditionally, in every environment** — silently disabling **11 CLI command-test files** plus the `semantic-id-stability` integration test. These suites are not in CI's `test/unit/*.test.js` coverage path, so the breakage went unnoticed. (Independently confirmed by #292's author: "those tests' analyze step fails in `beforeEach`… worth a separate cleanup.")

## Spec

- **Given** a CLI command test that runs `grafema analyze` in `beforeEach`, **when** it invokes the CLI, **then** it must use only flags the `analyze` command defines — i.e. not the removed `--auto-start`.
- **Given** auto-start is the default, **when** the flag is dropped, **then** behavior is unchanged (it was a no-op even when it existed).

## Fix

Drop the redundant `--auto-start` from all live invocations (18 in 11 CLI test files + 2 in the integration test) and fix the integration test's stale doc comment. Add a class-not-instance regression guard `test/unit/AnalyzeAutoStartFlag.test.js` (mirrors the repo's `GitFixtureSigningHermeticity` / `RfdbBinaryResolutionSiblings` idiom) that scans test files and bans the removed flag; its premise auto-relaxes if `analyze` ever re-defines a real `--auto-start` option. No production code changed.

## Before / After (actual live output, built CLI)

```
# Before — old test arg
$ node packages/cli/dist/cli.js analyze --auto-start <dir>
error: unknown option '--auto-start'   # exit 1, fails beforeEach

# After — new test arg
$ node packages/cli/dist/cli.js analyze <dir>
# parses OK, proceeds into the real pipeline
# (in THIS sandbox it then stops only because the grafema-orchestrator
#  binary can't be downloaded — GitHub API 403 rate-limit — an orthogonal,
#  pre-existing infra dependency, not a parsing error)
```

## Tests / verification (actual outputs)

```
# guard test, red for the right reason (before fix):
#   FAIL — 12 offenders listed (context-class, explain-command, explore,
#   impact-class, impact-polymorphic-callers, ls-command, query-http-requests,
#   query-http-routes, query-natural-language, query-type-flag, types-command,
#   semantic-id-stability)
# guard test, after fix:  # pass 1  # fail 0

# Full gate (clean checkout, ordered build):
pnpm build         -> exit 0
./scripts/test.sh  -> # tests 689  # pass 689  # fail 0   (was 688; +1 = new guard)
pnpm typecheck     -> exit 0
pnpm lint          -> exit 0
```

## Adversarial review

- **A — Correctness:** `--auto-start` is *not* a substring of the valid `--no-auto-start` (the leading `--` sits before `no`), so the literal scan can't false-match the good flag. No command in the repo defines a positive `--auto-start` (only `--no-auto-start` in `analyze.ts`/`resolve.ts`), so the ban can't suppress a legitimate flag. Removal is purely subtractive of an invalid arg — no new failure mode.
- **B — Structural:** new guard is 95 lines (< 500), self-skips, assembles the needle from parts, premise reads `analyze.ts` so the ban auto-relaxes. No god-file, no duplication, no production code touched.
- **C — Class-not-instance:** every live test invocation fixed (verified: `grep -rn -- '--auto-start' packages/cli/test test/integration` → none); guard prevents repo-wide regression.

## Blast radius

Test-only change. `pnpm typecheck` (covers `@grafema/cli`) and `pnpm lint` (covers `packages/`) both clean. The integration test is not run in CI by default; the 11 CLI suites are not in CI's coverage glob — this change is a prerequisite for them to run at all wherever the orchestrator binary is provisioned.

## Follow-ups (same stale-reference class, deliberately out of scope)

- `packages/rfdb/ts/client.ts:119,127,135` — connection-error hints still tell users to "Use `--auto-start` flag"; user-facing wording, no test asserts these strings.
- `.claude/skills/rfdb-v2-clear-ephemeral-trap/SKILL.md` — examples use `analyze --clear --auto-start`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KzYfJfMXqNMwLMugRq93Ao

---
_Generated by [Claude Code](https://claude.ai/code/session_01KzYfJfMXqNMwLMugRq93Ao)_