### PR TITLE
fix(rfdb): connection-error hints no longer point users at the removed --auto-start flag

### DIFF
--- a/.claude/skills/rfdb-v2-clear-ephemeral-trap/SKILL.md
+++ b/.claude/skills/rfdb-v2-clear-ephemeral-trap/SKILL.md
@@ -24,7 +24,7 @@ error.
 
 ## Context / Trigger Conditions
 
-- `grafema analyze --clear --auto-start` reports successful analysis with node/edge counts
+- `grafema analyze --clear` reports successful analysis with node/edge counts
 - On restart, rfdb-server logs "Default database: 0 nodes, 0 edges"
 - `manifest_index.json` shows `"total_nodes": 0, "total_edges": 0`
 - Segment directories (`segments/00/`, `segments/01/`, etc.) exist but are empty
@@ -68,10 +68,10 @@ but nothing is written to disk. When the process exits, all data is lost.
 
 ```dockerfile
 # BAD: --clear makes V2 engine ephemeral, data lost
-RUN grafema analyze /build --clear --auto-start
+RUN grafema analyze /build --clear
 
 # GOOD: No --clear needed for fresh build (no existing DB)
-RUN grafema analyze /build --auto-start
+RUN grafema analyze /build
 ```
 
 If you truly need to clear and re-analyze an existing database, the proper approach is to
@@ -79,7 +79,7 @@ delete the database directory before starting the server, rather than using `--c
 
 ```bash
 rm -rf .grafema/graph.rfdb
-grafema analyze . --auto-start
+grafema analyze .
 ```
 
 ## Verification

--- a/packages/rfdb/ts/client.test.ts
+++ b/packages/rfdb/ts/client.test.ts
@@ -306,6 +306,64 @@ describe('RFDBClient.addNodes() Metadata Preservation', () => {
 });
 
 // ============================================================================
+// Connection Error Hints — removed auto-start flag (follow-up of PR #295)
+// ============================================================================
+
+/**
+ * WHY: `_enhanceConnectionError()` rewrites low-level socket errors into a
+ * human-readable hint that tells the user how to get the RFDB server running.
+ * It historically told them to use the opt-in auto-start flag — but that CLI
+ * flag was removed (auto-start is now the DEFAULT; only `--no-auto-start`
+ * remains, see packages/cli/src/commands/analyze.ts). Commander rejects unknown
+ * options, so a user who follows the stale hint and re-runs `grafema analyze`
+ * with that flag gets `error: unknown option` — the guidance actively breaks.
+ *
+ * Invariant: the connection-error hint must never name the removed auto-start
+ * flag, and must still point the user at a working remedy (`rfdb-server start`).
+ */
+describe('RFDBClient connection-error hints (removed auto-start flag)', () => {
+  // Assemble the removed flag from parts so a source scan of THIS test file
+  // does not flag itself (mirrors test/unit/AnalyzeAutoStartFlag.test.js).
+  const REMOVED_FLAG = '--auto' + '-start';
+
+  function hintFor(code: string): string {
+    const client = new RFDBClient('/tmp/test-nonexistent.sock');
+    const err = Object.assign(new Error('boom'), { code }) as NodeJS.ErrnoException;
+    // _enhanceConnectionError is private; access via the runtime instance.
+    return (client as unknown as {
+      _enhanceConnectionError(e: NodeJS.ErrnoException): Error;
+    })._enhanceConnectionError(err).message;
+  }
+
+  for (const code of ['ENOENT', 'ECONNREFUSED', 'EPIPE', 'ECONNRESET']) {
+    it(`${code}: hint does not name the removed auto-start flag`, () => {
+      const msg = hintFor(code);
+      assert.ok(
+        !msg.includes(REMOVED_FLAG),
+        `hint for ${code} must not reference the removed ${REMOVED_FLAG} flag; got:\n${msg}`,
+      );
+    });
+
+    it(`${code}: hint points at a working remedy (rfdb-server start)`, () => {
+      const msg = hintFor(code);
+      assert.ok(
+        msg.includes('rfdb-server start'),
+        `hint for ${code} should tell the user how to start the server; got:\n${msg}`,
+      );
+    });
+  }
+
+  it('unknown error codes are passed through unchanged', () => {
+    const client = new RFDBClient('/tmp/test-nonexistent.sock');
+    const original = Object.assign(new Error('weird'), { code: 'ESOMETHING' }) as NodeJS.ErrnoException;
+    const out = (client as unknown as {
+      _enhanceConnectionError(e: NodeJS.ErrnoException): Error;
+    })._enhanceConnectionError(original);
+    assert.strictEqual(out, original, 'non-connection errors should be returned as-is');
+  });
+});
+
+// ============================================================================
 // Snapshot API Tests
 // ============================================================================
 

--- a/packages/rfdb/ts/client.ts
+++ b/packages/rfdb/ts/client.ts
@@ -108,7 +108,10 @@ export class RFDBClient extends BaseRFDBClient {
   }
 
   /**
-   * Enhance connection errors with helpful messages about --auto-start
+   * Enhance connection errors with helpful guidance on starting the RFDB server.
+   * Hints point at the manual remedy `rfdb-server start`: auto-start is the
+   * default (disable via `--no-auto-start`), and the former opt-in
+   * `--auto-start` flag was removed (commander rejects it as unknown).
    */
   private _enhanceConnectionError(err: NodeJS.ErrnoException): Error {
     const code = err.code;
@@ -116,7 +119,7 @@ export class RFDBClient extends BaseRFDBClient {
     if (code === 'EPIPE' || code === 'ECONNRESET') {
       return new Error(
         `RFDB server connection lost (${code}). The server may have crashed or been stopped.\n` +
-        `Try running with --auto-start flag to automatically start the server, or manually start it with:\n` +
+        `It normally auto-starts by default; if you disabled that with --no-auto-start, restart it with:\n` +
         `  rfdb-server start`
       );
     }
@@ -124,7 +127,7 @@ export class RFDBClient extends BaseRFDBClient {
     if (code === 'ENOENT') {
       return new Error(
         `RFDB server socket not found at ${this.socketPath}.\n` +
-        `The server is not running. Use --auto-start flag to automatically start it, or manually start with:\n` +
+        `The server is not running. It normally auto-starts by default; if you disabled that with --no-auto-start, start it with:\n` +
         `  rfdb-server start`
       );
     }
@@ -132,7 +135,7 @@ export class RFDBClient extends BaseRFDBClient {
     if (code === 'ECONNREFUSED') {
       return new Error(
         `Cannot connect to RFDB server at ${this.socketPath} (connection refused).\n` +
-        `The server may not be running. Use --auto-start flag to automatically start it, or manually start with:\n` +
+        `The server may not be running. It normally auto-starts by default; if you disabled that with --no-auto-start, start it with:\n` +
         `  rfdb-server start`
       );
     }

--- a/test/unit/RfdbConnectionErrorHint.test.js
+++ b/test/unit/RfdbConnectionErrorHint.test.js
@@ -1,0 +1,88 @@
+/**
+ * Regression guard (class-not-instance): the RFDB client's connection-error
+ * hint must not direct users to the removed auto-start flag.
+ *
+ * Why this matters:
+ *   - `RFDBClient._enhanceConnectionError()` (packages/rfdb/ts/client.ts)
+ *     rewrites low-level socket errors (ENOENT / ECONNREFUSED / EPIPE /
+ *     ECONNRESET) into a human-readable hint about getting the server running.
+ *   - It historically told users to use the opt-in auto-start flag. That flag
+ *     was removed: auto-start is now the DEFAULT and only the negation
+ *     `--no-auto-start` remains (see packages/cli/src/commands/analyze.ts; the
+ *     sibling guard test/unit/AnalyzeAutoStartFlag.test.js encodes this for the
+ *     `analyze` test suites).
+ *   - Commander rejects unknown options, so a user who follows the stale hint
+ *     and re-runs `grafema analyze` with that flag gets
+ *     `error: unknown option` — the guidance actively breaks.
+ *
+ * This is the runtime-message sibling of AnalyzeAutoStartFlag.test.js: that one
+ * guards the test suites, this one guards the user-facing client error hint.
+ *
+ * Premise check: if `analyze` ever re-introduces a real auto-start option, the
+ * ban auto-relaxes (the flag becomes valid again), exactly like the sibling.
+ *
+ * Note the removed flag's leading-`--` form is NOT a substring of the valid
+ * `--no-auto-start` (the leading `--` sits before `no`), so a literal scan of
+ * the assembled flag does not false-match the surviving negation. The banned
+ * literal is assembled from parts below so this guard does not flag itself.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..');
+
+// Assemble the flag from parts so THIS guard file does not match its own scan
+// (and so the sibling AnalyzeAutoStartFlag guard does not flag this file).
+const FLAG = '--auto' + '-start';
+const ANALYZE_CMD_SRC = join(REPO_ROOT, 'packages/cli/src/commands/analyze.ts');
+const CLIENT_SRC = join(REPO_ROOT, 'packages/rfdb/ts/client.ts');
+
+/** Whether the `analyze` command currently defines the auto-start flag as an option. */
+function analyzeDefinesAutoStart() {
+  const src = readFileSync(ANALYZE_CMD_SRC, 'utf8');
+  return src.includes(`.option('${FLAG}'`) || src.includes(`.option("${FLAG}"`);
+}
+
+/**
+ * Source of the `_enhanceConnectionError` method body (the hint strings only).
+ *
+ * Anchors on the method DEFINITION, not the earlier call site, and starts after
+ * the doc comment — so an explanatory doc comment that names the removed flag to
+ * record its history does not false-trip this scan. We only inspect the runtime
+ * hint strings the user actually sees.
+ */
+function enhanceConnectionErrorSource() {
+  const src = readFileSync(CLIENT_SRC, 'utf8');
+  const def = src.indexOf('private _enhanceConnectionError');
+  assert.notStrictEqual(def, -1, 'expected client.ts to define _enhanceConnectionError');
+  // Capture a generous window covering the method body (short, self-contained).
+  return src.slice(def, def + 1500);
+}
+
+test('RFDB client connection-error hint does not name the removed auto-start flag', () => {
+  if (analyzeDefinesAutoStart()) {
+    // The flag is a real option again — nothing to ban.
+    return;
+  }
+
+  const body = enhanceConnectionErrorSource();
+  assert.ok(
+    !body.includes(FLAG),
+    `_enhanceConnectionError references the removed ${FLAG} flag; commander rejects it ` +
+      'as an unknown option. Auto-start is the default — point users at `rfdb-server start` ' +
+      'instead.',
+  );
+});
+
+test('RFDB client connection-error hint still points at a working remedy', () => {
+  const body = enhanceConnectionErrorSource();
+  assert.ok(
+    body.includes('rfdb-server start'),
+    'the connection-error hint should tell the user how to start the server (`rfdb-server start`)',
+  );
+});


### PR DESCRIPTION
## Problem

`RFDBClient._enhanceConnectionError()` (`packages/rfdb/ts/client.ts`) rewrites low-level socket errors (`ENOENT` / `ECONNREFUSED` / `EPIPE` / `ECONNRESET`) into a human-readable hint about getting the server running. All three hints told the user to **"Use `--auto-start` flag"**.

That flag was **removed**: auto-start is now the default and only the negation `--no-auto-start` remains (`packages/cli/src/commands/analyze.ts:24`). Commander rejects unknown options, so a user who follows the stale hint and runs `grafema analyze --auto-start` gets `error: unknown option '--auto-start'` — **the guidance actively breaks**.

This is the runtime-message sibling of the merged source-scan guard `test/unit/AnalyzeAutoStartFlag.test.js` (PR #295): that guard covers test-suite invocations of the removed flag; the user-facing client hint was left as a recorded follow-up.

### Reproduce (before) — live, in-env

```
$ grep -n "auto-start" packages/rfdb/ts/client.ts
119:  `Try running with --auto-start flag to automatically start the server, ...`
127:  `The server is not running. Use --auto-start flag to automatically start it, ...`
135:  `The server may not be running. Use --auto-start flag to automatically start it, ...`
```
```
# behavioral, against built dist:
[ENOENT]       contains --auto-start: true
[ECONNREFUSED] contains --auto-start: true
[EPIPE]        contains --auto-start: true
```
`analyze.ts` defines only `.option('--no-auto-start', ...)` — commander rejects the flag the hint names.

## Spec

- **Invariant restored:** the connection-error hint must never name the removed `--auto-start` flag and must still point the user at a working remedy.
- **Given** any connection error (`ENOENT`/`ECONNREFUSED`/`EPIPE`/`ECONNRESET`) **When** `_enhanceConnectionError` builds the hint **Then** the message names no removed flag, points at `rfdb-server start`, and mentions that auto-start is the default (disable via `--no-auto-start`).
- Non-connection errors (any other `code`) are passed through unchanged.

## Fix

`packages/rfdb/ts/client.ts` — rewrite the three hint strings + the method doc comment. Hints now read e.g.:

```
RFDB server socket not found at <path>.
The server is not running. It normally auto-starts by default; if you disabled that with --no-auto-start, start it with:
  rfdb-server start
```

Same-class cleanup: the `rfdb-v2-clear-ephemeral-trap` skill examples (`.claude/skills/.../SKILL.md`) used the removed flag in `grafema analyze ... --auto-start` snippets — dropped (`--auto-start` was a no-op default even when it existed).

## Verify (after)

```
[ENOENT]       contains --auto-start: false   → "...start it with:  rfdb-server start"
[ECONNREFUSED] contains --auto-start: false
[EPIPE]        contains --auto-start: false
```

- **CI-gated guard** `test/unit/RfdbConnectionErrorHint.test.js` (root glob, no build): red → green. Source-scans the method body; anchors on the method *definition* so an explanatory doc comment can record the flag's history without false-tripping. Premise-relaxes if `analyze` ever re-adds a real auto-start option (mirrors the sibling guard).
- **Behavioral** subtests in `packages/rfdb/ts/client.test.ts`: all four error codes × {no removed flag, points at `rfdb-server start`} + pass-through of unknown codes — **51/51** via `node --import tsx --test`.
- Full gate: `pnpm build` exit 0 · `./scripts/test.sh` **691 pass / 0 fail** · `pnpm typecheck` exit 0 · `pnpm lint` exit 0.
- Sibling precedent guard `AnalyzeAutoStartFlag.test.js` stays green (my test files keep the `--`-prefixed literal out of their prose; the banned literal is assembled from parts).

## Adversarial review

- **Round A (correctness):** all four codes rewritten; pass-through for other codes is tested. Hints reference only the surviving `--no-auto-start` (not a substring of the banned `--auto-start`) and `rfdb-server start`. ✓
- **Round B (structural):** `client.ts` is 496 lines (< 500) — trimmed the doc comment to keep margin after the threshold-adjacent edit. The CI guard anchors on `private _enhanceConnectionError` (not the earlier call site) so its scan window covers the hint strings, not the doc comment. ✓
- **Round C (class-not-instance):** swept `packages/`, `scripts/`, `docs/`, `.claude/` for `--auto-start` excluding `--no-auto-start`/tests/dist — only client.ts (fixed) and the skill doc (fixed). The lone remaining literal is the intentional explanatory doc comment in client.ts. No other connection-error hint site shares the pattern. The removed-flag class is now covered by two guards: `AnalyzeAutoStartFlag` (test suites) + `RfdbConnectionErrorHint` (runtime client hint). ✓

## Blast radius

One method's three hint strings (error path only) + one skill doc's examples + two test artifacts. No behavior change beyond the message text; success paths untouched.

## Follow-ups

- None outstanding for this class — the previously-recorded stale `--auto-start` references (client.ts hints + skill examples) are now resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
https://claude.ai/code/session_01FDsvLcbc9uXabC838Xss27

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDsvLcbc9uXabC838Xss27)_