### PR TITLE
fix(rfdb): resolve RETURN aliases in non-aggregate ORDER BY

### DIFF
--- a/packages/rfdb-server/src/cypher/planner.rs
+++ b/packages/rfdb-server/src/cypher/planner.rs
@@ -150,9 +150,14 @@ pub fn plan<'a>(
             op = Box::new(Sort::new(op, order_by.clone(), limits));
         }
     } else {
-        // Sort before Project (operates on full node records).
+        // Sort before Project (operates on full node records). ORDER BY may
+        // reference a RETURN alias (e.g. `RETURN n.name AS nm ORDER BY nm`),
+        // but alias columns are not materialised until Project runs afterwards.
+        // Rewrite alias references to the underlying RETURN expression so Sort
+        // can evaluate them against the full pattern record.
         if let Some(ref order_by) = query.order_by {
-            op = Box::new(Sort::new(op, order_by.clone(), limits));
+            let order_by = rewrite_order_by_aliases(order_by, &query.return_clause);
+            op = Box::new(Sort::new(op, order_by, limits));
         }
 
         op = Box::new(Project::new(op, query.return_clause.items.clone()));
@@ -198,6 +203,65 @@ fn split_return_items(ret: &ReturnClause) -> (Vec<ReturnItem>, Vec<AggregateItem
     }
 
     (group_keys, aggregates)
+}
+
+/// Rewrite ORDER BY terms that reference a RETURN alias to the underlying
+/// RETURN expression, for the non-aggregate query path.
+///
+/// Here the `Sort` operator runs *before* `Project`, so it sees the raw pattern
+/// bindings (e.g. node `n`) but none of the RETURN-clause aliases, which
+/// `Project` materialises afterwards. An `ORDER BY <alias>` term is parsed as
+/// `Variable(alias)`; without this rewrite `eval_expr` looks up an absent
+/// variable, yields `NULL` for every row, and the result silently falls back to
+/// scan order (the ORDER BY no-ops). Mapping each such `Variable(alias)` back to
+/// the aliased expression lets `Sort` evaluate it against the full record.
+///
+/// Terms that match no alias — a raw property, or a variable that is a real
+/// pattern binding — are left unchanged.
+fn rewrite_order_by_aliases(
+    order_by: &[(Expr, SortDir)],
+    ret: &ReturnClause,
+) -> Vec<(Expr, SortDir)> {
+    order_by
+        .iter()
+        .map(|(expr, dir)| (rewrite_alias_expr(expr, ret), *dir))
+        .collect()
+}
+
+/// Recursively replace a `Variable(alias)` reference with the expression the
+/// matching aliased RETURN item projects. See [`rewrite_order_by_aliases`].
+///
+/// The substituted expression is returned as-is (not re-rewritten): RETURN
+/// expressions are pattern-scoped and cannot reference other aliases, so a
+/// single substitution suffices and self-aliases (`RETURN n AS n`) cannot loop.
+fn rewrite_alias_expr(expr: &Expr, ret: &ReturnClause) -> Expr {
+    if let Expr::Variable(name) = expr {
+        if let Some(item) = ret
+            .items
+            .iter()
+            .find(|it| it.alias.as_deref() == Some(name.as_str()))
+        {
+            return item.expr.clone();
+        }
+    }
+
+    match expr {
+        Expr::BinaryOp(l, op, r) => Expr::BinaryOp(
+            Box::new(rewrite_alias_expr(l, ret)),
+            *op,
+            Box::new(rewrite_alias_expr(r, ret)),
+        ),
+        Expr::And(l, r) => Expr::And(
+            Box::new(rewrite_alias_expr(l, ret)),
+            Box::new(rewrite_alias_expr(r, ret)),
+        ),
+        Expr::Or(l, r) => Expr::Or(
+            Box::new(rewrite_alias_expr(l, ret)),
+            Box::new(rewrite_alias_expr(r, ret)),
+        ),
+        Expr::Not(inner) => Expr::Not(Box::new(rewrite_alias_expr(inner, ret))),
+        other => other.clone(),
+    }
 }
 
 /// Format an expression for use in a generated alias.

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -2459,4 +2459,96 @@ mod integration_tests {
         assert_eq!(result.columns, vec!["f.name", "calls"]);
         assert!(result.row_count >= 1);
     }
+
+    // ── ORDER BY a RETURN alias in a non-aggregate query ──────────────────
+    //
+    // In the non-aggregate path the planner runs Sort BEFORE Project, so Sort
+    // sees the full pattern record (node bound to `n`) but NOT the RETURN
+    // aliases (which Project creates afterwards). `ORDER BY <alias>` is parsed
+    // as `Variable(alias)`; evaluating it against the pre-projection record
+    // yields NULL for every row, so the rows fall back to scan/insertion order
+    // and the ORDER BY silently no-ops. The fix rewrites alias references in
+    // ORDER BY to the underlying RETURN expression so Sort can evaluate them.
+    //
+    // The three FUNCTION nodes are inserted as main, helper, validate (id
+    // 10,11,12). Alphabetical ASC is helper,main,validate and DESC is
+    // validate,main,helper — neither equals insertion order, so a no-op sort
+    // cannot satisfy either assertion.
+
+    #[test]
+    fn order_by_alias_ascending_non_aggregate() {
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.name AS nm ORDER BY nm",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        assert_eq!(result.columns, vec!["nm"]);
+        let names: Vec<&str> = result
+            .rows
+            .iter()
+            .map(|row| row[0].as_str().unwrap())
+            .collect();
+        assert_eq!(names, vec!["helper", "main", "validate"]);
+    }
+
+    #[test]
+    fn order_by_alias_descending_non_aggregate() {
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.name AS nm ORDER BY nm DESC",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        assert_eq!(result.columns, vec!["nm"]);
+        let names: Vec<&str> = result
+            .rows
+            .iter()
+            .map(|row| row[0].as_str().unwrap())
+            .collect();
+        assert_eq!(names, vec!["validate", "main", "helper"]);
+    }
+
+    #[test]
+    fn order_by_alias_with_limit_non_aggregate() {
+        // The alias rewrite must compose with LIMIT: sort first, then take 2.
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.name AS nm ORDER BY nm DESC LIMIT 2",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        let names: Vec<&str> = result
+            .rows
+            .iter()
+            .map(|row| row[0].as_str().unwrap())
+            .collect();
+        assert_eq!(names, vec!["validate", "main"]);
+    }
+
+    #[test]
+    fn order_by_plain_property_still_works_non_aggregate() {
+        // Regression guard: ORDER BY a raw property (no alias indirection) must
+        // keep working — the rewrite must leave non-alias terms untouched.
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.name AS nm ORDER BY n.name DESC",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        let names: Vec<&str> = result
+            .rows
+            .iter()
+            .map(|row| row[0].as_str().unwrap())
+            .collect();
+        assert_eq!(names, vec!["validate", "main", "helper"]);
+    }
 }


### PR DESCRIPTION
## Summary

`ORDER BY <alias>` silently did not sort in **non-aggregate** Cypher queries.

In the non-aggregate path the planner builds `Sort` **before** `Project` (`packages/rfdb-server/src/cypher/planner.rs:152`), so `Sort` sees the raw pattern bindings (node `n`) but **none of the RETURN-clause aliases** — `Project` materialises those afterwards. The parser turns `ORDER BY nm` into `Expr::Variable("nm")` (`parser.rs:651`). Evaluating that against the pre-projection record (`executor.rs:834`: `record.get("nm")` → `None` → `CypherValue::Null`) yields `NULL` for every row, so all rows compare equal (`values.rs:162`) and the result silently falls back to scan/insertion order.

This is the **complementary sibling** of the open PR #345, which fixed the same class of bug on the *aggregate* path (Sort runs after HashAggregate there). #345 explicitly left the non-aggregate path untouched; this PR closes it.

## Spec

- **Invariant restored:** `ORDER BY <return-alias>` orders by the aliased value, identically to `ORDER BY <underlying-expression>`.
- **BDD:** *Given* `MATCH (n:FUNCTION) RETURN n.name AS nm`, *When* I append `ORDER BY nm DESC`, *Then* rows come back in descending `n.name` order — not scan order.
- **Blast radius:** one operator-tree branch in `plan()` (non-aggregate ORDER BY). Aggregate path, WHERE filtering, and raw-property ORDER BY are untouched. WHERE cannot reference RETURN aliases in standard Cypher (it precedes RETURN), so there is no latent twin there.

## Fix

`planner.rs` — before constructing `Sort` in the non-aggregate branch, rewrite each ORDER BY term: a `Variable(name)` that matches a RETURN item's alias is replaced by that item's underlying expression (recursing through compound `AND`/`OR`/`NOT`/comparison terms). Non-alias terms (raw properties, real pattern bindings) are left unchanged. Self-aliases (`RETURN n AS n`) substitute once without re-recursing, so they cannot loop.

## Before / After evidence

Failing red (before fix), `order_by_alias_descending_non_aggregate`:
```
assertion `left == right` failed
  left: ["main", "helper", "validate"]   # scan order — ORDER BY no-opped
 right: ["validate", "main", "helper"]
```

After fix:
```
$ cargo test -p rfdb --lib cypher::tests::integration_tests::order_by
running 7 tests
test ...::order_by_alias_with_limit_non_aggregate ... ok
test ...::order_by_alias_ascending_non_aggregate ... ok
test ...::order_by_alias_descending_non_aggregate ... ok
test ...::order_by ... ok
test ...::order_by_desc ... ok
test ...::order_by_plain_property_still_works_non_aggregate ... ok
test ...::order_by_with_limit ... ok
test result: ok. 7 passed; 0 failed
```

Full gate (Rust-only change, isolated to the `rfdb` crate):
```
$ cargo test -p rfdb --lib       → ok. 871 passed; 0 failed
$ cargo clippy -p rfdb --lib     → exit 0 (planner.rs clean; remaining warnings pre-existing in other files)
$ cargo build -p rfdb --bins     → Finished dev profile
```

## Adversarial review

- **Round A — correctness:** multi-term ORDER BY rewritten per term; self-alias does not infinite-loop (single substitution); unknown alias falls through unchanged (no behavior change); compound expressions recurse. Regression guard `order_by_plain_property_still_works_non_aggregate` confirms raw-property ORDER BY is unaffected.
- **Round B — structure:** `planner.rs` 275 lines (<500); both new functions carry agent-facing doc comments explaining the Sort-before-Project rationale.
- **Round C — class-not-instance:** aggregate-path twin is PR #345 (separate branch). No other Sort-before-Project alias gap exists in HEAD. No follow-ups needed.

## Sibling issues found
None beyond the already-open #345.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LdxDA8Lm4Yxcf1b8Xy2jjk)_