### PR TITLE
fix(cli): REG-1149 — finish --json not-found contract for check & trace --from-route

### DIFF
--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -199,7 +199,7 @@ Examples:
         if (guarantees.length === 0) {
           if (options.json) {
             // --json contract: no guarantees → empty results, parseable stdout.
-            emitJsonNotFound({ results: [] }, 'No guarantees found.');
+            emitJsonNotFound({ total: 0, passed: 0, failed: 0, errors: 0, results: [] }, 'No guarantees found.');
             return;
           }
           console.log('No guarantees found.');
@@ -219,7 +219,7 @@ Examples:
           if (options.json) {
             // --json contract: parseable stdout mirroring the results shape.
             // (return runs the enclosing finally → backend.close().)
-            emitJsonNotFound({ results: [] }, `Guarantee not found: ${rule}`);
+            emitJsonNotFound({ total: 0, passed: 0, failed: 0, errors: 0, results: [] }, `Guarantee not found: ${rule}`);
             return;
           }
           exitWithError(`Guarantee not found: ${rule}`, [

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -17,7 +17,7 @@ import {
   DIAGNOSTIC_CATEGORIES,
 } from '@grafema/util';
 import type { GuaranteeGraph, DiagnosticCategoryKey } from '@grafema/util';
-import { exitWithError } from '../utils/errorFormatter.js';
+import { exitWithError, emitJsonNotFound } from '../utils/errorFormatter.js';
 
 
 // Available built-in validators
@@ -111,6 +111,11 @@ Examples:
         const validatorInfo = BUILT_IN_VALIDATORS[options.guarantee];
         if (!validatorInfo) {
           const available = Object.keys(BUILT_IN_VALIDATORS).join(', ');
+          if (options.json) {
+            // --json contract: parseable stdout mirroring the validator shape.
+            emitJsonNotFound({ guarantee: options.guarantee, passed: false }, `Unknown guarantee: ${options.guarantee}`);
+            return;
+          }
           exitWithError(`Unknown guarantee: ${options.guarantee}`, [
             `Available: ${available}`
           ]);
@@ -155,11 +160,14 @@ Examples:
         }
 
         if (!options.skipReanalysis) {
-          console.log(`Reanalyzing ${freshness.staleCount} stale module(s)...`);
+          // Status chatter must NOT hit stdout under --json (stdout = JSON only).
+          if (!options.json) console.log(`Reanalyzing ${freshness.staleCount} stale module(s)...`);
           const reanalyzer = new IncrementalReanalyzer(backend, projectPath);
           const result = await reanalyzer.reanalyze(freshness.staleModules);
-          console.log(`Reanalyzed ${result.modulesReanalyzed} module(s) in ${result.durationMs}ms`);
-          console.log('');
+          if (!options.json) {
+            console.log(`Reanalyzed ${result.modulesReanalyzed} module(s) in ${result.durationMs}ms`);
+            console.log('');
+          }
         } else {
           console.warn(`Warning: ${freshness.staleCount} stale module(s) detected. Use --skip-reanalysis to suppress.`);
           for (const stale of freshness.staleModules.slice(0, 5)) {
@@ -168,9 +176,9 @@ Examples:
           if (freshness.staleModules.length > 5) {
             console.warn(`  ... and ${freshness.staleModules.length - 5} more`);
           }
-          console.log('');
+          if (!options.json) console.log('');
         }
-      } else if (!options.quiet) {
+      } else if (!options.quiet && !options.json) {
         console.log('Graph is fresh');
         console.log('');
       }
@@ -189,6 +197,11 @@ Examples:
         const guarantees = await manager.list();
 
         if (guarantees.length === 0) {
+          if (options.json) {
+            // --json contract: no guarantees → empty results, parseable stdout.
+            emitJsonNotFound({ results: [] }, 'No guarantees found.');
+            return;
+          }
           console.log('No guarantees found.');
           console.log('');
           console.log('Create guarantees in .grafema/guarantees.yaml or use --file option.');
@@ -203,6 +216,12 @@ Examples:
 
         if (toCheck.length === 0 && rule) {
           const available = guarantees.map((g) => g.id).join(', ');
+          if (options.json) {
+            // --json contract: parseable stdout mirroring the results shape.
+            // (return runs the enclosing finally → backend.close().)
+            emitJsonNotFound({ results: [] }, `Guarantee not found: ${rule}`);
+            return;
+          }
           exitWithError(`Guarantee not found: ${rule}`, [
             `Available: ${available}`
           ]);

--- a/packages/cli/src/commands/trace.ts
+++ b/packages/cli/src/commands/trace.ts
@@ -12,7 +12,7 @@ import { isAbsolute, resolve, join } from 'path';
 import { existsSync } from 'fs';
 import { RFDBServerBackend, parseSemanticId, parseSemanticIdV2, traceValues, traceDataflow, renderTraceNarrative, type ValueSource, type DataflowBackend } from '@grafema/util';
 import { formatNodeDisplay } from '../utils/formatNode.js';
-import { exitWithError } from '../utils/errorFormatter.js';
+import { exitWithError, emitJsonNotFound } from '../utils/errorFormatter.js';
 
 interface TraceOptions {
   project: string;
@@ -723,6 +723,12 @@ async function handleRouteTrace(
   const route = await findRouteByPattern(backend, pattern);
 
   if (!route) {
+    if (jsonOutput) {
+      // --json contract: stdout is always parseable JSON. Mirror the success
+      // shape (route + responses) with a null route; human note to stderr.
+      emitJsonNotFound({ route: null, responses: [] }, `Route not found: ${pattern}`);
+      return;
+    }
     console.log(`Route not found: ${pattern}`);
     console.log('');
     console.log('Hint: Use "grafema query" to list available routes');

--- a/packages/cli/test/json-notfound-contract.test.ts
+++ b/packages/cli/test/json-notfound-contract.test.ts
@@ -98,4 +98,25 @@ describe('CLI --json not-found contract (get/context/describe/ls)', { timeout: 9
     assert.deepStrictEqual(parsed.functions, []);
     assert.deepStrictEqual(parsed.imports, []);
   });
+
+  it('check --guarantee <unknown> --json → parseable JSON, passed:false (REG-1149)', () => {
+    const out = runCli(['check', '--guarantee', '__unknown__', '--json'], tempDir).stdout;
+    const parsed = JSON.parse(out); // must not throw
+    assert.strictEqual(parsed.guarantee, '__unknown__', `guarantee echoed:\n${out}`);
+    assert.strictEqual(parsed.passed, false);
+  });
+
+  it('check <unknown-rule> --json → parseable JSON, empty results (REG-1149)', () => {
+    // --skip-reanalysis isolates the not-found path from incremental reanalysis.
+    const out = runCli(['check', '__unknownRule__', '--skip-reanalysis', '--json'], tempDir).stdout;
+    const parsed = JSON.parse(out); // must not throw
+    assert.deepStrictEqual(parsed.results, [], `results should be empty:\n${out}`);
+  });
+
+  it('trace --from-route <missing> --json → parseable JSON, route:null (REG-1149)', () => {
+    const out = runCli(['trace', '--from-route', '/__missing__', '--json'], tempDir).stdout;
+    const parsed = JSON.parse(out); // must not throw
+    assert.strictEqual(parsed.route, null, `route should be null:\n${out}`);
+    assert.deepStrictEqual(parsed.responses, []);
+  });
 });

--- a/packages/cli/test/json-notfound-contract.test.ts
+++ b/packages/cli/test/json-notfound-contract.test.ts
@@ -110,7 +110,13 @@ describe('CLI --json not-found contract (get/context/describe/ls)', { timeout: 9
     // --skip-reanalysis isolates the not-found path from incremental reanalysis.
     const out = runCli(['check', '__unknownRule__', '--skip-reanalysis', '--json'], tempDir).stdout;
     const parsed = JSON.parse(out); // must not throw
+    // Must mirror the full CheckAllResult success shape (not a degenerate {results:[]}),
+    // so consumers reading total/passed/failed/errors on success don't get undefined here.
     assert.deepStrictEqual(parsed.results, [], `results should be empty:\n${out}`);
+    assert.strictEqual(parsed.total, 0, `total:\n${out}`);
+    assert.strictEqual(parsed.passed, 0, `passed:\n${out}`);
+    assert.strictEqual(parsed.failed, 0, `failed:\n${out}`);
+    assert.strictEqual(parsed.errors, 0, `errors:\n${out}`);
   });
 
   it('trace --from-route <missing> --json → parseable JSON, route:null (REG-1149)', () => {


### PR DESCRIPTION
Closes REG-1149.

## Problem

Two commands still violated the `--json` "stdout is always parseable JSON" contract on not-found (flagged in #311/#313 Round-C sweeps):

- **`trace --from-route <missing> --json`** (`trace.ts:725`) printed plain text `Route not found: ${pattern}` regardless of `--json` → `JSON.parse(stdout)` threw.
- **`check --json`** (`check.ts`) called `exitWithError` (empty stdout) on not-found.

Investigating `check` surfaced **three** not-found stdout-pollution paths plus a broader one:
1. `--guarantee <unknown>` → `exitWithError("Unknown guarantee")` (L114)
2. no guarantees configured → `console.log("No guarantees found.")` (L199)
3. `<rule>` not found among guarantees → `exitWithError("Guarantee not found")` (L206)
4. **freshness/reanalysis status** (`"Reanalyzing…"`, `"Graph is fresh"`) printed to **stdout** unconditionally — pollutes `--json` output even on the success path.

### Reproduce (before)
```
$ trace --from-route /x --json   # exit 0, stdout="Route not found: /x" → JSON.parse throws
$ check __unknownRule__ --json   # stdout="Graph is fresh\nNo guarantees found.…" → JSON.parse throws
```

## Spec

- **Invariant:** under `--json`, stdout is ALWAYS parseable JSON; status/human chatter goes to stderr or the non-json branch.
- **Given** a not-found input **When** `<cmd> --json` runs **Then** stdout is a JSON object mirroring the command's success shape.

## Fix

All via the shared `emitJsonNotFound` helper:
| Path | Not-found JSON |
|---|---|
| `trace --from-route` (success = `{route, responses}`) | `{ route: null, responses: [] }` |
| `check --guarantee <unknown>` (success = `{guarantee, passed, …}`) | `{ guarantee, passed: false }` |
| `check` no guarantees / `<rule>` not found (success = `CheckAllResult` w/ `.results`) | `{ results: [] }` |

Plus: the freshness/reanalysis status `console.log`s are now gated to the non-`--json` path (reanalysis still runs; only the chatter is suppressed under `--json`). Non-json behavior is unchanged.

## Verify
```
$ trace --from-route /x --json   → {route:null, responses:[]}        (exit 0, valid JSON)
$ check --guarantee X --json     → {guarantee:"X", passed:false}     (valid JSON)
# json-notfound-contract.test.ts: 9 cases | pass 9 | fail 0  (added check×2 + trace --from-route, asserting shape)
```
- `tsc` build exit 0; `eslint` exit 0; pre-commit CI suite 22/22.

## Adversarial review

- **Round A:** all not-found paths return parseable JSON + stderr note; non-json paths unchanged (freshness still prints, `exitWithError` still exits 1); the `check <rule>` test uses `--skip-reanalysis` to isolate the not-found path from incremental reanalysis.
- **Round B:** `check.ts` remains a large file (pre-existing; not split here). The freshness gating adds `!options.json` guards rather than restructuring. Reused the established `emitJsonNotFound` pattern.
- **Round C:** swept `check` for remaining stdout under `--json` — the residual `console.log`s (`"Running ${validator}…"` L370, `"Checking ${category}…"` L492, `"Checking N guarantee(s)…"` L247) are on **success** paths (L247 is in the non-json `else`), not the not-found paths this issue scopes. The not-found paths all return before them.

## Follow-up

- [ ] `check --json` **success** paths (`--guarantee <valid>` via `runBuiltInValidator`, `<category>` via `runCategoryCheck`) still emit `"Running…"`/`"Checking…"` status to stdout before their JSON — a separate, broader `check --json` cleanliness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)