### PR TITLE
docs(mcp): REG-658 — document all Datalog predicates in get_documentation

### DIFF
--- a/packages/mcp/src/handlers/documentation-handlers.ts
+++ b/packages/mcp/src/handlers/documentation-handlers.ts
@@ -40,11 +40,21 @@ Grafema is a static code analyzer that builds a graph of your codebase.
 ## Syntax
 violation(X) :- node(X, "TYPE"), attr(X, "name", "value").
 
-## Available Predicates
-- type(Id, Type) - match nodes (alias: node)
-- edge(Src, Dst, Type) - match edges
-- attr(Id, Name, Value) - match node attributes (name, file, line, etc.)
-- \\+ - negation (not)
+## Node / Edge / Attribute Predicates
+- node(Id, Type) - match nodes by type (alias: type(Id, Type))
+- edge(Src, Dst, Type) - match outgoing edges Src -> Dst of the given type
+- incoming(Dst, Src, Type) - match edges pointing TO Dst (reverse of edge)
+- path(Src, Dst) - transitive reachability Src -> Dst (BFS over edges)
+- attr(Id, Name, Value) - match node attributes (name, file, line, ...; nested paths like "a.b" supported)
+- attr_edge(Src, Dst, EdgeType, AttrName, Value) - match EDGE attributes; Src/Dst/EdgeType/AttrName must be bound, Value may be variable/constant/wildcard
+- parent_function(NodeId, FunctionId) - bind the enclosing FUNCTION of NodeId via CONTAINS; NodeId must be bound; empty at module level
+
+## Negation & String Predicates
+- \\+ - negation (not); also for negative joins on a dst-position variable, e.g. \\+ edge(X, _, "CALLS")
+- neq(X, Y) - inequality; BOTH arguments must be bound
+- starts_with(Value, Prefix) - string prefix match
+- not_starts_with(Value, Prefix) - negative string prefix match
+- string_contains(Value, Substring) - substring match
 
 ## Numeric Comparison Predicates
 - gt(Value, Threshold) - greater than
@@ -54,6 +64,11 @@ violation(X) :- node(X, "TYPE"), attr(X, "name", "value").
 
 Values are parsed as floating-point numbers. Non-numeric values produce no matches.
 Use with attr() to filter by metadata values (e.g., metrics, line numbers).
+
+## Limitations
+- No aggregations (count/sum/avg), no GROUP BY, no ORDER BY - aggregate/sort client-side.
+- Predicate ORDER matters: bind a variable (via node/edge/attr) before a comparison /
+  string / attr_edge predicate uses it, or the query fails to place ("circular dependency").
 
 ## Examples
 Find all functions:
@@ -67,6 +82,12 @@ Find files where parsing took > 500ms:
 
 Find functions with more than 100 lines:
   violation(X, Lines) :- node(X, "FUNCTION"), attr(X, "line", Start), attr(X, "endLine", End), gt(End, Start).
+
+Find the enclosing function of every call:
+  violation(C, F) :- node(C, "CALL"), parent_function(C, F).
+
+Find nodes that have incoming CALLS edges (i.e. are called):
+  violation(D) :- incoming(D, _, "CALLS").
 `,
     types: `
 # Node & Edge Types

--- a/packages/mcp/test/documentation-queries.test.ts
+++ b/packages/mcp/test/documentation-queries.test.ts
@@ -1,0 +1,36 @@
+/**
+ * REG-658 — get_documentation(topic="queries") must list the Datalog predicates
+ * the engine actually implements, not just node/edge/attr/negation.
+ *
+ * Source of truth: the builtin dispatch in
+ * packages/rfdb-server/src/datalog/eval.rs (eval_atom match arm).
+ * Each predicate below was verified to execute via a live query_graph at authoring.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { handleGetDocumentation } from '../dist/handlers/documentation-handlers.js';
+
+async function queriesDoc(): Promise<string> {
+  const res = await handleGetDocumentation({ topic: 'queries' });
+  return res.content.map((c: { text?: string }) => c.text ?? '').join('\n');
+}
+
+describe('get_documentation("queries") — REG-658', () => {
+  it('documents every builtin Datalog predicate from eval.rs', async () => {
+    const doc = await queriesDoc();
+    for (const pred of [
+      'node(', 'edge(', 'incoming(', 'path(', 'attr(', 'attr_edge(',
+      'parent_function(', 'neq(', 'starts_with(', 'not_starts_with(',
+      'string_contains(', 'gt(', 'lt(', 'gte(', 'lte(',
+    ]) {
+      assert.ok(doc.includes(pred), `queries doc should document predicate "${pred}"`);
+    }
+  });
+
+  it('documents negation and known limitations', async () => {
+    const doc = await queriesDoc();
+    assert.match(doc, /negation/i, 'should mention negation');
+    assert.match(doc, /no aggregations|GROUP BY|ORDER BY/i, 'should state aggregation/ordering limits');
+  });
+});


### PR DESCRIPTION
Closes **REG-658**.

## Problem
`get_documentation(topic="queries")` listed only `node`/`edge`/`attr`/`\+` + numeric comparisons. The engine implements **8 more** builtins (source of truth: `packages/rfdb-server/src/datalog/eval.rs` `eval_atom` match arm, lines 711-724): `incoming`, `path`, `attr_edge`, `parent_function`, `neq`, `starts_with`, `not_starts_with`, `string_contains`. Agents querying the graph couldn't discover them.

## Change
- `packages/mcp/src/handlers/documentation-handlers.ts`: document every builtin with signature + binding constraints, a **Limitations** section (no aggregations / GROUP BY / ORDER BY; predicate ordering), and examples for `parent_function` + `incoming`.
- New **CI-gated** test `packages/mcp/test/documentation-queries.test.ts` asserting the doc lists every predicate from `eval.rs` — guards against future drift.

## Evidence (live `query_graph` on the self-graph, each predicate executes)
| predicate | query | count |
|---|---|---|
| incoming | `incoming(D,_,"CONTAINS"), node(D,"FUNCTION")` | 3217 |
| starts_with | `node(X,"MODULE"), attr(X,"file",F), starts_with(F,"packages")` | 340 |
| parent_function | `node(C,"CALL"), parent_function(C,F)` | 8460 |
| attr_edge (bound) | `edge(S,D,"PASSES_ARGUMENT"), attr_edge(S,D,"PASSES_ARGUMENT","argIndex",V)` | 4465 |

`attr_edge` with unbound Src/Dst correctly errors (`circular dependency, cannot place`), matching its "all args except Value must be bound" contract — documented as such.

## Verification
```
$ node --import tsx --experimental-test-module-mocks --test packages/mcp/test/documentation-queries.test.ts
# tests 2 # pass 2 # fail 0

$ pnpm --filter @grafema/mcp test
# tests 101 # pass 100 # fail 0     (no test pinned the old wording)
```
mcp build (tsc) ok; pre-commit hook (lint + regressions) green. Docs-only behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)