### PR TITLE
refactor(cli): extract resolveProjectRoot helper, DRY file.ts/explain.ts (REG-1154)

### DIFF
--- a/packages/cli/src/commands/explain.ts
+++ b/packages/cli/src/commands/explain.ts
@@ -15,7 +15,7 @@
 import { Command } from 'commander';
 import { resolve, join, relative, normalize } from 'path';
 import { existsSync, realpathSync } from 'fs';
-import { toRelativeDisplay } from '../utils/pathUtils.js';
+import { toRelativeDisplay, resolveProjectRoot } from '../utils/pathUtils.js';
 import { RFDBServerBackend, FileExplainer, type EnhancedNode } from '@grafema/util';
 import { exitWithError, emitJsonNotFound } from '../utils/errorFormatter.js';
 
@@ -45,15 +45,7 @@ If a file shows NOT_ANALYZED:
   - Check if file is excluded in config
 `)
   .action(async (file: string, options: ExplainOptions) => {
-    // realpath the project root so it shares a base with the realpath'd file
-    // path computed below; otherwise relative() breaks when the root is a
-    // symlink (e.g. macOS /tmp -> /private/tmp), and the file reads NOT_ANALYZED.
-    let projectPath = resolve(options.project);
-    try {
-      projectPath = realpathSync(projectPath);
-    } catch {
-      // Project dir missing — leave resolved; the dbPath check below reports it.
-    }
+    const projectPath = resolveProjectRoot(options.project);
     const grafemaDir = join(projectPath, '.grafema');
     const dbPath = join(grafemaDir, 'graph.rfdb');
 

--- a/packages/cli/src/commands/file.ts
+++ b/packages/cli/src/commands/file.ts
@@ -17,6 +17,7 @@ import { existsSync, realpathSync } from 'fs';
 import { RFDBServerBackend, FileOverview } from '@grafema/util';
 import type { FileOverviewResult, FunctionOverview } from '@grafema/util';
 import { exitWithError, emitJsonNotFound } from '../utils/errorFormatter.js';
+import { resolveProjectRoot } from '../utils/pathUtils.js';
 import { Spinner } from '../utils/spinner.js';
 
 interface FileOptions {
@@ -50,15 +51,7 @@ Output shows:
 Use 'grafema context <id>' to dive deeper into any specific entity.
 `)
   .action(async (file: string, options: FileOptions) => {
-    // realpath the project root so it shares a base with the realpath'd file
-    // path computed below; otherwise relative() breaks when the root is a
-    // symlink (e.g. macOS /tmp -> /private/tmp), and the file reads NOT_ANALYZED.
-    let projectPath = resolve(options.project);
-    try {
-      projectPath = realpathSync(projectPath);
-    } catch {
-      // Project dir missing — leave resolved; the dbPath check below reports it.
-    }
+    const projectPath = resolveProjectRoot(options.project);
     const grafemaDir = join(projectPath, '.grafema');
     const dbPath = join(grafemaDir, 'graph.rfdb');
 

--- a/packages/cli/src/utils/pathUtils.ts
+++ b/packages/cli/src/utils/pathUtils.ts
@@ -2,8 +2,29 @@
  * Convert a node file path to relative display format.
  * Handles both legacy absolute paths and new relative paths (REG-408).
  */
-import { relative, isAbsolute } from 'path';
+import { relative, isAbsolute, resolve } from 'path';
+import { realpathSync } from 'fs';
 
 export function toRelativeDisplay(file: string, projectPath: string): string {
   return isAbsolute(file) ? relative(projectPath, file) : file;
+}
+
+/**
+ * Resolve a command's `--project` option to an absolute, realpath'd project root.
+ *
+ * realpath matters because a symlinked root (e.g. macOS `/tmp` -> `/private/tmp`)
+ * otherwise breaks `relative()` against the realpath'd file paths the graph stores,
+ * making files read as NOT_ANALYZED. If the directory does not exist, the plain
+ * resolved path is returned — the caller's dbPath check reports the missing project.
+ *
+ * @param projectOption - the raw `--project` value (e.g. ".")
+ * @returns absolute project root, realpath'd when the directory exists
+ */
+export function resolveProjectRoot(projectOption: string): string {
+  const resolved = resolve(projectOption);
+  try {
+    return realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
 }

--- a/packages/cli/test/pathutils-resolveprojectroot.test.ts
+++ b/packages/cli/test/pathutils-resolveprojectroot.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Unit test for `resolveProjectRoot` (REG-1154) — extracted from the identical
+ * realpath/project-root block that `file.ts` and `explain.ts` each duplicated.
+ *
+ * The behavior that matters: realpath the project root so it shares a base with
+ * the realpath'd file paths the graph stores (a symlinked root like macOS
+ * `/tmp` -> `/private/tmp` otherwise makes files read NOT_ANALYZED), and fall
+ * back to the plain resolved path (no throw) when the directory does not exist.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { mkdtempSync, mkdirSync, symlinkSync, realpathSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { resolveProjectRoot } from '../dist/utils/pathUtils.js';
+
+describe('resolveProjectRoot (REG-1154)', () => {
+  it('follows a symlinked root to its realpath', () => {
+    const parent = mkdtempSync(join(tmpdir(), 'rpr-'));
+    try {
+      const real = join(parent, 'real');
+      mkdirSync(real);
+      const link = join(parent, 'link');
+      symlinkSync(real, link);
+      assert.strictEqual(resolveProjectRoot(link), realpathSync(real));
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('returns the resolved path (no throw) for a non-existent directory', () => {
+    const missing = join(tmpdir(), '__rpr_missing__', 'nope');
+    assert.strictEqual(resolveProjectRoot(missing), resolve(missing));
+  });
+});


### PR DESCRIPTION
Part of REG-1154 (the `resolveProjectRoot` DRY item only).

## Problem

`file.ts` and `explain.ts` each contained the **identical** ~8-line block resolving + realpath'ing the `--project` root — `file.ts`'s comment literally says *"same path resolution as explain"*. Duplicated logic = two places to drift / fix.

```ts
// file.ts:56-60 == explain.ts:51-55 (byte-identical)
let projectPath = resolve(options.project);
try {
  projectPath = realpathSync(projectPath);
} catch {
  // Project dir missing — leave resolved; the dbPath check below reports it.
}
```

## Fix

Extracted a documented, pure `resolveProjectRoot(projectOption)` into `packages/cli/src/utils/pathUtils.ts` (alongside the existing `toRelativeDisplay`) and replaced both call sites with `const projectPath = resolveProjectRoot(options.project);`.

**Behavior is unchanged** — realpath an existing root (so it shares a base with the realpath'd file paths the graph stores; a symlinked root like macOS `/tmp`→`/private/tmp` otherwise makes files read `NOT_ANALYZED`), and fall back to the resolved path (no throw) when the directory is missing.

## Verify

- New unit test `packages/cli/test/pathutils-resolveprojectroot.test.ts` — follows a symlinked root to its realpath; returns resolved path (no throw) for a missing dir. **2/2 pass.**
- Existing e2e `file-explain-symlinked-root.test.ts` (the symlink-root regression #293 guards) — **still 2/2 pass** (behavior preserved).
- `tsc` build exit 0; `eslint` 0 errors; pre-commit suite 22/22.

## Adversarial review

- **Round A:** existing-dir (realpath) and missing-dir (resolved, no throw) both covered by the unit test; e2e symlink test confirms identical behavior. `resolve`/`realpathSync` remain used in both files for the *file-path* resolution (no dead imports — tsc-clean).
- **Round B:** `pathUtils.ts` ~30 lines (< 500); the helper is the natural home + documented for agents.
- **Round C (class):** swept all `packages/cli/src/commands/*.ts` for the same `realpathSync(projectPath)` block — **only** file/explain had it (now refactored). Other commands use `resolve(options.project)` without realpath (they don't currently need it); adding realpath there would be a behavior change beyond this DRY scope.

## Blast radius

Two commands' project-root resolution, factored into one helper. No behavior change. New export is additive.

## Follow-up (rest of REG-1154, not in this PR)

- [ ] cross-language pointer/generic normalization (`unwrap_smart_pointer`, #273)
- [ ] `CONTEXT_NODE_TYPES` NAMESPACE inclusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)