### PR TITLE
fix(cli): context --json not-found shape mirrors success (source/edges)

### DIFF
--- a/packages/cli/src/commands/context.ts
+++ b/packages/cli/src/commands/context.ts
@@ -96,7 +96,13 @@ Examples:
       if (!node) {
         spinner.stop();
         if (options.json) {
-          emitJsonNotFound({ node: null }, `Node not found: "${semanticId}"`);
+          // Mirror the success NodeContext shape ({ node, source, outgoing,
+          // incoming }) so consumers reading result.outgoing / result.incoming
+          // on success don't crash on not-found (sibling of the get fix #308).
+          emitJsonNotFound(
+            { node: null, source: null, outgoing: [], incoming: [] },
+            `Node not found: "${semanticId}"`,
+          );
           return;
         }
         exitWithError(`Node not found: "${semanticId}"`, [

--- a/packages/cli/test/json-notfound-contract.test.ts
+++ b/packages/cli/test/json-notfound-contract.test.ts
@@ -58,10 +58,16 @@ describe('CLI --json not-found contract (get/context/describe/ls)', { timeout: 9
     assert.deepStrictEqual(parsed.stats, { incomingCount: 0, outgoingCount: 0 }, `stats shape:\n${out}`);
   });
 
-  it('context <missing> --json → parseable JSON, node:null', () => {
+  it('context <missing> --json → parseable JSON, shape mirrors success', () => {
     const out = runCli(['context', '__missing__', '--json'], tempDir).stdout;
     const parsed = JSON.parse(out); // must not throw
     assert.strictEqual(parsed.node, null, `node should be null:\n${out}`);
+    // Must mirror the success NodeContext shape ({ node, source, outgoing,
+    // incoming }) so consumers reading source / outgoing / incoming on success
+    // don't crash on not-found (regression guard for the context shape mismatch).
+    assert.strictEqual(parsed.source, null, `source should be null:\n${out}`);
+    assert.deepStrictEqual(parsed.outgoing, [], `outgoing shape:\n${out}`);
+    assert.deepStrictEqual(parsed.incoming, [], `incoming shape:\n${out}`);
   });
 
   it('describe <missing> --json → parseable JSON, target:null', () => {


### PR DESCRIPTION
## Summary

`grafema context <missing> --json` emitted `{ node: null }`, while the **success** path emits the full `NodeContext` `{ node, source, outgoing, incoming }` (`packages/util/src/queries/NodeContext.ts:86-91`). A consumer reading `result.outgoing` / `result.incoming` on success gets `undefined` on not-found and crashes on `.length`/iteration.

This is the **same bug class** fixed for `get` in #308 (`d57cb77`: "get --json not-found shape mirrors success"). `context` was the remaining sibling among the `get`/`context`/`describe`/`ls` commands that share the `emitJsonNotFound` not-found contract.

## Spec

- **Invariant restored:** under `--json`, a command's not-found payload mirrors the shape it emits on success (the documented `emitJsonNotFound` contract — `packages/cli/src/utils/errorFormatter.ts`: *"payload should mirror the shape the command emits on success"*).
- **Given** an analyzed graph **When** `grafema context <missing-id> --json` is run **Then** stdout is parseable JSON whose `node` is `null` and whose `source`/`outgoing`/`incoming` keys are present (`null`, `[]`, `[]`) so success-shape consumers don't crash.

## Before / After (live, verified locally)

Built `rfdb-server` + `grafema-orchestrator` from source, analyzed a minimal project, ran the real CLI:

```
# BEFORE (original source, rebuilt CLI)
$ grafema context __missing__ --json
{
  "node": null
}

# AFTER (this PR)
$ grafema context __missing__ --json
{
  "node": null,
  "source": null,
  "outgoing": [],
  "incoming": []
}
```

(stderr still carries the human note `Node not found: "__missing__"`; exit code unchanged at 0.)

## Test

Tightened the existing `get/context/describe/ls` contract test (`packages/cli/test/json-notfound-contract.test.ts`) so the `context` case asserts `source`/`outgoing`/`incoming` parity (mirroring the `get` guard) — fails red on the old `{ node: null }`, green on the fix.

> Note: that contract test runs `init` + `analyze` on a JS fixture, which requires the Haskell `grafema-analyzer` binary. The Haskell toolchain (GHC/cabal) is **not available** in my execution environment, so I could not run that specific integration test here. I verified the behavior directly with the built Rust binaries against a no-JS project (output above), and ran the rest of the gate.

## Gate (this environment)

| Step | Result |
|------|--------|
| `pnpm install` | ✅ |
| `pnpm -r build` (incl. CLI tsc) | ✅ |
| `pnpm typecheck` | ✅ exit 0 |
| `pnpm lint` | ✅ exit 0 |
| `context --json` BEFORE/AFTER | ✅ shown above |
| `json-notfound-contract.test.ts` | ⚠️ not runnable here (needs Haskell js-analyzer) — runs in CI |

## Adversarial review

- **A — Correctness:** `source: null` matches `SourcePreview | null`; `outgoing`/`incoming` `[]` match `EdgeGroup[]`. `memberContexts` is intentionally omitted — it is optional even on success (present only for CLASS nodes with members) and `JSON.stringify` drops `undefined`, so omitting it stays consistent with non-CLASS success. Only the `--json` branch changes; the human path and exit code are untouched.
- **B — Structural:** one-line payload change in a ~290-line file; no new coupling. The per-command hand-written mirror is the existing convention (`get`/`describe`/`ls` each do it); the contract test is the anti-drift guard.
- **C — Class, not instance:** enumerated all `emitJsonNotFound` call sites — `get` (#308 ✅), `describe` ✅, `ls` ✅, `context` ❌→fixed. No other command uses the helper.

## Blast radius

Only `grafema context --json` on a not-found node. Success output, human (non-JSON) output, and exit codes are unchanged. No callers of `context` internals affected (it's a leaf CLI command).

## Sibling latent issue found (follow-up, out of scope here)

- **`trace --from-route <missing> --json`** prints plain text `Route not found: ${pattern}` (`packages/cli/src/commands/trace.ts:725-729`) regardless of `--json`, so `JSON.parse(stdout)` would throw — same bug class, different command, not covered by the `json-notfound-contract` test. Left out of this PR because it lives in a different command and needs route analysis (Express/JS analyzer) to verify end-to-end, which I can't run in this environment. Worth a dedicated fix + contract-test extension.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lj9tMmpuRjsfWUr23efaZa)_