### PR TITLE
fix(mcp): semantic_search no longer fabricates similarity scores

### DIFF
--- a/packages/mcp/src/handlers/enox-handlers.ts
+++ b/packages/mcp/src/handlers/enox-handlers.ts
@@ -389,9 +389,9 @@ export async function handleSemanticSearch(
     for (let i = 0; i < results.length; i++) {
       const node = results[i];
       const meta = parseMeta(node);
-      // Pseudo-similarity score based on match quality (placeholder until embeddings)
-      const similarity = (1.0 - (i * 0.05)).toFixed(2);
-      lines.push(`${i + 1}. [${similarity}] ${node.name} (${node.nodeType})`);
+      // NOTE: this is substring matching, not embeddings — do not fabricate a
+      // similarity score (it would read to an agent as a real metric). Just rank.
+      lines.push(`${i + 1}. ${node.name} (${node.nodeType})`);
       if (meta.domain) lines.push(`   Domain: ${meta.domain}`);
       if (meta.content) lines.push(`   ${String(meta.content).slice(0, 200)}`);
       lines.push('');

--- a/packages/mcp/test/semantic-search-topk.test.ts
+++ b/packages/mcp/test/semantic-search-topk.test.ts
@@ -61,4 +61,14 @@ describe('semantic_search top_k parameter (schema/handler contract)', () => {
       `expected default 10 (limit ignored), got:\n${countFromResult(res)}`,
     );
   });
+
+  it('does not fabricate a similarity score (substring search has no real similarity)', async () => {
+    // The handler does substring matching (no embeddings yet), so a bracketed decimal
+    // like "[0.95]" would read to an agent as a real similarity metric that was never computed.
+    const res = await handleSemanticSearch({ query: 'match', top_k: 3 }, fakeClient(5));
+    const text = countFromResult(res);
+    assert.ok(!/\[\d\.\d{2}\]/.test(text), `must not fabricate a similarity score, got:\n${text}`);
+    // Results are still listed by name so the tool remains useful.
+    assert.ok(text.includes('match1'), `should still list result names, got:\n${text}`);
+  });
 });


### PR DESCRIPTION
## Problem

`handleSemanticSearch` does **substring matching** (`queryNodes` with `substringMatch` — no embeddings yet, per its own `// TODO: Wire to RFDB embedding engine` / "placeholder until embeddings"), but it rendered each result with a **fabricated, purely-positional** "similarity" score:

```js
// enox-handlers.ts (before)
const similarity = (1.0 - (i * 0.05)).toFixed(2);   // 0.95, 0.90, 0.85, ...
lines.push(`${i + 1}. [${similarity}] ${node.name} (${node.nodeType})`);
```

So `semantic_search(query="x")` returns lines like `1. [0.95] foo (FACT)`. An agent consuming this reads `[0.95]` as a real **similarity/confidence metric** — but it was never computed; it's just `1.0 - index*0.05`. This is the REG-1144 **"advertised-but-fake" trust-hole** class the project explicitly flags as "the worst kind for agents." The tool is live (dispatched at `server.ts` `case 'semantic_search'`).

## Spec

- **Invariant:** the tool must not present a metric it did not compute.
- **Given** `semantic_search` (substring backend) **When** results are returned **Then** the output ranks/lists them by name but contains no fabricated similarity score.

## Fix

`packages/mcp/src/handlers/enox-handlers.ts` — remove the fabricated score; keep the numbered ranking + name:
```js
// after
lines.push(`${i + 1}. ${node.name} (${node.nodeType})`);
```
When real embeddings land, a genuine score can be re-added (the TODO remains).

## Verify

New subtest in `semantic-search-topk.test.ts` (uses the injected-client seam):
```js
assert.ok(!/\[\d\.\d{2}\]/.test(text), 'must not fabricate a similarity score');
assert.ok(text.includes('match1'), 'should still list result names');
```
**Red→green proven:** with the old code the subtest fails (output has `[0.95]`); after the fix it passes.
```
# before fix: not ok 4 - does not fabricate a similarity score
# after fix:  # tests 4 | pass 4 | fail 0
# full mcp suite: 98 tests | 97 pass | 0 fail | 1 skipped (no regression)
```
- `tsc` build exit 0; `eslint` exit 0 (`i` still used in `${i + 1}`).

## Adversarial review

- **Round A:** output now honest (`1. match1 (fact)`); empty-results early-return unchanged; no unused var.
- **Round B:** the tool is still a substring-search **placeholder** named `semantic_search` — the deeper honesty gap (the *name* implies embeddings) remains a design decision (implement embeddings, or relabel). This PR removes the most-misleading element (a fabricated numeric metric) without over-reaching.
- **Round C (class):** swept `packages/mcp/src/handlers/` for other fabricated/positional metrics presented as real (`1.0 -`, `* 0.0x`, `Pseudo`, `similarity =`, hardcoded confidence) — none found. This was the only instance.

## Blast radius

One tool's output formatting. No schema/contract change; result count and names unchanged.

## Follow-up

- [ ] `semantic_search` still does substring matching under a name that implies embeddings — wire real embeddings (the existing TODO) or relabel the tool honestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)