### PR TITLE
fix(mcp): REG-1152 — make semantic_search schema honest (drop include_edges, fix description)

### DIFF
--- a/packages/mcp/src/definitions/enox-tools.ts
+++ b/packages/mcp/src/definitions/enox-tools.ts
@@ -124,14 +124,13 @@ Example: recall(query="federation architecture", depth=2)`,
   },
   {
     name: 'semantic_search',
-    description: `Embedding-based similarity search across the knowledge graph.
+    description: `Substring search across knowledge-graph node names (case-insensitive).
 
-Use this for precise similarity matching — finds nodes whose content
-is semantically close to the query, even if exact keywords differ.
+NOTE: despite the name, embedding-based semantic ranking is not wired yet
+(RFD-63). This currently matches substrings of node names — results are
+plain matches, not similarity-ranked. Use recall for broader retrieval.
 
-More targeted than recall: returns ranked results without graph traversal.
-
-Example: semantic_search(query="Docker container auth token", top_k=5, domain="devops")`,
+Example: semantic_search(query="auth token", top_k=5, domain="devops")`,
     inputSchema: {
       type: 'object',
       properties: {
@@ -146,10 +145,6 @@ Example: semantic_search(query="Docker container auth token", top_k=5, domain="d
         domain: {
           type: 'string',
           description: 'Filter results to a specific domain',
-        },
-        include_edges: {
-          type: 'boolean',
-          description: 'Include edges connected to matched nodes (default: false)',
         },
       },
       required: ['query'],

--- a/packages/mcp/test/semantic-search-topk.test.ts
+++ b/packages/mcp/test/semantic-search-topk.test.ts
@@ -14,6 +14,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { handleSemanticSearch } from '../dist/handlers/enox-handlers.js';
+import { ENOX_TOOLS } from '../dist/definitions/enox-tools.js';
 
 /** Minimal fake RFDBClient — handleSemanticSearch only calls queryNodes(). */
 function fakeClient(nodeCount: number): any {
@@ -70,5 +71,17 @@ describe('semantic_search top_k parameter (schema/handler contract)', () => {
     assert.ok(!/\[\d\.\d{2}\]/.test(text), `must not fabricate a similarity score, got:\n${text}`);
     // Results are still listed by name so the tool remains useful.
     assert.ok(text.includes('match1'), `should still list result names, got:\n${text}`);
+  });
+
+  it('schema is honest: drops unimplemented include_edges, description reflects substring (REG-1152)', () => {
+    const tool = ENOX_TOOLS.find((t: any) => t.name === 'semantic_search') as any;
+    assert.ok(tool, 'semantic_search tool exists');
+    const props = tool.inputSchema.properties;
+    // include_edges was advertised but never read by the handler — must not be advertised.
+    assert.strictEqual(props.include_edges, undefined, 'include_edges must not be advertised');
+    // The real params stay.
+    assert.ok(props.query && props.top_k, 'query/top_k still advertised');
+    // Description must not overpromise embedding-based semantic search (it does substring matching).
+    assert.match(tool.description, /substring/i, 'description should reflect substring matching');
   });
 });


### PR DESCRIPTION
Addresses REG-1152 (the conservative acceptance for both items).

## Problem

Two remaining "advertised-but-not-real" trust holes in `semantic_search` (REG-1144 class), after #314 (top_k) and #319 (fake score removed):

1. **`include_edges` advertised but ignored** — the schema (`enox-tools.ts`) advertised `include_edges`, but the handler never reads it (`SemanticSearchArgs` is `{query, top_k?, domain?}`).
2. **Description overpromises** — it claimed *"Embedding-based similarity search … finds nodes whose content is semantically close … even if exact keywords differ"*, but the handler does `queryNodes({ substringMatch: true })` on node **names** (with a `// TODO: Wire to RFDB embedding engine` placeholder).

An agent reading the schema/description is misled on both counts.

## Spec

- **Invariant:** the tool advertises only what it does.
- REG-1152 acceptance: `include_edges` → *"implement it, OR drop it until embeddings land"*; embeddings → *"wire … OR relabel … to reflect substring matching until then."* This PR takes the **conservative/honest** option for both (drop + relabel); wiring the RFD-63 embedding index is the larger alternative, left as a separate feature.

## Fix (`enox-tools.ts`, schema only — no handler change)

- Removed the `include_edges` property from `semantic_search`'s `inputSchema`.
- Rewrote the description to honestly state substring matching:
  > Substring search across knowledge-graph node names (case-insensitive). NOTE: despite the name, embedding-based semantic ranking is not wired yet (RFD-63). This currently matches substrings of node names — results are plain matches, not similarity-ranked. Use recall for broader retrieval.

## Verify

- Test extended (`semantic-search-topk.test.ts`): asserts `semantic_search` schema no longer advertises `include_edges`, still advertises `query`/`top_k`, and the description reflects substring matching. **5/5** in the file; full mcp suite **99 tests, 98 pass, 0 fail, 1 skipped** (pre-existing).
- `tsc` build exit 0; `eslint` exit 0.

## Adversarial review

- **Round A:** structural schema change; handler unaffected (already ignored `include_edges`). The real params (`query`, `top_k`, `domain`) stay. Description is factual (matches the handler's substring behavior).
- **Round B:** `enox-tools.ts` is a definitions array; minimal edit.
- **Round C (class):** swept `include_edges` across `packages/mcp/src` — the only other uses are the **`context`/`get_context`** tool, where it **is** implemented (`context-handlers.ts` reads it). So `semantic_search` was the sole advertised-but-ignored instance.

## Blast radius

One tool's schema + description. No handler/output behavior change; `include_edges` was already a no-op.

## Follow-up (REG-1152 item 2, larger)

- [ ] Wire `semantic_search` to the RFD-63 embedding index for genuine similarity ranking (then re-add a real score + optionally `include_edges`), replacing the substring placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)