### PR TITLE
fix(resolve): REG-585 part 2 — INSTANCE_OF edges for new X() (VARIABLE→CLASS)

### DIFF
--- a/packages/grafema-resolve/src/ClassInheritance.hs
+++ b/packages/grafema-resolve/src/ClassInheritance.hs
@@ -188,6 +188,43 @@ resolveOneCore classIdx importIdx exportIdx classNode =
                               }
                           ]
 
+-- | Resolve a VARIABLE/CONSTANT initialized from `new X()` (carrying
+-- `instanceOfName` metadata, stamped by the analyzer) to an INSTANCE_OF edge
+-- to its CLASS (REG-585 pt2). Resolution order: same-file CLASS, imported
+-- CLASS, builtin CLASS. Source is the VARIABLE (consumed by getShape).
+resolveInstanceOf :: ClassIndex -> ImportBindingIndex -> ExportIndex -> GraphNode -> [PluginCommand]
+resolveInstanceOf classIdx importIdx exportIdx varNode =
+  case lookupMetaText "instanceOfName" (gnMetadata varNode) of
+    Nothing -> []
+    Just cn ->
+      let file = gnFile varNode
+          edgeTo targetId via extra =
+            [ EmitEdge GraphEdge
+                { geSource   = gnId varNode
+                , geTarget   = targetId
+                , geType     = "INSTANCE_OF"
+                , geMetadata = Map.fromList (("resolvedVia", MetaText via) : extra)
+                }
+            ]
+      in case Map.lookup (file, cn) classIdx of
+        -- 1. same-file class
+        Just targetId -> edgeTo targetId "instance-of" []
+        Nothing ->
+          -- 2. imported class
+          case Map.lookup (file, cn) importIdx of
+            Just ib
+              | Just resolvedPath <- resolveModulePath file (ibSource ib) exportIdx Map.empty
+              , Just exports <- Map.lookup resolvedPath exportIdx
+              , Just entry <- findMatchingExport (ibImportedName ib) exports ->
+                  edgeTo (eeNodeId entry) "instance-of" [("importedFrom", MetaText (ibSource ib))]
+            _ ->
+              -- 3. builtin class
+              if isBuiltinClass cn
+                then let name = builtinBaseName cn
+                     in EmitNode (mkBuiltinClassNode name)
+                        : edgeTo (builtinClassNodeId name) "instance-of-builtin" []
+                else []
+
 -- | Resolve all CLASS inheritance edges.
 resolveAll :: [GraphNode] -> [PluginCommand]
 resolveAll nodes =
@@ -200,7 +237,13 @@ resolveAll nodes =
           isJsTsFile (gnFile n) &&
           Map.member "superClass" (gnMetadata n)
         ) nodes
+      varNodes = filter (\n ->
+          (gnType n == "VARIABLE" || gnType n == "CONSTANT") &&
+          isJsTsFile (gnFile n) &&
+          Map.member "instanceOfName" (gnMetadata n)
+        ) nodes
       results = concatMap (resolveOne classIdx importIdx exportIdx) classNodes
+             ++ concatMap (resolveInstanceOf classIdx importIdx exportIdx) varNodes
   in results
 
 -- | Resolve with a pre-built export index (for streaming per-file mode).
@@ -216,4 +259,10 @@ resolveFileWithIndex exportIdx fileNodes =
           isJsTsFile (gnFile n) &&
           Map.member "superClass" (gnMetadata n)
         ) fileNodes
+      varNodes = filter (\n ->
+          (gnType n == "VARIABLE" || gnType n == "CONSTANT") &&
+          isJsTsFile (gnFile n) &&
+          Map.member "instanceOfName" (gnMetadata n)
+        ) fileNodes
   in concatMap (resolveOne classIdx importIdx exportIdx) classNodes
+  ++ concatMap (resolveInstanceOf classIdx importIdx exportIdx) varNodes

--- a/packages/grafema-resolve/test/Spec.hs
+++ b/packages/grafema-resolve/test/Spec.hs
@@ -645,6 +645,16 @@ mkSimpleClass file className =
     file
     Map.empty
 
+-- | VARIABLE node initialized from `new <className>()` (REG-585 pt2 metadata).
+mkVarWithInstanceOf :: Text -> Text -> Text -> GraphNode
+mkVarWithInstanceOf file varName className =
+  mkNode
+    (file <> "->VARIABLE->" <> varName)
+    "VARIABLE"
+    varName
+    file
+    (Map.fromList [("kind", MetaText "const"), ("instanceOfName", MetaText className)])
+
 -- | Same-file inheritance: class Dog extends Animal in same .ts file.
 testSameFileExtends :: TestResult
 testSameFileExtends =
@@ -721,6 +731,37 @@ testCrossFileExtends =
         , geType e == "EXTENDS"
         -> Pass
     _ -> Fail $ "Expected 1 cross-file EXTENDS edge Dog→Animal, got: " ++ show edges
+
+-- | REG-585 pt2: const x = new Foo() (same-file class) → VARIABLE -INSTANCE_OF-> CLASS Foo.
+testInstanceOfSameFile :: TestResult
+testInstanceOfSameFile =
+  let file  = "src/app.ts"
+      nodes = [ mkSimpleClass file "Foo", mkVarWithInstanceOf file "x" "Foo" ]
+      ioEdges = filter (\e -> geType e == "INSTANCE_OF") (extractEdges (ClassInheritance.resolveAll nodes))
+  in case ioEdges of
+    [e] | geSource e == file <> "->VARIABLE->x", geTarget e == file <> "->CLASS->Foo" -> Pass
+    _ -> Fail $ "Expected INSTANCE_OF x->Foo, got: " ++ show ioEdges
+
+-- | REG-585 pt2: const e = new Error() → VARIABLE -INSTANCE_OF-> BUILTIN_CLASS::Error + node.
+testInstanceOfBuiltin :: TestResult
+testInstanceOfBuiltin =
+  let file  = "src/app.ts"
+      cmds  = ClassInheritance.resolveAll [ mkVarWithInstanceOf file "e" "Error" ]
+      ioEdges = filter (\e -> geType e == "INSTANCE_OF") (extractEdges cmds)
+      clsNodes = filter (\n -> gnType n == "CLASS" && gnId n == "BUILTIN_CLASS::Error") (extractNodes cmds)
+  in case (ioEdges, clsNodes) of
+    ([e], (_:_)) | geSource e == file <> "->VARIABLE->e", geTarget e == "BUILTIN_CLASS::Error" -> Pass
+    _ -> Fail $ "Expected INSTANCE_OF e->BUILTIN_CLASS::Error + node, got: " ++ show ioEdges
+
+-- | REG-585 pt2: VARIABLE without instanceOfName → no INSTANCE_OF edge.
+testInstanceOfNoMetadata :: TestResult
+testInstanceOfNoMetadata =
+  let file  = "src/app.ts"
+      nodes = [ mkNode (file <> "->VARIABLE->y") "VARIABLE" "y" file (Map.singleton "kind" (MetaText "const")) ]
+      ioEdges = filter (\e -> geType e == "INSTANCE_OF") (extractEdges (ClassInheritance.resolveAll nodes))
+  in case ioEdges of
+    [] -> Pass
+    _  -> Fail $ "Expected no INSTANCE_OF edge, got: " ++ show ioEdges
 
 -- ---------------------------------------------------------------------------
 -- ImportResolution unit tests
@@ -834,6 +875,9 @@ main = do
     , runTest "builtin superClass (EventEmitter) creates EXTENDS to BUILTIN_CLASS node" testBuiltinBaseExtends
     , runTest "unknown non-builtin superClass produces no edge" testUnknownNonBuiltinSuper
     , runTest "cross-file inheritance via import creates EXTENDS edge" testCrossFileExtends
+    , runTest "new Foo() (same-file) creates INSTANCE_OF edge" testInstanceOfSameFile
+    , runTest "new Error() creates INSTANCE_OF to BUILTIN_CLASS node" testInstanceOfBuiltin
+    , runTest "VARIABLE without instanceOfName produces no INSTANCE_OF" testInstanceOfNoMetadata
     ]
   putStrLn ""
   putStrLn "ImportResolution unit tests:"

--- a/packages/js-analyzer/src/Rules/Declarations.hs
+++ b/packages/js-analyzer/src/Rules/Declarations.hs
@@ -89,6 +89,20 @@ ruleVariableDeclarator node parentDecl = do
         parent <- askNamedParent
         isExported <- askExported
         let nodeId = semanticId file nodeType name parent Nothing
+            -- REG-585 pt2: if initialized from `new X()` (simple identifier callee),
+            -- stamp the constructor name so the resolver can emit VARIABLE -INSTANCE_OF-> CLASS.
+            mInstanceOf = case getChildrenMaybe "init" node of
+              Just initNode -> case initNode of
+                NewExpressionNode _ _ -> case getChildrenMaybe "callee" initNode of
+                  Just calleeNode@(IdentifierNode _ _) ->
+                    let cn = getTextFieldOr "name" "" calleeNode
+                    in if T.null cn then Nothing else Just cn
+                  _ -> Nothing
+                _ -> Nothing
+              Nothing -> Nothing
+            varMeta = case mInstanceOf of
+              Just cn -> Map.fromList [("kind", MetaText kind), ("instanceOfName", MetaText cn)]
+              Nothing -> Map.singleton "kind" (MetaText kind)
         emitNode GraphNode
           { gnId       = nodeId
           , gnType     = nodeType
@@ -99,7 +113,7 @@ ruleVariableDeclarator node parentDecl = do
           , gnEndLine  = spanEnd idSp
           , gnEndColumn = 0
           , gnExported = isExported
-          , gnMetadata = Map.singleton "kind" (MetaText kind)
+          , gnMetadata = varMeta
           }
         emitEdge GraphEdge
           { geSource = curScopeId


### PR DESCRIPTION
Part 2 of **REG-585** (part 1 = EXTENDS, merged in #331). Completes the issue.

## Problem
`const x = new Foo()` / `new Error()` emitted **no INSTANCE_OF edge** anywhere. `getShape.ts:93-99` consumes `VARIABLE →INSTANCE_OF→ CLASS` for type/hover, so it had nothing to follow.

## Why it spans two packages
Resolver passes receive **only `[GraphNode]`** (`Main.hs`), not edges — so the `VARIABLE --ASSIGNED_FROM--> new-CALL` link is invisible to the resolver. The fix carries the constructor name on **node metadata**:
- **js-analyzer** `Rules/Declarations.hs` (`ruleVariableDeclarator`): when a declarator's init is `new <Identifier>()`, stamp the VARIABLE/CONSTANT node with `instanceOfName=<ctor>`. Simple-identifier callees only (member/odd callees skipped → just don't resolve, never a bad edge).
- **grafema-resolve** `ClassInheritance.hs`: new `resolveInstanceOf` reads `instanceOfName` and emits `VARIABLE →INSTANCE_OF→ CLASS`, resolving same-file → imported → builtin (reusing #331's `BUILTIN_CLASS` registry). Wired into `resolveAll` + `resolveFileWithIndex`.

Owner decision honored: **VARIABLE→CLASS** source (feeds getShape), covering builtin **and** user classes.

## Scope (v1)
Declarator inits (`const/let/var x = new X()`). Out of scope (deferred): bare reassignment `x = new X()` and class-field initializers (different AST rule).

## Verification
```
$ cabal test   # grafema-resolve, GHC 9.8.4
38/38 tests passed
  PASS: new Foo() (same-file) creates INSTANCE_OF edge
  PASS: new Error() creates INSTANCE_OF to BUILTIN_CLASS node
  PASS: VARIABLE without instanceOfName produces no INSTANCE_OF
```
js-analyzer builds clean (Declarations compiled + linked). JS pre-commit hook (lint + mcp regressions) green. End-to-end (binary redeploy + `violation(X) :- edge(X,Y,"INSTANCE_OF"), \+ node(Y,"CLASS")` → empty) is release-time.

With this + #331, **REG-585 is fully addressed** (EXTENDS + INSTANCE_OF to builtin & user classes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)