### PR TITLE
test(mcp)+ci: serialize mcp test files (--test-concurrency=1) and CI-gate the full suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,10 @@ jobs:
           set -o pipefail
           pnpm test:coverage 2>&1 | tee /tmp/pnpm-test-coverage.log
 
-      - name: Run regression tests (REG-655 / REG-656 / REG-652)
+      - name: Run MCP package tests
         run: |
           set -o pipefail
-          node --import tsx --test packages/mcp/test/regressions.test.ts 2>&1 | tee /tmp/regression-test.log
+          pnpm --filter @grafema/mcp test 2>&1 | tee /tmp/mcp-test.log
 
       - name: Run VSCode extension unit tests
         run: |

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -26,8 +26,8 @@
     "build": "tsc",
     "clean": "rm -rf dist",
     "start": "node dist/server.js",
-    "test": "node --import tsx --experimental-test-module-mocks --test test/*.test.ts",
-    "test:watch": "node --import tsx --experimental-test-module-mocks --test --watch test/*.test.ts"
+    "test": "node --import tsx --experimental-test-module-mocks --test --test-concurrency=1 test/*.test.ts",
+    "test:watch": "node --import tsx --experimental-test-module-mocks --test --test-concurrency=1 --watch test/*.test.ts"
   },
   "keywords": [
     "grafema",


### PR DESCRIPTION
## Problem

Finishes the #315 follow-up (CI-gate `packages/mcp/test` so it can't silently rot). Two coupled issues surfaced while attempting the gating:

1. **Nondeterministic failures from concurrent test files.** The mcp test script ran `test/*.test.ts` with `node:test`'s default (concurrent) file isolation. Test files that mutate **shared module singletons** race across files — e.g. `tools-onboarding.test.ts`'s `setProjectPath()` vs the knowledge-client singleton read by `semantic-search-topk.test.ts`'s handler. Result: 3 flaky failures (`Error: Failed to search: RFDB server socket not found`) in the full-glob run, while **each file passed in isolation** (and every preceding pair passed) — the hallmark of cross-file pollution.

2. **The mcp suite was never CI-gated.** CI ran only `packages/mcp/test/regressions.test.ts`; the rest (mcp/prompts/query-graph-count/tools-onboarding/semantic-search-topk) had no gate — the exact root cause of #315's rot.

### Reproduce (before)
```
$ pnpm --filter @grafema/mcp test        # default concurrency
# tests 97 | pass 93 | fail 3   (semantic-search-topk: "socket not found")
$ node ... --test test/semantic-search-topk.test.ts   # isolated
# tests 3 | pass 3 | fail 0     (passes alone → cross-file race, not a real bug)
```

## Spec

- **Invariant:** the mcp suite is deterministically green and gated by CI.
- **Given** `pnpm --filter @grafema/mcp test` **When** run **Then** all files pass regardless of ordering; **And** CI fails if any mcp test fails.

## Fix

1. `packages/mcp/package.json` `test` + `test:watch`: add `--test-concurrency=1` — serial file execution, no cross-file singleton races. This is the **same flag the root `test:coverage` script already uses** (`c8 node --test --test-concurrency=1 'test/unit/*.test.js'`).
2. `.github/workflows/ci.yml`: replace the regressions-only step with the full suite — `pnpm --filter @grafema/mcp test` (regressions.test.ts is included, so REG-655/656/652 coverage is preserved and expanded). All mcp tests are mock/fs-based (verified: `MCPTestHarness`/`MockBackend` are in-process mocks; no `spawn`/`connect` in helpers) — no live RFDB backend needed in CI.

## Verify (after)
```
$ pnpm --filter @grafema/mcp test        # the exact CI command
# tests 97 | pass 96 | fail 0 | skipped 1    (deterministic across repeated runs)
```
- ci.yml is valid YAML; diff is 2 lines per file.

## Adversarial review

- **Round A:** `--test-concurrency=1` serializes file execution → eliminates the race; green verified across 3 runs. Regressions (REG-655/656/652) still run (part of the suite). The 1 skipped test is pre-existing.
- **Round B:** the CI step is renamed "Run regression tests…" → "Run MCP package tests" (accurate — it now runs all mcp tests). Slight CI-time cost from serialization, negligible for a ~100-test suite. CI now genuinely depends on the mcp suite — that's the intent.
- **Round C (class):** other package test scripts also lack `--test-concurrency=1` (`@grafema/api`, `@grafema/cli`, `grafema-explore`), but only mcp had the *manifested* race (shared in-process singletons + concurrent files); `cli` tests use `spawnSync` per test (process-isolated). Left as a follow-up — see below.

## Blast radius

Test runner config + one CI step. No production code. No test logic changed — only execution order serialized.

## Follow-ups

- [ ] Defensively add `--test-concurrency=1` to `@grafema/api` / `@grafema/cli` / `grafema-explore` test scripts (match root convention) and CI-gate those suites too — after verifying each is green/backend-free in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)