### PR TITLE
fix(rfdb): exclude NULL-property rows from Cypher WHERE comparisons

### DIFF
--- a/packages/rfdb-server/src/cypher/executor.rs
+++ b/packages/rfdb-server/src/cypher/executor.rs
@@ -942,7 +942,17 @@ fn eval_literal_expr(expr: &Expr) -> CypherValue {
 }
 
 /// Evaluate a binary comparison operator.
+///
+/// Follows Cypher three-valued logic: a comparison where either operand is NULL
+/// evaluates to NULL (unknown), never to a definite boolean. This matters in a
+/// `WHERE` clause — a NULL predicate is not truthy, so the row is excluded. Without
+/// this guard the ordering operators delegated to `partial_cmp_values`, which orders
+/// NULL as Less-than-everything (so `null < x` was `true`), and `Neq` returned `true`
+/// for `null <> x` — both wrongly admitting rows whose compared property is absent.
 fn eval_binop(l: &CypherValue, op: BinOp, r: &CypherValue) -> CypherValue {
+    if matches!(l, CypherValue::Null) || matches!(r, CypherValue::Null) {
+        return CypherValue::Null;
+    }
     match op {
         BinOp::Eq => CypherValue::Bool(l == r),
         BinOp::Neq => CypherValue::Bool(l != r),

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -2346,6 +2346,96 @@ mod integration_tests {
         assert_eq!(result.rows[0][0], serde_json::json!(30));
     }
 
+    // ── WHERE comparisons with a NULL operand (Cypher three-valued logic) ──
+    //
+    // In Cypher, a comparison where either operand is NULL evaluates to NULL
+    // (unknown), which is not truthy, so WHERE must EXCLUDE the row. Node `d`
+    // has no `lineCount` property, so `d.lineCount` evaluates to NULL.
+    //
+    // Regression guard: `eval_binop` previously delegated ordering operators to
+    // `partial_cmp_values`, which orders NULL as Less-than-everything — so
+    // `null < 100` was `true` and wrongly ADMITTED `d`. Likewise `null <> 10`
+    // returned `true` (via `!=`) and admitted `d`. Both must now exclude it.
+
+    #[test]
+    fn where_less_than_excludes_null_property() {
+        let engine = create_numeric_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) WHERE n.lineCount < 100 RETURN n.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        let mut names: Vec<String> = result
+            .rows
+            .iter()
+            .map(|row| row[0].as_str().unwrap().to_string())
+            .collect();
+        names.sort();
+        // d (no lineCount → NULL) must NOT appear: `null < 100` is NULL, not true.
+        assert_eq!(names, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn where_lte_excludes_null_property() {
+        let engine = create_numeric_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) WHERE n.lineCount <= 100 RETURN n.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        let mut names: Vec<String> = result
+            .rows
+            .iter()
+            .map(|row| row[0].as_str().unwrap().to_string())
+            .collect();
+        names.sort();
+        assert_eq!(names, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn where_not_equal_excludes_null_property() {
+        let engine = create_numeric_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) WHERE n.lineCount <> 10 RETURN n.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        let mut names: Vec<String> = result
+            .rows
+            .iter()
+            .map(|row| row[0].as_str().unwrap().to_string())
+            .collect();
+        names.sort();
+        // a excluded (10 <> 10 = false); d excluded (null <> 10 is NULL, not true).
+        assert_eq!(names, vec!["b", "c"]);
+    }
+
+    #[test]
+    fn where_greater_than_present_property_unaffected() {
+        // Sanity: non-NULL operands keep working exactly as before.
+        let engine = create_numeric_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) WHERE n.lineCount > 15 RETURN n.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        let mut names: Vec<String> = result
+            .rows
+            .iter()
+            .map(|row| row[0].as_str().unwrap().to_string())
+            .collect();
+        names.sort();
+        assert_eq!(names, vec!["b", "c"]);
+    }
+
     #[test]
     fn sum_aggregate_grouped() {
         // Two groups by file, each with distinct numeric sums.


### PR DESCRIPTION
## Problem

A Cypher comparison where either operand is `NULL` must evaluate to `NULL` (unknown) under three-valued logic. A `NULL` predicate is not truthy, so the row is **excluded** from `WHERE`. `eval_binop` (`packages/rfdb-server/src/cypher/executor.rs:945`) violated this in two ways:

- The ordering operators (`<`, `<=`, `>`, `>=`) delegated to `partial_cmp_values` (`values.rs:154-167`), which orders `NULL` as **Less-than-everything** (`(Null, _) => Less`). So `null < 100` returned `true`.
- `Neq` returned `true` for `null <> x` via `l != r` (PartialEq's `(Null, non-null) => false`, so `!=` is `true`).

A property a matched node lacks evaluates to `NULL` (`values.rs:property()` → `Null`; `Filter` admits a row when `eval_expr(...).is_truthy()`, `executor.rs:514`).

**Net effect:** a `WHERE` filter on a property that some matched nodes don't have — e.g. `WHERE n.line < 100` or `WHERE n.x <> 5` — **wrongly ADMITTED** nodes whose property is absent. False positives in filtered queries, silent and shape-dependent. In a code graph this is common (filtering by a numeric/metadata property that not all node types carry).

This is a net-new seam: prior parity work swept the Datalog evaluators and the Cypher `Expand`/`VarLengthExpand` operators (open PR #340); the comparison/`Filter` path was not covered.

## Spec

- **Invariant restored:** for any Cypher comparison (`=`, `<>`, `<`, `>`, `<=`, `>=`), if either operand is `NULL` the result is `NULL` — never a definite boolean — so a `WHERE` predicate over an absent property excludes the row (matches Neo4j three-valued comparison semantics).
- **Given** FUNCTIONs `a=10, b=20, c=30` and `d` with **no** `lineCount` property, **When** `MATCH (n:FUNCTION) WHERE n.lineCount < 100 RETURN n.name`, **Then** exactly `a, b, c` — `d` is excluded because `null < 100` is `NULL`, not `true`.
- **And** `WHERE n.lineCount <> 10` returns exactly `b, c` (`a` excluded by `10 <> 10 = false`; `d` excluded because `null <> 10` is `NULL`, not `true`).

## Fix

Short-circuit `eval_binop`: return `CypherValue::Null` when either operand is `Null`, before the operator match. One guard covers all six comparison operators (fix the class, not an instance). `partial_cmp_values` is **left unchanged**, so `ORDER BY` null-ordering (`Sort`, `executor.rs:633`) keeps its current behavior — that's a separate concern (see follow-ups). +10 lines, no signature/API change.

## Before / After (evidence)

**RED** (before fix) — new tests fail for the right reason:
```
---- where_not_equal_excludes_null_property ----
assertion `left == right` failed
  left: ["b", "c", "d"]      <- d wrongly admitted by `null <> 10`
 right: ["b", "c"]

failures:
    cypher::tests::integration_tests::where_less_than_excludes_null_property
    cypher::tests::integration_tests::where_lte_excludes_null_property
    cypher::tests::integration_tests::where_not_equal_excludes_null_property
test result: FAILED. 5 passed; 3 failed
```
(The `where_greater_than_present_property_unaffected` sanity test passed in RED — confirms `>` already excluded `d` and the non-NULL path is what we keep.)

**GREEN** (after fix):
```
cargo test -p rfdb --lib cypher::   → 124 passed; 0 failed
cargo test -p rfdb --lib            → 871 passed; 0 failed   (was 867 on main HEAD #339, +4)
```

Formatting / lint:
- `rustfmt --check` on the two edited files: my added code shows **no** diff (the only reported diff is a pre-existing import-order line at `executor.rs:7` I didn't author — same pre-existing-`benches/` note as #340).
- `cargo clippy --lib`: no warning/error references the changed lines.

**Rust-only change** (`packages/rfdb-server/src/cypher/{executor,tests}.rs`). No TS/JS touched; the Node `build`/`typecheck`/`lint`/`test` gate is unaffected, and CI does not build native binaries for the cli integration suite (per `CONTRIBUTING.md`). Authoritative gate for this change is the rfdb lib suite above.

## Adversarial review

- **Round A — correctness (null/edge/ordering).** Both operands null (`null = null`): now `NULL` → excluded from `WHERE` (was `true` via PartialEq; matches Cypher `null = null` → null). One operand null, every operator: now `NULL` → excluded. Node operands: neither is `Null` → unchanged (`Eq` by id, ordering → `partial_cmp_values` `None` → `false`). `IS NULL` / `IS NOT NULL`: handled by dedicated `Expr::IsNull`/`IsNotNull` arms, not `eval_binop` — untouched (`is_null`, `filter_is_null` tests green). Non-null comparisons: all pre-existing comparison tests green; planner inline-property matching (`(n {k: v})` → `Eq`) compares a present property to a literal, so the guard no-ops there.
- **Round B — structural fragility.** 3-line guard + doc at the top of `eval_binop`, no new coupling. `executor.rs` is a pre-existing >500-line module (one struct per Volcano operator); splitting it is a separate refactor, out of scope. The guard is deliberately scoped to `eval_binop` and does **not** touch `partial_cmp_values`, so `Sort`/`ORDER BY` semantics are not silently changed by this fix.
- **Round C — class-not-instance + invariants.** All six `BinOp` comparison operators route through `eval_binop` and are covered by the single guard — the class is fully closed for binary comparisons. No analysis-pipeline invariant touched (query-time evaluation only; no graph shape change).

## Blast radius

Only Cypher `WHERE`/`Filter` predicates (and any `RETURN` of a comparison expression) where an operand is `NULL` — previously these wrongly admitted/returned rows; now they are correctly excluded. Comparisons over present properties are byte-for-byte unchanged. No wire-protocol or API change. `Datalog` is unaffected.

## Sibling latent issues found (evidence-backed follow-ups — NOT in this PR)

Same "NULL operand → definite boolean" family, **different operators / code paths**, each needs its own RED test:

1. **`Contains` / `StartsWith` / `EndsWith`** (`executor.rs:865-894`) return `Bool(false)` for a `NULL` operand. Harmless for a plain `WHERE` (false → excluded, same as null → excluded), but under negation — `WHERE NOT (n.s CONTAINS 'a')` with `s` absent — Cypher yields `NOT null` → null → excluded, whereas current yields `NOT false` → `true` → wrongly **included**. Lower impact (requires `NOT`).
2. **`ORDER BY` null placement** (`partial_cmp_values` orders `NULL` first; Neo4j sorts `NULL` last in ASC). Separate semantics decision; intentionally left untouched here.
3. **`value_to_group_key`** (`executor.rs:1015`) can collide distinct values to one `GROUP BY` key (e.g. `Int(5)` and `Str("5")` → `"5"`, `Null` and `Str("__null__")`). Different class (grouping), edge-casey in a typed code graph.

## Intake note

No OPEN GitHub issues on this repo and no Linear MCP is wired into this environment (only `github` + `Enox`), so this is a dogfood-discovered correctness bug rather than a tracked ticket — full repro/expected-vs-actual and acceptance encoded as tests above.

---
_Generated by [Claude Code](https://claude.ai/code/session_0186LHpxCQKRKTocg5JiueNY)_