### PR TITLE
fix(coverage): REG-408 — normalize symlinked project root in CoverageAnalyzer

### DIFF
--- a/packages/util/src/core/CoverageAnalyzer.ts
+++ b/packages/util/src/core/CoverageAnalyzer.ts
@@ -12,7 +12,7 @@
  *   const result = await analyzer.analyze();
  */
 
-import { readdirSync, existsSync, lstatSync } from 'fs';
+import { readdirSync, existsSync, lstatSync, realpathSync } from 'fs';
 import { join, relative, extname } from 'path';
 import type { GraphBackend } from '@grafema/types';
 
@@ -112,9 +112,28 @@ export class CoverageAnalyzer {
   private graph: GraphBackend;
   private projectPath: string;
 
+  /**
+   * @param graph - graph backend to query for MODULE/ISSUE nodes
+   * @param projectPath - absolute project root to scan and to strip from node
+   *   paths. It is realpath'd here (REG-408 class): the graph stores realpath'd
+   *   ABSOLUTE file paths, so a symlinked root (e.g. macOS `/tmp` ->
+   *   `/private/tmp`) would otherwise never `startsWith` an absolute MODULE path
+   *   — keeping the file absolute while {@link scanProjectFiles} emits relative
+   *   paths, double-counting the same file as both `analyzed` and `unreachable`
+   *   and inflating `total`. Callers (`grafema coverage`, MCP `get_coverage`)
+   *   pass a raw `resolve()`'d / user-supplied root, so normalizing here fixes
+   *   every caller in one place. Falls back to the given path if it does not
+   *   exist on disk (the caller's own dbPath check reports a missing project).
+   */
   constructor(graph: GraphBackend, projectPath: string) {
     this.graph = graph;
-    this.projectPath = projectPath;
+    let normalized = projectPath;
+    try {
+      normalized = realpathSync(projectPath);
+    } catch {
+      // Path does not exist (or is not resolvable): keep the raw value.
+    }
+    this.projectPath = normalized;
   }
 
   /**

--- a/test/unit/coverageAnalyzerSymlinkedRoot.test.js
+++ b/test/unit/coverageAnalyzerSymlinkedRoot.test.js
@@ -1,0 +1,107 @@
+/**
+ * Regression: CoverageAnalyzer must normalize a symlinked project root.
+ *
+ * REG-408 class (realpath-vs-symlink): the graph stores realpath'd ABSOLUTE
+ * file paths, but `grafema coverage` / the MCP `get_coverage` handler pass the
+ * raw project root (`resolve(options.project)` / `getProjectPath()` /
+ * `args.path`) WITHOUT collapsing symlinks. REG-408 fixed this for the `file`
+ * and `explain` commands via `resolveProjectRoot` (realpath), but coverage was
+ * missed in both packages.
+ *
+ * Under a symlinked root (e.g. macOS `/tmp` -> `/private/tmp`, or any explicit
+ * symlink), an absolute MODULE path never `startsWith` the symlink root, so
+ * CoverageAnalyzer keeps it absolute while `scanProjectFiles()` emits relative
+ * paths. The SAME file then matches neither set the other way: it is counted as
+ * `analyzed` (it has a MODULE node) AND as `unreachable` (its scanned relative
+ * path is not in the analyzed set), double-inflating `total`.
+ *
+ * This test reproduces the double-count with an explicit symlink and a fake
+ * graph holding canonical absolute MODULE paths. It is hermetic — no analyzer
+ * binary, no `grafema analyze`, no rfdb server.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  symlinkSync,
+  realpathSync,
+  rmSync,
+  existsSync,
+} from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { CoverageAnalyzer } from '@grafema/util';
+
+/**
+ * Minimal GraphBackend stand-in: yields the MODULE/ISSUE nodes the
+ * CoverageAnalyzer queries (`queryNodes({ type })`). Mirrors how the real
+ * analyzer stores file paths — here we feed canonical ABSOLUTE MODULE paths,
+ * which is the case that exposes the symlink bug.
+ */
+class FakeGraph {
+  constructor(moduleAbsoluteFiles) {
+    this.moduleFiles = moduleAbsoluteFiles;
+  }
+
+  async *queryNodes(filter) {
+    if (filter && filter.type === 'MODULE') {
+      for (const file of this.moduleFiles) {
+        yield {
+          id: `module:${file}`,
+          type: 'MODULE',
+          nodeType: 'MODULE',
+          name: file.split('/').pop() || file,
+          file,
+          line: 1,
+          column: 0,
+          metadata: '{}',
+        };
+      }
+    }
+    // No ISSUE nodes in this fixture.
+  }
+}
+
+describe('CoverageAnalyzer — symlinked project root (REG-408 class)', () => {
+  let realRoot; // canonical (realpath'd) directory the files actually live in
+  let linkRoot; // symlink pointing at realRoot — the un-normalized "project root"
+
+  beforeEach(() => {
+    // Canonicalize first: tmpdir() itself may be a symlink (macOS), and we want
+    // realRoot to be the canonical target so the symlink delta is purely ours.
+    const base = realpathSync(mkdtempSync(join(tmpdir(), 'cov-real-')));
+    realRoot = base;
+    mkdirSync(join(realRoot, 'src'), { recursive: true });
+    writeFileSync(join(realRoot, 'src', 'index.ts'), 'export const x = 1;');
+
+    linkRoot = join(dirname(realRoot), `cov-link-${process.pid}-${Date.now()}`);
+    symlinkSync(realRoot, linkRoot, 'dir');
+  });
+
+  afterEach(() => {
+    if (linkRoot && existsSync(linkRoot)) rmSync(linkRoot, { force: true });
+    if (realRoot && existsSync(realRoot)) rmSync(realRoot, { recursive: true, force: true });
+  });
+
+  it('does not double-count a file when the root is a symlink', async () => {
+    // Graph stores the canonical ABSOLUTE module path (what the analyzer emits).
+    const graph = new FakeGraph([join(realRoot, 'src', 'index.ts')]);
+
+    // Caller passes the SYMLINK path un-normalized (as coverage.ts / MCP do).
+    const analyzer = new CoverageAnalyzer(graph, linkRoot);
+    const result = await analyzer.analyze();
+
+    // The single file is analyzed exactly once, never also unreachable.
+    assert.strictEqual(result.analyzed.count, 1, 'file should be counted as analyzed once');
+    assert.strictEqual(result.unreachable.count, 0, 'analyzed file must not also be unreachable');
+    assert.strictEqual(result.total, 1, 'total must not be inflated by double-counting');
+    assert.ok(
+      result.analyzed.files.includes('src/index.ts'),
+      'analyzed file should be reported as the project-relative path',
+    );
+  });
+});


### PR DESCRIPTION
Fixes the last reachable instance of the **REG-408 realpath-vs-symlink class** — `grafema coverage` (and the MCP `get_coverage` handler) double-count files under a symlinked project root.

## Spec

**Invariant restored:** `CoverageAnalyzer` compares MODULE/ISSUE node paths against a filesystem walk; both sides must be in the same canonical form. The graph stores realpath'd ABSOLUTE file paths, so the project root must be realpath'd too.

**Given** a project whose root is reached via a symlink (e.g. macOS `/tmp` → `/private/tmp`, or any symlinked checkout)
**And** the graph holds canonical absolute MODULE paths
**When** `grafema coverage` / MCP `get_coverage` runs
**Then** each analyzed file is counted exactly once (not as both `analyzed` and `unreachable`) and `total` is not inflated.

## Root cause

Callers pass the raw root un-normalized:
- CLI `packages/cli/src/commands/coverage.ts:29` → `const projectPath = resolve(options.project)`
- MCP `packages/mcp/src/handlers/coverage-handlers.ts` → `getProjectPath()` / `args.path`

In `CoverageAnalyzer.getAnalyzedFiles()` (`packages/util/src/core/CoverageAnalyzer.ts:234`), `node.file.startsWith(this.projectPath)` is **false** for an absolute realpath'd path when `projectPath` is the symlink, so the path is kept absolute. Meanwhile `scanProjectFiles()` emits project-relative paths. The same file then appears in both the analyzed set (it has a MODULE node) and the unreachable set (its relative scan path isn't in the analyzed set) → `analyzed=1` **and** `unreachable=1`, `total=2`.

REG-408 fixed exactly this class for the `file`/`explain` commands via `resolveProjectRoot` (realpath); coverage was missed in both packages.

## Fix

Normalize the root at the **analyzer layer** — realpath in the `CoverageAnalyzer` constructor with a fallback when the path doesn't exist. This covers **both** the CLI and MCP callers in one place (neither `@grafema/util` nor `@grafema/mcp` may depend on the CLI's `resolveProjectRoot`), and makes the analyzer correct for any future caller.

## Before / After (hermetic regression test)

`test/unit/coverageAnalyzerSymlinkedRoot.test.js` — explicit symlink + fake graph with a canonical absolute MODULE path, no analyzer binary / no `grafema analyze` / no rfdb server. Placed at the CI-gated top-level `test/unit/*.test.js` (the existing `test/unit/core/CoverageAnalyzer.test.ts` is **not** in the `pnpm test:coverage` glob).

**Before (RED, right reason):**
```
FAIL: does not double-count a file when the root is a symlink
      analyzed file must not also be unreachable
  expected: 0
  actual: 1   (result.unreachable.count)
```

**After (GREEN):**
```
# tests 1
# pass 1
# fail 0
```

## Full gate (actual outputs)

- `pnpm build` — OK
- `./scripts/test.sh` — **694 pass / 0 fail** (was 693; +1 new test)
- existing `test/unit/core/CoverageAnalyzer.test.ts` — **25 pass / 0 fail** (no regression from the constructor change)
- `pnpm typecheck` — clean (platform WARNs only)
- `pnpm lint` — clean

## Adversarial review

- **Round A (correctness):** non-existent root → `try/catch` keeps the raw value (the caller's own dbPath check reports the missing project; existing empty-project test green). Relative MODULE paths (current default) are preserved — `startsWith` stays false, scan still matches (existing 25 tests green). `realpathSync` is idempotent for already-canonical roots.
- **Round B (structure):** `CoverageAnalyzer.ts` is 345 lines (< 500); fix is localized to the constructor and documented for agents.
- **Round C (class):** the analyzer-layer fix covers both call-sites; `file`/`explain` were already fixed by REG-408; this was the last reachable coverage instance of the class.

## Blast radius

`CoverageAnalyzer` is consumed only by `packages/cli/src/commands/coverage.ts` and `packages/mcp/src/handlers/coverage-handlers.ts`; both benefit, neither passes an already-realpath'd root today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvU7bX4MKpG6VT8GGLRPzL)_