### PR TITLE
fix(cli): impact --json always emits valid JSON, even when target not found

### DIFF
--- a/packages/cli/src/commands/impact.ts
+++ b/packages/cli/src/commands/impact.ts
@@ -74,10 +74,25 @@ Examples:
       const target = await findTarget(backend, type, name);
 
       if (!target) {
+        const notFoundMessage = `No ${type || 'node'} "${name}" found`;
         if (options.json) {
-          process.stderr.write(`No ${type || 'node'} "${name}" found\n`);
+          // --json is an agent-facing contract: ALWAYS emit a valid JSON object on
+          // stdout, even when the target is missing. A not-found result is still a
+          // valid answer, not an empty stream + a side-channel stderr line (which
+          // makes a consumer's JSON.parse throw "Unexpected end of JSON input").
+          // The shape mirrors the success payload so callers can read
+          // directCallers/affectedModules unconditionally; target=null plus a
+          // human-readable `error` string signal the miss.
+          console.log(JSON.stringify({
+            target: null,
+            error: notFoundMessage,
+            directCallers: 0,
+            transitiveCallers: 0,
+            affectedModules: {},
+            callChains: [],
+          }, null, 2));
         } else {
-          console.log(`No ${type || 'node'} "${name}" found`);
+          console.log(notFoundMessage);
         }
         return;
       }

--- a/packages/cli/test/impact-notfound-json.test.ts
+++ b/packages/cli/test/impact-notfound-json.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Test for `grafema impact <target> --json` ALWAYS emitting valid JSON on stdout,
+ * including when the target node is not found.
+ *
+ * Bug (pre-existing, surfaced by impact-class.test.ts:622 "class impact >= single
+ * method impact"): when `--json` was set and `findTarget` returned null, impact.ts
+ * wrote the "No <type> <name> found" message to *stderr* and emitted nothing on
+ * stdout. An agent consuming the documented `--json` contract then does
+ * `JSON.parse(stdout)` on an empty string and gets "Unexpected end of JSON input".
+ *
+ * `--json` is an AI-first machine contract: a not-found result is still a valid
+ * answer and must be a parseable JSON object, not an empty stream + a side-channel
+ * stderr line. This test pins that contract.
+ *
+ * Setup note: unlike the sibling impact tests, this one populates a minimal graph
+ * directly through RFDBServerBackend instead of running `grafema analyze`. The
+ * not-found path is independent of how the graph was built — it only needs a graph
+ * to exist and a single FUNCTION node to also exercise the found-target path — so
+ * avoiding the language analyzer keeps the test fast and self-contained.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { mkdtempSync, rmSync, mkdirSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, dirname } from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { RFDBServerBackend } from '@grafema/util';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliPath = join(__dirname, '../dist/cli.js');
+
+function runCli(args: string[], cwd: string): { stdout: string; stderr: string; status: number | null } {
+  const r = spawnSync('node', [cliPath, ...args], { cwd, encoding: 'utf-8', env: { ...process.env, NO_COLOR: '1' } });
+  return { stdout: r.stdout || '', stderr: r.stderr || '', status: r.status };
+}
+
+describe('grafema impact --json: always emits valid JSON', { timeout: 60000 }, () => {
+  let tempDir: string;
+
+  before(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'gfm-impact-json-'));
+    mkdirSync(join(tempDir, '.grafema'), { recursive: true });
+    const dbPath = join(tempDir, '.grafema', 'graph.rfdb');
+
+    // Populate a minimal real graph: one FUNCTION node. This creates graph.rfdb
+    // (so the command's existsSync check passes) and gives us a found-target case.
+    const backend = new RFDBServerBackend({ dbPath, clientName: 'test' });
+    await backend.connect();
+    await backend.addNodes([
+      { id: 'fn:existingFn', type: 'FUNCTION', name: 'existingFn', file: join(tempDir, 'src', 'a.js'), line: 1 },
+    ]);
+    await backend.flush();
+    await backend.close();
+  });
+
+  after(() => {
+    if (tempDir && existsSync(tempDir)) {
+      runCli(['server', 'stop'], tempDir);
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('emits valid JSON (target=null) when the target is not found', () => {
+    const result = runCli(['impact', 'function NonExistentFn_xyz', '--json'], tempDir);
+
+    assert.strictEqual(result.status, 0, `impact should not crash. stderr: ${result.stderr}`);
+
+    let parsed: any;
+    assert.doesNotThrow(() => {
+      parsed = JSON.parse(result.stdout);
+    }, `--json must emit valid JSON even when the target is not found. stdout=${JSON.stringify(result.stdout)}`);
+
+    // Shape mirrors the success payload so consumers can read these fields
+    // unconditionally; target=null + a non-empty error string signal the miss.
+    assert.strictEqual(parsed.target, null, 'target should be null when not found');
+    assert.strictEqual(parsed.directCallers, 0, 'directCallers should be 0');
+    assert.strictEqual(parsed.transitiveCallers, 0, 'transitiveCallers should be 0');
+    assert.deepStrictEqual(parsed.affectedModules, {}, 'affectedModules should be empty');
+    assert.deepStrictEqual(parsed.callChains, [], 'callChains should be empty');
+    assert.ok(
+      typeof parsed.error === 'string' && parsed.error.length > 0,
+      `should include a human-readable error string. Got: ${JSON.stringify(parsed.error)}`
+    );
+  });
+
+  it('still emits valid JSON for a target that exists', () => {
+    const result = runCli(['impact', 'function existingFn', '--json'], tempDir);
+
+    assert.strictEqual(result.status, 0, `impact should not crash. stderr: ${result.stderr}`);
+
+    let parsed: any;
+    assert.doesNotThrow(() => {
+      parsed = JSON.parse(result.stdout);
+    }, `--json must emit valid JSON for a found target. stdout=${JSON.stringify(result.stdout)}`);
+
+    assert.ok(parsed.target, 'found target should be present');
+    assert.strictEqual(parsed.target.name, 'existingFn', 'target name should match');
+  });
+});


### PR DESCRIPTION
## Problem

`grafema impact <target> --json` is an agent-facing machine contract, but when the target node could not be resolved, it wrote the diagnostic to **stderr** and emitted **nothing on stdout** while exiting **0** — a silent success. Any consumer doing `JSON.parse(stdout)` then gets `Unexpected end of JSON input`.

This is the pre-existing failure behind `impact-class.test.ts:622` ("class impact >= single method impact"), flagged as a follow-up in #303: that test runs `impact function findById --json` where `findById` is a `METHOD` (not found when searched as `FUNCTION`), so the method result was empty stdout and the test's `JSON.parse` threw.

`impact` was the **only** CLI command in this failure class — `who`/`trace` already emit valid JSON on empty/not-found, and `describe`/`explain`/`get` signal not-found via a non-zero `exitWithError`. `impact` alone returned **0 + empty stdout**.

## Reproduce (live, before fix)

Minimal graph (one FUNCTION node) populated via `RFDBServerBackend`, then:

```
$ grafema impact "function existingFn"  --json   # found  → valid JSON, status 0
$ grafema impact "function Nonexistent" --json   # missing → status 0, stdout "", JSON.parse → "Unexpected end of JSON input"
```

Actual before-fix stdout for the missing target: `""` → `JSON.parse(stdout) error: Unexpected end of JSON input`.

## Fix

`packages/cli/src/commands/impact.ts` — in the `--json` not-found branch, emit a JSON object that mirrors the success shape (`directCallers` / `transitiveCallers` / `affectedModules` / `callChains`) with `target: null` and a human-readable `error` string. Plain (non-json) text output is unchanged.

After fix, the missing-target stdout is:

```json
{
  "target": null,
  "error": "No FUNCTION \"Nonexistent\" found",
  "directCallers": 0,
  "transitiveCallers": 0,
  "affectedModules": {},
  "callChains": []
}
```

`target: null` plus a non-empty `error` lets a consumer distinguish "found with 0 callers" from "not found" while reading the count/collection fields unconditionally — consistent with `who`/`trace`.

## Spec

- **Given** an analyzed graph, **when** `impact "<missing>" --json`, **then** stdout is a valid JSON object with `target: null`, zeroed counts, and a non-empty `error` (exit 0).
- **Given** a target that exists, **when** `impact "<target>" --json`, **then** stdout is a valid JSON object with `target` populated (unchanged behavior).

## Test (red → green)

New `packages/cli/test/impact-notfound-json.test.ts`. It populates a minimal graph directly through `RFDBServerBackend` (no language analyzer) so it's fast and self-contained, then asserts the `--json` contract for both not-found and found targets.

- **Red** (unfixed): not-found subtest fails at `JSON.parse` (`Unexpected end of JSON input`); found subtest passes. → `1 fail / 1 pass`.
- **Green** (fixed): `2 pass / 0 fail`.

## Adversarial review

- **A — Correctness:** message is plain string interpolation; `type || 'node'` covers bare-name targets; `JSON.stringify` escapes quotes/Unicode in names. Success path untouched. Non-json text path identical to before (still `console.log("No … found")`).
- **B — Structural:** 17-line localized change in one file; no new coupling; reuses the existing success-payload shape.
- **C — Class-not-instance:** swept all CLI commands. `impact` was the sole "status 0 + `--json` + empty stdout" case; `who`/`trace` already emit JSON on not-found, `describe`/`explain`/`get` use non-zero `exitWithError`. No sibling fix or follow-up needed.

## Verification (actual, this run)

- New test: **red 1/2 → green 2/2** (run via the prebuilt rfdb-server).
- `pnpm typecheck` → exit 0. `pnpm lint` → exit 0. CLI build clean.
- Diff: 1 file changed in `src` (17 +/2 −) plus the new test.

### Environment note on the full gate

`pnpm build` (all packages) and `./scripts/test.sh` need the native toolchain — Rust orchestrator + the Haskell `js-analyzer` — which is **not provisioned in this execution environment** (no GHC/cabal), so the `analyze`-dependent sibling tests (incl. `impact-class.test.ts` itself) can't run here. The new test deliberately avoids `analyze` and exercises the exact `JSON.parse` failure those tests hit, so the fixed path is verified end-to-end via the CLI. CI (with the analyzer built) should additionally green `impact-class.test.ts:622`.

Follows up #303 / REG-543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vqymbx5dbxJX5XgShHGj5M)_