### PR TITLE
fix(rfdb): sort aggregate-query ORDER BY by produced columns

### DIFF
--- a/packages/rfdb-server/src/cypher/executor.rs
+++ b/packages/rfdb-server/src/cypher/executor.rs
@@ -1001,7 +1001,11 @@ fn edge_record_to_value(edge: &EdgeRecord) -> CypherValue {
 }
 
 /// Format a RETURN expression as a column name.
-fn format_return_expr(expr: &Expr) -> String {
+///
+/// `pub(crate)` so the planner can reconstruct the exact group-key column names
+/// produced by `HashAggregate` when rewriting `ORDER BY` expressions (an
+/// aggregate query sorts over these produced columns, not the raw pattern).
+pub(crate) fn format_return_expr(expr: &Expr) -> String {
     match expr {
         Expr::Property(var, prop) => format!("{}.{}", var, prop),
         Expr::Variable(v) => v.clone(),

--- a/packages/rfdb-server/src/cypher/planner.rs
+++ b/packages/rfdb-server/src/cypher/planner.rs
@@ -143,11 +143,22 @@ pub fn plan<'a>(
 
     if has_aggregates {
         let (group_keys, aggregates) = split_return_items(&query.return_clause);
+
+        // Rewrite ORDER BY to reference the columns HashAggregate produces.
+        // Post-aggregation the original node bindings are gone and aggregate
+        // calls are not re-evaluated, so Sort must reference the produced
+        // column names. Done BEFORE the groups/aggregates are moved into the
+        // operator below.
+        let order_by = query
+            .order_by
+            .as_ref()
+            .map(|ob| rewrite_order_by_for_aggregates(ob, &group_keys, &aggregates));
+
         op = Box::new(HashAggregate::new(op, group_keys, aggregates, limits));
 
-        // Sort after aggregate (operates on named columns).
-        if let Some(ref order_by) = query.order_by {
-            op = Box::new(Sort::new(op, order_by.clone(), limits));
+        // Sort after aggregate (operates on the produced named columns).
+        if let Some(order_by) = order_by {
+            op = Box::new(Sort::new(op, order_by, limits));
         }
     } else {
         // Sort before Project (operates on full node records).
@@ -198,6 +209,96 @@ fn split_return_items(ret: &ReturnClause) -> (Vec<ReturnItem>, Vec<AggregateItem
     }
 
     (group_keys, aggregates)
+}
+
+/// The column name `HashAggregate` produces for a group-key RETURN item.
+///
+/// MUST stay identical to the key `HashAggregate::materialize` inserts for the
+/// same item (`alias` else `format_return_expr(expr)`), so that an `ORDER BY`
+/// expression rewritten to `Variable(name)` resolves to the right column.
+fn group_key_name(item: &ReturnItem) -> String {
+    item.alias
+        .clone()
+        .unwrap_or_else(|| format_return_expr(&item.expr))
+}
+
+/// Rewrite the `ORDER BY` expressions of an aggregate query so they reference
+/// the columns the `HashAggregate` operator emits.
+///
+/// In an aggregate query the `Sort` operator runs *after* `HashAggregate`,
+/// whose output records carry only the produced columns: one per group key
+/// (keyed by [`group_key_name`]) and one per aggregate (keyed by its alias).
+/// The original `ORDER BY` AST instead holds the raw pattern expressions:
+///
+/// - `ORDER BY n.file` is a `Property("n", "file")`, but `n` no longer exists
+///   in the post-aggregation record (only the string column `"n.file"` does),
+///   so `eval_expr` would yield `NULL` and the rows would not sort.
+/// - `ORDER BY COUNT(*)` is a `FunctionCall`, which `eval_expr` returns `NULL`
+///   for (aggregates are not re-evaluated post-aggregation), again no sort.
+///
+/// This rewrite maps any `ORDER BY` term that matches a RETURN item — by
+/// structural equality for group keys, by function name + argument for
+/// aggregates — to a `Variable` referencing that item's produced column, so
+/// `Sort` reads the already-computed value. Terms that match nothing (e.g. an
+/// alias already referenced directly, or an expression not in RETURN) are left
+/// unchanged.
+fn rewrite_order_by_for_aggregates(
+    order_by: &[(Expr, SortDir)],
+    group_keys: &[ReturnItem],
+    aggregates: &[AggregateItem],
+) -> Vec<(Expr, SortDir)> {
+    order_by
+        .iter()
+        .map(|(expr, dir)| (rewrite_order_expr(expr, group_keys, aggregates), *dir))
+        .collect()
+}
+
+/// Recursively rewrite a single `ORDER BY` expression. See
+/// [`rewrite_order_by_for_aggregates`] for the rationale.
+fn rewrite_order_expr(
+    expr: &Expr,
+    group_keys: &[ReturnItem],
+    aggregates: &[AggregateItem],
+) -> Expr {
+    // An aggregate call that also appears in RETURN -> its produced column.
+    if let Expr::FunctionCall(name, args) = expr {
+        if is_aggregate_function(name) {
+            let func = name.to_uppercase();
+            let arg = args.first().cloned().unwrap_or(Expr::Star);
+            if let Some(agg) = aggregates
+                .iter()
+                .find(|a| a.function == func && a.arg == arg)
+            {
+                return Expr::Variable(agg.alias.clone());
+            }
+        }
+    }
+
+    // A group-key expression that appears in RETURN -> its produced column.
+    if let Some(gk) = group_keys.iter().find(|g| g.expr == *expr) {
+        return Expr::Variable(group_key_name(gk));
+    }
+
+    // Recurse into compound expressions so combinations resolve too.
+    match expr {
+        Expr::BinaryOp(l, op, r) => Expr::BinaryOp(
+            Box::new(rewrite_order_expr(l, group_keys, aggregates)),
+            *op,
+            Box::new(rewrite_order_expr(r, group_keys, aggregates)),
+        ),
+        Expr::And(l, r) => Expr::And(
+            Box::new(rewrite_order_expr(l, group_keys, aggregates)),
+            Box::new(rewrite_order_expr(r, group_keys, aggregates)),
+        ),
+        Expr::Or(l, r) => Expr::Or(
+            Box::new(rewrite_order_expr(l, group_keys, aggregates)),
+            Box::new(rewrite_order_expr(r, group_keys, aggregates)),
+        ),
+        Expr::Not(inner) => {
+            Expr::Not(Box::new(rewrite_order_expr(inner, group_keys, aggregates)))
+        }
+        other => other.clone(),
+    }
 }
 
 /// Format an expression for use in a generated alias.

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -2459,4 +2459,111 @@ mod integration_tests {
         assert_eq!(result.columns, vec!["f.name", "calls"]);
         assert!(result.row_count >= 1);
     }
+
+    // ── ORDER BY in aggregate queries (sort by aggregate / group-key expr) ──
+
+    /// Three files with distinct grouped SUMs, laid out so that the group
+    /// insertion order (a.js, m.js, z.js — ascending node id) matches NONE of
+    /// the sorted orders we assert below. This makes the tests fail reliably
+    /// when ORDER BY silently no-ops (rows fall back to insertion order),
+    /// regardless of the storage scan order.
+    ///
+    /// Grouped SUM(lineCount): a.js=10, m.js=100, z.js=1.
+    fn order_by_agg_graph() -> GraphEngineV2 {
+        let mut engine = GraphEngineV2::create_ephemeral();
+        let mk = |id: u128, file: &str, lc: i64| NodeRecord {
+            id,
+            node_type: Some("FUNCTION".to_string()),
+            name: Some(format!("f{}", id)),
+            file: Some(file.to_string()),
+            file_id: 0,
+            name_offset: 0,
+            version: "main".into(),
+            exported: true,
+            replaces: None,
+            deleted: false,
+            metadata: Some(format!(r#"{{"lineCount": {}}}"#, lc)),
+            semantic_id: None,
+        };
+        engine.add_nodes(vec![
+            mk(20, "a.js", 5),
+            mk(21, "a.js", 5),
+            mk(22, "m.js", 100),
+            mk(23, "z.js", 1),
+        ]);
+        engine
+    }
+
+    #[test]
+    fn order_by_aggregate_expression_sorts_groups() {
+        // ORDER BY <aggregate function> in an aggregate query must sort by the
+        // computed aggregate. The Sort operator runs on HashAggregate output
+        // (columns keyed "n.file" / "total"); evaluating the raw FunctionCall
+        // expr returns NULL post-aggregation, so without a rewrite every row
+        // compares equal and the result stays in group-insertion order.
+        let engine = order_by_agg_graph();
+
+        let asc = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.file, SUM(n.lineCount) AS total ORDER BY SUM(n.lineCount) ASC",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        let asc_totals: Vec<i64> = asc.rows.iter().map(|r| r[1].as_i64().unwrap()).collect();
+        let asc_files: Vec<&str> = asc.rows.iter().map(|r| r[0].as_str().unwrap()).collect();
+        assert_eq!(asc_totals, vec![1, 10, 100], "totals must be ascending");
+        assert_eq!(asc_files, vec!["z.js", "a.js", "m.js"]);
+
+        let desc = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.file, SUM(n.lineCount) AS total ORDER BY SUM(n.lineCount) DESC",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        let desc_totals: Vec<i64> = desc.rows.iter().map(|r| r[1].as_i64().unwrap()).collect();
+        assert_eq!(desc_totals, vec![100, 10, 1], "totals must be descending");
+    }
+
+    #[test]
+    fn order_by_aliased_aggregate_sorts_groups() {
+        // ORDER BY the aggregate's alias must also sort (this already worked via
+        // the Variable lookup path, but is asserted to lock in the behavior).
+        let engine = order_by_agg_graph();
+        let res = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.file, SUM(n.lineCount) AS total ORDER BY total DESC",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        let totals: Vec<i64> = res.rows.iter().map(|r| r[1].as_i64().unwrap()).collect();
+        assert_eq!(totals, vec![100, 10, 1]);
+    }
+
+    #[test]
+    fn order_by_group_key_property_in_aggregate_query() {
+        // Sibling case: ORDER BY a group-key PROPERTY (n.file) in an aggregate
+        // query. Post-aggregation node `n` is gone and the column is keyed
+        // "n.file"; the raw Property("n","file") expr looked up absent var `n`,
+        // yielding NULL and no sort. Assert both directions so insertion order
+        // (which equals at most one of them) cannot satisfy both.
+        let engine = order_by_agg_graph();
+
+        let asc = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.file, SUM(n.lineCount) AS total ORDER BY n.file ASC",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        let asc_files: Vec<&str> = asc.rows.iter().map(|r| r[0].as_str().unwrap()).collect();
+        assert_eq!(asc_files, vec!["a.js", "m.js", "z.js"]);
+
+        let desc = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.file, SUM(n.lineCount) AS total ORDER BY n.file DESC",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        let desc_files: Vec<&str> = desc.rows.iter().map(|r| r[0].as_str().unwrap()).collect();
+        assert_eq!(desc_files, vec!["z.js", "m.js", "a.js"]);
+    }
 }


### PR DESCRIPTION
## Summary

In an aggregate Cypher query (`RETURN ... <agg> ... ORDER BY ...`), the engine **silently ignored `ORDER BY`** unless the sort term happened to be a bare alias variable. Results came back in group-insertion order, masquerading as sorted.

This is a net-new correctness bug found by dogfooding the RFDB Cypher engine (no open GitHub issue; Linear unavailable in this environment). It sits in the same family as the recent Cypher hardening PRs (#340–#344) but in an untouched area (the planner's aggregate `ORDER BY` wiring).

## Root cause

`packages/rfdb-server/src/cypher/planner.rs` — in the aggregate branch, `Sort` runs **after** `HashAggregate`. `HashAggregate` output records carry only the *produced* columns: one per group key (keyed by name/alias, e.g. `"n.file"`) and one per aggregate (keyed by its alias, e.g. `"total"`). But the `ORDER BY` AST still held the raw pattern expressions, which `eval_expr` cannot resolve against that post-aggregation record:

- `ORDER BY n.file` → `Property("n","file")` → looks up the node binding `n`, which **no longer exists** post-aggregation (only the string column `"n.file"` does) → `NULL` → no sort (`executor.rs:827`).
- `ORDER BY COUNT(*)` → `FunctionCall` → `eval_expr` returns `NULL` for function calls (aggregates aren't re-evaluated post-aggregation) → no sort (`executor.rs:906-917`).

Only `ORDER BY <alias>` (a `Variable`) worked, because the alias matches a produced column key.

## Fix

The planner now rewrites each `ORDER BY` term that matches a `RETURN` item — **structural equality** for group keys, **function name + argument** for aggregates — to a `Variable` referencing that item's produced column. `Sort` then reads the already-computed value. Terms that match nothing are left unchanged (no behavior change). `format_return_expr` is exposed `pub(crate)` so the planner reconstructs the *exact* group-key column names `HashAggregate` emits (the coupling is documented at both sites).

## SPEC (BDD)

- **Given** a graph grouped by `n.file` with grouped `SUM(n.lineCount)` of `z.js=1, a.js=10, m.js=100`
- **When** `MATCH (n:FUNCTION) RETURN n.file, SUM(n.lineCount) AS total ORDER BY SUM(n.lineCount) ASC`
- **Then** rows are `[z.js=1, a.js=10, m.js=100]` (ascending by the computed aggregate); `DESC` is the reverse.
- **And** `ORDER BY n.file` (group-key property) sorts by file; `ORDER BY total` (alias) keeps working.

**Invariant restored:** in an aggregate query, `ORDER BY <expr-in-RETURN>` sorts by the produced column for that expression.

## Before / After (live `cargo test`)

Both new tests were **RED before** the fix for the right reason:

```
---- order_by_aggregate_expression_sorts_groups ----
assertion `left == right` failed: totals must be descending
  left: [1, 10, 100]      # insertion order, unsorted
 right: [100, 10, 1]
---- order_by_group_key_property_in_aggregate_query ---- (also FAILED)
```

**AFTER:**
```
running 6 tests
test cypher::tests::integration_tests::order_by ... ok
test cypher::tests::integration_tests::order_by_desc ... ok
test cypher::tests::integration_tests::order_by_aliased_aggregate_sorts_groups ... ok
test cypher::tests::integration_tests::order_by_aggregate_expression_sorts_groups ... ok
test cypher::tests::integration_tests::order_by_with_limit ... ok
test cypher::tests::integration_tests::order_by_group_key_property_in_aggregate_query ... ok
test result: ok. 6 passed; 0 failed
```

Full gate (affected package):
```
cargo test -p rfdb --lib   -> test result: ok. 870 passed; 0 failed
cargo clippy --lib         -> no new warnings in cypher/{planner,executor,tests}.rs
```
(Change is Rust-only in `rfdb-server`; the JS CI suites are unaffected.)

## Adversarial review

- **Round A (correctness):** Aggregate with explicit alias + ordered by expression (`SUM(n.lineCount) AS total ORDER BY SUM(n.lineCount)`) resolves to `Variable("total")` — exercised by the passing test. Ordering by alias directly still works. Multiple aggregates of the same function with different args are disambiguated by argument match. Red tests assert both ASC and DESC so the unsorted insertion order (which can equal at most one direction) cannot satisfy both — robust against storage scan order.
- **Round B (structure):** `planner.rs` is ~300 lines (< 500). The one structural coupling (group-key column naming must match `HashAggregate`) is centralized in `group_key_name` / `format_return_expr` and documented at both sites. No god-file, no duplication introduced beyond the shared formatter.
- **Round C (class-not-instance):** Fixed **both** instances in the aggregate path (aggregate-function term **and** group-key-property term). Searched the sibling path and found one more instance, filed below.

## Sibling latent issue found (follow-up, out of scope)

Non-aggregate `RETURN x AS a ORDER BY a` is *also* unsorted, but via a **different** mechanism: there `Sort` runs **before** `Project`, so the alias column doesn't exist yet (the fix is the *opposite* rewrite: alias → underlying expr). Reproduced live: `MATCH (n:FUNCTION) RETURN n.file AS f ORDER BY f DESC` → `["a.js","z.js","a.js","m.js"]` (unsorted). Kept out of this PR to stay focused and single-concern; recommend a separate fix.

## Blast radius

Only the aggregate `ORDER BY` planning path. Non-aggregate ORDER BY (`Sort` before `Project`) is untouched; all pre-existing cypher tests (123) and the full rfdb-server lib suite (870) pass.

https://claude.ai/code/session_018A1MGRhHh3AUYq6ZJ2L4N2

---
_Generated by [Claude Code](https://claude.ai/code/session_018A1MGRhHh3AUYq6ZJ2L4N2)_