### PR TITLE
fix(cli): REG-279 — disambiguate duplicate node names in `ls` output

### DIFF
--- a/packages/cli/src/commands/ls.ts
+++ b/packages/cli/src/commands/ls.ts
@@ -25,7 +25,7 @@ interface LsOptions {
   limit: string;
 }
 
-interface NodeInfo {
+export interface NodeInfo {
   id: string;
   type: string;
   name: string;
@@ -126,9 +126,8 @@ Discover available types:
         console.log(`[${nodeType}] (${showing}${showing < totalCount ? ` of ${totalCount}` : ''}):`);
         console.log('');
 
-        for (const node of nodes) {
-          const display = formatNodeForList(node, nodeType, projectPath);
-          console.log(`  ${display}`);
+        for (const line of formatNodeList(nodes, nodeType, projectPath)) {
+          console.log(`  ${line}`);
         }
 
         if (showing < totalCount) {
@@ -176,4 +175,17 @@ function formatNodeForList(node: NodeInfo, nodeType: string, projectPath: string
   // Default: name (location)
   const name = node.name || node.id;
   return loc ? `${name}  (${loc})` : name;
+}
+
+/**
+ * Format a whole node list for display, disambiguating entries whose base
+ * display string collides (REG-279). Same-name/same-location nodes are
+ * otherwise indistinguishable; for those (and only those) the semantic ID is
+ * appended so the user can tell them apart. Unique entries are left untouched.
+ */
+export function formatNodeList(nodes: NodeInfo[], nodeType: string, projectPath: string): string[] {
+  const base = nodes.map((n) => formatNodeForList(n, nodeType, projectPath));
+  const counts = new Map<string, number>();
+  for (const b of base) counts.set(b, (counts.get(b) ?? 0) + 1);
+  return base.map((b, i) => ((counts.get(b) ?? 0) > 1 ? `${b}  [${nodes[i].id}]` : b));
 }

--- a/packages/cli/test/ls-format-dedup.test.ts
+++ b/packages/cli/test/ls-format-dedup.test.ts
@@ -1,0 +1,41 @@
+/**
+ * REG-279 — `ls` disambiguates duplicate node names.
+ *
+ * Backend-free: exercises the pure formatNodeList() helper directly, no
+ * analyze/db needed → safe for the CI unit gate.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { formatNodeList, type NodeInfo } from '../src/commands/ls.js';
+
+const node = (over: Partial<NodeInfo>): NodeInfo => ({
+  id: 'id', type: 'MODULE', name: '', file: '', ...over,
+});
+
+describe('formatNodeList — duplicate disambiguation (REG-279)', () => {
+  it('appends the semantic id to entries whose display collides', () => {
+    const nodes: NodeInfo[] = [
+      node({ id: 'a.js->MODULE->app', name: 'app.js', file: 'app.js' }),
+      node({ id: 'b.js->MODULE->app', name: 'app.js', file: 'app.js' }),
+    ];
+    const out = formatNodeList(nodes, 'MODULE', '/p');
+
+    // Both collide → both carry their (distinct) id, so the two lines differ.
+    assert.notStrictEqual(out[0], out[1], 'colliding entries must be distinguishable');
+    assert.match(out[0], /\[a\.js->MODULE->app\]/);
+    assert.match(out[1], /\[b\.js->MODULE->app\]/);
+  });
+
+  it('leaves unique entries untouched (no id noise)', () => {
+    const nodes: NodeInfo[] = [
+      node({ id: 'x->FUNCTION->foo', type: 'FUNCTION', name: 'foo', file: 'x.ts', line: 1 }),
+      node({ id: 'y->FUNCTION->bar', type: 'FUNCTION', name: 'bar', file: 'y.ts', line: 2 }),
+    ];
+    const out = formatNodeList(nodes, 'FUNCTION', '/p');
+
+    assert.doesNotMatch(out[0], /\[/, 'unique entry should not get an id suffix');
+    assert.doesNotMatch(out[1], /\[/, 'unique entry should not get an id suffix');
+    assert.match(out[0], /foo/);
+  });
+});


### PR DESCRIPTION
Closes **REG-279**.

## Problem
When two nodes render to the same `name  (location)` line, `ls` output is ambiguous (issue's example):
```
[MODULE] (2):
  app.js  (app.js)
  app.js  (app.js)
```
User can't tell why there are two entries.

## Fix
New exported pure helper `formatNodeList(nodes, nodeType, projectPath)` in `ls.ts`: formats the list, detects entries whose base display **collides**, and appends the **semantic id** to *only those* entries (acceptance: "show semantic ID/scope to differentiate"). Unique entries are byte-identical to before — no id noise. Action loop now uses it.
```
[MODULE] (2):
  app.js  (app.js)  [a.js->MODULE->app]
  app.js  (app.js)  [b.js->MODULE->app]
```

## Test
New **backend-free** regression `packages/cli/test/ls-format-dedup.test.ts` exercising the helper directly (no analyze/db → CI-unit-gate ready): collisions get distinct ids; uniques get no suffix.

## Verification
```
$ node --import tsx --test packages/cli/test/ls-format-dedup.test.ts
# tests 2 # pass 2 # fail 0
```
- Non-colliding output is unchanged ⇒ existing `ls-command.test.ts` integration assertions unaffected.
- cli build (tsc) ok; eslint clean; pre-commit hook (lint + regressions) green.

## Scope
+16/−4 in ls.ts + one test file. No behavior change for the common (unique) case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)