### PR TITLE
fix(rfdb): support full Cypher variable-length grammar (*, *N, *N..)

### DIFF
--- a/packages/rfdb-server/src/cypher/parser.rs
+++ b/packages/rfdb-server/src/cypher/parser.rs
@@ -572,25 +572,50 @@ impl<'a> Parser<'a> {
         Ok((variable, rel_types, length))
     }
 
-    /// Parse variable-length specifier after '*': min..max
+    /// Parse the variable-length specifier following `*`, returning `(min, max)`.
+    ///
+    /// Supports the full standard Cypher grammar (the leading `*` is already
+    /// consumed by the caller):
+    /// - `*`        → `(1, u32::MAX)`  — one or more hops, no upper bound
+    /// - `*N`       → `(N, N)`         — exactly N hops
+    /// - `*N..`     → `(N, u32::MAX)`  — at least N hops, no upper bound
+    /// - `*..M`     → `(1, M)`         — up to M hops
+    /// - `*N..M`    → `(N, M)`         — between N and M hops
+    /// - `*..`      → `(1, u32::MAX)`  — equivalent to bare `*`
+    ///
+    /// An omitted bound is "unbounded", represented as [`u32::MAX`] rather than a
+    /// magic finite cap: `VarLengthExpand`'s BFS dedupes visited nodes (so it is
+    /// O(V+E) per source and always terminates) and `EvalLimits` bounds result
+    /// volume, so there is no silent depth truncation. The previous code called
+    /// `expect("..")` unconditionally — rejecting `*` and `*N`, and defaulting an
+    /// omitted max to 10, which silently dropped any path longer than 10 hops.
     fn parse_var_length(&mut self) -> Result<(u32, u32), ParseError> {
         self.skip_whitespace();
-        let min = if self.remaining().chars().next().map(|c| c.is_ascii_digit()) == Some(true) {
+        let has_min = self.remaining().chars().next().map(|c| c.is_ascii_digit()) == Some(true);
+        let min = if has_min {
             self.parse_integer()? as u32
         } else {
             1 // default min
         };
 
-        self.expect("..")?;
-
         self.skip_whitespace();
-        let max = if self.remaining().chars().next().map(|c| c.is_ascii_digit()) == Some(true) {
-            self.parse_integer()? as u32
+        if self.remaining().starts_with("..") {
+            // Range form `*min..` / `*min..max` / `*..max` / `*..`.
+            self.pos += 2;
+            self.skip_whitespace();
+            let max = if self.remaining().chars().next().map(|c| c.is_ascii_digit()) == Some(true) {
+                self.parse_integer()? as u32
+            } else {
+                u32::MAX // omitted upper bound → unbounded
+            };
+            Ok((min, max))
+        } else if has_min {
+            // Exact-length form `*N` → exactly N hops.
+            Ok((min, min))
         } else {
-            10 // default max
-        };
-
-        Ok((min, max))
+            // Bare `*` → one or more hops, unbounded.
+            Ok((1, u32::MAX))
+        }
     }
 
     // ========================================================================

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -79,6 +79,53 @@ mod parser_tests {
         assert_eq!(rel.length, Some((1, 5)));
     }
 
+    // ── Variable-length forms beyond `*min..max` (standard Cypher grammar) ──
+    //
+    // `parse_var_length` used to call `expect("..")` unconditionally, so the
+    // unbounded `*` and exact-length `*N` forms were REJECTED with a parse error,
+    // and the open-ended `*N..` / `*..` forms silently defaulted `max` to 10 —
+    // a traversal that silently truncated at depth 10. These guard each form.
+
+    #[test]
+    fn variable_length_unbounded() {
+        // Bare `*` = "one or more hops", no upper bound.
+        let q = parse_cypher("MATCH (a)-[:CALLS*]->(b) RETURN b.name").unwrap();
+        let (rel, _) = &q.match_clause.pattern.segments[0];
+        assert_eq!(rel.length, Some((1, u32::MAX)));
+    }
+
+    #[test]
+    fn variable_length_exact() {
+        // `*3` = "exactly three hops" → (3, 3).
+        let q = parse_cypher("MATCH (a)-[:CALLS*3]->(b) RETURN b.name").unwrap();
+        let (rel, _) = &q.match_clause.pattern.segments[0];
+        assert_eq!(rel.length, Some((3, 3)));
+    }
+
+    #[test]
+    fn variable_length_min_unbounded() {
+        // `*2..` = "at least two hops", no upper bound — NOT silently capped at 10.
+        let q = parse_cypher("MATCH (a)-[:CALLS*2..]->(b) RETURN b.name").unwrap();
+        let (rel, _) = &q.match_clause.pattern.segments[0];
+        assert_eq!(rel.length, Some((2, u32::MAX)));
+    }
+
+    #[test]
+    fn variable_length_max_only() {
+        // `*..5` = "up to five hops", min defaults to 1.
+        let q = parse_cypher("MATCH (a)-[:CALLS*..5]->(b) RETURN b.name").unwrap();
+        let (rel, _) = &q.match_clause.pattern.segments[0];
+        assert_eq!(rel.length, Some((1, 5)));
+    }
+
+    #[test]
+    fn variable_length_open_both_ends() {
+        // `*..` = "one or more hops" — equivalent to bare `*`.
+        let q = parse_cypher("MATCH (a)-[:CALLS*..]->(b) RETURN b.name").unwrap();
+        let (rel, _) = &q.match_clause.pattern.segments[0];
+        assert_eq!(rel.length, Some((1, u32::MAX)));
+    }
+
     #[test]
     fn where_with_and_or() {
         let q = parse_cypher(
@@ -2135,6 +2182,94 @@ mod integration_tests {
         // So only helper and validate at depth >= 1.
         let names = collect_string_column(&result, 0);
         assert_eq!(names, vec!["helper", "validate"]);
+    }
+
+    /// Build a straight CALLS chain `n0 -> n1 -> ... -> n{len-1}`.
+    fn create_chain_graph(len: u128) -> GraphEngineV2 {
+        let mut engine = GraphEngineV2::create_ephemeral();
+        let nodes: Vec<NodeRecord> = (0..len)
+            .map(|i| NodeRecord {
+                id: i + 1,
+                node_type: Some("FUNCTION".to_string()),
+                name: Some(format!("n{}", i)),
+                file: Some("src/chain.js".to_string()),
+                file_id: 0,
+                name_offset: 0,
+                version: "main".into(),
+                exported: false,
+                replaces: None,
+                deleted: false,
+                metadata: None,
+                semantic_id: None,
+            })
+            .collect();
+        engine.add_nodes(nodes);
+
+        let edges: Vec<EdgeRecord> = (0..len - 1)
+            .map(|i| EdgeRecord {
+                src: i + 1,
+                dst: i + 2,
+                edge_type: Some("CALLS".to_string()),
+                version: "main".into(),
+                metadata: None,
+                deleted: false,
+            })
+            .collect();
+        engine.add_edges(edges, true);
+        engine
+    }
+
+    #[test]
+    fn variable_length_unbounded_reaches_beyond_depth_10() {
+        // 15-node chain n0 -> n1 -> ... -> n14. Bare `*` must reach ALL 14
+        // descendants of n0. Before the parse fix, `*` failed to parse at all;
+        // the open-ended `*N..` form silently capped traversal at depth 10, so
+        // n11..n14 vanished from results.
+        let engine = create_chain_graph(15);
+        let result = execute(
+            &engine,
+            "MATCH (a:FUNCTION)-[:CALLS*]->(b) WHERE a.name = 'n0' RETURN b.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        let mut names = collect_string_column(&result, 0);
+        names.sort();
+        let mut expected: Vec<String> = (1..15).map(|i| format!("n{}", i)).collect();
+        expected.sort();
+        assert_eq!(names, expected, "bare `*` must reach all 14 descendants");
+    }
+
+    #[test]
+    fn variable_length_min_unbounded_not_capped_at_10() {
+        // `*12..` from n0 must reach n12, n13, n14 (depths 12,13,14) — depths the
+        // old silent max-of-10 default excluded entirely.
+        let engine = create_chain_graph(15);
+        let result = execute(
+            &engine,
+            "MATCH (a:FUNCTION)-[:CALLS*12..]->(b) WHERE a.name = 'n0' RETURN b.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        let mut names = collect_string_column(&result, 0);
+        names.sort();
+        assert_eq!(names, vec!["n12", "n13", "n14"]);
+    }
+
+    #[test]
+    fn variable_length_exact_depth() {
+        // `*5` from n0 is exactly n5 — no shorter, no longer.
+        let engine = create_chain_graph(15);
+        let result = execute(
+            &engine,
+            "MATCH (a:FUNCTION)-[:CALLS*5]->(b) WHERE a.name = 'n0' RETURN b.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        let names = collect_string_column(&result, 0);
+        assert_eq!(names, vec!["n5"]);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`parse_var_length` (`packages/rfdb-server/src/cypher/parser.rs`) called `expect("..")` **unconditionally**, so the variable-length relationship grammar only accepted `*min..max`. Two standard Cypher forms were broken — a sibling of the recent RFDB Cypher-correctness series (#340–#343), and untouched by any of those PRs.

- **Rejected (loud):** bare `*` (unbounded) and `*N` (exact length) failed to parse with `ParseError "expected '..'"`. So bread-and-butter transitive queries like `(a)-[:CALLS*]->(b)` and `[:DEPENDS_ON*2]` were unusable.
- **Silently wrong:** the omitted-upper-bound forms `*N..` / `*..` defaulted `max` to a magic **10**, so a traversal silently truncated at depth 10 — any path longer than 10 hops vanished from results with no error.

This is a net-new seam: the recent correctness work touched the executor (#340/#341/#342) and the Datalog explain evaluator (#337/#338); none touch `parse_var_length`. `parse_var_length` has a single caller (`parse_rel_bracket_contents`), and `(min, max)` flows unchanged into `VarLengthExpand`.

## Spec

- **Invariant restored:** the parser accepts the full standard variable-length grammar, and an omitted bound means *unbounded*, never a silent finite cap.

| Form | Result | Meaning |
|------|--------|---------|
| `*` | `(1, u32::MAX)` | one or more hops |
| `*N` | `(N, N)` | exactly N hops |
| `*N..` | `(N, u32::MAX)` | at least N hops |
| `*..M` | `(1, M)` | up to M hops |
| `*N..M` | `(N, M)` | between N and M |
| `*..` | `(1, u32::MAX)` | one or more hops |

- **Given** `MATCH (a)-[:CALLS*]->(b) ...` over a 15-node chain `n0→…→n14`, **When** run from `n0`, **Then** all 14 descendants are returned (not capped at 10).
- **And** `*12..` returns depths 12–14 (excluded entirely by the old default of 10); `*5` returns exactly depth 5.

"Unbounded" is `u32::MAX`, not a finite magic number: `VarLengthExpand`'s BFS dedupes visited nodes (O(V+E) per source, always terminates — `depth >= u32::MAX` is unreachable) and `EvalLimits` bounds result volume. So removing the cap introduces no runtime-safety or termination risk.

## Before / After (actual output)

Baseline (before fix), new tests fail for the right reason:
```
parser_tests::variable_length_unbounded ... FAILED   // ParseError "expected '..'" (pos 18)
parser_tests::variable_length_exact ... FAILED        // ParseError "expected '..'" (pos 19)
parser_tests::variable_length_min_unbounded ... FAILED // got (2,10), expected (2, u32::MAX)
integration::variable_length_min_unbounded_not_capped_at_10 ... FAILED // n12..n14 missing
integration::variable_length_unbounded_reaches_beyond_depth_10 ... FAILED // ParseError
```

After fix:
```
test result: ok. 128 passed; 0 failed   (cypher::)   // 120 baseline + 8 new
test result: ok. 875 passed; 0 failed   (full rfdb --lib)
```

## Adversarial review

- **Round A — correctness/edge cases.** Whitespace-tolerant (`* 2 .. 5` ok). `*-5` → still a loud parse error (`-` isn't a digit → bare `*`, then caller's `expect("]")` fails) — no silent misparse. `*0` → `(0,0)` parses but yields nothing (BFS `depth > 0` guard, pre-existing). `*5..2` (min>max) → empty range (pre-existing). `u32::MAX` max is never reached by `depth`, BFS terminates via the visited set.
- **Round B — structural.** Change is confined to one function; the `(u32, u32)` contract with `VarLengthExpand`/planner is unchanged; the function is fully documented for agents. (`parser.rs` was already >500 lines before this change; not expanded materially — splitting the parser is out of scope.)
- **Round C — class-not-instance.** `parse_var_length` has exactly one caller; no other code hardcodes the `10` cap (`grep`). The same `expect("..")` anti-pattern exists nowhere else.

## Blast radius

`parse_var_length` → `ast.length: Option<(u32,u32)>` → `planner::plan` → `VarLengthExpand{min_depth,max_depth}`. No wire-protocol/API change; previously-accepted queries (`*min..max`, `*..max`) parse identically. The only behavior change is for forms that previously errored or silently capped.

## Verification gate

Rust-only change in the `rfdb` crate's Cypher parser. Gate run:
- `cargo test --lib` → **875 passed, 0 failed**
- `cargo clippy --lib` → no new warnings on edited lines (pre-existing warnings unrelated)
- `rustfmt --check` → edited function is clean

JS gate (`pnpm build/test/typecheck/lint`) not re-run: the change is isolated to the Rust crate with no wire-format/API change, and no JS test exercises these (previously-erroring) forms.

## Sibling latent issues found (follow-ups, not in scope)

- `parse_integer()? as u32` truncates explicit depths > `u32::MAX` (e.g. `*4294967296` → 0). Pre-existing, absurd input; left as-is.
- `VarLengthExpand` BFS uses a single global visited set ("shortest-path" dedup). For `min_depth ≥ 2`, a node reachable both below `min` and within `[min,max]` is emitted only at its shortest depth, so it can be silently dropped. Contestable as a deliberate node-reachability simplification; not addressed here.

https://claude.ai/code/session_01FWuUQUrPUEHXXpJUnjzt51

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWuUQUrPUEHXXpJUnjzt51)_