### PR TITLE
fix(rfdb): honor bound vars in Datalog explain hash-join (REG-503 parity)

### DIFF
--- a/packages/rfdb-server/src/datalog/eval_explain.rs
+++ b/packages/rfdb-server/src/datalog/eval_explain.rs
@@ -392,6 +392,19 @@ impl<'a> EvaluatorExplain<'a> {
                         }
                     }
 
+                    // Honour an already-bound variable on the dst end — critical
+                    // for self-join patterns like `edge(M, C, T1), edge(C, M, T2)`.
+                    // Without this, the second edge atom rebinds the shared var to
+                    // any outgoing dst, silently producing cross-joined rows.
+                    // Mirror of Evaluator::eval_edge_hash_join (REG-503 parity).
+                    if let Term::Var(var) = dst_term {
+                        if let Some(existing) = bindings.get(var).and_then(|v| v.as_id()) {
+                            if existing != dst_id {
+                                continue;
+                            }
+                        }
+                    }
+
                     let mut new_bindings = bindings.clone();
 
                     match dst_term {
@@ -446,6 +459,17 @@ impl<'a> EvaluatorExplain<'a> {
                     if let Term::Const(expected_src) = src_term {
                         if expected_src.parse::<u128>().ok() != Some(src_id) {
                             continue;
+                        }
+                    }
+
+                    // Honour an already-bound variable on the src end — same bug
+                    // as eval_edge_hash_join for `incoming(A, B, T1), incoming(B, A, T2)`.
+                    // Mirror of Evaluator::eval_incoming_hash_join (REG-503 parity).
+                    if let Term::Var(var) = src_term {
+                        if let Some(existing) = bindings.get(var).and_then(|v| v.as_id()) {
+                            if existing != src_id {
+                                continue;
+                            }
                         }
                     }
 

--- a/packages/rfdb-server/src/datalog/tests.rs
+++ b/packages/rfdb-server/src/datalog/tests.rs
@@ -4307,6 +4307,176 @@ mod hash_join_tests {
         assert_eq!(b.get("B").unwrap().as_id().unwrap(), (n + 1) as u128);
     }
 
+    /// REG-503 explain↔plain parity for the shared-variable hash-join fix.
+    ///
+    /// The plain `Evaluator` honours an already-bound variable on the non-key
+    /// end of a self-join `edge(M, C, T1), edge(C, M, T2)` (see
+    /// `test_hash_join_shared_var_across_two_edges`). The explain evaluator
+    /// (`EvaluatorExplain`) drives the SAME `eval_edge_hash_join` shape and
+    /// MUST produce identical bindings under `--explain`. Without the bound-var
+    /// guard ported into the explain path, the second edge atom rebinds `M` to
+    /// every `SENDS_MESSAGE` dst, yielding ~n spurious rows — so `--explain`
+    /// silently changes the answer, violating the parity invariant.
+    #[test]
+    fn test_explain_edge_hash_join_shared_var_matches_plain() {
+        use crate::datalog::eval_explain::EvaluatorExplain;
+        let mut engine = GraphEngineV2::create_ephemeral();
+        let n = HASH_JOIN_THRESHOLD + 10;
+
+        let mut nodes = Vec::with_capacity(3 * n);
+        for i in 1..=n {
+            nodes.push(NodeRecord {
+                id: i as u128,
+                node_type: Some("MESSAGE_TYPE".to_string()),
+                name: Some(format!("msg_{}", i)),
+                file: Some("t.ex".to_string()),
+                file_id: 0, name_offset: 0, version: "main".into(),
+                exported: false, replaces: None, deleted: false,
+                metadata: None, semantic_id: None,
+            });
+            nodes.push(NodeRecord {
+                id: (n + i) as u128,
+                node_type: Some("CALL".to_string()),
+                name: Some(format!("call_{}", i)),
+                file: Some("t.ex".to_string()),
+                file_id: 0, name_offset: 0, version: "main".into(),
+                exported: false, replaces: None, deleted: false,
+                metadata: None, semantic_id: None,
+            });
+            nodes.push(NodeRecord {
+                id: (2 * n + i) as u128,
+                node_type: Some("MESSAGE_TYPE".to_string()),
+                name: Some(format!("other_msg_{}", i)),
+                file: Some("t.ex".to_string()),
+                file_id: 0, name_offset: 0, version: "main".into(),
+                exported: false, replaces: None, deleted: false,
+                metadata: None, semantic_id: None,
+            });
+        }
+        engine.add_nodes(nodes);
+
+        let contains: Vec<EdgeRecord> = (1..=n).map(|i| EdgeRecord {
+            src: i as u128,
+            dst: (n + i) as u128,
+            edge_type: Some("CONTAINS".to_string()),
+            version: "main".into(), metadata: None, deleted: false,
+        }).collect();
+        engine.add_edges(contains, false);
+
+        let mut sends: Vec<EdgeRecord> = (1..=n).map(|i| EdgeRecord {
+            src: (n + i) as u128,
+            dst: (2 * n + i) as u128,
+            edge_type: Some("SENDS_MESSAGE".to_string()),
+            version: "main".into(), metadata: None, deleted: false,
+        }).collect();
+        sends.push(EdgeRecord {
+            src: (n + 1) as u128,
+            dst: 1_u128,
+            edge_type: Some("SENDS_MESSAGE".to_string()),
+            version: "main".into(), metadata: None, deleted: false,
+        });
+        engine.add_edges(sends, false);
+
+        let query = "edge(M, C, \"CONTAINS\"), edge(C, M, \"SENDS_MESSAGE\")";
+
+        // Plain evaluator: ground truth (exactly one self-loop).
+        let plain = Evaluator::new(&engine);
+        let plain_results = plain.eval_query(&parse_query(query).unwrap()).unwrap();
+        assert_eq!(plain_results.len(), 1, "plain evaluator baseline: one self-loop");
+
+        // Explain evaluator MUST match.
+        let mut explain = EvaluatorExplain::new(&engine, true);
+        let explain_result = explain.eval_query(&parse_query(query).unwrap()).unwrap();
+        assert_eq!(
+            explain_result.bindings.len(), plain_results.len(),
+            "explain evaluator must honour already-bound vars in edge hash-join \
+             (parity with plain evaluator) — got spurious rows under --explain"
+        );
+        let b = &explain_result.bindings[0];
+        assert_eq!(b.get("M").map(String::as_str), Some("1"));
+        assert_eq!(b.get("C").map(String::as_str), Some((n + 1).to_string().as_str()));
+    }
+
+    /// REG-503 explain↔plain parity for the `incoming/3` flavour of the
+    /// shared-variable hash-join fix. Mirror of
+    /// `test_incoming_hash_join_shared_var` through `EvaluatorExplain`.
+    #[test]
+    fn test_explain_incoming_hash_join_shared_var_matches_plain() {
+        use crate::datalog::eval_explain::EvaluatorExplain;
+        let mut engine = GraphEngineV2::create_ephemeral();
+        let n = HASH_JOIN_THRESHOLD + 10;
+
+        let mut nodes = Vec::with_capacity(3 * n);
+        for i in 1..=n {
+            nodes.push(NodeRecord {
+                id: i as u128,
+                node_type: Some("A".to_string()),
+                name: Some(format!("a_{}", i)),
+                file: Some("t.ex".to_string()),
+                file_id: 0, name_offset: 0, version: "main".into(),
+                exported: false, replaces: None, deleted: false,
+                metadata: None, semantic_id: None,
+            });
+            nodes.push(NodeRecord {
+                id: (n + i) as u128,
+                node_type: Some("B".to_string()),
+                name: Some(format!("b_{}", i)),
+                file: Some("t.ex".to_string()),
+                file_id: 0, name_offset: 0, version: "main".into(),
+                exported: false, replaces: None, deleted: false,
+                metadata: None, semantic_id: None,
+            });
+            nodes.push(NodeRecord {
+                id: (2 * n + i) as u128,
+                node_type: Some("A".to_string()),
+                name: Some(format!("other_a_{}", i)),
+                file: Some("t.ex".to_string()),
+                file_id: 0, name_offset: 0, version: "main".into(),
+                exported: false, replaces: None, deleted: false,
+                metadata: None, semantic_id: None,
+            });
+        }
+        engine.add_nodes(nodes);
+
+        let fw: Vec<EdgeRecord> = (1..=n).map(|i| EdgeRecord {
+            src: i as u128,
+            dst: (n + i) as u128,
+            edge_type: Some("F".to_string()),
+            version: "main".into(), metadata: None, deleted: false,
+        }).collect();
+        engine.add_edges(fw, false);
+        let mut bk: Vec<EdgeRecord> = (1..=n).map(|i| EdgeRecord {
+            src: (n + i) as u128,
+            dst: (2 * n + i) as u128,
+            edge_type: Some("G".to_string()),
+            version: "main".into(), metadata: None, deleted: false,
+        }).collect();
+        bk.push(EdgeRecord {
+            src: (n + 1) as u128,
+            dst: 1u128,
+            edge_type: Some("G".to_string()),
+            version: "main".into(), metadata: None, deleted: false,
+        });
+        engine.add_edges(bk, false);
+
+        let query = "node(A, \"A\"), incoming(A, B, \"G\"), incoming(B, A, \"F\")";
+
+        let plain = Evaluator::new(&engine);
+        let plain_results = plain.eval_query(&parse_query(query).unwrap()).unwrap();
+        assert_eq!(plain_results.len(), 1, "plain evaluator baseline: one round-trip");
+
+        let mut explain = EvaluatorExplain::new(&engine, true);
+        let explain_result = explain.eval_query(&parse_query(query).unwrap()).unwrap();
+        assert_eq!(
+            explain_result.bindings.len(), plain_results.len(),
+            "explain evaluator must honour already-bound vars in incoming hash-join \
+             (parity with plain evaluator) — got spurious rows under --explain"
+        );
+        let b = &explain_result.bindings[0];
+        assert_eq!(b.get("A").map(String::as_str), Some("1"));
+        assert_eq!(b.get("B").map(String::as_str), Some((n + 1).to_string().as_str()));
+    }
+
     /// Regression: when a variable appears in *both* edge atoms on opposite
     /// sides (self-join pattern `edge(A, B, T1), edge(B, A, T2)`), the hash-
     /// join path must verify the variable still unifies — not rebind it to


### PR DESCRIPTION
## Problem

The plain Datalog `Evaluator` honors an **already-bound** variable on the non-key end of a self-join hash-join — the `rfdb-datalog-hash-join-shared-var` fix — via a guard in `eval_edge_hash_join` (`eval.rs:569-575`) and `eval_incoming_hash_join` (`eval.rs:644-650`):

```rust
if let Term::Var(var) = dst_term {
    if let Some(existing) = bindings.get(var).and_then(|v| v.as_id()) {
        if existing != dst_id { continue; }
    }
}
```

The **explain** evaluator (`EvaluatorExplain`, `eval_explain.rs`) drives the *same* hash-join fast path (`eval_explain.rs:241-245`) but never received that guard. Its `eval_edge_hash_join` / `eval_incoming_hash_join` only checked the `Term::Const` filter, then unconditionally rebound an already-bound `Var`.

**Net effect:** a self-join Datalog query/guarantee — `edge(M, C, T1), edge(C, M, T2)` or `incoming(A, B, T1), incoming(B, A, T2)` — returns the correct rows normally, but **WRONG (inflated) rows under `--explain`**. The second edge atom rebinds the shared variable to every hash-joined dst/src, producing spurious cross-joined rows.

This violates the **REG-503 explain↔plain parity invariant**. It's the same evaluator-drift class as the `attr_edge` gap fixed in #337 — different instance, and a worse failure mode (wrong rows, not just empty).

## Spec

- **Invariant restored (REG-503):** for any query, `EvaluatorExplain`'s bindings equal the plain `Evaluator`'s.
- **Given** a graph with `>HASH_JOIN_THRESHOLD` entities where exactly one self-loop exists (`msg_1 -CONTAINS-> call_1` and `call_1 -SENDS_MESSAGE-> msg_1`), **When** `edge(M, C, "CONTAINS"), edge(C, M, "SENDS_MESSAGE")` is evaluated via `EvaluatorExplain::eval_query`, **Then** it returns exactly **1** binding `{M=1, C=n+1}` — identical to the plain `Evaluator`. (And the symmetric `incoming/3` case.)

## Fix

Port the bound-variable guard into **both** explain hash-join functions (`eval_explain.rs`), a verbatim mirror of the proven plain-evaluator path. 24 lines added, no logic change elsewhere.

## Before / After (evidence)

RED (before fix) — new parity tests fail for the right reason:
```
test ... test_explain_incoming_hash_join_shared_var_matches_plain ... FAILED
assertion `left == right` failed: explain evaluator must honour already-bound
vars in incoming hash-join (parity with plain evaluator) — got spurious rows under --explain
  left: 27
 right: 1
```

GREEN (after fix):
```
running 4 tests
test ... test_hash_join_shared_var_across_two_edges ... ok
test ... test_incoming_hash_join_shared_var ... ok
test ... test_explain_edge_hash_join_shared_var_matches_plain ... ok
test ... test_explain_incoming_hash_join_shared_var_matches_plain ... ok
test result: ok. 4 passed; 0 failed
```

Full gate (first-hand):
- `cargo test -p rfdb --lib`: **862 pass / 0 fail** (was 860, +2)
- `pnpm build`: OK
- `./scripts/test.sh` (node): **694 pass / 0 fail**
- `pnpm typecheck`: clean (platform WARNs only)
- `pnpm lint`: clean

## Adversarial review

- **Round A — correctness:** the ported guard is a verbatim mirror of the proven `eval.rs` path. Edge cases behave identically: wildcard dst/src (no guard, binds nothing — correct), const dst/src (handled by the prior `Term::Const` filter), unbound var (`bindings.get` → `None`, no skip — fresh bind), bound var (skip on mismatch). `as_id()` handles both `Id` and id-parseable `Str`.
- **Round B — structure:** duplicating the builtin matches the existing convention — `eval_explain.rs` already keeps parallel copies of every builtin. The root cause is the two hand-maintained evaluators drifting (no shared builtin registry); `eval_explain.rs` is a pre-existing >500-line module. Extracting a shared builtin trait is a larger refactor, out of scope — same fragility follow-up #337 noted.
- **Round C — class-not-instance:** I fixed **both** instances of *this* class (edge + incoming bound-guard). I then diffed every shared builtin between the two evaluators (normalized for stat-tracking). The small builtins (`neq`, `numeric_cmp`, `starts_with`, `not_starts_with`, `string_contains`, `parent_function`), `eval_attr`, and `eval_path` are logic-identical. **Separate divergences found and confirmed by reading both sources** (see below) — filed as follow-ups, deliberately NOT bundled here (different class — missing match arms vs missing guard — and each needs its own RED test).

## Blast radius

Only the `--explain`/trace path of Datalog queries & guarantee checks. Non-explain results were already correct and are untouched. No public API or wire-protocol change.

## Sibling latent issues found (evidence-backed follow-ups — NOT in this PR)

These are additional `EvaluatorExplain`↔`Evaluator` parity gaps, same drift root cause, distinct class (missing match arms → `_ => vec[]` where the plain evaluator handles the case):

1. **`eval_node` wildcard arms** — plain `eval.rs:738-845` handles all 9 `(id, type)` term combinations including 5 `Term::Wildcard` arms; explain `eval_explain.rs:657-721` has only 4 arms + `_ => vec[]`. ⇒ any `node()` atom containing `_` (e.g. `node(_, "FUNCTION")`) returns **0** under `--explain`, N under plain.
2. **`eval_edge` wildcard-src arm** — plain has a `Term::Wildcard` full-scan src arm; explain's `match src_term` lacks it (`_ => vec[]`). ⇒ `edge(_, X, "T")` empty under `--explain`.
3. **`eval_incoming` wildcard-src arm** — same shape as (2).

Root-cause follow-up (carried from #337): extract the shared builtin set into one place so a future builtin/arm can't be added to one evaluator and forgotten in the other.

---
_Generated by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1MFdfSHuuACt9PUtpCZ8m)_