### PR TITLE
fix(rfdb): support attr_edge builtin in Datalog explain evaluator

### DIFF
--- a/packages/rfdb-server/src/datalog/eval_explain.rs
+++ b/packages/rfdb-server/src/datalog/eval_explain.rs
@@ -580,6 +580,7 @@ impl<'a> EvaluatorExplain<'a> {
             "incoming" => self.eval_incoming(atom),
             "path" => self.eval_path(atom),
             "attr" => self.eval_attr(atom),
+            "attr_edge" => self.eval_attr_edge(atom),
             "neq" => self.eval_neq(atom),
             "gt" | "lt" | "gte" | "lte" => self.eval_numeric_cmp(atom),
             "starts_with" => self.eval_starts_with(atom),
@@ -605,6 +606,7 @@ impl<'a> EvaluatorExplain<'a> {
             "incoming" => self.eval_incoming(atom),
             "path" => self.eval_path(atom),
             "attr" => self.eval_attr(atom),
+            "attr_edge" => self.eval_attr_edge(atom),
             "neq" => self.eval_neq(atom),
             "gt" | "lt" | "gte" | "lte" => self.eval_numeric_cmp(atom),
             "starts_with" => self.eval_starts_with(atom),
@@ -991,6 +993,98 @@ impl<'a> EvaluatorExplain<'a> {
             None => return vec![],
         };
 
+        match value_term {
+            Term::Var(var) => {
+                let mut b = Bindings::new();
+                b.set(var, Value::Str(attr_value));
+                vec![b]
+            }
+            Term::Const(expected) => {
+                if &attr_value == expected {
+                    vec![Bindings::new()]
+                } else {
+                    vec![]
+                }
+            }
+            Term::Wildcard => {
+                vec![Bindings::new()]
+            }
+        }
+    }
+
+    /// Evaluate attr_edge(Src, Dst, EdgeType, AttrName, Value) — read a metadata
+    /// attribute off a specific edge. Mirrors `Evaluator::eval_attr_edge` so the
+    /// explain path produces identical bindings to the plain path (REG-315).
+    /// Src/Dst must be bound node IDs; EdgeType and AttrName must be constants;
+    /// Value may be a variable (bind), constant (match), or wildcard (exists).
+    fn eval_attr_edge(&mut self, atom: &Atom) -> Vec<Bindings> {
+        let args = atom.args();
+        if args.len() < 5 {
+            return vec![];
+        }
+
+        let src_term = &args[0];
+        let dst_term = &args[1];
+        let type_term = &args[2];
+        let attr_term = &args[3];
+        let value_term = &args[4];
+
+        // 1. Need bound src ID
+        let src_id = match src_term {
+            Term::Const(s) => match s.parse::<u128>() {
+                Ok(id) => id,
+                Err(_) => return vec![],
+            },
+            _ => return vec![],
+        };
+
+        // 2. Need bound dst ID
+        let dst_id = match dst_term {
+            Term::Const(s) => match s.parse::<u128>() {
+                Ok(id) => id,
+                Err(_) => return vec![],
+            },
+            _ => return vec![],
+        };
+
+        // 3. Need constant edge type
+        let edge_type = match type_term {
+            Term::Const(s) => s.as_str(),
+            _ => return vec![],
+        };
+
+        // 4. Need constant attr name
+        let attr_name = match attr_term {
+            Term::Const(s) => s.as_str(),
+            _ => return vec![],
+        };
+
+        // 5. Find the edge
+        self.stats.outgoing_edge_calls += 1;
+        let edges = self.engine.get_outgoing_edges(src_id, Some(&[edge_type]));
+        self.stats.edges_traversed += edges.len();
+        let edge = match edges.into_iter().find(|e| e.dst == dst_id) {
+            Some(e) => e,
+            None => return vec![],
+        };
+
+        // 6. Parse metadata
+        let metadata_str = match edge.metadata.as_ref() {
+            Some(s) => s,
+            None => return vec![],
+        };
+        let metadata: serde_json::Value = match serde_json::from_str(metadata_str) {
+            Ok(m) => m,
+            Err(_) => return vec![],
+        };
+
+        // 7. Get attribute value using the shared helper (supports nested paths)
+        let attr_value = match crate::datalog::utils::get_metadata_value(&metadata, attr_name) {
+            Some(v) => v,
+            None => return vec![],
+        };
+
+        // 8. Match against value_term (same logic as eval_attr)
         match value_term {
             Term::Var(var) => {
                 let mut b = Bindings::new();

--- a/packages/rfdb-server/src/datalog/tests.rs
+++ b/packages/rfdb-server/src/datalog/tests.rs
@@ -2223,6 +2223,90 @@ mod eval_tests {
             "stats.total_results should match number of bindings");
     }
 
+    // REG-315 / REG-503 regression: the explain evaluator must support the
+    // attr_edge() builtin exactly like the plain evaluator. Before the fix,
+    // EvaluatorExplain omitted attr_edge from its builtin dispatch, so under
+    // `--explain` the atom fell through to derived-predicate lookup (no such
+    // rule) and silently returned zero bindings — making `--explain` change
+    // the answer for any query/guarantee that uses attr_edge.
+    #[test]
+    fn test_explain_attr_edge_matches_plain_evaluator() {
+        use crate::datalog::eval_explain::EvaluatorExplain;
+
+        let mut engine = GraphEngineV2::create_ephemeral();
+
+        engine.add_nodes(vec![
+            NodeRecord {
+                id: 1,
+                node_type: Some("LOOP".to_string()),
+                name: Some("for_loop".to_string()),
+                file: Some("test.js".to_string()),
+                file_id: 0,
+                name_offset: 0,
+                version: "main".into(),
+                exported: false,
+                replaces: None,
+                deleted: false,
+                metadata: None,
+                semantic_id: None,
+            },
+            NodeRecord {
+                id: 2,
+                node_type: Some("VARIABLE".to_string()),
+                name: Some("items".to_string()),
+                file: Some("test.js".to_string()),
+                file_id: 0,
+                name_offset: 0,
+                version: "main".into(),
+                exported: false,
+                replaces: None,
+                deleted: false,
+                metadata: None,
+                semantic_id: None,
+            },
+        ]);
+
+        engine.add_edges(vec![
+            EdgeRecord {
+                src: 1,
+                dst: 2,
+                edge_type: Some("ITERATES_OVER".to_string()),
+                version: "main".into(),
+                metadata: Some(r#"{"scale": "nodes", "reason": "array_iteration"}"#.to_string()),
+                deleted: false,
+            },
+        ], false);
+
+        // attr_edge(1, 2, "ITERATES_OVER", "scale", X)
+        let query = Atom::new("attr_edge", vec![
+            Term::constant("1"),
+            Term::constant("2"),
+            Term::constant("ITERATES_OVER"),
+            Term::constant("scale"),
+            Term::var("X"),
+        ]);
+
+        // Plain evaluator (ground truth)
+        let plain = Evaluator::new(&engine);
+        let plain_results = plain.query_atom(&query).unwrap();
+        assert_eq!(plain_results.len(), 1, "plain evaluator should bind X once");
+        assert_eq!(plain_results[0].get("X"), Some(&Value::Str("nodes".to_string())));
+
+        // Explain evaluator must produce the SAME binding
+        let mut explain_eval = EvaluatorExplain::new(&engine, true);
+        let explain_result = explain_eval.query(&query);
+        assert_eq!(
+            explain_result.bindings.len(),
+            plain_results.len(),
+            "explain evaluator must produce the same attr_edge bindings as the plain evaluator"
+        );
+        assert_eq!(
+            explain_result.bindings[0].get("X").map(|s| s.as_str()),
+            Some("nodes"),
+            "explain evaluator must bind X to the edge metadata value"
+        );
+    }
+
     #[test]
     fn test_eval_attr_edge_in_rule() {
         // Test attr_edge() used in a Datalog rule context


### PR DESCRIPTION
## Problem

The RFDB Datalog **explain** evaluator (`EvaluatorExplain`, `packages/rfdb-server/src/datalog/eval_explain.rs`) was missing the `attr_edge(...)` builtin (REG-315) that the plain evaluator (`Evaluator`, `eval.rs:1283`) has. Both explain dispatch tables (`eval_explain.rs` `eval_atom_checked` and `eval_atom`) listed every other builtin — `node/edge/incoming/path/attr/neq/gt|lt|gte|lte/starts_with/not_starts_with/string_contains/parent_function` — but **not** `attr_edge`.

Because of that, an `attr_edge(...)` atom under `--explain` fell through to derived-predicate evaluation. `eval_derived_inner` (`eval_explain.rs:1364`) does `self.rules.get("attr_edge")` → `None` → `Ok(vec[])`, i.e. **silently returns zero bindings**.

The server branches the evaluators on the `explain` flag (`rfdb_server.rs`):
- `execute_datalog_query` / `execute_check_guarantee` / `execute_datalog`: `explain=false` → `Evaluator` (has `attr_edge`); `explain=true` → `EvaluatorExplain` (lacked it) — e.g. lines 2477-2530.

**Net effect: a Datalog query or guarantee that uses `attr_edge` returns the correct rows normally, but EMPTY under `--explain` — explain mode silently changes the answer.**

## Spec

- **Invariant restored** (REG-503): for any query, the explain evaluator's `bindings` equal the plain evaluator's. The repo already had `test_explain_bindings_match_plain_evaluator` asserting this — but only for `node()`.
- **Given** a graph with an edge carrying metadata `{"scale":"nodes"}`, **When** `attr_edge(1,2,"ITERATES_OVER","scale",X)` is evaluated via `EvaluatorExplain::query`, **Then** it binds `X="nodes"` — identical to the plain `Evaluator`.

## Fix

- Port `eval_attr_edge` into `EvaluatorExplain` (verbatim mirror of `Evaluator::eval_attr_edge`, adapted to `&mut self` + explain-stats instrumentation `outgoing_edge_calls` / `edges_traversed`).
- Wire `"attr_edge" => self.eval_attr_edge(atom)` into **both** explain dispatch tables.

## Before / After (evidence)

RED (before fix) — new test failed for the right reason:
```
test ... test_explain_attr_edge_matches_plain_evaluator ... FAILED
assertion `left == right` failed: explain evaluator must produce the same attr_edge bindings as the plain evaluator
  left: 0
 right: 1
```

GREEN (after fix):
```
test ... test_explain_attr_edge_matches_plain_evaluator ... ok
test result: ok. 861 passed; 0 failed; 0 ignored
```

Full gate (first-hand):
- `pnpm build`: OK
- `./scripts/test.sh` (node): 694 pass / 0 fail
- `cargo test -p rfdb --lib`: **861 pass / 0 fail** (was 860, +1)
- `pnpm typecheck`: clean (platform WARNs only)
- `pnpm lint`: clean

## Adversarial review

- **Round A — correctness:** ported body is a verbatim mirror of the proven `eval.rs` path; every guard (args<5, unbound src/dst, non-const type/attr, missing edge, absent/invalid metadata, missing attr, Var/Const/Wildcard value) behaves identically. The two added stat increments do not affect bindings.
- **Round B — structure:** duplicating the builtin matches the existing convention (the explain evaluator already keeps parallel copies of `eval_attr`, `eval_neq`, `eval_numeric_cmp`, …). `eval_explain.rs` is a pre-existing large module (>500 lines); splitting the two evaluators into a shared builtin trait is a larger refactor, out of scope here — noted as a fragility follow-up.
- **Round C — class-not-instance:** diffed the two evaluators' builtin dispatch sets; `attr_edge` was the **only** divergence. After the fix the sets match exactly, so the explain/plain parity hole is fully closed (not just one instance).

## Blast radius

- Only the explain/trace path of Datalog queries & guarantee checks (`--explain`). Non-explain results were already correct and are untouched.
- No public API or wire-protocol change; purely an additive builtin in the explain evaluator.

## Follow-ups (not in scope)
- Consider extracting the shared builtin set into one place so a future builtin can't be added to one evaluator and forgotten in the other (the root cause of this class).


---
_Generated by [Claude Code](https://claude.ai/code/session_01HTsy9EAY6xoyQSC9aZbKbH)_