### PR TITLE
fix(cli): impact CLASS-target method aggregation (REG-543) — HAS_METHOD + internal-call exclusion

### DIFF
--- a/packages/cli/src/commands/impact.ts
+++ b/packages/cli/src/commands/impact.ts
@@ -9,7 +9,7 @@
 import { Command } from 'commander';
 import { isAbsolute, resolve, join, dirname, relative } from 'path';
 import { existsSync } from 'fs';
-import { RFDBServerBackend, findContainingFunction as findContainingFunctionCore } from '@grafema/util';
+import { RFDBServerBackend, findContainingFunction as findContainingFunctionCore, parseSemanticIdV2 } from '@grafema/util';
 import { formatNodeDisplay, formatNodeInline } from '../utils/formatNode.js';
 import { exitWithError } from '../utils/errorFormatter.js';
 
@@ -181,10 +181,13 @@ async function findMethodInClass(
   classId: string,
   methodName: string
 ): Promise<string | null> {
-  const containsEdges = await backend.getOutgoingEdges(classId, ['CONTAINS']);
-  for (const edge of containsEdges) {
+  // Classes link to their methods via HAS_METHOD edges to METHOD nodes; the
+  // class's direct CONTAINS edge goes to its body SCOPE, not the methods. Accept
+  // FUNCTION too for analyzers that model methods as FUNCTION children.
+  const methodEdges = await backend.getOutgoingEdges(classId, ['HAS_METHOD', 'CONTAINS']);
+  for (const edge of methodEdges) {
     const child = await backend.getNode(edge.dst);
-    if (child && child.type === 'FUNCTION' && child.name === methodName) {
+    if (child && (child.type === 'METHOD' || child.type === 'FUNCTION') && child.name === methodName) {
       return child.id;
     }
   }
@@ -389,6 +392,10 @@ async function collectCallersBFS(
   const callChains: string[][] = [];
   const visited = new Set<string>();
   const initialTargetIds = new Set(targetIds);
+  // Names of the target class's own methods — used to recognise internal callers
+  // whose enclosing scope is a method body (`<expression>[in:method]`) rather than
+  // the METHOD node itself. Empty for non-CLASS targets.
+  const classMethodNames = new Set(targetMethodNames.values());
 
   const queue: Array<{ id: string; depth: number; chain: string[] }> = targetIds.map(id => ({
     id,
@@ -415,8 +422,14 @@ async function collectCallersBFS(
         const container = await findContainingFunctionCore(backend, callNode.id);
 
         if (container && !visited.has(container.id)) {
-          // Skip internal callers (methods of the same class being analyzed)
-          if (target.type === 'CLASS' && targetIds.includes(container.id)) continue;
+          // Skip internal callers (the class's own methods calling each other):
+          // either the method node itself, or a method-body `<expression>` FUNCTION
+          // whose enclosing scope (`[in:method]`) is one of the class's methods.
+          if (target.type === 'CLASS') {
+            if (targetIds.includes(container.id)) continue;
+            const enclosing = parseSemanticIdV2(container.id)?.namedParent;
+            if (enclosing && classMethodNames.has(enclosing)) continue;
+          }
 
           const caller: NodeInfo = {
             id: container.id,
@@ -476,11 +489,14 @@ async function getClassMethods(
   const methods: Array<{ id: string; name: string }> = [];
 
   try {
-    const edges = await backend.getOutgoingEdges(classId, ['CONTAINS']);
+    // Classes link to their methods via HAS_METHOD edges to METHOD nodes; the
+    // class's direct CONTAINS edge goes to its body SCOPE, not the methods.
+    // Accept FUNCTION too for analyzers that model methods as FUNCTION children.
+    const edges = await backend.getOutgoingEdges(classId, ['HAS_METHOD', 'CONTAINS']);
 
     for (const edge of edges) {
       const node = await backend.getNode(edge.dst);
-      if (node && node.type === 'FUNCTION') {
+      if (node && (node.type === 'METHOD' || node.type === 'FUNCTION')) {
         methods.push({ id: node.id, name: node.name || '' });
       }
     }


### PR DESCRIPTION
## Problem

`grafema impact "class X"` aggregated **nothing** (0 callers), and `impact-polymorphic-callers.test.ts` (**REG-543**) was failing on main. Root cause: `getClassMethods` / `findMethodInClass` enumerate a class's methods via `getOutgoingEdges(classId, ['CONTAINS'])` filtering `node.type==='FUNCTION'` — but **classes link to methods via `HAS_METHOD` edges to `METHOD` nodes** (the class's direct `CONTAINS` edge goes to its body SCOPE). Verified live: `CLASS Repo` outgoing edges = `HAS_METHOD ×2 + HAS_SCOPE`; methods are type `METHOD`. So 0 methods were seeded → 0 callers.

This was hidden until #295 removed the invalid `--auto-start` flag that made these tests fail in `beforeEach`. Once runnable: impact-class **7/15**, impact-polymorphic **10/11**.

## Fix
1. `getClassMethods` + `findMethodInClass`: walk `['HAS_METHOD','CONTAINS']` and accept `(METHOD || FUNCTION)`.
2. **Internal-call exclusion**: a method body is an `<expression>` FUNCTION nested in the METHOD, so an internal caller's container is `FUNCTION-><expression>[in:method]`, not the METHOD node — its id isn't in `targetIds`, so internal method-to-method calls were over-counted as external impact (REG-1143 confidently-wrong). Now also exclude a caller whose enclosing scope (`[in:method]` via `parseSemanticIdV2`) is one of the class's own methods.

## Spec
- **Given** `class InternalClass` whose methods only call each other, **when** `impact "class InternalClass"`, **then** `0 direct callers` (internal calls excluded).
- **Given** a class with externally-called methods, **when** `impact "class X"`, **then** the external callers of each method are aggregated.

## Verification (actual)
- `impact-class.test.ts`: **7/15 → 14/15**. The one remaining failure ("class impact >= single method") is **PRE-EXISTING** — fails identically on clean main with `'Unexpected end of JSON input'` because it runs `impact function findById` for a METHOD (searched as FUNCTION → not found → no JSON). Proven via stash-compare. Separate follow-up (impact `--json` should emit JSON on not-found, and/or the test should use a bare/METHOD target).
- `impact-polymorphic-callers.test.ts` (**REG-543**): **10/11 → 11/11** (fully repaired).
- `impact-method-target.test.ts` (REG-1143): **2/2** unchanged.
- `eslint` clean; `tsc` build clean; diff is 5 scoped hunks in one file.

## Adversarial review
- **A:** top-level caller (no `[in:]`) → `namedParent` undefined → not excluded (correct); the direct-METHOD container case is still caught by `targetIds`; cross-class same-method-name → excluded (same documented imprecision as the existing name-scan fallback).
- **B:** localized to `impact.ts`; reuses `parseSemanticIdV2`.
- **C:** the two method-enumeration sites were the class; both fixed.

Builds on #297 (name-scan) + #300 (findContainingFunction METHOD) — both merged. Closes the impact CLASS-target aggregation follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)