### PR TITLE
fix(cli): `impact <method>` resolves METHOD targets and finds their callers

### DIFF
--- a/packages/cli/src/commands/impact.ts
+++ b/packages/cli/src/commands/impact.ts
@@ -137,7 +137,11 @@ async function findTarget(
   type: string | null,
   name: string
 ): Promise<NodeInfo | null> {
-  const searchTypes = type ? [type] : ['FUNCTION', 'CLASS'];
+  // METHOD is searched too: `impact greet` should resolve a bare method name to
+  // its METHOD node (consistent with `who`). The downstream flow derives
+  // methodName via extractMethodName(target.name) and the findByAttr CALL-by-method
+  // fallback surfaces unresolved `obj.greet()` call sites as affected callers.
+  const searchTypes = type ? [type] : ['FUNCTION', 'CLASS', 'METHOD'];
 
   for (const nodeType of searchTypes) {
     for await (const node of backend.queryNodes({ nodeType: nodeType as any })) {
@@ -564,6 +568,34 @@ async function findCallsToNode(
     } catch (err) {
       process.stderr.write(`[grafema impact] Warning: findByAttr fallback failed for '${methodName}': ${err}\n`);
 
+    }
+
+    // Additional fallback: match CALL nodes by the method part of their name
+    // (e.g. `s.greet` -> `greet`). The `method` attribute is not populated for
+    // every `receiver.method()` form, so findByAttr alone misses those call
+    // sites; matching on the call name (as `who` does) recovers them. Runs once
+    // (methodName is only set for the depth-0 target). Bare `greet()` (no dot)
+    // also matches. Same cross-class imprecision as the findByAttr fallback.
+    try {
+      const lowerMethod = methodName.toLowerCase();
+      for await (const callNode of backend.queryNodes({ nodeType: 'CALL' as any })) {
+        if (seen.has(callNode.id)) continue;
+        const callName = callNode.name || '';
+        const dotIdx = callName.lastIndexOf('.');
+        const part = dotIdx >= 0 ? callName.slice(dotIdx + 1) : callName;
+        if (part.toLowerCase() === lowerMethod) {
+          seen.add(callNode.id);
+          calls.push({
+            id: callNode.id,
+            type: callNode.type || 'CALL',
+            name: callName,
+            file: callNode.file || '',
+            line: callNode.line,
+          });
+        }
+      }
+    } catch (err) {
+      process.stderr.write(`[grafema impact] Warning: name-scan fallback failed for '${methodName}': ${err}\n`);
     }
   }
 

--- a/packages/cli/test/impact-method-target.test.ts
+++ b/packages/cli/test/impact-method-target.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Test for `grafema impact <method>` finding METHOD targets (found by dogfooding).
+ *
+ * Bug: `findTarget` searched only `['FUNCTION', 'CLASS']` (impact.ts:140), so
+ * `grafema impact greet` reported `No node "greet" found` even though a `greet`
+ * METHOD node exists and `grafema who greet` finds it. impact already has the
+ * method machinery (extractMethodName + the findByAttr CALL-by-method fallback),
+ * it just never resolved a bare method name to its METHOD node.
+ *
+ * Fix: include `METHOD` in the default search types. The downstream flow then
+ * sets methodName = extractMethodName(target.name) and the findByAttr fallback
+ * surfaces the (unresolved) `s.greet()` call site, so `run` shows as affected.
+ *
+ * Pattern matches impact-class.test.ts (real analyze, assert stdout).
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, dirname } from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliPath = join(__dirname, '../dist/cli.js');
+
+function runCli(args: string[], cwd: string): { stdout: string; stderr: string; status: number | null } {
+  const r = spawnSync('node', [cliPath, ...args], { cwd, encoding: 'utf-8', env: { ...process.env, NO_COLOR: '1' } });
+  return { stdout: r.stdout || '', stderr: r.stderr || '', status: r.status };
+}
+
+describe('grafema impact: METHOD target', { timeout: 60000 }, () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'gfm-impact-method-'));
+    const srcDir = join(tempDir, 'src');
+    mkdirSync(srcDir);
+    writeFileSync(join(tempDir, 'package.json'),
+      JSON.stringify({ name: 'impact-method-test', version: '1.0.0', main: 'src/main.js' }));
+    writeFileSync(join(srcDir, 'service.js'),
+      'export class Service {\n  greet(name) { return `hi ${name}`; }\n}\n');
+    writeFileSync(join(srcDir, 'main.js'),
+      "import { Service } from './service.js';\nexport function run() {\n  const s = new Service();\n  return s.greet('x');\n}\n");
+
+    const init = runCli(['init'], tempDir);
+    assert.strictEqual(init.status, 0, `init failed: ${init.stderr}`);
+    const analyze = runCli(['analyze'], tempDir);
+    assert.strictEqual(analyze.status, 0, `analyze failed: ${analyze.stderr}`);
+  });
+
+  afterEach(() => {
+    if (tempDir && existsSync(tempDir)) {
+      runCli(['server', 'stop'], tempDir);
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves a bare method name to its METHOD node (not "No node found")', () => {
+    const out = runCli(['impact', 'greet'], tempDir).stdout;
+    assert.ok(!/No node/.test(out), `impact should find the 'greet' METHOD node:\n${out}`);
+  });
+
+  it('reports the calling function as affected by a method change', () => {
+    // `s.greet('x')` is called inside function run(); changing greet impacts run.
+    const out = runCli(['impact', 'greet'], tempDir).stdout;
+    assert.match(out, /\brun\b/, `impact greet should surface 'run' as affected:\n${out}`);
+  });
+});


### PR DESCRIPTION
## Problem (found by dogfooding)

`grafema impact greet` reported **`No node "greet" found`** even though a `greet` METHOD node exists in the graph and `grafema who greet` finds it (and its caller). `impact` — the change-impact command — couldn't analyze methods at all.

## Root cause (two layers)

1. **`findTarget` excluded METHOD** (`impact.ts:140`): `const searchTypes = type ? [type] : ['FUNCTION', 'CLASS'];` — a bare method name never resolved to its METHOD node.
2. Adding METHOD alone is **not enough** — it would replace "not found" with a *confidently-wrong* `0 callers` (cf. REG-1143), because the caller analysis (`findCallsToNode`) relies on `findByAttr({nodeType:'CALL', method})`, and the `method` attribute is **not populated** for `receiver.method()` CALL nodes:
   ```
   $ grafema query --raw 'v(X):-node(X,"CALL"),attr(X,"method","greet").'
   No results.            # but the CALL node IS named `s.greet`
   ```

## Fix

1. Include `METHOD` in the default search types.
2. Add a **name-based fallback** in `findCallsToNode`: match CALL nodes by the method part of their name (`s.greet` → `greet`), the way `who` does. Additive to `findByAttr` (preserves the existing path), runs once for the depth-0 target, bare `greet()` also matches.

## Before / After (live)
```
# Before
$ grafema impact greet
No node "greet" found

# After
$ grafema impact greet
[METHOD] greet  (src/service.js:2)
Direct impact: ... run        # the function that calls s.greet()
```

## Spec
- **Given** a `greet` method called inside `run()`, **when** `grafema impact greet`, **then** it resolves the METHOD node and lists `run` as affected (not "No node found", not a false "0 callers").

## Verification (actual)
- New `packages/cli/test/impact-method-target.test.ts` (real analyze → `impact greet`): red before, **green after (2/2)**.
- **Net-repairs REG-543** `impact-polymorphic-callers.test.ts`: those assertions could not run until `--auto-start` was removed (#295); now-runnable, they **fail on clean HEAD** (e.g. "find useGraph as a caller of addNode … Got: 0") and **pass with this change** (10/11).
- `impact-class.test.ts` unchanged: **7/8 with and without** this change (no regression).
- `eslint` clean; diff is 2 scoped hunks.

## Adversarial review
- **A:** name-scan guarded by `if (methodName)`; dedups via `seen`; case-insensitive; bare (no-dot) calls match; empty graph → no matches.
- **B:** the fallback is one full CALL scan for the depth-0 target only (same cost shape as `who`); `impact.ts` is a pre-existing >500-line command.
- **C / honest finding:** impact's **CLASS-target method aggregation is broadly broken on main** (`impact-class` 8/15 fail, `impact-polymorphic` 1/11 fail — the `resolveTargetSet` CLASS branch), surfaced now that these tests can run. **Separate path, out of scope — filed as follow-up.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)