### PR TITLE
fix(cli): --json empty-result contract for `query` & `types`

### DIFF
--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -15,7 +15,7 @@ import { toRelativeDisplay } from '../utils/pathUtils.js';
 import { existsSync } from 'fs';
 import { RFDBServerBackend, parseSemanticId, parseSemanticIdV2, findCallsInFunction as findCallsInFunctionCore, findContainingFunction as findContainingFunctionCore } from '@grafema/util';
 import { formatNodeDisplay, formatNodeInline, formatLocation } from '../utils/formatNode.js';
-import { exitWithError } from '../utils/errorFormatter.js';
+import { exitWithError, emitJsonNotFound } from '../utils/errorFormatter.js';
 import { Spinner } from '../utils/spinner.js';
 import { extractQueriedTypes, findSimilarTypes } from '../utils/queryHints.js';
 import type { DatalogExplainResult, CypherResult } from '@grafema/types';
@@ -229,6 +229,13 @@ Examples:
       const hasScope = query.file !== null || query.scopes.length > 0;
 
       if (nodes.length === 0) {
+        // --json contract: stdout is always parseable JSON. The success path
+        // (below) emits a JSON array of nodes, so an empty result mirrors it with
+        // `[]`; the human "No results" note + suggestions go to stderr.
+        if (options.json) {
+          emitJsonNotFound([], `No results for "${pattern}"`);
+          return;
+        }
         console.log(`No results for "${pattern}"`);
         if (hasScope) {
           console.log(`  Try: grafema query "${query.name}" (search all scopes)`);

--- a/packages/cli/src/commands/types.ts
+++ b/packages/cli/src/commands/types.ts
@@ -12,7 +12,7 @@ import { Command } from 'commander';
 import { resolve, join } from 'path';
 import { existsSync } from 'fs';
 import { RFDBServerBackend } from '@grafema/util';
-import { exitWithError } from '../utils/errorFormatter.js';
+import { exitWithError, emitJsonNotFound } from '../utils/errorFormatter.js';
 
 interface TypesOptions {
   project: string;
@@ -53,6 +53,13 @@ Use with query --type:
       const entries = Object.entries(nodeCounts);
 
       if (entries.length === 0) {
+        // --json contract: stdout is always parseable JSON. Emit the empty
+        // success shape ({ types, totalTypes, totalNodes }) so a consumer reading
+        // those fields never chokes on the human "No nodes in graph" string.
+        if (options.json) {
+          emitJsonNotFound({ types: [], totalTypes: 0, totalNodes: 0 }, 'No nodes in graph. Run: grafema analyze');
+          return;
+        }
         console.log('No nodes in graph. Run: grafema analyze');
         return;
       }

--- a/packages/cli/test/json-notfound-query-types.test.ts
+++ b/packages/cli/test/json-notfound-query-types.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Test the `--json` not-found / empty-result contract for `query` and `types`.
+ *
+ * Bug class (siblings of impact #304 / wtf #307 / get·context·describe·ls #308 /
+ * explain·file #311 / check·trace #313): when a command produces no rows, its
+ * empty path printed a HUMAN string to stdout (or exited with empty stdout) even
+ * under `--json`, so a consumer doing `JSON.parse(stdout)` got
+ * "Unexpected end of JSON input" / "Unexpected token N in JSON".
+ *
+ * Two remaining violators found by the Round-C sweep:
+ *   - `query "<no-match>" --json` printed `No results for "..."` (query.ts) — the
+ *     `nodes.length === 0` early-return sat BEFORE the `if (options.json)` branch.
+ *   - `types --json` on an empty graph printed `No nodes in graph...` (types.ts) —
+ *     the `entries.length === 0` early-return sat BEFORE the `if (options.json)`
+ *     branch.
+ *
+ * Contract: under `--json`, stdout is ALWAYS parseable JSON. On empty result each
+ * command emits the SAME shape it emits on success (an array for `query`, the
+ * `{ types, totalTypes, totalNodes }` object for `types`) and the human note goes
+ * to stderr.
+ *
+ * The graph fixture is built directly via {@link RFDBServerBackend} rather than
+ * `grafema analyze`, so the test exercises the stdout-routing contract without
+ * depending on the language-analyzer binaries (faster, hermetic, and runnable in
+ * environments where the analyzer toolchain is unavailable).
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, dirname } from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { RFDBServerBackend } from '@grafema/util';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliPath = join(__dirname, '../dist/cli.js');
+
+interface FixtureNode {
+  id: string;
+  type: string;
+  name: string;
+  file: string;
+  line: number;
+}
+
+function runCli(args: string[], cwd: string): { stdout: string; stderr: string; status: number | null } {
+  const r = spawnSync('node', [cliPath, ...args], { cwd, encoding: 'utf-8', env: { ...process.env, NO_COLOR: '1' } });
+  return { stdout: r.stdout || '', stderr: r.stderr || '', status: r.status };
+}
+
+/**
+ * Build the graph fixture by writing nodes straight to RFDB (no `analyze`).
+ * Passing an empty array leaves a connected-but-empty graph on disk, which is
+ * exactly the state the `types`/`query` empty-result paths must handle.
+ */
+async function populateGraph(cwd: string, nodes: FixtureNode[]): Promise<void> {
+  const dbPath = join(cwd, '.grafema', 'graph.rfdb');
+  const backend = new RFDBServerBackend({ dbPath, clientName: 'test-setup' });
+  await backend.connect();
+  try {
+    for (const n of nodes) await backend.addNode(n);
+    await backend.flush();
+  } finally {
+    await backend.close();
+  }
+}
+
+const FOO: FixtureNode = { id: 'FUNCTION#src/m.js#foo', type: 'FUNCTION', name: 'foo', file: 'src/m.js', line: 1 };
+
+describe('CLI --json empty-result contract (query/types)', { timeout: 90000 }, () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'gfm-json-qt-'));
+    mkdirSync(join(tempDir, 'src'));
+    writeFileSync(join(tempDir, 'package.json'),
+      JSON.stringify({ name: 'json-qt-test', version: '1.0.0', main: 'src/m.js' }));
+    writeFileSync(join(tempDir, 'src', 'm.js'), 'export function foo() { return 1; }\n');
+    assert.strictEqual(runCli(['init'], tempDir).status, 0);
+  });
+
+  afterEach(() => {
+    if (tempDir && existsSync(tempDir)) {
+      runCli(['server', 'stop'], tempDir);
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('query "<no-match>" --json → parseable JSON, empty array', async () => {
+    await populateGraph(tempDir, [FOO]);
+    const out = runCli(['query', '__missing__', '--json'], tempDir).stdout;
+    const parsed = JSON.parse(out); // must not throw
+    // Success shape is a JSON array of nodes; empty result must mirror it.
+    assert.ok(Array.isArray(parsed), `expected an array:\n${out}`);
+    assert.strictEqual(parsed.length, 0, `expected empty array:\n${out}`);
+  });
+
+  it('query "<match>" --json → array still populated (success path unaffected)', async () => {
+    await populateGraph(tempDir, [FOO]);
+    const out = runCli(['query', 'foo', '--json'], tempDir).stdout;
+    const parsed = JSON.parse(out);
+    assert.ok(Array.isArray(parsed), `expected an array:\n${out}`);
+    assert.strictEqual(parsed.length, 1, `expected one match:\n${out}`);
+    assert.strictEqual(parsed[0].name, 'foo');
+  });
+
+  it('types --json (empty graph) → parseable JSON, empty shape mirrors success', async () => {
+    await populateGraph(tempDir, []); // connected but zero nodes
+    const out = runCli(['types', '--json'], tempDir).stdout;
+    const parsed = JSON.parse(out); // must not throw
+    // Must mirror the success shape ({ types, totalTypes, totalNodes }) so a
+    // consumer reading those fields on success doesn't get undefined here.
+    assert.deepStrictEqual(parsed.types, [], `types should be empty:\n${out}`);
+    assert.strictEqual(parsed.totalTypes, 0, `totalTypes:\n${out}`);
+    assert.strictEqual(parsed.totalNodes, 0, `totalNodes:\n${out}`);
+  });
+
+  it('types --json (non-empty) → success shape unaffected', async () => {
+    await populateGraph(tempDir, [FOO]);
+    const out = runCli(['types', '--json'], tempDir).stdout;
+    const parsed = JSON.parse(out);
+    assert.strictEqual(parsed.totalNodes, 1, `totalNodes:\n${out}`);
+    assert.ok(parsed.types.some((t: { type: string; count: number }) => t.type === 'FUNCTION'),
+      `expected FUNCTION type:\n${out}`);
+  });
+});


### PR DESCRIPTION
## Summary

Two remaining violators of the `--json` **"stdout is always parseable JSON"** contract — the exact bug class the recent sweep has been closing (impact #304 / wtf #307 / get·context·describe·ls #308 / explain·file #311 / check·trace #313, REG-1149):

- **`grafema query "<no-match>" --json`** printed `No results for "..."` as **plain text**. The `nodes.length === 0` early-return in `query.ts` sat *before* the `if (options.json)` branch, so a consumer doing `JSON.parse(stdout)` got `Unexpected token 'N'`.
- **`grafema types --json`** on an empty graph printed `No nodes in graph. Run: grafema analyze` as **plain text** — same pre-`json` early-return bug in `types.ts`.

Both now route through the shared `emitJsonNotFound` helper (same convention as every prior fix in this class): the machine payload goes to **stdout**, the human note to **stderr**.

## Spec

**Invariant restored:** under `--json`, stdout is *always* parseable JSON, and the empty/not-found payload mirrors the command's success shape.

- `query` success emits a JSON **array** of nodes → empty result emits `[]`.
- `types` success emits `{ types, totalTypes, totalNodes }` → empty graph emits `{ types: [], totalTypes: 0, totalNodes: 0 }`.

**BDD**
- *Given* a graph with no node matching `<pattern>`, *When* `grafema query "<pattern>" --json`, *Then* stdout is `[]` and the `No results` note is on stderr.
- *Given* a connected-but-empty graph, *When* `grafema types --json`, *Then* stdout is `{ "types": [], "totalTypes": 0, "totalNodes": 0 }` and the human note is on stderr.

## Before / After (live, this branch)

```
# BEFORE (current main build)
$ grafema query "__missing__" --json
No results for "__missing__"          ← plain text on stdout → JSON.parse throws
$ grafema types --json                 # empty graph
No nodes in graph. Run: grafema analyze ← plain text on stdout

# AFTER (this PR)
$ grafema query "__missing__" --json
[]                                     ← stdout; "No results for ..." moved to stderr
$ grafema types --json                 # empty graph
{
  "types": [],
  "totalTypes": 0,
  "totalNodes": 0
}
```

## Adversarial review

**Round A — Correctness.** Non-`--json` paths are byte-for-byte unchanged (human text + suggestions). `query --type <missing> --json` no longer prints the human suggestions (correct — those are human-only). Empty array `[]` and the empty object both round-trip through `JSON.parse`. `emitJsonNotFound` routes payload→stdout, note→stderr, returns (exit 0, `finally` closes the backend).

**Round B — Structural.** ~7 lines each, reusing the existing `emitJsonNotFound` helper (no new abstraction, no duplication). `types.ts` ≈101 lines, `query.ts` unchanged size class — both well under the 500-line limit.

**Round C — Class, not instance.** Swept **every** `--json` command. `query` (main pattern path) and `types` (empty graph) were the only *reachable* violators. Verified already-gated: `query`'s cypher helper, datalog helper, and datalog `--explain` path (the `if (json) … return` precedes `renderExplainOutput`, so its `No results.` is unreachable under `--json`); and `who` / `why` / `overview` / `stats` / `coverage` / `features` / `impact` / `describe` / `trace`. No sibling left.

## Verification

| Gate | Result |
|------|--------|
| New test `json-notfound-query-types.test.ts` | **4/4 pass** (red→green: both empty cases failed pre-fix with `Unexpected token 'N'`) |
| `pnpm typecheck` | ✅ exit 0 |
| `pnpm lint` | ✅ exit 0 |
| `pnpm build` | ✅ |

The new test builds its graph fixture directly via `RFDBServerBackend` instead of `grafema analyze`, so it's hermetic and does **not** depend on the language-analyzer binaries — faster, and runnable in environments where that toolchain is unavailable.

> Note on scope: the broader analyze-dependent CLI integration suite was not runnable in the authoring sandbox (analyzer binaries unavailable / GitHub binary download rate-limited), which is precisely why the new regression test is analyze-free. CI exercises the full suite.

## Blast radius

Only the empty-result branches of `query` and `types` change. Success output and all non-`--json` output are untouched (guarded by the two success-path tests added).

https://claude.ai/code/session_01WzYwZj6TXsZYEPfkTwJazM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzYwZj6TXsZYEPfkTwJazM)_