### PR TITLE
fix(resolve): REG-585 (part 1) — resolve EXTENDS to builtin base classes

### DIFF
--- a/packages/grafema-resolve/src/ClassInheritance.hs
+++ b/packages/grafema-resolve/src/ClassInheritance.hs
@@ -80,14 +80,74 @@ isJsTsFile f = any (`T.isSuffixOf` f) [".ts", ".tsx", ".js", ".jsx", ".mjs", ".c
 -- Resolution
 -- ---------------------------------------------------------------------------
 
--- | Resolve a single CLASS node that has a superClass to an EXTENDS edge.
-resolveOne
+-- | Builtin JS/TS base classes/constructors that resolve to a virtual CLASS
+-- node (REG-585). Closed, language-defined set; extend as needed.
+builtinClassNames :: [Text]
+builtinClassNames =
+  [ "Error", "TypeError", "RangeError", "ReferenceError", "SyntaxError"
+  , "URIError", "EvalError", "AggregateError"
+  , "Object", "Array", "Map", "Set", "WeakMap", "WeakSet", "Promise"
+  , "EventEmitter"
+  ]
+
+-- | Last dotted segment, e.g. "events.EventEmitter" -> "EventEmitter".
+builtinBaseName :: Text -> Text
+builtinBaseName = T.takeWhileEnd (/= '.')
+
+isBuiltinClass :: Text -> Bool
+isBuiltinClass sc = builtinBaseName sc `elem` builtinClassNames
+
+builtinClassNodeId :: Text -> Text
+builtinClassNodeId name = "BUILTIN_CLASS::" <> name
+
+-- | Virtual CLASS node for a builtin base; deduped by id at the store layer.
+mkBuiltinClassNode :: Text -> GraphNode
+mkBuiltinClassNode name = GraphNode
+  { gnId        = builtinClassNodeId name
+  , gnType      = "CLASS"
+  , gnName      = name
+  , gnFile      = "<builtin>"
+  , gnLine      = 0
+  , gnColumn    = 0
+  , gnEndLine   = 0
+  , gnEndColumn = 0
+  , gnExported  = True
+  , gnMetadata  = Map.singleton "source" (MetaText "ecmascript-builtin")
+  }
+
+-- | When same-file + cross-file resolution find no target, resolve a builtin
+-- base (e.g. @class MyError extends Error@) to a virtual BUILTIN_CLASS node so
+-- the EXTENDS edge is no longer silently dropped (REG-585).
+builtinFallback :: GraphNode -> [PluginCommand]
+builtinFallback classNode =
+  case lookupMetaText "superClass" (gnMetadata classNode) of
+    Just sc | isBuiltinClass sc ->
+      let name = builtinBaseName sc
+      in [ EmitNode (mkBuiltinClassNode name)
+         , EmitEdge GraphEdge
+             { geSource   = gnId classNode
+             , geTarget   = builtinClassNodeId name
+             , geType     = "EXTENDS"
+             , geMetadata = Map.singleton "resolvedVia" (MetaText "builtin-class")
+             }
+         ]
+    _ -> []
+
+-- | Resolve a CLASS node's superClass: same-file/cross-file, else builtin fallback.
+resolveOne :: ClassIndex -> ImportBindingIndex -> ExportIndex -> GraphNode -> [PluginCommand]
+resolveOne classIdx importIdx exportIdx classNode =
+  case resolveOneCore classIdx importIdx exportIdx classNode of
+    []   -> builtinFallback classNode
+    cmds -> cmds
+
+-- | Core resolution: same-file then cross-file (no builtin fallback).
+resolveOneCore
   :: ClassIndex
   -> ImportBindingIndex
   -> ExportIndex
   -> GraphNode  -- must be a CLASS node with superClass metadata
   -> [PluginCommand]
-resolveOne classIdx importIdx exportIdx classNode =
+resolveOneCore classIdx importIdx exportIdx classNode =
   let file       = gnFile classNode
       superName  = lookupMetaText "superClass" (gnMetadata classNode)
   in case superName of

--- a/packages/grafema-resolve/test/Spec.hs
+++ b/packages/grafema-resolve/test/Spec.hs
@@ -105,6 +105,13 @@ extractEdges = concatMap getEdge
     getEdge (EmitEdge e) = [e]
     getEdge _            = []
 
+-- | Extract emitted nodes from plugin commands.
+extractNodes :: [PluginCommand] -> [GraphNode]
+extractNodes = concatMap getNode
+  where
+    getNode (EmitNode n) = [n]
+    getNode _            = []
+
 -- | Create a CLASS node with line range.
 mkClass :: Text -> Text -> Int -> Int -> GraphNode
 mkClass file name startLine endLine =
@@ -667,16 +674,34 @@ testNoSuperClass =
     [] -> Pass
     _  -> Fail $ "Expected 0 edges for class without superClass, got: " ++ show edges
 
--- | Unknown superClass (not in file, not imported) → no edge.
-testUnknownSuperClass :: TestResult
-testUnknownSuperClass =
+-- | Builtin superClass (e.g. EventEmitter) → EXTENDS edge to a virtual
+-- BUILTIN_CLASS node + the CLASS node itself (REG-585).
+testBuiltinBaseExtends :: TestResult
+testBuiltinBaseExtends =
   let file  = "src/animals.ts"
-      nodes = [ mkClassWithSuper file "Dog" "EventEmitter" ]
+      nodes = [ mkClassWithSuper file "Logger" "EventEmitter" ]
+      cmds  = ClassInheritance.resolveAll nodes
+      edges = extractEdges cmds
+      clsNodes = filter (\n -> gnType n == "CLASS" && gnId n == "BUILTIN_CLASS::EventEmitter") (extractNodes cmds)
+  in case (edges, clsNodes) of
+    ([e], (_:_))
+      | geSource e == file <> "->CLASS->Logger"
+      , geTarget e == "BUILTIN_CLASS::EventEmitter"
+      , geType e == "EXTENDS"
+      , Map.lookup "resolvedVia" (geMetadata e) == Just (MetaText "builtin-class")
+      -> Pass
+    _ -> Fail $ "Expected builtin EXTENDS edge + BUILTIN_CLASS node, got edges: " ++ show edges
+
+-- | Unknown NON-builtin superClass (not in file, not imported, not builtin) → no edge.
+testUnknownNonBuiltinSuper :: TestResult
+testUnknownNonBuiltinSuper =
+  let file  = "src/animals.ts"
+      nodes = [ mkClassWithSuper file "Dog" "TotallyMadeUpBase" ]
       cmds  = ClassInheritance.resolveAll nodes
       edges = extractEdges cmds
   in case edges of
     [] -> Pass
-    _  -> Fail $ "Expected 0 edges for unknown superClass, got: " ++ show edges
+    _  -> Fail $ "Expected 0 edges for unknown non-builtin superClass, got: " ++ show edges
 
 -- | Cross-file inheritance: Animal imported from ./base, class Dog extends Animal.
 testCrossFileExtends :: TestResult
@@ -806,7 +831,8 @@ main = do
   ciResults <- sequence
     [ runTest "same-file class extends creates EXTENDS edge" testSameFileExtends
     , runTest "class without superClass produces no edge" testNoSuperClass
-    , runTest "unknown superClass produces no edge" testUnknownSuperClass
+    , runTest "builtin superClass (EventEmitter) creates EXTENDS to BUILTIN_CLASS node" testBuiltinBaseExtends
+    , runTest "unknown non-builtin superClass produces no edge" testUnknownNonBuiltinSuper
     , runTest "cross-file inheritance via import creates EXTENDS edge" testCrossFileExtends
     ]
   putStrLn ""


### PR DESCRIPTION
Part 1 of **REG-585** (the EXTENDS half; INSTANCE_OF deferred — see below).

## Problem
`class MyError extends Error` / `class X extends EventEmitter` had their **EXTENDS edge silently dropped**: `packages/grafema-resolve/src/ClassInheritance.hs` `resolveOne` returned `[]` when the super was neither a same-file CLASS nor a relative import. This was even codified by `testUnknownSuperClass` (Spec.hs), which asserted **0 edges** for `extends EventEmitter`. No CLASS node exists for any JS builtin today (builtins are `GLOBAL_DEFINITION`).

## Ticket-premise correction
The ticket says "DERIVES_FROM" and dangling "INSTANCE_OF". In reality inheritance is **`EXTENDS`** (DERIVES_FROM is a dataflow edge), and **INSTANCE_OF is never emitted** (`new X()` → CALL+CALLS only). This PR fixes the real defect (dropped EXTENDS) using the real edge type.

## Change
- Builtin-class registry + `builtinFallback` in `ClassInheritance.hs`: when same-file + cross-file resolution miss and the super (last dotted segment, so `events.EventEmitter` works) is a known builtin → emit a virtual CLASS node `BUILTIN_CLASS::<name>` (file `<builtin>`, `source=ecmascript-builtin`) + the `EXTENDS` edge (`resolvedVia=builtin-class`). Deduped by id at the store layer.
- Set: `Error`/`TypeError`/`RangeError`/`ReferenceError`/`SyntaxError`/`URIError`/`EvalError`/`AggregateError`, `Object`/`Array`/`Map`/`Set`/`WeakMap`/`WeakSet`/`Promise`, `EventEmitter`.
- Replaced the codified-broken `testUnknownSuperClass` with `testBuiltinBaseExtends` (asserts EXTENDS edge **and** the BUILTIN_CLASS node) + a non-builtin `→0` guard; added `extractNodes` test helper.

## Verification
```
$ cabal test            # grafema-resolve, GHC 9.8.4
35/35 tests passed
  PASS: same-file class extends creates EXTENDS edge
  PASS: builtin superClass (EventEmitter) creates EXTENDS to BUILTIN_CLASS node
  PASS: unknown non-builtin superClass produces no edge
  PASS: cross-file inheritance via import creates EXTENDS edge
```
Unit suite exercises the real `resolveAll` path. End-to-end (binary redeploy + `violation(X) :- edge(X,Y,"EXTENDS"), \+ node(Y,"CLASS"), \+ node(Y,"INTERFACE")` → empty) is release-time. JS pre-commit hook (lint + regressions) green (no JS touched).

## Deferred — INSTANCE_OF (part 2)
`new Error()` INSTANCE_OF resolution needs a design decision: source endpoint **CALL→CLASS** (simplest, satisfies acceptance) vs **VARIABLE→CLASS** (what `getShape.ts:93-95` consumes). Flagged on the issue; will follow up once decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)