### PR TITLE
fix(mcp): semantic_search honors its advertised top_k parameter

### DIFF
--- a/packages/mcp/src/handlers/enox-handlers.ts
+++ b/packages/mcp/src/handlers/enox-handlers.ts
@@ -348,14 +348,25 @@ export async function handleRecall(args: RecallArgs): Promise<ToolResult> {
 
 export interface SemanticSearchArgs {
   query: string;
-  limit?: number;
+  top_k?: number;
   domain?: string;
 }
 
-export async function handleSemanticSearch(args: SemanticSearchArgs): Promise<ToolResult> {
+/**
+ * Handle the `semantic_search` MCP tool.
+ *
+ * @param args - tool input. `top_k` (matching the published schema) caps the
+ *   number of results; defaults to 10 per the schema's documented default.
+ * @param clientOverride - optional RFDB client, injected by tests; production
+ *   callers omit it and the shared knowledge client is used.
+ */
+export async function handleSemanticSearch(
+  args: SemanticSearchArgs,
+  clientOverride?: RFDBClient,
+): Promise<ToolResult> {
   try {
-    const client = await getKnowledgeClient();
-    const limit = args.limit ?? 20;
+    const client = clientOverride ?? await getKnowledgeClient();
+    const limit = args.top_k ?? 10;
 
     // TODO: Wire to RFDB embedding engine when enabled.
     // For now, fall back to substring search via queryNodes.

--- a/packages/mcp/test/semantic-search-topk.test.ts
+++ b/packages/mcp/test/semantic-search-topk.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Test the `semantic_search` MCP tool honors its published `top_k` parameter.
+ *
+ * Bug: the tool's input schema (definitions/enox-tools.ts) advertises `top_k`
+ * (and the description example uses `top_k=5`), but the handler read `args.limit`
+ * with a default of 20. So a caller passing `top_k=5` was silently ignored and
+ * got 20 results — a schema/handler param mismatch on a live tool
+ * (dispatched at server.ts `case 'semantic_search'`).
+ *
+ * The handler accepts an optional injected client so its result-limiting logic
+ * is testable without standing up the knowledge RFDB backend.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { handleSemanticSearch } from '../dist/handlers/enox-handlers.js';
+
+/** Minimal fake RFDBClient — handleSemanticSearch only calls queryNodes(). */
+function fakeClient(nodeCount: number): any {
+  const nodes = Array.from({ length: nodeCount }, (_, i) => ({
+    id: `n${i + 1}`,
+    name: `match${i + 1}`,
+    nodeType: 'fact',
+    metadata: '{}',
+  }));
+  return {
+    // eslint-disable-next-line require-yield
+    async *queryNodes() {
+      for (const n of nodes) yield n;
+    },
+  };
+}
+
+function countFromResult(res: any): string {
+  return res.content?.[0]?.text ?? '';
+}
+
+describe('semantic_search top_k parameter (schema/handler contract)', () => {
+  it('respects top_k=3 (caps results to 3, not the old default)', async () => {
+    const res = await handleSemanticSearch({ query: 'match', top_k: 3 }, fakeClient(25));
+    assert.ok(!res.isError, 'should not error');
+    assert.ok(
+      countFromResult(res).includes('Found 3 result(s)'),
+      `expected 3 results, got:\n${countFromResult(res)}`,
+    );
+  });
+
+  it('defaults to 10 (the schema-documented default), not 20', async () => {
+    const res = await handleSemanticSearch({ query: 'match' }, fakeClient(25));
+    assert.ok(
+      countFromResult(res).includes('Found 10 result(s)'),
+      `expected default 10, got:\n${countFromResult(res)}`,
+    );
+  });
+
+  it('ignores the old `limit` arg — `top_k` is the contract', async () => {
+    // Passing `limit` (no longer a recognized param) must NOT override; default 10 applies.
+    const res = await handleSemanticSearch({ query: 'match', limit: 5 } as any, fakeClient(25));
+    assert.ok(
+      countFromResult(res).includes('Found 10 result(s)'),
+      `expected default 10 (limit ignored), got:\n${countFromResult(res)}`,
+    );
+  });
+});


### PR DESCRIPTION
## Problem

The `semantic_search` MCP tool's input schema advertises a `top_k` parameter (and its own description shows `Example: semantic_search(query="...", top_k=5, domain="devops")`), but the handler read `args.limit`. So `top_k` was **silently ignored** — a schema/handler param mismatch on a **live** tool.

Evidence (HEAD):
- Schema declares `top_k` (default 10): `packages/mcp/src/definitions/enox-tools.ts:142`
- Handler read `args.limit ?? 20`: `packages/mcp/src/handlers/enox-handlers.ts:358` — never references `args.top_k`
- Tool is live: `packages/mcp/src/server.ts:423` `case 'semantic_search'` → `handleSemanticSearch(asArgs<SemanticSearchArgs>(args))`

Result: a caller passing `top_k=5` got **20** results (the handler's wrong default), and the default itself (20) contradicted the schema-documented default (10).

## Spec

- **Invariant:** a tool must honor the parameters it advertises in its schema.
- **Given** `semantic_search` with a published `top_k` param **When** a caller passes `top_k=N` **Then** at most N results are returned; **When** omitted **Then** the schema default (10) applies.

## Fix

`packages/mcp/src/handlers/enox-handlers.ts`:
- `SemanticSearchArgs.limit` → `top_k` (matches the schema).
- `const limit = args.top_k ?? 10;` (was `args.limit ?? 20`).
- Added an optional injected `clientOverride` param (documented) so the result-limiting logic is unit-testable without standing up the knowledge RFDB backend. Production caller (`server.ts`) is unchanged (single-arg call).

## Verify

New test `packages/mcp/test/semantic-search-topk.test.ts` (injects a fake client yielding 25 nodes):
- `top_k=3` → "Found 3 result(s)"
- omitted → "Found 10 result(s)" (schema default, not 20)
- legacy `limit` arg → ignored, default 10 applies (proves `top_k` is the contract)

**Red→green proven:** with the old logic restored (`args.limit ?? 20`) all 3 fail with "Found 20 result(s)"; with the fix, **3/3 pass**.

```
# fix:   # tests 3 # pass 3 # fail 0
# bugged: not ok 1..3 — "Found 20 result(s)" (expected 3 / 10 / 10)
```

- `tsc` build exit 0; `eslint` exit 0.

## Adversarial review

- **Round A:** `top_k` respected ✓; default 10 ✓; legacy `limit` ignored ✓; `clientOverride` optional → production path unchanged ✓.
- **Round B:** the injected-client param is a standard, documented test seam (optional; defaults to the shared knowledge client). `enox-handlers.ts` is a large file but the change is +15 lines and doesn't worsen structure.
- **Round C (class):** swept the other enox tools — `query_graph` (`enox-tools.ts:293`) and `recent_activity` (`:367`) use `limit` in **both** schema and handler (consistent). `semantic_search` was the only `top_k`/`limit` mismatch — an instance, not a widespread class.

## Blast radius

One tool's result limiting. No output-shape change; production dispatch unchanged.

## Follow-ups (not filed — need maintainer go-ahead)

- [ ] `semantic_search` also advertises `include_edges` (`enox-tools.ts:150`) which the handler never reads. The handler is an explicit embeddings placeholder (`// TODO: Wire to RFDB embedding engine`), so `include_edges` is pending that work — either implement it or drop it from the schema until then (advertised-but-ignored = trust hole, cf. REG-1144).
- [ ] **Unrelated pre-existing failures** noticed while running the mcp suite: `test/query-graph-count.test.ts` and `test/tools-onboarding.test.ts` fail on clean `main` (proven by stashing this change and rebuilding — both fail 0/2 without my change). Not touched here; flagging for triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)