### PR TITLE
fix(rfdb): type-distinct Cypher GROUP BY keys (value_to_group_key collision)

### DIFF
--- a/packages/rfdb-server/src/cypher/executor.rs
+++ b/packages/rfdb-server/src/cypher/executor.rs
@@ -1011,14 +1011,25 @@ fn format_return_expr(expr: &Expr) -> String {
     }
 }
 
-/// Convert a CypherValue to a string for use as a group key in HashAggregate.
+/// Convert a CypherValue into a `GROUP BY` bucket key for HashAggregate.
+///
+/// Two values must map to the SAME key iff they are equal under
+/// `CypherValue`'s `PartialEq` (the relation `GROUP BY` groups on). The first
+/// character is a per-type discriminant, so values of different types can never
+/// collide even when they render to the same text — `Int(5)` (`"#5"`),
+/// `Str("5")` (`"S5"`), `Bool(true)` (`"Btrue"`) and `Null` (`"N"`) are all
+/// distinct buckets. `Int` and `Float` deliberately share the `#` numeric
+/// namespace because `Int(5) == Float(5.0)` holds (`values.rs` PartialEq), so
+/// `5` and `5.0` must group together — and they do, since `5.0_f64` renders to
+/// `"5"`. Without the discriminant a bare `to_string()` silently merged
+/// distinct-typed values (e.g. `Int(5)` with `Str("5")`) into one group.
 fn value_to_group_key(val: &CypherValue) -> String {
     match val {
-        CypherValue::Null => "__null__".to_string(),
-        CypherValue::Bool(b) => b.to_string(),
-        CypherValue::Int(i) => i.to_string(),
-        CypherValue::Float(f) => f.to_string(),
-        CypherValue::Str(s) => s.clone(),
-        CypherValue::Node { id, .. } => id.to_string(),
+        CypherValue::Null => "N".to_string(),
+        CypherValue::Bool(b) => format!("B{b}"),
+        CypherValue::Int(i) => format!("#{i}"),
+        CypherValue::Float(f) => format!("#{f}"),
+        CypherValue::Str(s) => format!("S{s}"),
+        CypherValue::Node { id, .. } => format!("@{id}"),
     }
 }

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -2459,4 +2459,135 @@ mod integration_tests {
         assert_eq!(result.columns, vec!["f.name", "calls"]);
         assert!(result.row_count >= 1);
     }
+
+    // ── GROUP BY key must distinguish value types (value_to_group_key) ─────
+    //
+    // `value_to_group_key` must map two values to the SAME bucket iff they are
+    // equal under `CypherValue`'s `PartialEq` (the relation GROUP BY groups on).
+    // The old implementation collapsed every variant to a bare `to_string()`,
+    // so distinct-typed values that render to the same text — Int(5)/Str("5"),
+    // Bool/Str, Null/Str("__null__") — were silently merged into ONE group,
+    // corrupting aggregates. These tests pin the type-distinction (and guard
+    // that Int(5) == Float(5.0) still groups together — no over-splitting).
+
+    /// Build a graph of FUNCTION nodes whose `tag` metadata is injected verbatim
+    /// as a JSON fragment, so each node's `n.tag` resolves to the exact
+    /// `CypherValue` variant the test needs.
+    fn graph_with_tags(tags: &[(u128, &str)]) -> GraphEngineV2 {
+        let mut engine = GraphEngineV2::create_ephemeral();
+        let nodes = tags
+            .iter()
+            .map(|(id, meta)| NodeRecord {
+                id: *id,
+                node_type: Some("FUNCTION".to_string()),
+                name: Some(format!("f{}", id)),
+                file: Some("src/m.js".to_string()),
+                file_id: 0,
+                name_offset: 0,
+                version: "main".into(),
+                exported: true,
+                replaces: None,
+                deleted: false,
+                metadata: Some(meta.to_string()),
+                semantic_id: None,
+            })
+            .collect();
+        engine.add_nodes(nodes);
+        engine
+    }
+
+    #[test]
+    fn group_key_int_and_string_do_not_collide() {
+        // Int(5) and Str("5") are NOT equal under PartialEq → two groups.
+        let engine = graph_with_tags(&[
+            (40, r#"{"tag": 5}"#),   // n.tag -> Int(5)
+            (41, r#"{"tag": "5"}"#), // n.tag -> Str("5")
+        ]);
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.tag, COUNT(*) AS c",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            result.row_count, 2,
+            "Int(5) and Str(\"5\") must form two distinct GROUP BY buckets, got rows: {:?}",
+            result.rows
+        );
+        // Exactly one numeric-tag group and one string-tag group, each count 1.
+        let mut counts: Vec<(bool, i64)> = result
+            .rows
+            .iter()
+            .map(|row| (row[0].is_string(), row[1].as_i64().unwrap()))
+            .collect();
+        counts.sort();
+        assert_eq!(counts, vec![(false, 1), (true, 1)]);
+    }
+
+    #[test]
+    fn group_key_null_and_sentinel_string_do_not_collide() {
+        // A missing property -> Null; a literal Str("__null__") must not share
+        // the Null bucket (the old "__null__" sentinel collided with it).
+        let engine = graph_with_tags(&[
+            (42, r#"{"other": 1}"#),        // no `tag` -> n.tag = Null
+            (43, r#"{"tag": "__null__"}"#), // n.tag -> Str("__null__")
+        ]);
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.tag, COUNT(*) AS c",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            result.row_count, 2,
+            "Null and Str(\"__null__\") must not collide, got rows: {:?}",
+            result.rows
+        );
+    }
+
+    #[test]
+    fn group_key_bool_and_string_do_not_collide() {
+        // Bool(true) and Str("true") are NOT equal under PartialEq → two groups.
+        let engine = graph_with_tags(&[
+            (46, r#"{"tag": true}"#),    // n.tag -> Bool(true)
+            (47, r#"{"tag": "true"}"#),  // n.tag -> Str("true")
+        ]);
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.tag, COUNT(*) AS c",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            result.row_count, 2,
+            "Bool(true) and Str(\"true\") must not collide, got rows: {:?}",
+            result.rows
+        );
+    }
+
+    #[test]
+    fn group_key_int_and_equal_float_still_group() {
+        // Guard against over-splitting: Int(5) == Float(5.0) under PartialEq, so
+        // they MUST stay in one group (Int/Float share the numeric namespace).
+        let engine = graph_with_tags(&[
+            (44, r#"{"tag": 5}"#),   // Int(5)
+            (45, r#"{"tag": 5.0}"#), // Float(5.0)
+        ]);
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.tag, COUNT(*) AS c",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            result.row_count, 1,
+            "Int(5) and Float(5.0) are equal and must share one group, got rows: {:?}",
+            result.rows
+        );
+        assert_eq!(result.rows[0][1].as_i64().unwrap(), 2);
+    }
 }


### PR DESCRIPTION
## Problem

`GROUP BY` buckets values by **equality**. `CypherValue`'s `PartialEq` (`packages/rfdb-server/src/cypher/values.rs:170-183`) treats `Int(5)` vs `Str("5")`, `Bool(true)` vs `Str("true")`, and `Null` vs `Str("__null__")` as **not equal** (they fall to `_ => false`) — so they must form **separate** groups.

But `value_to_group_key` (`packages/rfdb-server/src/cypher/executor.rs:1015`, the bucket-key function consumed by `HashAggregate` at `executor.rs:738`) rendered every variant to a bare `to_string()`:

```rust
CypherValue::Null    => "__null__",
CypherValue::Bool(b) => b.to_string(),     // true        -> "true"
CypherValue::Int(i)  => i.to_string(),     // 5           -> "5"
CypherValue::Str(s)  => s.clone(),         // "5"/"true"/"__null__"
...
```

So distinct-typed values that **render to the same text** collapsed into one bucket: `Int(5)` merged with `Str("5")`, `Bool(true)` with `Str("true")`, `Null` with the literal `Str("__null__")`.

**Net effect:** `RETURN n.prop, COUNT(*)` (and every `SUM`/`AVG`/`MIN`/`MAX` group) over a property whose values span types — common in a loosely-typed code graph where metadata mixes numbers and strings — **silently merges distinct groups into one**, corrupting the aggregate. Silent, shape-dependent wrong rows.

This is a net-new seam: dogfood-discovered, filed as an evidence-backed **sibling follow-up #3 in the still-open PR #341** ("`value_to_group_key` can collide distinct values to one GROUP BY key — e.g. `Int(5)` and `Str("5")`, `Null` and `Str("__null__")`"). Independent code path from #341 (which fixes `eval_binop`/`WHERE`/`Filter`).

## Spec

- **Invariant restored:** for any two values, `value_to_group_key(a) == value_to_group_key(b)` iff `a == b` under `CypherValue::PartialEq` (the relation `GROUP BY` groups on).
- **Given** FUNCTION nodes whose `n.tag` resolves to `Int(5)` and `Str("5")`, **When** `MATCH (n:FUNCTION) RETURN n.tag, COUNT(*)`, **Then** **two** groups (one numeric, one string), each count 1 — not one merged group of 2.
- **And** `Null` (missing property) vs `Str("__null__")`, and `Bool(true)` vs `Str("true")`, each form two groups.
- **And** (guard against over-splitting) `Int(5)` and `Float(5.0)` still form **one** group, because `Int(5) == Float(5.0)` holds in `PartialEq`.

## Fix

Prefix each variant's key with a one-char per-type discriminant (`N`/`B`/`#`/`S`/`@`). Different types ⟹ different first char ⟹ different key, so cross-type collision is impossible. `Int` and `Float` deliberately share the `#` numeric namespace so `5` and `5.0` group together (`5.0_f64` renders to `"5"`, preserving the prior — correct — numeric grouping). The match is exhaustive (no `_`), so a future `CypherValue` variant must declare its discriminant. +12 lines (mostly doc), no signature/API change.

The group key is **internal** to `HashAggregate` — emitted values come from `key_values` (`executor.rs:785`), not the key string — so the format change cannot leak to wire output.

## Before / After (evidence)

**RED** (before fix) — new tests fail for the right reason:
```
---- group_key_bool_and_string_do_not_collide ----
assertion `left == right` failed: Bool(true) and Str("true") must not collide,
got rows: [[Bool(true), Number(2)]]      <- both merged into the Bool(true) bucket
  left: 1
 right: 2

failures:
    cypher::tests::integration_tests::group_key_int_and_string_do_not_collide
    cypher::tests::integration_tests::group_key_null_and_sentinel_string_do_not_collide
    cypher::tests::integration_tests::group_key_bool_and_string_do_not_collide
test result: FAILED. 1 passed; 3 failed
```
(`group_key_int_and_equal_float_still_group` passed in RED — confirms `Int(5)`/`Float(5.0)` already grouped and the fix doesn't over-split.)

**GREEN** (after fix):
```
running 4 tests
test cypher::tests::integration_tests::group_key_bool_and_string_do_not_collide ... ok
test cypher::tests::integration_tests::group_key_int_and_equal_float_still_group ... ok
test cypher::tests::integration_tests::group_key_null_and_sentinel_string_do_not_collide ... ok
test cypher::tests::integration_tests::group_key_int_and_string_do_not_collide ... ok
test result: ok. 4 passed; 0 failed

cargo test -p rfdb --lib   ->  871 passed; 0 failed   (was 867 on main HEAD #339, +4)
```

Formatting / lint:
- `rustfmt --check` on the two edited files: my added code shows **no** diff (the only reported diffs are pre-existing — import-order at `executor.rs:7` and `find_by_attr_chunked` layout at `:157`, neither authored here; same pre-existing note as #340/#341).
- `cargo clippy --lib`: no warning/error references the changed lines.

**Rust-only change** (`packages/rfdb-server/src/cypher/{executor,tests}.rs`). No TS/JS touched; the Node `build`/`typecheck`/`lint`/`test` gate is unaffected, and CI does not build native binaries for the cli integration suite (per `CONTRIBUTING.md`). Authoritative gate is the rfdb lib suite above.

## Adversarial review

- **Round A — correctness (null/edge/numeric).** Discriminants `N/B/#/S/@` are distinct, so no two variants collide except `Int`/`Float` (intentional, matches `PartialEq`). `Int(5)`/`Float(5.0)` → `"#5"` (group, correct). `Float(5.5)` → `"#5.5"`, `Str("5.5")` → `"S5.5"` (distinct). `Str("N")` → `"SN"` vs `Null` → `"N"` (distinct). Empty `Str("")` → `"S"` vs `Null` → `"N"` (distinct). Negative ints `Int(-5)`/`Float(-5.0)` → `"#-5"` (group). Node id vs int: `"@123"` vs `"#123"` (distinct).
  - **Pre-existing, unreachable edges left as-is (not a regression):** `f64` `NaN` (`NaN != NaN` in `PartialEq`, but `"#NaN" == "#NaN"`) and `-0.0` vs `0.0` (`-0.0 == 0.0` but `"#-0" != "#0"`) keep the exact prior behavior — both the old and new code stringify the float component. Neither is reachable from JSON metadata (`serde_json` rejects `NaN`; `-0.0` does not arise from a code graph), so out of scope here.
- **Round B — structural fragility.** Self-contained pure function, no new coupling; the key never leaks to output (confirmed: values come from `key_values`). `executor.rs` is a pre-existing >500-line module (one struct per Volcano operator); splitting it is a separate refactor, out of scope (same note as #340/#341).
- **Round C — class-not-instance + invariants.** The class is "GROUP BY key must respect value equality." All six `CypherValue` variants are covered in the single function, and `value_to_group_key` (`executor.rs:738`) is the **only** value→string equality-keying in the Cypher engine — grep confirms the only other `HashSet` (`executor.rs:401`) is the `VarLengthExpand` BFS `visited` set keyed by node `id` (`u128`), and there is **no `DISTINCT` operator**. Class fully closed. Query-time only; no graph-shape or analysis-pipeline invariant touched.

## Blast radius

Only `GROUP BY` / aggregation over columns whose values span multiple `CypherValue` types where two types previously rendered to the same text — these wrongly merged and now form correct separate groups. Single-type group columns (the common case — e.g. group by `n.file`, all `Str`) are unaffected (one discriminant prefix, no behavior change). No wire-protocol or API change. Datalog unaffected.

## Intake note

No OPEN GitHub issues on this repo and no Linear MCP is wired into this environment (only `github` + `Enox`), so this is a dogfood-discovered correctness bug picked from PR #341's evidence-backed follow-up list — full repro/expected-vs-actual and acceptance encoded as tests above.

---
_Generated by [Claude Code](https://claude.ai/code/session_019omdraJHncQBMTKkceBUAM)_