### PR TITLE
fix(config): empty vestigial JS-pipeline plugin defaults (root of REG-519/501/572 dead-config)

### DIFF
--- a/packages/util/src/config/ConfigLoader.ts
+++ b/packages/util/src/config/ConfigLoader.ts
@@ -13,16 +13,8 @@ import { GRAFEMA_VERSION, getSchemaVersion, isCompatibleVersion, parseVersion } 
  *
  * ```yaml
  * # Plugins for each analysis phase
- * plugins:
- *   indexing:
- *     - JSModuleIndexer
- *   analysis:
- *     - CoreV2Analyzer
- *     - ExpressRouteAnalyzer
- *   enrichment:
- *     - ExportEntityLinker
- *   validation:
- *     - EvalBanValidator
+ * plugins:           # analysis/enrichment/validation run natively in the v3
+ *   analysis: []     # orchestrator; these TS lists default to empty.
  *
  * # Optional: Explicit service definitions (bypass auto-discovery)
  * services:
@@ -144,42 +136,15 @@ export interface WorkspaceConfig {
 export const DEFAULT_CONFIG: GrafemaConfig = {
   version: getSchemaVersion(GRAFEMA_VERSION),
   plugins: {
+    // Legacy JS analysis-pipeline plugins were removed in the v3 migration
+    // (commit e063fc4e). The orchestrator now applies its own native passes
+    // (see packages/grafema-orchestrator config); these TS lists are vestigial
+    // (read only by `doctor` reporting + `write_config`) and default to empty.
     discovery: [],
-    indexing: ['JSModuleIndexer'],
-    analysis: [
-      'CoreV2Analyzer',
-      'ExpressRouteAnalyzer',
-      'ExpressResponseAnalyzer',
-      'NestJSRouteAnalyzer',
-      'SocketIOAnalyzer',
-      'DatabaseAnalyzer',
-      'FetchAnalyzer',
-      'ServiceLayerAnalyzer',
-    ],
-    enrichment: [
-      'ExportEntityLinker',
-      'CallbackCallResolver',
-      'RejectionPropagationEnricher',
-      'ValueDomainAnalyzer',
-      'MountPointResolver',
-      'ExpressHandlerLinker',
-      'PrefixEvaluator',
-      'ConfigRoutingMapBuilder',
-      'ServiceConnectionEnricher',
-      'RedisEnricher',
-    ],
-    validation: [
-      'GraphConnectivityValidator',
-      'DataFlowValidator',
-      'EvalBanValidator',
-      'CallResolverValidator',
-      'SQLInjectionValidator',
-      'AwaitInLoopValidator',
-      'ShadowingDetector',
-      'BrokenImportValidator',
-      'UnconnectedRouteValidator',
-      'PackageCoverageValidator',
-    ],
+    indexing: [],
+    analysis: [],
+    enrichment: [],
+    validation: [],
   },
   services: [], // Empty by default (uses auto-discovery)
   strict: false, // Graceful degradation by default

--- a/test/unit/config/ConfigLoader.test.ts
+++ b/test/unit/config/ConfigLoader.test.ts
@@ -490,19 +490,14 @@ plugins:
       assert.ok(Array.isArray(DEFAULT_CONFIG.plugins.validation));
     });
 
-    it('should have non-empty default plugins', () => {
-      assert.ok(DEFAULT_CONFIG.plugins.indexing.length > 0, 'indexing should have default plugins');
-      assert.ok(DEFAULT_CONFIG.plugins.analysis.length > 0, 'analysis should have default plugins');
-      assert.ok(DEFAULT_CONFIG.plugins.enrichment.length > 0, 'enrichment should have default plugins');
-      assert.ok(DEFAULT_CONFIG.plugins.validation.length > 0, 'validation should have default plugins');
-    });
-
-    it('should include expected default plugins', () => {
-      // Based on Joel's spec
-      assert.ok(DEFAULT_CONFIG.plugins.indexing.includes('JSModuleIndexer'));
-      assert.ok(DEFAULT_CONFIG.plugins.analysis.includes('CoreV2Analyzer'));
-      assert.ok(DEFAULT_CONFIG.plugins.enrichment.includes('ExportEntityLinker'));
-      assert.ok(DEFAULT_CONFIG.plugins.validation.includes('EvalBanValidator'));
+    it('should have empty default plugins (legacy JS pipeline removed in v3)', () => {
+      // The JS analysis-plugin pipeline was deleted in the v3 migration (e063fc4e);
+      // analysis/enrichment/validation run natively in the Rust orchestrator now.
+      // The TS plugin lists are vestigial and must default to empty so `doctor`
+      // does not report deleted plugins as configured. See test/unit/configDefaultPlugins.
+      for (const phase of ['discovery', 'indexing', 'analysis', 'enrichment', 'validation'] as const) {
+        assert.deepStrictEqual(DEFAULT_CONFIG.plugins[phase], [], `default plugins.${phase} must be empty`);
+      }
     });
   });
 

--- a/test/unit/configDefaultPlugins.test.js
+++ b/test/unit/configDefaultPlugins.test.js
@@ -1,0 +1,46 @@
+/**
+ * Default plugin config must not reference deleted JS-pipeline plugins.
+ *
+ * The v3 migration (commit e063fc4e) removed the entire JS analysis-plugin
+ * pipeline; analysis/enrichment/validation now run natively in the Rust
+ * orchestrator. The TS `DEFAULT_CONFIG.plugins` lists are vestigial (read only
+ * by `doctor` for reporting + `write_config`). They previously still named the
+ * deleted plugins, which made `grafema doctor` (a) count nonexistent plugins as
+ * "configured" and (b) warn "Plugin(s) not found" on its OWN default config
+ * (the default list contained names absent from doctor's allowlist).
+ *
+ * Regression guard: every default plugin phase must be empty.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { DEFAULT_CONFIG, loadConfig } from '@grafema/util';
+
+const PHASES = ['discovery', 'indexing', 'analysis', 'enrichment', 'validation'];
+
+describe('DEFAULT_CONFIG.plugins — no dead JS-pipeline plugin names', () => {
+  it('every default plugin phase is empty', () => {
+    for (const phase of PHASES) {
+      assert.deepStrictEqual(
+        DEFAULT_CONFIG.plugins[phase],
+        [],
+        `default plugins.${phase} must be empty (legacy JS plugins were removed)`,
+      );
+    }
+  });
+
+  it('loadConfig() on a project with no config returns empty plugin phases', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'grafema-cfg-'));
+    try {
+      const cfg = loadConfig(dir, { warn: () => {} });
+      for (const phase of PHASES) {
+        assert.deepStrictEqual(cfg.plugins[phase], [], `loaded default plugins.${phase} must be empty`);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes the shared **dead-config root cause** behind the now-canceled REG-519 / REG-501 and the REG-572 dangling-validator residual.

## Problem
The v3 migration (`e063fc4e`) removed the entire JS analysis-plugin pipeline — analysis/enrichment/validation now run **natively in the Rust orchestrator** (its own `config.rs` + `with_defaults()`: `js-import-resolution`, `runtime-globals`). But `DEFAULT_CONFIG.plugins` (TS `ConfigLoader.ts`) still listed **all the deleted plugins**. Every name verified `impl=0` in TS *and* Rust:
```
DEAD  JSModuleIndexer / CoreV2Analyzer / ExpressRouteAnalyzer / … (analysis ×8)
DEAD  ExportEntityLinker / CallbackCallResolver / … (enrichment ×10)
DEAD  EvalBanValidator / BrokenImportValidator / GraphConnectivityValidator / … (validation ×10)
```
Consequences (consumer = `grafema doctor`, `checks.ts:294`):
- doctor counted nonexistent plugins as "Config valid: N plugins configured";
- the default `validation` list (10) contained 4 names **absent** from doctor's `VALID_PLUGIN_NAMES` allowlist → doctor warned **"Plugin(s) not found"** on its *own default config*.

## Why decision-free (was earlier flagged "needs your call")
"Empty vs list real enrichers" is moot — **there are no real ones** in this TS mechanism; the real v3 plugins live in the orchestrator's Rust config. Safe to empty: the CLI does **not** pass TS `config.plugins` to the orchestrator (verified), so analysis is unaffected; the only TS consumers are doctor-reporting + `write_config`.

## Change
- Empty all 5 `DEFAULT_CONFIG.plugins` phases.
- Fix the misleading header-doc YAML example (showed deleted plugins as usable).
- **CI-gated** regression `test/unit/configDefaultPlugins.test.js`; update the two `ConfigLoader.test.ts` cases that encoded the old non-empty expectation.

## Verification (actual)
```
$ node --test test/unit/configDefaultPlugins.test.js          # 2/2
$ node --import tsx --test test/unit/config/ConfigLoader.test.ts  # 118/118
$ node --test test/unit/WorkspaceMultiRoot.test.js            # 10/10
$ pnpm --filter @grafema/util build                          # tsc clean
```
Pre-commit hook (lint + mcp regressions) green.

## Follow-up (noted, out of scope)
doctor's `VALID_PLUGIN_NAMES` (`checks.ts:40`) is now a stale allowlist of dead names — only consulted for user-supplied plugins, harmless with empty defaults. A deeper pass could remove doctor's TS-plugin check entirely (the field is vestigial) or point it at the orchestrator's real plugin config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)