### PR TITLE
test(ci): CI-gate api + types package suites (+ add missing types test script)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,11 @@ jobs:
           set -o pipefail
           node --import tsx --test 'packages/vscode/test/unit/*.test.ts' 2>&1 | tee /tmp/vscode-test.log
 
+      - name: Run API & types package tests
+        run: |
+          set -o pipefail
+          pnpm --filter @grafema/api --filter @grafema/types test 2>&1 | tee /tmp/api-types-test.log
+
       - name: Summarize failed tests
         if: failure()
         run: |

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -17,7 +17,8 @@
   ],
   "scripts": {
     "build": "tsc",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test": "node --import tsx --test --test-concurrency=1 test/*.test.ts"
   },
   "keywords": [
     "grafema",


### PR DESCRIPTION
## Problem

Continues the #315 / #317 arc: package test suites silently rot because CI runs only root `test/unit/*.test.js` plus a few cherry-picked files. Two clean, backend-free suites were ungated:

- **`@grafema/api`**: 14 tests (pagination logic), green, has a `test` script — but never run in CI.
- **`@grafema/types`**: 18 tests (cardinality types), green — but had **no `test` script at all** (orphaned: `pnpm test` does nothing for it).

## Spec

- **Invariant:** these green, backend-free suites are runnable via `pnpm test` and gated by CI.
- **Given** the api/types suites **When** CI runs **Then** it fails if either suite fails.

## Fix

- `packages/types/package.json`: add `"test": "node --import tsx --test --test-concurrency=1 test/*.test.ts"` (the `--test-concurrency=1` per the #317 lesson — serial files avoid cross-file singleton races).
- `.github/workflows/ci.yml`: new step `pnpm --filter @grafema/api --filter @grafema/types test`.

Both suites are **pure logic** — verified no `RFDBClient`/`spawn`/`socket` imports in `packages/{api,types}/test/` — so they're CI-safe on ubuntu without the Rust `rfdb-server` binary.

## Verify
```
$ pnpm --filter @grafema/api --filter @grafema/types test
packages/api test:   # tests 14 | pass 14 | fail 0
packages/types test: # tests 18 | pass 18 | fail 0
combined exit code: 0
```
- ci.yml is valid YAML; diff is +5 (ci.yml) / +1 line net (types script).

## Adversarial review

- **Round A:** both suites green + backend-free (no socket/spawn). `--test-concurrency=1` is harmless for these (1 file each today) and future-proofs against the #317 race class. Combined `pnpm --filter` exits non-zero if either fails → CI gates correctly.
- **Round B:** additive CI step (composes with #317's mcp step, which modifies a *different* step). No production code.
- **Round C (class):** remaining ungated package suites — `@grafema/cli` (26 files) is **backend-dependent** (its tests run `grafema analyze`, which needs the Rust `rfdb-server` binary CI doesn't build) → not CI-safe, left out. `packages/core-v2` has a `.mjs` test with no `test` script — separate follow-up. `vscode` and `mcp` (#317) are already gated.

## Blast radius

CI config + one new package script. No production code.

## Follow-ups

- [ ] `packages/core-v2` (`constant-value-source.test.mjs`) has no `test` script — add one + gate.
- [ ] `@grafema/cli` tests need the `rfdb-server` binary in CI before they can be gated (build it in CI, or split out the backend-free cli tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)