### PR TITLE
fix(cli): impact --json emits valid JSON when target not found

### DIFF
--- a/packages/cli/src/commands/impact.ts
+++ b/packages/cli/src/commands/impact.ts
@@ -75,7 +75,17 @@ Examples:
 
       if (!target) {
         if (options.json) {
+          // --json contract: stdout is always parseable JSON. Emit a zero-impact
+          // object (target:null) so scripts/agents don't choke on empty output;
+          // the human-readable note goes to stderr.
           process.stderr.write(`No ${type || 'node'} "${name}" found\n`);
+          console.log(JSON.stringify({
+            target: null,
+            directCallers: 0,
+            transitiveCallers: 0,
+            affectedModules: {},
+            callChains: [],
+          }, null, 2));
         } else {
           console.log(`No ${type || 'node'} "${name}" found`);
         }

--- a/packages/cli/test/impact-json-not-found.test.ts
+++ b/packages/cli/test/impact-json-not-found.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Test for `grafema impact <missing> --json` emitting valid JSON.
+ *
+ * Bug: when the target node is not found, the --json path wrote a message to
+ * stderr and returned with EMPTY stdout, so `JSON.parse(stdout)` threw
+ * "Unexpected end of JSON input". The --json contract is that stdout is always
+ * parseable JSON (scripts/agents consume it). On not-found it should emit a
+ * zero-impact object with target:null. (This also unblocks impact-class.test.ts's
+ * "class impact >= single method impact", which parses `impact function findById
+ * --json` for a method searched as FUNCTION → not found.)
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, dirname } from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliPath = join(__dirname, '../dist/cli.js');
+
+function runCli(args: string[], cwd: string): { stdout: string; stderr: string; status: number | null } {
+  const r = spawnSync('node', [cliPath, ...args], { cwd, encoding: 'utf-8', env: { ...process.env, NO_COLOR: '1' } });
+  return { stdout: r.stdout || '', stderr: r.stderr || '', status: r.status };
+}
+
+describe('grafema impact: --json on not-found', { timeout: 60000 }, () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'gfm-impact-json-'));
+    mkdirSync(join(tempDir, 'src'));
+    writeFileSync(join(tempDir, 'package.json'),
+      JSON.stringify({ name: 'impact-json-test', version: '1.0.0', main: 'src/m.js' }));
+    writeFileSync(join(tempDir, 'src', 'm.js'), 'export function foo() { return 1; }\n');
+    assert.strictEqual(runCli(['init'], tempDir).status, 0);
+    assert.strictEqual(runCli(['analyze'], tempDir).status, 0);
+  });
+
+  afterEach(() => {
+    if (tempDir && existsSync(tempDir)) {
+      runCli(['server', 'stop'], tempDir);
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('emits parseable JSON (target null, zero impact) when the target is not found', () => {
+    const out = runCli(['impact', 'doesNotExist', '--json'], tempDir).stdout;
+    const parsed = JSON.parse(out); // must not throw
+    assert.strictEqual(parsed.target, null, `target should be null for a missing node:\n${out}`);
+    assert.strictEqual(parsed.directCallers, 0);
+    assert.strictEqual(parsed.transitiveCallers, 0);
+  });
+});


### PR DESCRIPTION
## Problem

`grafema impact <missing> --json` wrote `No node "<x>" found` to **stderr** and returned with **empty stdout** — so any consumer doing `JSON.parse(stdout)` got `Unexpected end of JSON input`. The `--json` contract is that stdout is always parseable JSON (scripts/agents depend on it).

Live repro: `impact nonexistent --json` → **0 bytes** stdout.

## Fix
On not-found, emit a zero-impact object to stdout (same shape as the success case, with `target: null`); the human-readable note stays on stderr:
```json
{ "target": null, "directCallers": 0, "transitiveCallers": 0, "affectedModules": {}, "callChains": [] }
```
Non-`--json` path unchanged.

## Spec
- **Given** a symbol not in the graph, **when** `impact <symbol> --json`, **then** stdout is parseable JSON with `target: null` and zero impact (not empty).

## Verification (actual)
- New `packages/cli/test/impact-json-not-found.test.ts`: **red** (`Unexpected end of JSON input`) → **green** (parses; `target===null`; 0 callers).
- Unblocks `impact-class.test.ts` "class impact >= single method impact" (it parses `impact function findById --json`, a METHOD searched as FUNCTION → not found): that subtest now **passes** (impact-class 7→8 on main; the remaining 7 land with #303).
- `eslint` + `tsc` build clean; diff is one scoped hunk.

## Adversarial review
- **A:** not-found → valid JSON (`target:null`, zeros); found case + non-json text unchanged.
- **B:** minimal; reuses the success-case JSON shape.
- **C (class — `--json` always valid JSON):** `wtf --json` on a missing symbol also emits 0 bytes — but it uses `exitWithError` (changing its exit semantics is a design call), so **filed as a follow-up**, not scope-crept here. `who`/`trace --json` already emit JSON.

Relates to the impact work (REG-543 / REG-1143; PRs #297/#300/#303). Independent of #303 (different region of impact.ts) — both are needed for impact-class 15/15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)