### PR TITLE
feat(orchestrator): emit resolve_progress telemetry during per-file JS resolve

### DIFF
--- a/packages/grafema-orchestrator/src/main.rs
+++ b/packages/grafema-orchestrator/src/main.rs
@@ -1058,6 +1058,7 @@ async fn main() -> Result<()> {
                             &ws_packages,
                             "js-resolution",
                             generation,
+                            prof.as_ref(),
                         ).await?;
 
                         // Extract IMPORTS_FROM edges for DEPENDS_ON derivation
@@ -2011,6 +2012,7 @@ async fn main() -> Result<()> {
                             &ws_packages,
                             "js-resolution",
                             generation,
+                            None,
                         ).await?;
 
                         // Extract IMPORTS_FROM edges for DEPENDS_ON derivation

--- a/packages/grafema-orchestrator/src/plugin.rs
+++ b/packages/grafema-orchestrator/src/plugin.rs
@@ -1101,6 +1101,27 @@ impl CheckpointAccumulator {
     }
 }
 
+/// Build the fields for a `resolve_progress` profiler event.
+///
+/// Kept pure (no Profiler / RFDB) so the event schema is unit-testable. Emitted
+/// every [`RESOLVE_CHECKPOINT_INTERVAL`] files (and once at completion) so a long
+/// per-file resolve's liveness and rate are visible in `analysis-profile.jsonl`
+/// instead of being a silent gap between `js_resolve_start` and `js_resolve_complete`
+/// that run-health tooling must reconstruct from rfdb.log. See REG-1138 (defect 2).
+fn resolve_progress_fields(
+    phase: &str,
+    files_done: usize,
+    total_files: usize,
+    edges_so_far: usize,
+) -> Vec<(&'static str, String)> {
+    vec![
+        ("phase", phase.to_string()),
+        ("files_done", files_done.to_string()),
+        ("total_files", total_files.to_string()),
+        ("edges_so_far", edges_so_far.to_string()),
+    ]
+}
+
 /// Per-file resolve: builds an export index on the worker, then resolves each
 /// file individually by querying RFDB for that file's nodes.
 ///
@@ -1126,6 +1147,7 @@ pub async fn resolve_per_file(
     workspace_packages: &[WorkspacePackageWire],
     name: &str,
     generation: u64,
+    profiler: Option<&crate::profiler::Profiler>,
 ) -> Result<PluginOutput> {
     // Step 1: Get all MODULE nodes to find files for this language
     let module_nodes = rfdb.query_nodes_by_type("MODULE").await?;
@@ -1225,6 +1247,11 @@ pub async fn resolve_per_file(
         if (i + 1) % 500 == 0 || i + 1 == total_files {
             eprintln!("    Per-file resolve: {}/{} files ({} edges so far)",
                 i + 1, total_files, all_output.edges.len());
+            if let Some(prof) = profiler {
+                let fields = resolve_progress_fields(name, i + 1, total_files, all_output.edges.len());
+                let refs: Vec<(&str, &str)> = fields.iter().map(|(k, v)| (*k, v.as_str())).collect();
+                prof.event("resolve_progress", &refs);
+            }
         }
     }
 
@@ -1812,5 +1839,19 @@ mod tests {
         acc.record(&[ck_node("a")], &[]);
         acc.record(&[ck_node("b")], &[]);
         assert!(acc.take_if_due().is_some(), "counter reset after empty checkpoint");
+    }
+
+    // -- resolve_progress telemetry (REG-1138 defect 2) --
+
+    /// The `resolve_progress` event carries the phase + progress counters under
+    /// the field names run-health tooling parses; lock that schema.
+    #[test]
+    fn resolve_progress_fields_schema() {
+        let f = resolve_progress_fields("js-resolution", 500, 9059, 12345);
+        let map: std::collections::HashMap<_, _> = f.into_iter().collect();
+        assert_eq!(map.get("phase").map(String::as_str), Some("js-resolution"));
+        assert_eq!(map.get("files_done").map(String::as_str), Some("500"));
+        assert_eq!(map.get("total_files").map(String::as_str), Some("9059"));
+        assert_eq!(map.get("edges_so_far").map(String::as_str), Some("12345"));
     }
 }

--- a/packages/grafema-orchestrator/src/plugin.rs
+++ b/packages/grafema-orchestrator/src/plugin.rs
@@ -1244,7 +1244,7 @@ pub async fn resolve_per_file(
             commit_resolve_chunk(&mut chunk, name, generation, rfdb).await?;
         }
 
-        if (i + 1) % 500 == 0 || i + 1 == total_files {
+        if (i + 1) % RESOLVE_CHECKPOINT_INTERVAL == 0 || i + 1 == total_files {
             eprintln!("    Per-file resolve: {}/{} files ({} edges so far)",
                 i + 1, total_files, all_output.edges.len());
             if let Some(prof) = profiler {


### PR DESCRIPTION
## Problem

Per-file JS/TS resolve (`plugin::resolve_per_file`) can run for a long time on large repos while emitting only an every-500-files `eprintln!` to stderr. The profiler stream (`.grafema/analysis-profile.jsonl`) had a **silent gap** between `js_resolve_start` and `js_resolve_complete`, so run-health / profiling tooling had to reconstruct resolve liveness and rate from `rfdb.log`.

This is **defect 2** of the JS-resolve wedge trilogy (defect 1 = mid-phase checkpoint #286; defect 3 = honest `--resolve-jobs` #287), now unblocked by #286 landing.

## Fix

`resolve_per_file` emits a `resolve_progress` profiler event at the **same cadence** as the existing eprintln — every `RESOLVE_CHECKPOINT_INTERVAL` (500) files and once at completion — carrying `phase` / `files_done` / `total_files` / `edges_so_far`.

- `profiler: Option<&Profiler>` param; the Analyze path passes `prof.as_ref()`, the `resolve` subcommand (no profiler set up) passes `None` (no-op).
- The field construction is a pure `resolve_progress_fields` helper so the event schema is unit-testable without a Profiler/RFDB.

## Spec
- **Given** a JS/TS resolve over N files, **when** the orchestrator runs under a profiler, **then** `analysis-profile.jsonl` contains `resolve_progress` events (≥1, at the cadence above) carrying the progress counters — no more silent gap.

## Verification (actual outputs)

Live (analyze a 2-file fixture with the rebuilt orchestrator):
```json
{"ts":"2026-06-05T08:26:28Z","elapsed_ms":114,"event":"resolve_progress","rss_mb":11.5,"cpu_s":0.00,"phase":"js-resolution","files_done":2,"total_files":2,"edges_so_far":7}
```
(Before: no `resolve_progress` line existed.)

- `cargo build` clean; `cargo test` → 420 lib + 6 bin + 14 integration + 1 doctest pass, incl. the new `resolve_progress_fields_schema`; `cargo clippy --lib` 0 errors.

## Adversarial review
- **A (correctness):** `profiler = None` (resolve subcommand) → no emission, no panic; `total_files == 0` → loop body never runs → no event (nothing to report); large repos → every 500 files + completion. JSON is escaped by `Profiler::event`.
- **B (structural):** pure helper extracted + tested; emission is 4 lines at the existing progress point.
- **C (class):** same "no progress telemetry" gap exists in `stream_and_resolve_single_worker` (other-language resolvers) and the `resolve` subcommand (no profiler) — noted as follow-ups, not scoped here.

Related: #286, #287, REG-1138 (JS-resolve wedge). Closes defect 2 of 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)