### PR TITLE
fix(util): findContainingFunction recognizes METHOD as a container

### DIFF
--- a/packages/util/src/queries/findContainingFunction.ts
+++ b/packages/util/src/queries/findContainingFunction.ts
@@ -1,5 +1,7 @@
 /**
- * Find the FUNCTION, CLASS, or MODULE that contains a node.
+ * Find the FUNCTION, METHOD, CLASS, or MODULE that contains a node.
+ * (METHOD is a most-specific container, like FUNCTION: a CALL inside a class
+ * method is contained by that METHOD, not the enclosing CLASS.)
  *
  * Supports two graph layouts:
  *
@@ -56,7 +58,9 @@ interface GraphBackend {
 const DEFAULT_MAX_DEPTH = 15;
 
 /**
- * Find the FUNCTION, CLASS, or MODULE that contains a node.
+ * Find the FUNCTION, METHOD, CLASS, or MODULE that contains a node.
+ * (METHOD is a most-specific container, like FUNCTION: a CALL inside a class
+ * method is contained by that METHOD, not the enclosing CLASS.)
  *
  * @param backend - Graph backend for queries
  * @param nodeId - ID of the node to find container for
@@ -92,8 +96,14 @@ export async function findContainingFunction(
       const parentNode = await backend.getNode(edge.src);
       if (!parentNode || visited.has(parentNode.id)) continue;
 
-      // Found container!
-      if (parentNode.type === 'FUNCTION' || parentNode.type === 'CLASS' || parentNode.type === 'MODULE') {
+      // Found container! METHOD is a callable too — a CALL inside a class method
+      // is contained by that METHOD, not the enclosing CLASS.
+      if (
+        parentNode.type === 'FUNCTION' ||
+        parentNode.type === 'METHOD' ||
+        parentNode.type === 'CLASS' ||
+        parentNode.type === 'MODULE'
+      ) {
         const candidate: CallerInfo = {
           id: parentNode.id,
           name: parentNode.name || '<anonymous>',
@@ -102,8 +112,12 @@ export async function findContainingFunction(
           line: parentNode.line,
         };
 
-        // FUNCTION/CLASS is most specific — return immediately
-        if (parentNode.type === 'FUNCTION' || parentNode.type === 'CLASS') {
+        // FUNCTION/METHOD/CLASS is most specific — return immediately
+        if (
+          parentNode.type === 'FUNCTION' ||
+          parentNode.type === 'METHOD' ||
+          parentNode.type === 'CLASS'
+        ) {
           return candidate;
         }
 

--- a/test/unit/queries/findContainingFunction.test.ts
+++ b/test/unit/queries/findContainingFunction.test.ts
@@ -115,6 +115,38 @@ describe('findContainingFunction', () => {
     });
 
     /**
+     * WHY: a CALL inside a class METHOD is contained by that METHOD, not the
+     * enclosing CLASS. METHOD is a callable and the most-specific container, so
+     * it must be recognized (was skipped, returning the CLASS — which breaks
+     * `impact` internal-call exclusion and mislabels callers).
+     *
+     * Graph:
+     * ```
+     * CLASS -[HAS_SCOPE]-> class_body -[CONTAINS]-> METHOD
+     *                       METHOD -[HAS_SCOPE]-> method_body -[CONTAINS]-> CALL
+     * ```
+     */
+    it('should find the containing METHOD for a CALL inside a class method', async () => {
+      await backend.addNode({ id: 'class-1', type: 'CLASS', name: 'Repo', file: 'file.js', line: 1 });
+      await backend.addNode({ id: 'class-scope', type: 'SCOPE', name: 'class_body', file: 'file.js', line: 1 });
+      await backend.addNode({ id: 'method-1', type: 'METHOD', name: 'save', file: 'file.js', line: 2 });
+      await backend.addNode({ id: 'method-scope', type: 'SCOPE', name: 'method_body', file: 'file.js', line: 2 });
+      await backend.addNode({ id: 'call-1', type: 'CALL', name: 'helper', file: 'file.js', line: 3 });
+
+      await backend.addEdge({ src: 'class-1', dst: 'class-scope', type: 'HAS_SCOPE' });
+      await backend.addEdge({ src: 'class-scope', dst: 'method-1', type: 'CONTAINS' });
+      await backend.addEdge({ src: 'method-1', dst: 'method-scope', type: 'HAS_SCOPE' });
+      await backend.addEdge({ src: 'method-scope', dst: 'call-1', type: 'CONTAINS' });
+
+      const container = await findContainingFunction(backend, 'call-1');
+
+      assert.ok(container, 'Should find a container');
+      assert.strictEqual(container.type, 'METHOD', `expected METHOD, got ${container?.type}`);
+      assert.strictEqual(container.id, 'method-1');
+      assert.strictEqual(container.name, 'save');
+    });
+
+    /**
      * WHY: CALL nested inside multiple scopes (if-block, loop, etc.)
      * Must traverse up through all nested scopes.
      *


### PR DESCRIPTION
## Problem

`findContainingFunction` (the shared util used by `impact`, `query`, mcp context handlers, `traceCallChain`) stops only at `FUNCTION` / `CLASS` / `MODULE` (`findContainingFunction.ts:96`). A node inside a **class method** is contained by that **METHOD**, but the walk skips METHOD and returns the enclosing **CLASS** (or MODULE).

Verified live (analyze `class Repo { save(){...} }`, call inside `save`): `findContainingFunction(call)` returns the CLASS, not `save`.

## Impact on consumers
- callers inside methods are mislabelled by their class;
- `impact`'s internal-call exclusion (compares the container id against the class's method ids) fails to recognise internal method-to-method calls → over-counts them (the precision regression noted in the impact CLASS-aggregation follow-up).

## Fix
Treat `METHOD` as a most-specific container and return it immediately (like FUNCTION). In the scope walk METHOD is reached before its CLASS, so the correct most-specific container is returned. A node directly in a class body (not in a method) still resolves to the CLASS.

## Spec
- **Given** a CALL inside `class Repo { save() { … } }`, **when** `findContainingFunction(call)`, **then** it returns the `save` METHOD (not the `Repo` CLASS).

## Verification (actual)
- Red→green mock-backend unit test `should find the containing METHOD for a CALL inside a class method` — before: `expected METHOD, got CLASS`; after: **22/22 pass** in `test/unit/queries/findContainingFunction.test.ts`.
- Full CI unit suite `node --test 'test/unit/*.test.js'`: **689 / 689 pass** — no consumer regression.
- `eslint` clean; diff is 2 scoped hunks.

## Adversarial review
- **A:** node directly in class body → CLASS (no METHOD ancestor); call in arrow-fn inside a method → the arrow FUNCTION (innermost) returns first; METHOD-CALL node test still passes.
- **B:** minimal change to the container-type predicate in a focused util.
- **C:** this is the single canonical "containing callable" util; consumers all want the enclosing callable, for which METHOD is strictly more correct (689/689 confirms). The analogous METHOD-vs-FUNCTION gap in `impact`'s `getClassMethods`/`findMethodInClass` is a separate path — tracked as the impact CLASS-aggregation follow-up.

Context: REG-254 (findContainingFunction). Unblocks the internal-call-exclusion half of the impact CLASS-target method-aggregation follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)