### PR TITLE
fix(rfdb): enforce repeated-variable constraint in Cypher Expand/VarLengthExpand

### DIFF
--- a/packages/rfdb-server/src/cypher/executor.rs
+++ b/packages/rfdb-server/src/cypher/executor.rs
@@ -311,6 +311,21 @@ impl<'a> Operator for Expand<'a> {
                         .unwrap_or(0);
                     let target_id = self.target_id(edge, src_node_id);
 
+                    // Repeated-variable constraint: if `dst_var` is already
+                    // bound (the pattern reuses this node variable, e.g.
+                    // `(a)-[:R]->(a)` or `(m)-[:R1]->(c)-[:R2]->(m)`), the
+                    // discovered target must equal the existing binding —
+                    // Cypher requires the same variable to denote the same
+                    // node. Overwriting it would fabricate rows for
+                    // non-existent self-loops/cycles, so skip on mismatch.
+                    if let Some(ref dv) = self.dst_var {
+                        if let Some(existing) = input_rec.get(dv).and_then(|v| v.as_node_id()) {
+                            if existing != target_id {
+                                continue;
+                            }
+                        }
+                    }
+
                     if let Some(target_rec) = self.engine.get_node(target_id) {
                         self.limits.track_intermediate()?;
                         let mut out = input_rec.clone();
@@ -456,6 +471,19 @@ impl<'a> Operator for VarLengthExpand<'a> {
                 while self.result_pos < self.results.len() {
                     let nid = self.results[self.result_pos];
                     self.result_pos += 1;
+
+                    // Repeated-variable constraint (see Expand::next): if
+                    // `dst_var` is already bound (e.g. `(a)-[:R*1..2]->(a)`),
+                    // a reached node must equal the existing binding rather
+                    // than overwrite it. Skip on mismatch to avoid fabricating
+                    // rows that rebind the variable to a different node.
+                    if let Some(ref dv) = self.dst_var {
+                        if let Some(existing) = input_rec.get(dv).and_then(|v| v.as_node_id()) {
+                            if existing != nid {
+                                continue;
+                            }
+                        }
+                    }
 
                     if let Some(node_rec) = self.engine.get_node(nid) {
                         self.limits.track_intermediate()?;

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -941,6 +941,146 @@ mod executor_tests {
         assert!(expand.next().unwrap().is_none());
     }
 
+    // ── Repeated-variable / self-join pattern tests ─────────────────────
+    //
+    // A node variable used twice in a MATCH pattern (e.g. `(a)-[:R]->(a)` or
+    // `(m)-[:R1]->(c)-[:R2]->(m)`) must denote the SAME node: the second
+    // occurrence is an equality constraint, not a fresh binding. The Expand /
+    // VarLengthExpand operators must FILTER (keep only rows whose discovered
+    // target equals the already-bound node), not overwrite the binding —
+    // overwriting fabricates rows for non-existent self-loops / cycles. This
+    // is the same self-join class as the Datalog hash-join shared-var guard.
+
+    fn person(id: u128, name: &str) -> NodeRecord {
+        NodeRecord {
+            id,
+            node_type: Some("PERSON".to_string()),
+            name: Some(name.to_string()),
+            file: Some("g".to_string()),
+            file_id: 0,
+            name_offset: 0,
+            version: "main".into(),
+            exported: false,
+            replaces: None,
+            deleted: false,
+            metadata: None,
+            semantic_id: None,
+        }
+    }
+
+    fn rel(src: u128, dst: u128, ty: &str) -> EdgeRecord {
+        EdgeRecord {
+            src,
+            dst,
+            edge_type: Some(ty.to_string()),
+            version: "main".into(),
+            metadata: None,
+            deleted: false,
+        }
+    }
+
+    #[test]
+    fn expand_self_loop_repeated_var() {
+        // alice -LOOPS-> alice (real self-loop); bob -LOOPS-> carol (not one).
+        // `MATCH (a)-[:LOOPS]->(a)` must return ONLY alice.
+        let mut engine = GraphEngineV2::create_ephemeral();
+        engine.add_nodes(vec![person(1, "alice"), person(2, "bob"), person(3, "carol")]);
+        engine.add_edges(vec![rel(1, 1, "LOOPS"), rel(2, 3, "LOOPS")], true);
+
+        let res = crate::cypher::execute(
+            &engine,
+            "MATCH (a)-[:LOOPS]->(a) RETURN a.name",
+            default_limits(),
+        )
+        .unwrap();
+
+        let mut names: Vec<String> = res
+            .rows
+            .iter()
+            .map(|r| r[0].as_str().unwrap_or("").to_string())
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec!["alice"],
+            "self-loop pattern must bind `a` to the same node on both ends; bob->carol must not appear"
+        );
+    }
+
+    #[test]
+    fn expand_two_hop_cycle_repeated_var() {
+        // Mutual: alice<->bob. One-way chain: carol->dave->erin.
+        // `MATCH (m)-[:KNOWS]->(c)-[:KNOWS]->(m)` must return ONLY the mutual
+        // pair, in both directions: (alice,bob) and (bob,alice).
+        let mut engine = GraphEngineV2::create_ephemeral();
+        engine.add_nodes(vec![
+            person(1, "alice"),
+            person(2, "bob"),
+            person(3, "carol"),
+            person(4, "dave"),
+            person(5, "erin"),
+        ]);
+        engine.add_edges(
+            vec![
+                rel(1, 2, "KNOWS"),
+                rel(2, 1, "KNOWS"),
+                rel(3, 4, "KNOWS"),
+                rel(4, 5, "KNOWS"),
+            ],
+            true,
+        );
+
+        let res = crate::cypher::execute(
+            &engine,
+            "MATCH (m)-[:KNOWS]->(c)-[:KNOWS]->(m) RETURN m.name, c.name",
+            default_limits(),
+        )
+        .unwrap();
+
+        let mut pairs: Vec<(String, String)> = res
+            .rows
+            .iter()
+            .map(|r| {
+                (
+                    r[0].as_str().unwrap_or("").to_string(),
+                    r[1].as_str().unwrap_or("").to_string(),
+                )
+            })
+            .collect();
+        pairs.sort();
+        assert_eq!(
+            pairs,
+            vec![
+                ("alice".to_string(), "bob".to_string()),
+                ("bob".to_string(), "alice".to_string()),
+            ],
+            "two-hop cycle must close back to the same start node; the carol->dave->erin chain must not yield a row"
+        );
+    }
+
+    #[test]
+    fn varlength_expand_repeated_var_no_fabricated_rows() {
+        // One-way chain alice->bob->carol; nothing returns to alice.
+        // `MATCH (a)-[:KNOWS*1..2]->(a)` has no valid binding, so it must
+        // return NOTHING — and must never rebind `a` to bob or carol.
+        let mut engine = GraphEngineV2::create_ephemeral();
+        engine.add_nodes(vec![person(1, "alice"), person(2, "bob"), person(3, "carol")]);
+        engine.add_edges(vec![rel(1, 2, "KNOWS"), rel(2, 3, "KNOWS")], true);
+
+        let res = crate::cypher::execute(
+            &engine,
+            "MATCH (a)-[:KNOWS*1..2]->(a) RETURN a.name",
+            default_limits(),
+        )
+        .unwrap();
+
+        assert!(
+            res.rows.is_empty(),
+            "variable-length repeated-var pattern must not fabricate rows by rebinding `a`; got {:?}",
+            res.rows
+        );
+    }
+
     // ── Filter tests ────────────────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
## Problem

A node variable used twice in a Cypher `MATCH` pattern must denote the **same** node — the second occurrence is an *equality constraint*, not a fresh binding. The classic shapes:

- self-loop: `MATCH (a)-[:R]->(a)`
- mutual / two-hop cycle: `MATCH (m)-[:R1]->(c)-[:R2]->(m)`

The planner (`planner.rs:45-99`) chains one `Expand` per pattern segment, keyed by the node variable name, with no handling for a variable that is **already bound**. The executor's `Expand::next()` (`executor.rs:314-323`) and `VarLengthExpand::next()` (`executor.rs:462-465`) then **unconditionally** did `out.insert(dst_var, target)` — overwriting the existing binding instead of filtering.

**Net effect:** repeated-variable patterns silently returned **wrong** results — they fabricated rows for self-loops/cycles that don't exist by rebinding the variable to whatever the last edge pointed at. Self-loop detection and mutual-edge queries were broken.

This is the same self-join / shared-variable class as the Datalog hash-join guard (the `rfdb-datalog-hash-join-shared-var` fix), in a code path that wasn't previously covered — the Cypher executor.

## Spec

- **Invariant:** for any `MATCH` pattern, a node variable bound earlier in the chain keeps its identity; a later traversal that targets the same variable acts as a filter (`target == existing`), never a rebind.
- **Given** `alice -LOOPS-> alice` (real self-loop) and `bob -LOOPS-> carol` (not), **When** `MATCH (a)-[:LOOPS]->(a) RETURN a.name`, **Then** only `alice` is returned.
- **Given** mutual `alice<->bob` plus one-way chain `carol->dave->erin`, **When** `MATCH (m)-[:KNOWS]->(c)-[:KNOWS]->(m) RETURN m.name, c.name`, **Then** exactly `(alice,bob)` and `(bob,alice)` — the chain yields nothing.

## Fix

In both `Expand::next()` and `VarLengthExpand::next()`, before emitting: if `dst_var` is already bound in the input record, keep the row only when the discovered target id equals the existing binding; otherwise `continue` (skip). A verbatim mirror of the proven Datalog bound-var guard. +28 lines, no signature/API change.

## Before / After (evidence)

RED (before fix) — new tests fail for the right reason:
```
---- expand_two_hop_cycle_repeated_var ----
assertion `left == right` failed: two-hop cycle must close back to the same start node
  left: [("alice", "bob"), ("bob", "alice"), ("erin", "dave")]   <- fabricated ("erin","dave")
 right: [("alice", "bob"), ("bob", "alice")]

---- varlength_expand_repeated_var_no_fabricated_rows ----
... must not fabricate rows by rebinding `a`; got [["carol"], ["bob"], ["carol"]]
```

GREEN (after fix):
```
running 3 tests
test cypher::tests::executor_tests::expand_self_loop_repeated_var ... ok
test cypher::tests::executor_tests::expand_two_hop_cycle_repeated_var ... ok
test cypher::tests::executor_tests::varlength_expand_repeated_var_no_fabricated_rows ... ok
test result: ok. 3 passed; 0 failed
```

Full Rust gate (first-hand):
- `cargo test -p rfdb --lib`: **870 pass / 0 fail** (was 867, +3)
- full cypher suite: **123 pass / 0 fail** (no regression)
- `cargo fmt --check` on the two edited files: clean (only pre-existing diffs in `benches/`)
- `cargo clippy --lib`: no new warnings reference the changed lines

This change is **Rust-only** (`packages/rfdb-server/src/cypher/{executor,tests}.rs`); no TypeScript/JS touched, so the Node typecheck/lint/build gate is unaffected.

## Adversarial review

- **Round A — correctness.** `dst_var = None` (anonymous target) → guard skipped, unchanged. `dst_var` bound to a non-node value → `as_node_id()` is `None` → guard skipped (matches the Datalog guard's `as_id()` semantics). `dst_var == src_var` (`(a)-[:R]->(a)`) → only true self-loop edges pass (tested). `Direction::Both` → comparison uses `target_id()` which already resolves the "other" end. Parallel edges to the same bound target → all pass (correct). `get_node(target)` returning `None` after the guard → falls through to the existing "target missing — skip", unchanged.
- **Round B — structure.** Both operators duplicate the same small guard, mirroring the existing per-operator style. `executor.rs` is a pre-existing >500-line module (one struct per Volcano operator); splitting it is a separate refactor, out of scope.
- **Round C — class-not-instance.** The planner only emits `Expand` / `VarLengthExpand` for pattern segments; `NodeScan` binds the start variable (no repeat possible) and `Filter/Project/Sort/Limit/HashAggregate` don't traverse edges. Both edge-traversal operators are fixed, so the class is fully covered.

## Blast radius

Only affects `MATCH` patterns that **reuse a node variable** — previously these returned wrong rows; now they return the correct set. Patterns with all-distinct variables are byte-for-byte unchanged (the guard's `input_rec.get(dst_var)` is `None`, so it no-ops). No wire-protocol or API change.

## Follow-up (not in scope)

`VarLengthExpand::bfs()` pre-marks the start node as visited (`executor.rs:405`), so a *genuine* returning cycle like `(a)-[:R*2]->(a)` over a 2-cycle is not detected — this fix makes such a repeated-var var-length pattern return empty (no fabricated rows, strictly correct-er) but full returning-cycle support needs BFS changes. Filing as a separate concern.

---
_Generated by [Claude Code](https://claude.ai/code/session_0159ckNHBN5Y5EA5ktgEKWBa)_