### PR TITLE
fix(cli): REG-278 — helpful error when `ls` runs without --type

### DIFF
--- a/packages/cli/src/commands/ls.ts
+++ b/packages/cli/src/commands/ls.ts
@@ -40,7 +40,7 @@ interface NodeInfo {
 
 export const lsCommand = new Command('ls')
   .description('List nodes by type')
-  .requiredOption('-t, --type <nodeType>', 'Node type to list (required)')
+  .option('-t, --type <nodeType>', 'Node type to list (required)')
   .option('-p, --project <path>', 'Project path', '.')
   .option('-j, --json', 'Output as JSON')
   .option('-l, --limit <n>', 'Limit results (default: 50)', '50')
@@ -57,6 +57,13 @@ Discover available types:
   grafema types                           List all types with counts
 `)
   .action(async (options: LsOptions) => {
+    if (!options.type) {
+      exitWithError("Type filter required for 'ls' command", [
+        'Run: grafema types    to see available types',
+        'Usage: grafema ls --type <type>',
+      ]);
+    }
+
     const projectPath = resolve(options.project);
     const grafemaDir = join(projectPath, '.grafema');
     const dbPath = join(grafemaDir, 'graph.rfdb');

--- a/packages/cli/test/ls-type-required.test.ts
+++ b/packages/cli/test/ls-type-required.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests for `grafema ls` missing --type error message — REG-278
+ *
+ * Backend-free: the missing-`--type` usage error is emitted before any
+ * database/backend access, so this file needs no `analyze` run and is
+ * safe for the CI unit gate.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { spawnSync } from 'child_process';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const cliPath = join(__dirname, '../dist/cli.js');
+
+function runCli(args: string[]): { stdout: string; stderr: string; status: number | null } {
+  const result = spawnSync('node', [cliPath, ...args], {
+    encoding: 'utf-8',
+    env: { ...process.env, NO_COLOR: '1' },
+  });
+  return { stdout: result.stdout || '', stderr: result.stderr || '', status: result.status };
+}
+
+describe('grafema ls — missing --type (REG-278)', () => {
+  it('exits non-zero with a helpful message guiding to `grafema types`', () => {
+    const { stderr, status } = runCli(['ls']);
+
+    assert.strictEqual(status, 1, `expected exit 1, got ${status}`);
+    assert.match(stderr, /Type filter required for 'ls' command/, `got: ${stderr}`);
+    assert.match(stderr, /grafema types/, 'should point to `grafema types`');
+    assert.match(stderr, /grafema ls --type/, 'should show correct usage');
+  });
+
+  it('does NOT emit commander\'s bare "required option" error', () => {
+    const { stderr } = runCli(['ls']);
+    assert.doesNotMatch(
+      stderr,
+      /required option .* not specified/,
+      'should replace the raw commander error with a guided message',
+    );
+  });
+});


### PR DESCRIPTION
Closes **REG-278**.

## Problem
`ls` used `.requiredOption('-t, --type')`, so omitting it produced commander's bare error (the issue's "Current"):
```
error: required option '-t, --type <nodeType>' not specified
```
Every other REG-253 cli error guides the user; this one didn't.

## Fix
`packages/cli/src/commands/ls.ts`: `.requiredOption` → `.option` + an explicit guard using the existing `exitWithError` helper. Actual output now (matches the issue's "Desired"):
```
✗ Type filter required for 'ls' command

→ Run: grafema types    to see available types
→ Usage: grafema ls --type <type>
```

## Test
New **backend-free** regression: `packages/cli/test/ls-type-required.test.ts` (spawns `grafema ls` with no `--type`; no `analyze`/db needed → ready for the cli unit gate from #325).

## Verification (actual)
```
$ node --import tsx --test packages/cli/test/ls-type-required.test.ts
# tests 2
# pass 2
# fail 0

$ node packages/cli/dist/cli.js ls ; echo exit=$?
✗ Type filter required for 'ls' command
→ Run: grafema types    to see available types
→ Usage: grafema ls --type <type>
exit=1
```
- Pre-fix behavior (the red): the issue documents commander's `required option … not specified`; the new test's `doesNotMatch(/required option .* not specified/)` + `match(/Type filter required/)` both fail pre-fix, pass post-fix.
- Existing `ls-command.test.ts` "should require --type flag" still satisfied — it asserts status 1 + stderr containing `--type`/`required`, and the new message contains both.
- `cli build` (tsc) ok; eslint clean; pre-commit hook (lint + mcp regressions) green.

## Scope
One-line option change + a 7-line guard + one test file. No behavior change when `--type` is supplied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)