### PR TITLE
fix(rfdb): port wildcard match arms into Datalog explain evaluator (REG-503 parity)

### DIFF
--- a/packages/rfdb-server/src/datalog/eval_explain.rs
+++ b/packages/rfdb-server/src/datalog/eval_explain.rs
@@ -693,7 +693,73 @@ impl<'a> EvaluatorExplain<'a> {
                 }
                 results
             }
-            _ => vec![],
+            // node(_, "type") - count/check all nodes of type (wildcard id)
+            (Term::Wildcard, Term::Const(node_type)) => {
+                self.stats.find_by_type_calls += 1;
+                let ids = self.engine.find_by_type(node_type);
+                self.stats.nodes_visited += ids.len();
+                ids.into_iter().map(|_| Bindings::new()).collect()
+            }
+            // node("id", _) - check if node exists (wildcard type)
+            (Term::Const(id_str), Term::Wildcard) => {
+                self.stats.get_node_calls += 1;
+                if let Ok(id) = id_str.parse::<u128>() {
+                    if self.engine.get_node(id).is_some() {
+                        self.stats.nodes_visited += 1;
+                        return vec![Bindings::new()];
+                    }
+                }
+                vec![]
+            }
+            // node(_, _) - enumerate all nodes (both wildcards)
+            (Term::Wildcard, Term::Wildcard) => {
+                self.warnings.push("Full node scan: consider binding type".to_string());
+                let type_counts = self.engine.count_nodes_by_type(None);
+                let mut results = vec![];
+                for node_type in type_counts.keys() {
+                    self.stats.find_by_type_calls += 1;
+                    let ids = self.engine.find_by_type(node_type);
+                    self.stats.nodes_visited += ids.len();
+                    for _ in ids {
+                        results.push(Bindings::new());
+                    }
+                }
+                results
+            }
+            // node(X, _) - enumerate all nodes, bind id only
+            (Term::Var(id_var), Term::Wildcard) => {
+                self.warnings.push("Full node scan: consider binding type".to_string());
+                let type_counts = self.engine.count_nodes_by_type(None);
+                let mut results = vec![];
+                for node_type in type_counts.keys() {
+                    self.stats.find_by_type_calls += 1;
+                    let ids = self.engine.find_by_type(node_type);
+                    self.stats.nodes_visited += ids.len();
+                    for id in ids {
+                        let mut b = Bindings::new();
+                        b.set(id_var, Value::Id(id));
+                        results.push(b);
+                    }
+                }
+                results
+            }
+            // node(_, Y) - enumerate all nodes, bind type only
+            (Term::Wildcard, Term::Var(type_var)) => {
+                self.warnings.push("Full node scan: consider binding type".to_string());
+                let type_counts = self.engine.count_nodes_by_type(None);
+                let mut results = vec![];
+                for node_type in type_counts.keys() {
+                    self.stats.find_by_type_calls += 1;
+                    let ids = self.engine.find_by_type(node_type);
+                    self.stats.nodes_visited += ids.len();
+                    for _ in ids {
+                        let mut b = Bindings::new();
+                        b.set(type_var, Value::Str(node_type.clone()));
+                        results.push(b);
+                    }
+                }
+                results
+            }
         }
     }
 
@@ -807,7 +873,57 @@ impl<'a> EvaluatorExplain<'a> {
                     })
                     .collect()
             }
-            _ => vec![],
+            Term::Wildcard => {
+                // Wildcard src: enumerate all edges, don't bind src
+                let type_filter: Option<&str> = type_term.and_then(|t| match t {
+                    Term::Const(s) => Some(s.as_str()),
+                    _ => None,
+                });
+
+                let edges = if let Some(edge_type) = type_filter {
+                    self.stats.edges_by_type_calls += 1;
+                    self.engine.get_edges_by_type(edge_type)
+                } else {
+                    self.warnings.push("Full edge scan: consider binding source node".to_string());
+                    self.stats.all_edges_calls += 1;
+                    self.engine.get_all_edges()
+                };
+                self.stats.edges_traversed += edges.len();
+
+                let dst_filter: Option<u128> = match dst_term {
+                    Term::Const(s) => s.parse::<u128>().ok(),
+                    _ => None,
+                };
+
+                edges
+                    .into_iter()
+                    .filter(|e| {
+                        if let Some(filter_dst) = dst_filter {
+                            if e.dst != filter_dst {
+                                return false;
+                            }
+                        }
+                        true
+                    })
+                    .map(|e| {
+                        let mut b = Bindings::new();
+
+                        // Bind destination if variable
+                        if let Term::Var(var) = dst_term {
+                            b.set(var, Value::Id(e.dst));
+                        }
+
+                        // Bind edge type if variable
+                        if let Some(Term::Var(var)) = type_term {
+                            if let Some(etype) = e.edge_type {
+                                b.set(var, Value::Str(etype));
+                            }
+                        }
+
+                        b
+                    })
+                    .collect()
+            }
         }
     }
 
@@ -910,7 +1026,63 @@ impl<'a> EvaluatorExplain<'a> {
                     })
                     .collect()
             }
-            _ => vec![],
+            Term::Wildcard => {
+                // Wildcard dst: enumerate all edges, don't bind dst
+                let type_filter: Option<&str> = type_term.and_then(|t| match t {
+                    Term::Const(s) => Some(s.as_str()),
+                    _ => None,
+                });
+
+                let edges = if let Some(edge_type) = type_filter {
+                    self.stats.edges_by_type_calls += 1;
+                    self.engine.get_edges_by_type(edge_type)
+                } else {
+                    self.warnings.push("Full edge scan: consider binding destination node".to_string());
+                    self.stats.all_edges_calls += 1;
+                    self.engine.get_all_edges()
+                };
+                self.stats.edges_traversed += edges.len();
+
+                let src_filter: Option<u128> = match src_term {
+                    Term::Const(s) => s.parse::<u128>().ok(),
+                    _ => None,
+                };
+
+                edges
+                    .into_iter()
+                    .filter(|e| {
+                        if let Some(filter_src) = src_filter {
+                            if e.src != filter_src {
+                                return false;
+                            }
+                        }
+                        true
+                    })
+                    .filter_map(|e| {
+                        let mut b = Bindings::new();
+
+                        // Bind src
+                        match src_term {
+                            Term::Var(var) => b.set(var, Value::Id(e.src)),
+                            Term::Const(s) => {
+                                if s.parse::<u128>().ok() != Some(e.src) {
+                                    return None;
+                                }
+                            }
+                            Term::Wildcard => {}
+                        }
+
+                        // Bind edge type if variable
+                        if let Some(Term::Var(var)) = type_term {
+                            if let Some(etype) = e.edge_type {
+                                b.set(var, Value::Str(etype));
+                            }
+                        }
+
+                        Some(b)
+                    })
+                    .collect()
+            }
         }
     }
 

--- a/packages/rfdb-server/src/datalog/tests.rs
+++ b/packages/rfdb-server/src/datalog/tests.rs
@@ -2205,6 +2205,97 @@ mod eval_tests {
             "binding values should match between plain and explain evaluators");
     }
 
+    /// REG-503 parity — wildcard arms.
+    ///
+    /// The plain `Evaluator` has dedicated match arms for every `Term::Wildcard`
+    /// combination in `node` / `edge` / `incoming`. The explain `EvaluatorExplain`
+    /// historically fell through those to `_ => vec![]`, so any atom containing a
+    /// bare `_` returned 0 bindings under `--explain` while plain returned N.
+    /// These tests pin the explain↔plain parity invariant for the wildcard arms.
+    ///
+    /// Each case asserts the explain evaluator's bindings (count, and for bound
+    /// vars the value set) equal the plain evaluator's on the shared test graph
+    /// (ids 1,3 = `queue:publish`, id 2 = `queue:consume`, id 4 = `FUNCTION`;
+    /// edges 1→4 and 4→2, both `CALLS`).
+    fn assert_explain_parity(query: &str, var: Option<&str>) {
+        use crate::datalog::eval_explain::EvaluatorExplain;
+
+        let engine = setup_test_graph();
+
+        let evaluator = Evaluator::new(&engine);
+        let plain = evaluator
+            .eval_query(&parse_query(query).unwrap())
+            .unwrap();
+
+        let mut explain_eval = EvaluatorExplain::new(&engine, true);
+        let explain = explain_eval
+            .eval_query(&parse_query(query).unwrap())
+            .unwrap();
+
+        assert_eq!(
+            plain.len(),
+            explain.bindings.len(),
+            "explain evaluator must produce the same number of bindings as plain for `{query}` (parity)"
+        );
+
+        if let Some(v) = var {
+            let mut plain_vals: Vec<String> =
+                plain.iter().filter_map(|b| b.get(v).map(|x| x.as_str())).collect();
+            plain_vals.sort();
+
+            let mut explain_vals: Vec<String> =
+                explain.bindings.iter().filter_map(|b| b.get(v).cloned()).collect();
+            explain_vals.sort();
+
+            assert_eq!(
+                plain_vals, explain_vals,
+                "explain evaluator must bind `{v}` to the same values as plain for `{query}` (parity)"
+            );
+        }
+    }
+
+    #[test]
+    fn test_explain_node_wildcard_id_matches_plain() {
+        // node(_, "type") — (Wildcard, Const): plain finds 2 publish nodes.
+        assert_explain_parity("node(_, \"queue:publish\")", None);
+    }
+
+    #[test]
+    fn test_explain_node_wildcard_type_matches_plain() {
+        // node(X, _) — (Var, Wildcard): plain enumerates all 4 nodes, binds id.
+        assert_explain_parity("node(X, _)", Some("X"));
+    }
+
+    #[test]
+    fn test_explain_node_wildcard_id_var_type_matches_plain() {
+        // node(_, T) — (Wildcard, Var): plain enumerates all 4 nodes, binds type.
+        assert_explain_parity("node(_, T)", Some("T"));
+    }
+
+    #[test]
+    fn test_explain_node_both_wildcard_matches_plain() {
+        // node(_, _) — (Wildcard, Wildcard): plain enumerates all 4 nodes.
+        assert_explain_parity("node(_, _)", None);
+    }
+
+    #[test]
+    fn test_explain_node_const_wildcard_type_matches_plain() {
+        // node("1", _) — (Const, Wildcard): plain checks node 1 exists.
+        assert_explain_parity("node(\"1\", _)", None);
+    }
+
+    #[test]
+    fn test_explain_edge_wildcard_src_matches_plain() {
+        // edge(_, X, "CALLS") — Wildcard src: plain enumerates 2 CALLS edges, binds dst.
+        assert_explain_parity("edge(_, X, \"CALLS\")", Some("X"));
+    }
+
+    #[test]
+    fn test_explain_incoming_wildcard_dst_matches_plain() {
+        // incoming(_, X, "CALLS") — Wildcard dst: plain enumerates 2 CALLS edges, binds src.
+        assert_explain_parity("incoming(_, X, \"CALLS\")", Some("X"));
+    }
+
     #[test]
     fn test_explain_stats_populated() {
         use crate::datalog::eval_explain::EvaluatorExplain;


### PR DESCRIPTION
## Problem

The RFDB Datalog **explain** evaluator (`EvaluatorExplain`, `packages/rfdb-server/src/datalog/eval_explain.rs`) was missing the `Term::Wildcard` match arms that the plain `Evaluator` (`eval.rs`) has in `eval_node` / `eval_edge` / `eval_incoming`. Those three matches fell through to `_ => vec[]`, so **any Datalog atom containing a bare `_` returned 0 bindings under `--explain` while the plain evaluator returned N** — explain mode silently changes the answer.

Verified against HEAD (`6df7d47`) by reading both evaluators:

| function | plain (`eval.rs`) | explain (`eval_explain.rs`, before) |
|---|---|---|
| `eval_node` | 9 arms — incl. 5 `Wildcard` combos (`eval.rs:792,800,809,820,833`) | 4 arms + `_ => vec[]` |
| `eval_edge` | `Term::Wildcard` src arm (`eval.rs:955`) | Const+Var + `_ => vec[]` |
| `eval_incoming` | `Term::Wildcard` dst arm (`eval.rs:1104`) | Const+Var + `_ => vec[]` |

This is the same evaluator-drift class as the `attr_edge` gap (#337) and the hash-join bound-var guard (#338) — a different instance, flagged as a sibling follow-up in #338's body. Failure mode: wrong (empty) rows under `--explain` for any `_`-containing atom.

## Spec

- **Invariant restored (REG-503):** for any query, `EvaluatorExplain`'s bindings equal the plain `Evaluator`'s.
- **Given** the shared test graph (ids 1,3 = `queue:publish`, id 2 = `queue:consume`, id 4 = `FUNCTION`; edges 1→4 and 4→2, both `CALLS`),
  **When** each wildcard atom is evaluated via `EvaluatorExplain::eval_query`,
  **Then** the bindings (count, and value-set for bound vars) equal the plain `Evaluator`'s:
  - `node(_, "queue:publish")` → 2 · `node(X, _)` → 4 · `node(_, T)` → 4 · `node(_, _)` → 4 · `node("1", _)` → 1
  - `edge(_, X, "CALLS")` → 2 (binds dst)
  - `incoming(_, X, "CALLS")` → 2 (binds src)

## Fix

Port the 5 `eval_node` wildcard arms + the `eval_edge`/`eval_incoming` `Term::Wildcard` arms into `EvaluatorExplain` — **verbatim mirrors of the proven `eval.rs` paths** plus the explain stat-tracking convention (`find_by_type_calls` / `nodes_visited` / `edges_by_type_calls` / `all_edges_calls` / `edges_traversed`), which does not affect bindings. The three matches are now **exhaustive (no `_` catch-all)**, so the compiler now prevents this drift class recurring (a new `Term` variant or combo won't silently return empty). 175 lines added in the evaluator, no logic change elsewhere.

## Before / After (evidence)

RED (before fix) — new parity tests fail for the right reason:
```
test ... test_explain_node_wildcard_type_matches_plain ... FAILED
assertion `left == right` failed: explain evaluator must produce the same
number of bindings as plain for `node(X, _)` (parity)
  left: 4
 right: 0
... 7 failed; 7 passed (pre-existing) ...
```

GREEN (after fix):
```
test datalog::tests::eval_tests::test_explain_edge_wildcard_src_matches_plain ... ok
test datalog::tests::eval_tests::test_explain_incoming_wildcard_dst_matches_plain ... ok
test datalog::tests::eval_tests::test_explain_node_both_wildcard_matches_plain ... ok
test datalog::tests::eval_tests::test_explain_node_const_wildcard_type_matches_plain ... ok
test datalog::tests::eval_tests::test_explain_node_wildcard_id_matches_plain ... ok
test datalog::tests::eval_tests::test_explain_node_wildcard_type_matches_plain ... ok
test datalog::tests::eval_tests::test_explain_node_wildcard_id_var_type_matches_plain ... ok
test result: ok. 14 passed; 0 failed
```

Full Rust gate (first-hand):
- `cargo test -p rfdb --lib`: **867 passed / 0 failed** (was 860, +7)
- `cargo clippy -p rfdb --lib`: exit 0, no new warnings in `eval_explain.rs`

> Note on the JS/TS gate: this change is isolated to Rust source compiled into the rfdb binary — there is no code path from `eval_explain.rs` into the JS/TS build, `./scripts/test.sh`, `pnpm typecheck`, or `pnpm lint`, so that gate is not load-bearing here. The meaningful gate is the Rust one above.

## Adversarial review

- **Round A — correctness:** each ported arm is a verbatim mirror of the proven `eval.rs` path; the two added stat increments per arm don't affect bindings. Edge cases behave identically to plain: non-existent type → empty; non-numeric const id → `parse` fails → empty; const dst/src filter on a wildcard end → filtered; `incoming(_, X)` with no type term → full scan (matches plain's Wildcard arm, which intentionally differs from the Var arm). Result ordering is set-semantics; the parity tests sort before comparing.
- **Round B — structure:** `eval_explain.rs` is a pre-existing >500-line module that already keeps parallel copies of every builtin — duplicating these arms matches the established convention. The root cause is the two hand-maintained evaluators drifting (no shared builtin registry); extracting a shared builtin trait is a larger refactor, out of scope (same follow-up #337/#338 noted). **This PR reduces the drift surface for these three functions** by removing the `_` catch-alls — the matches are now compiler-checked exhaustive.
- **Round C — class-not-instance:** I fixed **all three** instances flagged in #338. I then audited every remaining `_ => vec[]` in `eval_explain.rs`: the only one left is in `eval_path`, and the **plain** `eval_path` (`eval.rs:1434`) has the identical `_ => vec[]` (both support const-src paths only) — genuine parity, not a gap. The `attr_edge` dispatch gap is the separate, already-open #337 — deliberately not bundled here.

## Blast radius

Only the `--explain`/trace path of Datalog queries & guarantee checks. Non-explain results were already correct and are untouched. No public API or wire-protocol change.

## Sibling / related (not in this PR)

- #337 — `attr_edge` builtin missing from explain dispatch (separate open PR).
- #338 — hash-join bound-var guard missing from explain (separate open PR); this PR resolves the three wildcard-arm follow-ups its body enumerated.
- Root-cause follow-up (carried from #337/#338): extract the shared builtin set into one place so a future arm can't be added to one evaluator and forgotten in the other.

---
_Generated by [Claude Code](https://claude.ai/code/session_014CBN6k4AKFiKHV4wbXYQbw)_