### PR TITLE
fix(cli): wtf --json emits valid JSON when symbol not found

### DIFF
--- a/packages/cli/src/commands/wtf.ts
+++ b/packages/cli/src/commands/wtf.ts
@@ -101,6 +101,15 @@ Examples:
 
       if (!found) {
         spinner.stop();
+        if (options.json) {
+          // --json contract: stdout is always parseable JSON so scripts/agents
+          // don't choke on empty output. Emit a null-result object mirroring the
+          // found-case shape; the human-readable note goes to stderr. Matches
+          // `impact --json` not-found behavior (PR #304).
+          process.stderr.write(`Symbol not found: "${symbol}"\n`);
+          console.log(JSON.stringify({ symbol, node: null, results: [] }, null, 2));
+          return;
+        }
         exitWithError(`Symbol not found: "${symbol}"`, [
           'Check the symbol name and try again',
           'Use: grafema query "<name>" to search available nodes',

--- a/packages/cli/test/wtf-json-not-found.test.ts
+++ b/packages/cli/test/wtf-json-not-found.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Test for `grafema wtf <missing> --json` emitting valid JSON.
+ *
+ * Bug (sibling of the impact --json fix, PR #304 / REG-543 lineage): when the
+ * symbol is not found, the not-found path called `exitWithError()` — printing a
+ * human-readable message to stderr and `process.exit(1)` with EMPTY stdout —
+ * even under `--json`. So `JSON.parse(stdout)` threw "Unexpected end of JSON
+ * input". The --json contract is that stdout is always parseable JSON
+ * (scripts/agents consume it). On not-found it should emit a null-result object
+ * (node:null, results:[]) and the human note goes to stderr.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, dirname } from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliPath = join(__dirname, '../dist/cli.js');
+
+function runCli(args: string[], cwd: string): { stdout: string; stderr: string; status: number | null } {
+  const r = spawnSync('node', [cliPath, ...args], { cwd, encoding: 'utf-8', env: { ...process.env, NO_COLOR: '1' } });
+  return { stdout: r.stdout || '', stderr: r.stderr || '', status: r.status };
+}
+
+describe('grafema wtf: --json on not-found', { timeout: 60000 }, () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'gfm-wtf-json-'));
+    mkdirSync(join(tempDir, 'src'));
+    writeFileSync(join(tempDir, 'package.json'),
+      JSON.stringify({ name: 'wtf-json-test', version: '1.0.0', main: 'src/m.js' }));
+    writeFileSync(join(tempDir, 'src', 'm.js'), 'export function foo() { return 1; }\n');
+    assert.strictEqual(runCli(['init'], tempDir).status, 0);
+    assert.strictEqual(runCli(['analyze'], tempDir).status, 0);
+  });
+
+  afterEach(() => {
+    if (tempDir && existsSync(tempDir)) {
+      runCli(['server', 'stop'], tempDir);
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('emits parseable JSON (node null, empty results) when the symbol is not found', () => {
+    const out = runCli(['wtf', 'doesNotExistSymbol', '--json'], tempDir).stdout;
+    const parsed = JSON.parse(out); // must not throw
+    assert.strictEqual(parsed.node, null, `node should be null for a missing symbol:\n${out}`);
+    assert.deepStrictEqual(parsed.results, []);
+    assert.strictEqual(parsed.symbol, 'doesNotExistSymbol');
+  });
+});


### PR DESCRIPTION
## Problem

`grafema wtf <symbol> --json` violated the `--json` contract on the not-found path. When the symbol wasn't found, the code called `exitWithError()` — a human-readable message to **stderr** plus `process.exit(1)` with **empty stdout** — even under `--json`. A consumer doing `JSON.parse(stdout)` got `Unexpected end of JSON input`.

This is the exact sibling of the merged `impact --json` not-found bug (PR #304, REG-543 lineage) — flagged during that PR's Round C review.

### Reproduce (before)
```
$ grafema wtf __missing__ --json ; echo "exit=$?"
exit=1
# stdout: (empty)
# stderr: ✗ Symbol not found: "__missing__" ...
$ node -e 'JSON.parse(process.argv[1])' "$(grafema wtf __missing__ --json)"
SyntaxError: Unexpected end of JSON input
```

## Spec

- **Invariant restored:** under `--json`, stdout is ALWAYS parseable JSON.
- **Given** an analyzed project **When** `wtf <missing> --json` runs **Then** stdout is a JSON object `{ symbol, node: null, results: [] }` (mirroring the found-case shape `{ symbol, node, results }`), the human note goes to stderr, and the process exits 0 (the `finally` block closes the backend cleanly).
- Non-`--json` behavior is unchanged (`exitWithError`, exit 1).

## Fix

`packages/cli/src/commands/wtf.ts` — 9-line branch in the existing not-found block. Mirrors the merged `impact --json` convention (`impact.ts:76-89` on main).

## Verify (after)
```
$ grafema wtf __missing__ --json ; echo "exit=$?"
{
  "symbol": "__missing__",
  "node": null,
  "results": []
}
exit=0
# JSON.parse(stdout) → OK (node=null, results.length=0)
```

- New test `packages/cli/test/wtf-json-not-found.test.ts` (mirrors `impact-json-not-found.test.ts`): **red** at `JSON.parse(out)` before the fix → **green** after.
- Found-path regression check: `wtf node --json` still returns a populated `node` object (VARIABLE) — found path untouched.
- `tsc --noEmit` exit 0; `eslint packages/cli/src/commands/wtf.ts` exit 0.
- Pre-commit hook ran the root CI-gated suite: **22 pass, 0 fail**.

## Adversarial review

- **Round A (correctness):** missing-symbol → exit 0 + valid JSON ✓; found-symbol → found path unchanged, `node` populated ✓; `return` (not `process.exit`) lets `finally` close the backend — no leak/hang ✓; special chars in `symbol` are escaped by `JSON.stringify` ✓; `--json` false → unchanged exit-1 path ✓.
- **Round B (structural):** `wtf.ts` ~152 lines (< 500) ✓. The not-found JSON shape is now hand-mirrored against the found-case shape (lines ~122-132) — **fragility:** if the found `--json` shape changes, this branch must change too. Same copy-paste convention as `impact`/`trace`; a shared `emitJsonNotFound()` helper would centralize it (see follow-ups).
- **Round C (class-not-instance):** swept all `packages/cli/src/commands/*.ts` for `--json` + `exitWithError`-on-post-lookup-not-found. `trace.ts` and `why.ts` already branch on json (correct). The following are **structural candidates with the same latent bug** (not individually repro'd here; same shape as wtf/impact): `context.ts` (Node not found), `describe.ts` (Target not found), `explain.ts` (File not found), `file.ts` (File not found), `get.ts` (Node not found), `ls.ts` (No nodes of type found). Fixing the class beyond `wtf` is deliberately out of scope for this PR.

## Blast radius

One command (`wtf`), not-found path only. Found path and non-json path byte-for-byte unchanged.

## Follow-ups (not filed as issues — need maintainer go-ahead)

- [ ] Apply the same `--json` not-found fix to: `context`, `describe`, `explain`, `file`, `get`, `ls`.
- [ ] Consider a shared `emitJsonNotFound(shape)` helper in `errorFormatter` to retire the copy-paste convention across `impact`/`wtf`/`trace` and the commands above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)