### PR TITLE
fix(orchestrator): RFD-65 — rebuild index before unresolved-diagnostics query (deterministic ISSUE count)

### DIFF
--- a/packages/grafema-orchestrator/src/main.rs
+++ b/packages/grafema-orchestrator/src/main.rs
@@ -1654,6 +1654,13 @@ async fn main() -> Result<()> {
             // 8m. Generate unresolved diagnostics
             let diagnostics_start = std::time::Instant::now();
             {
+                // RFD-65: the resolver commits CALLS/IMPORTS_FROM edges with
+                // defer_index=true, so the index is stale here. Rebuild BEFORE the
+                // negation queries below — otherwise `\+ edge(X, _, "CALLS")` reads a
+                // stale index, over-counts unresolved nodes, and the ISSUE count
+                // alternates between runs depending on L0/L1 compaction timing.
+                rfdb.rebuild_indexes().await.context("Failed to rebuild indexes before unresolved diagnostics")?;
+
                 // Query for unresolved CALL nodes (no outgoing CALLS edge)
                 let unresolved_calls_query = r#"violation(X, Name, File) :- node(X, "CALL"), attr(X, "name", Name), attr(X, "file", File), \+ edge(X, _, "CALLS")."#;
 
@@ -2487,6 +2494,11 @@ async fn main() -> Result<()> {
             // Unresolved diagnostics
             let diagnostics_start = std::time::Instant::now();
             {
+                // RFD-65: rebuild the index before the unresolved-diagnostics negation
+                // queries (resolver commits CALLS/IMPORTS_FROM with defer_index=true);
+                // a stale index here makes the ISSUE count nondeterministic.
+                rfdb.rebuild_indexes().await.context("Failed to rebuild indexes before unresolved diagnostics")?;
+
                 let unresolved_calls_query = r#"violation(X, Name, File) :- node(X, "CALL"), attr(X, "name", Name), attr(X, "file", File), \+ edge(X, _, "CALLS")."#;
                 let unresolved_imports_query = r#"violation(X, Name, File) :- node(X, "IMPORT_BINDING"), attr(X, "name", Name), attr(X, "file", File), \+ edge(X, _, "IMPORTS_FROM")."#;
 


### PR DESCRIPTION
Closes **RFD-65**.

## Problem
`grafema analyze` produced an ISSUE-node count that **alternated between runs** (e.g. 21,358 ↔ 23,929 on the same code).

## Root cause (confirmed by reading)
The unresolved-diagnostics step runs Datalog negation queries `\+ edge(X,_,"CALLS")` / `\+ edge(X,_,"IMPORTS_FROM")` to find unresolved nodes — at `main.rs:1656` (analyze path) and `:2494` (resolve subcommand). The resolver commits CALLS/IMPORTS_FROM edges with **`defer_index=true`** (`plugin.rs`), and the post-resolve `rebuild_indexes()` (analyze: `:1807`) runs **after** these queries. So the negation could read a **stale index**, count already-resolved nodes as unresolved, and emit extra ISSUE nodes. Whether the stale read happened depended on L0/L1 compaction timing → the alternating count.

## Fix (RFD-65 option 1)
Call `rfdb.rebuild_indexes()` at the start of each unresolved-diagnostics block, **before** the negation queries, so they read a fresh index. The existing post-diagnostics rebuild stays (it indexes the freshly-committed diagnostic ISSUE nodes). 2 sites, +12 lines.

**Cost:** one extra full index rebuild in the resolve tail — accepted for determinism (per the option-1 decision); can be optimized later (option 2: `defer_index=false` on the diagnostic commit) if it shows up in resolve-phase timings.

## Verification
- `cargo build` clean (orchestrator).
- JS pre-commit hook (lint + mcp regressions) green (no JS touched).
- **Honest caveat:** the bug is compaction-timing-dependent, so empirically confirming "counts no longer alternate" needs several consecutive full `analyze` runs — that's a release-time check. This fix is root-cause-driven: the negation now provably reads a freshly-rebuilt index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)