### PR TITLE
fix(cli): explain/file --json emit valid JSON when file not found

### DIFF
--- a/packages/cli/src/commands/explain.ts
+++ b/packages/cli/src/commands/explain.ts
@@ -17,7 +17,7 @@ import { resolve, join, relative, normalize } from 'path';
 import { existsSync, realpathSync } from 'fs';
 import { toRelativeDisplay } from '../utils/pathUtils.js';
 import { RFDBServerBackend, FileExplainer, type EnhancedNode } from '@grafema/util';
-import { exitWithError } from '../utils/errorFormatter.js';
+import { exitWithError, emitJsonNotFound } from '../utils/errorFormatter.js';
 
 interface ExplainOptions {
   project: string;
@@ -78,6 +78,15 @@ If a file shows NOT_ANALYZED:
     // Resolve to absolute path for graph lookup
     const resolvedPath = resolve(projectPath, filePath);
     if (!existsSync(resolvedPath)) {
+      if (options.json) {
+        // --json contract: stdout is always parseable JSON. Mirror the
+        // FileExplainResult shape with a NOT_FOUND status; human note to stderr.
+        emitJsonNotFound(
+          { file, status: 'NOT_FOUND', nodes: [], byType: {}, totalCount: 0 },
+          `File not found: ${file}`,
+        );
+        return;
+      }
       exitWithError(`File not found: ${file}`, [
         'Check the file path and try again',
       ]);

--- a/packages/cli/src/commands/file.ts
+++ b/packages/cli/src/commands/file.ts
@@ -16,7 +16,7 @@ import { resolve, join, relative, normalize } from 'path';
 import { existsSync, realpathSync } from 'fs';
 import { RFDBServerBackend, FileOverview } from '@grafema/util';
 import type { FileOverviewResult, FunctionOverview } from '@grafema/util';
-import { exitWithError } from '../utils/errorFormatter.js';
+import { exitWithError, emitJsonNotFound } from '../utils/errorFormatter.js';
 import { Spinner } from '../utils/spinner.js';
 
 interface FileOptions {
@@ -79,6 +79,15 @@ Use 'grafema context <id>' to dive deeper into any specific entity.
 
     const resolvedPath = resolve(projectPath, filePath);
     if (!existsSync(resolvedPath)) {
+      if (options.json) {
+        // --json contract: stdout is always parseable JSON. Mirror the
+        // FileOverviewResult shape with a NOT_FOUND status; human note to stderr.
+        emitJsonNotFound(
+          { file, status: 'NOT_FOUND', imports: [], exports: [], classes: [], functions: [], variables: [] },
+          `File not found: ${file}`,
+        );
+        return;
+      }
       exitWithError(`File not found: ${file}`, [
         'Check the file path and try again',
       ]);

--- a/packages/cli/test/json-notfound-contract.test.ts
+++ b/packages/cli/test/json-notfound-contract.test.ts
@@ -76,4 +76,20 @@ describe('CLI --json not-found contract (get/context/describe/ls)', { timeout: 9
     assert.deepStrictEqual(parsed.nodes, [], `nodes should be empty:\n${out}`);
     assert.strictEqual(parsed.total, 0);
   });
+
+  it('explain <missing-file> --json → parseable JSON, NOT_FOUND, empty nodes', () => {
+    const out = runCli(['explain', '__nope__.ts', '--json'], tempDir).stdout;
+    const parsed = JSON.parse(out); // must not throw
+    assert.strictEqual(parsed.status, 'NOT_FOUND', `status should be NOT_FOUND:\n${out}`);
+    assert.deepStrictEqual(parsed.nodes, []);
+    assert.strictEqual(parsed.totalCount, 0);
+  });
+
+  it('file <missing-file> --json → parseable JSON, NOT_FOUND, empty collections', () => {
+    const out = runCli(['file', '__nope__.ts', '--json'], tempDir).stdout;
+    const parsed = JSON.parse(out); // must not throw
+    assert.strictEqual(parsed.status, 'NOT_FOUND', `status should be NOT_FOUND:\n${out}`);
+    assert.deepStrictEqual(parsed.functions, []);
+    assert.deepStrictEqual(parsed.imports, []);
+  });
 });


### PR DESCRIPTION
## Problem

`explain <file> --json` and `file <file> --json` violated the `--json` contract when the file doesn't exist on disk. The `!existsSync(resolvedPath)` check called `exitWithError()` — human message to **stderr** + `process.exit(1)` with **empty stdout** — even under `--json`. A consumer doing `JSON.parse(stdout)` got `Unexpected end of JSON input`.

This completes the `--json` not-found contract class: impact (#304), wtf (#307), get/context/describe/ls (#308), and now explain/file.

### Reproduce (before)
```
$ node packages/cli/dist/cli.js explain __nope__.ts --json ; echo "exit=$?"
exit=1
# stdout: (empty)   → JSON.parse fails: Unexpected end of JSON input
# stderr: ✗ File not found: __nope__.ts
```

## Spec

- **Invariant restored:** under `--json`, stdout is ALWAYS parseable JSON.
- **Given** an analyzed project **When** `explain|file <missing> --json` runs **Then** stdout is a JSON object mirroring the command's success shape with `status: "NOT_FOUND"` and empty collections; the human note goes to stderr; exit 0.
- Non-`--json` behavior unchanged (`exitWithError`, exit 1).

## Fix

Both not-found checks now branch on `options.json` and call the shared `emitJsonNotFound` helper (added in #308), mirroring the exact success shapes:

| Command | Success type | Not-found JSON |
|---|---|---|
| `explain` | `FileExplainResult` | `{ file, status: "NOT_FOUND", nodes: [], byType: {}, totalCount: 0 }` |
| `file` | `FileOverviewResult` | `{ file, status: "NOT_FOUND", imports: [], exports: [], classes: [], functions: [], variables: [] }` |

Both not-found checks run *before* any RFDB backend is created, so the branch is a clean `emit + return` (no finally/teardown concern).

### Design note — exit code
I chose **exit 0** (consistent with the 6 sibling `--json` commands): a machine consumer asking "what's in this file?" gets "no analysis available" (`NOT_FOUND`) as a valid empty result, exactly as graph-entity-not-found does. The human (non-json) path keeps `exitWithError` (exit 1) since a person likely typo'd a path. If you'd prefer `explain`/`file` to exit **1** under `--json` (treating file-absent-on-disk as a distinct input error vs. graph-entity-absent), that's a one-line flip — happy to change.

## Verify (after)
```
$ explain __nope__.ts --json  → exit 0, {status:"NOT_FOUND", totalCount:0, nodes:[]}, JSON.parse OK
$ file    __nope__.ts --json  → {status:"NOT_FOUND", functions:[], ...}, JSON.parse OK
$ explain packages/cli/src/commands/explain.ts --json  → exit 0, {status:"ANALYZED", totalCount:187}  (found path unchanged)
$ explain __nope__.ts          → exit 1  (non-json unchanged)
```

- Test `packages/cli/test/json-notfound-contract.test.ts` extended with explain/file subtests: **6/6 pass** (get/context/describe/ls/explain/file).
- `tsc` build exit 0; `eslint` on both files exit 0.
- Pre-commit hook ran the root CI-gated suite: **22 pass, 0 fail**.

## Adversarial review

- **Round A:** missing → exit 0 + valid JSON ✓; found path unchanged (ANALYZED, 187 nodes) ✓; non-json → exit 1 ✓; `JSON.stringify` escapes the path ✓; not-found check precedes backend creation → no teardown needed ✓.
- **Round B:** explain.ts 191 lines, file.ts 196 lines (< 500) ✓. Shapes mirror the actual success types faithfully (learning from #308's post-merge `get`-shape correction). Reuses the shared helper — no duplication.
- **Round C (class-not-instance):** re-swept all commands for `--json` + not-found `exitWithError`. The known 8 are now done (impact/wtf/get/context/describe/ls/explain/file). **Newly found:** `check.ts` has `--json` (line 43) + `exitWithError("Unknown guarantee"/"Guarantee not found")` — a likely additional member, left as a follow-up (not scope-crept). `schema.ts`/`tldr.ts` matched the grep but have **no** `--json` flag → not affected. `trace`/`why` already branch on json.

## Blast radius

Two commands, file-not-found path only. Found and non-json paths unchanged. No new exports (reuses #308's helper).

## Follow-ups

- [ ] Verify + fix `check --json` not-found (`Unknown guarantee` / `Guarantee not found` via `exitWithError`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)