### PR TITLE
test(cli): REG-1153 — gate backend-free cli unit suite in CI + fix rotted import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,11 @@ jobs:
           set -o pipefail
           pnpm --filter @grafema/api --filter @grafema/types test 2>&1 | tee /tmp/api-types-test.log
 
+      - name: Run CLI unit tests (backend-free subset — REG-1153)
+        run: |
+          set -o pipefail
+          pnpm --filter @grafema/cli test:unit 2>&1 | tee /tmp/cli-unit-test.log
+
       - name: Summarize failed tests
         if: failure()
         run: |
@@ -128,7 +133,7 @@ jobs:
       - name: Check for .only in test files
         run: |
           echo "Checking for .only() in test files..."
-          if grep -rE '\.only\s*\(' test/ packages/mcp/test/ packages/vscode/test/ --include="*.test.js" --include="*.test.ts" 2>/dev/null; then
+          if grep -rE '\.only\s*\(' test/ packages/cli/test/ packages/mcp/test/ packages/vscode/test/ --include="*.test.js" --include="*.test.ts" 2>/dev/null; then
             echo "::error::Found .only() in test files. Remove before merging."
             exit 1
           fi
@@ -138,7 +143,7 @@ jobs:
         if: github.ref == 'refs/heads/stable'
         run: |
           echo "Checking for .skip() in test files (stable branch)..."
-          if grep -rE '\.skip\s*\(' test/ packages/mcp/test/ packages/vscode/test/ --include="*.test.js" --include="*.test.ts" 2>/dev/null; then
+          if grep -rE '\.skip\s*\(' test/ packages/cli/test/ packages/mcp/test/ packages/vscode/test/ --include="*.test.js" --include="*.test.ts" 2>/dev/null; then
             echo "::error::Found .skip() in test files. All tests must pass on stable."
             exit 1
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,3 +42,22 @@ Rust packages:
 cargo test -p grafema-orchestrator
 cargo test -p rfdb-server
 ```
+
+## What runs in CI
+
+The `CI / Tests` job (`.github/workflows/ci.yml`) gates these suites on every PR:
+
+| Suite | Command | Gated | Notes |
+|-------|---------|-------|-------|
+| Root unit | `pnpm test:coverage` (`test/unit/*.test.js`) | ✅ | |
+| MCP | `pnpm --filter @grafema/mcp test` | ✅ | |
+| VSCode unit | `packages/vscode/test/unit/*.test.ts` | ✅ | |
+| API + types | `pnpm --filter @grafema/api --filter @grafema/types test` | ✅ | |
+| CLI unit (backend-free) | `pnpm --filter @grafema/cli test:unit` | ✅ | REG-1153 — pure-unit files, no spawned binary |
+| CLI integration | `pnpm --filter @grafema/cli test` (full) | ❌ | spawns `dist/cli.js` + needs native orchestrator/rfdb binaries not built in CI |
+
+`@grafema/cli test:unit` covers only files that import functions directly (no cli spawn, no
+`.grafema` db): `analyze-utils`, `formatNode`, `pathutils-resolveprojectroot`,
+`progressRenderer`, `query-raw-predicate-warning`. The remaining cli tests spawn the built
+binary and/or run `analyze`, so they require the Rust/Haskell native binaries; CI-gating them
+needs the workflow to build or fetch those first.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,8 @@
     "postbuild": "mkdir -p dist/plugins && cp src/plugins/pluginResolver.js dist/plugins/",
     "clean": "rm -rf dist",
     "start": "node dist/cli.js",
-    "test": "node --import tsx --test test/*.test.ts"
+    "test": "node --import tsx --test test/*.test.ts",
+    "test:unit": "node --import tsx --test --test-concurrency=1 test/analyze-utils.test.ts test/formatNode.test.ts test/pathutils-resolveprojectroot.test.ts test/progressRenderer.test.ts test/query-raw-predicate-warning.test.ts"
   },
   "keywords": [
     "grafema",

--- a/packages/cli/test/analyze-utils.test.ts
+++ b/packages/cli/test/analyze-utils.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { fetchNodeEdgeCounts, exitWithCode } from '../src/commands/analyze.js';
+import { fetchNodeEdgeCounts, exitWithCode } from '../src/commands/analyzeAction.js';
 
 class FakeBackend {
   public nodeCountCalls = 0;


### PR DESCRIPTION
Closes part of **REG-1153** (CI: gate remaining package test suites — `cli`, `explore`).

## Problem (repro)
The `cli` suite is **not run by any CI job** — `ci.yml` ran only root (`test/unit`), `mcp`, `vscode`, `api`+`types`. Result: it silently rotted.

```
# node --import tsx --test packages/cli/test/analyze-utils.test.ts
SyntaxError: The requested module '../src/commands/analyze.js'
  does not provide an export named 'exitWithCode'
not ok 1 - packages/cli/test/analyze-utils.test.ts
```

`fetchNodeEdgeCounts` / `exitWithCode` moved `analyze.ts` → `analyzeAction.ts` (prod code `packages/cli/src/commands/resolveAction.ts:21` already imports the new path); only the test was left behind.

## SPEC
- **Given** a PR that breaks a backend-free cli unit test, **When** CI runs, **Then** the `CI / Tests` job fails (previously: passed — cli untested).
- Invariant restored: the cli unit surface is guarded against silent rot.

## Change
- **Fix the rot:** `analyze-utils.test.ts` import `analyze.js` → `analyzeAction.js`.
- **`@grafema/cli` `test:unit`** runs the 5 *backend-free* pure-unit files (import functions directly; no spawned binary, no `.grafema` db): `analyze-utils`, `formatNode`, `pathutils-resolveprojectroot`, `progressRenderer`, `query-raw-predicate-warning`.
- **Gate it in CI:** new step `pnpm --filter @grafema/cli test:unit`.
- **Extend the `.only`/`.skip` guard greps** to cover `packages/cli/test/`.
- **Document** the "what runs in CI" matrix in `CONTRIBUTING.md`.

## Verification (actual output)
```
$ pnpm --filter @grafema/cli test:unit
# tests 84
# pass 84
# fail 0
```
- `.only`/`.skip` in `packages/cli/test/`: **none** (guard extension can't make CI red).
- `ci.yml`: valid YAML; `pnpm --filter @grafema/cli build`: ok.
- Pre-commit hook (eslint + mcp regression suite): green (22/22).

## Scope / blast radius
No production code changed (one test import, a `package.json` script, CI yaml, a doc). The cli test files are excluded from `tsc` build/typecheck (the previously-broken import passed CI build), so build/typecheck cannot regress.

## Deliberately out of scope (follow-ups)
1. **CLI integration suite (~21 files)** — they spawn `dist/cli.js` and/or run `analyze`, needing native orchestrator+rfdb binaries that CI does not build/fetch. Gating them requires the workflow to provide those binaries first. Documented in the matrix; not gated here.
2. **`plugin-resolver.test.ts` e2e rot** — its fixture imports `{ Plugin }` from `@grafema/util`, which no longer exports `Plugin` (`error: does not provide an export named 'Plugin'`). Pre-existing failure, independent of this PR; excluded from `test:unit`. Needs its own fix (restore export or update the plugin API/fixture), then add it to the gate.
3. **`grafema-explore`** — REG-1153's second bullet references a `grafema-explore` package test script, but no such package exists (explore is a cli subcommand); that bullet is obsolete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)