### PR TITLE
docs(changelog): record merged #321 (cli --json) and #323 (semantic_search schema)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ All notable changes to this project will be documented in this file.
 - fix(cli): `grafema context <missing> --json` not-found payload mirrors the success `NodeContext` shape (`{ node: null, source: null, outgoing: [], incoming: [] }`) instead of a degenerate `{ node: null }` (#313)
 - fix(mcp): `semantic_search` honors its advertised `top_k` parameter — the handler read `args.limit` (default 20) while the tool schema advertises `top_k` (default 10), so callers passing `top_k` were silently ignored; now respected with the schema default (#314)
 - fix(mcp): `semantic_search` no longer prints a fabricated similarity score — results were rendered with a purely positional `[0.95]`-style score (embeddings not yet wired; matching is substring-based) that an agent reads as a real confidence metric; results are now listed by rank + name without the fake score (#319)
+- fix(mcp): `semantic_search` tool schema is honest — drops the advertised-but-ignored `include_edges` parameter and rewrites the description to state case-insensitive substring matching on node names (embedding ranking not yet wired) instead of claiming embedding-based similarity (REG-1152, #323)
+- fix(cli): `check --json` and `trace --from-route --json` emit parseable JSON on not-found via the shared `emitJsonNotFound` helper (each payload mirrors its command's success shape — `check` returns the full `{total,passed,failed,errors,results}` with zero counts); previously `check` exited with empty stdout and `trace --from-route` printed plain text, breaking `JSON.parse` for scripts/agents (REG-1149, #321)
 
 ## [0.3.23] - 2026-04-01
 


### PR DESCRIPTION
`[Unreleased]` > Bug Fixes entries:

- mcp: `semantic_search` honest schema — drop `include_edges`, fix description (REG-1152, #323)
- cli: `check` / `trace --from-route` `--json` not-found contract (REG-1149, #321)

Documentation-only. (#322 — internal DRY refactor — no changelog.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)