### PR TITLE
fix(mcp): restore two rotted non-CI-gated tests + stale handlers.js refs (REG-461)

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -14,8 +14,8 @@
       "import": "./dist/server.js"
     },
     "./handlers": {
-      "types": "./dist/handlers.d.ts",
-      "import": "./dist/handlers.js"
+      "types": "./dist/handlers/index.d.ts",
+      "import": "./dist/handlers/index.js"
     }
   },
   "files": [
@@ -26,8 +26,8 @@
     "build": "tsc",
     "clean": "rm -rf dist",
     "start": "node dist/server.js",
-    "test": "node --import tsx --test test/*.test.ts",
-    "test:watch": "node --import tsx --test --watch test/*.test.ts"
+    "test": "node --import tsx --experimental-test-module-mocks --test test/*.test.ts",
+    "test:watch": "node --import tsx --experimental-test-module-mocks --test --watch test/*.test.ts"
   },
   "keywords": [
     "grafema",

--- a/packages/mcp/test/tools-onboarding.test.ts
+++ b/packages/mcp/test/tools-onboarding.test.ts
@@ -11,7 +11,7 @@ import assert from 'node:assert';
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { handleReadProjectStructure, handleWriteConfig } from '../dist/handlers.js';
+import { handleReadProjectStructure, handleWriteConfig } from '../dist/handlers/index.js';
 import { setProjectPath } from '../dist/state.js';
 
 describe('Onboarding Tools', () => {


### PR DESCRIPTION
## Problem

`packages/mcp/test` is **not CI-gated** (CI runs only root `test/unit/*.test.js`), so two test files rotted unnoticed — both fail on clean `main` (flagged in #314's follow-ups, proven by stash+rebuild):

1. **`query-graph-count.test.ts`** → `TypeError: mock.module is not a function`. It uses `node:test`'s experimental module mocking, which requires the `--experimental-test-module-mocks` flag — the test script didn't pass it.
2. **`tools-onboarding.test.ts`** → `ERR_MODULE_NOT_FOUND: Cannot find '.../dist/handlers.js'`. `handlers.ts` was decomposed into domain modules in `a649f0c1` (REG-461), but this import was never updated. The **same** REG-461 rot also left `package.json` `exports["./handlers"]` pointing at the dead `./dist/handlers.js`.

### Reproduce (before, on clean main)
```
$ pnpm --filter @grafema/mcp test
# query-graph-count.test.ts: TypeError: mock.module is not a function
# tools-onboarding.test.ts:   ERR_MODULE_NOT_FOUND .../dist/handlers.js
# 72 tests, 2 failing files (error at load)
```

## Spec

- **Invariant:** the mcp test suite runs green; the `@grafema/mcp/handlers` export resolves.
- **Given** `pnpm --filter @grafema/mcp test` **When** run **Then** all test files load and pass.

## Fix (3 minimal edits, test-infra/packaging only — no production code)

- `package.json` `test` + `test:watch`: add `--experimental-test-module-mocks`.
- `tools-onboarding.test.ts:14`: import from `../dist/handlers/index.js` (the barrel re-exporting `handleReadProjectStructure`/`handleWriteConfig` from `handlers/project-handlers.ts`).
- `package.json` `exports["./handlers"]`: point to `./dist/handlers/index.{js,d.ts}`.

## Verify (after)
```
$ pnpm --filter @grafema/mcp test
# tests 94 | pass 93 | fail 0 | skipped 1 | cancelled 0
```
Test count rose 72→94 because both files now execute all their subtests instead of erroring at load.
- `tsc` build clean; `package.json` is valid JSON; `dist/handlers/index.{js,d.ts}` (the new export target) exist.

## Adversarial review

- **Round A:** the flag is opt-in (only affects `mock.module` tests) — full suite stays green (93/0), so no collateral. Import target re-exports both handlers ✓. Export path resolves ✓.
- **Round B:** `--experimental-test-module-mocks` is experimental — a fragility (a future Node could rename/stabilize it). It's the correct current mechanism for the `mock.module` the tests already use; the alternative (rewriting the tests off `mock.module`) is a larger refactor. Documented here.
- **Round C (class):** swept all stale `dist/handlers.js` refs from the REG-461 decomposition — exactly two (the test import + the package export), both fixed. No external consumer imports `@grafema/mcp/handlers`, but the broken export is fixed anyway. Other `mock.module`-using tests are now also unblocked by the flag.

## Blast radius

Test runner config + one test import + one package-export path. No production code, no output changes.

## Follow-up (the systemic root cause)

- [ ] **CI-gate `packages/mcp/test`** (and other `packages/*/test`). These rotted precisely because CI only runs root `test/unit/*.test.js`. Wiring the package suites into CI would prevent recurrence — left as a separate change since it needs the suites verified reliably green in the CI environment (e.g. the 1 skipped test, any backend-dependent tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)