### PR TITLE
fix(rfdb): reject negative Cypher LIMIT (silent full-result-set bug)

### DIFF
--- a/packages/rfdb-server/src/cypher/parser.rs
+++ b/packages/rfdb-server/src/cypher/parser.rs
@@ -353,7 +353,21 @@ impl<'a> Parser<'a> {
 
         let limit = if self.keyword_ahead("LIMIT") {
             self.expect_keyword("LIMIT")?;
-            Some(self.parse_integer()? as u64)
+            // `parse_integer` accepts an optional leading sign, so a negative
+            // LIMIT would otherwise parse to a negative i64 and then wrap to a
+            // huge u64 via `as u64` (e.g. -1 → u64::MAX), making the Limit
+            // operator effectively unbounded — the query would silently return
+            // the entire result set instead of erroring. Reject it explicitly so
+            // a bad bound surfaces as a parse error, not wrong data.
+            let n_pos = self.pos;
+            let n = self.parse_integer()?;
+            if n < 0 {
+                return Err(ParseError::new(
+                    "LIMIT must be a non-negative integer",
+                    n_pos,
+                ));
+            }
+            Some(n as u64)
         } else {
             None
         };

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -219,6 +219,30 @@ mod parser_tests {
     }
 
     #[test]
+    fn limit_zero_parses() {
+        // LIMIT 0 is a valid (if pointless) non-negative bound.
+        let q = parse_cypher("MATCH (n:FUNCTION) RETURN n.name LIMIT 0").unwrap();
+        assert_eq!(q.limit, Some(0));
+    }
+
+    #[test]
+    fn negative_limit_rejected() {
+        // A negative LIMIT must be a parse error, not silently wrapped to a huge
+        // u64 (which would behave as "no limit" and return the entire result set).
+        let err = parse_cypher("MATCH (n:FUNCTION) RETURN n.name LIMIT -1")
+            .expect_err("LIMIT -1 must be rejected");
+        let msg = format!("{}", err).to_lowercase();
+        assert!(
+            msg.contains("limit") && msg.contains("non-negative"),
+            "expected a clear non-negative LIMIT error, got: {}",
+            msg
+        );
+
+        // Larger negative values are rejected the same way.
+        assert!(parse_cypher("MATCH (n:FUNCTION) RETURN n.name LIMIT -5").is_err());
+    }
+
+    #[test]
     fn full_complex_query() {
         let q = parse_cypher(
             "MATCH (f:FUNCTION)-[:CALLS]->(g) WHERE f.name = 'main' RETURN g.name, g.file LIMIT 5",
@@ -2458,5 +2482,41 @@ mod integration_tests {
         .unwrap();
         assert_eq!(result.columns, vec!["f.name", "calls"]);
         assert!(result.row_count >= 1);
+    }
+
+    #[test]
+    fn negative_limit_does_not_return_full_result_set() {
+        // Regression: `LIMIT -1` was parsed to i64 -1 then cast `as u64`, yielding
+        // u64::MAX — so the Limit operator never stopped and the query silently
+        // returned EVERY row instead of erroring. An agent that computes a limit
+        // and accidentally passes a negative value would get the whole graph back
+        // dressed up as a capped result. The fix rejects negative LIMIT at parse
+        // time, so execution surfaces a loud error rather than wrong data.
+        let engine = create_test_graph();
+
+        // Baseline: there is more than one FUNCTION node, so an unbounded scan
+        // returns multiple rows. This makes the "returned everything" failure
+        // mode observable.
+        let all = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        assert!(
+            all.row_count > 1,
+            "fixture must have >1 FUNCTION node for this test to be meaningful"
+        );
+
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.name LIMIT -1",
+            EvalLimits::none(),
+        );
+        assert!(
+            result.is_err(),
+            "negative LIMIT must error, not return {} rows",
+            result.map(|r| r.row_count).unwrap_or(0)
+        );
     }
 }


### PR DESCRIPTION
## Summary

A negative Cypher `LIMIT` (e.g. `LIMIT -1`) was **silently returning the entire result set** instead of erroring. This is an on-thesis silent-wrong-answer bug in the engine an AI agent queries: a result that looks like a capped page but is actually the whole graph.

## Spec

**Invariant restored:** `LIMIT n` either caps the result to `n` rows (`n ≥ 0`) or fails loudly. It must never silently behave as "unbounded".

**Given** a graph with more than one matching node
**When** a query runs with a negative bound, e.g. `MATCH (n:FUNCTION) RETURN n.name LIMIT -1`
**Then** the engine returns a parse error (`LIMIT must be a non-negative integer`), **not** the full result set.

`LIMIT 0` remains valid (returns 0 rows); non-negative bounds are unchanged.

## Root cause

`packages/rfdb-server/src/cypher/parser.rs` — the LIMIT clause did:

```rust
Some(self.parse_integer()? as u64)
```

`parse_integer` consumes an optional leading `-`/`+` sign, so `LIMIT -1` parsed to `-1_i64`, and `-1_i64 as u64 == u64::MAX`. The `Limit` operator's `remaining` counter (executor.rs) therefore never reached 0 and the pipeline yielded every row.

**Blast radius (class-not-instance):** `parse_integer` is called from exactly 3 sites (`rg parse_integer` in parser.rs): the LIMIT clause and the two var-length bounds (`*min..max`). The var-length callers guard with `is_ascii_digit()` *before* calling `parse_integer`, so a sign can never reach them — the LIMIT clause was the **only** vulnerable path. Negative number *literals* in `WHERE` go through `parse_number` (a different function), unaffected. The class is fully closed.

## Fix

Reject a negative LIMIT at parse time with a clear error, matching openCypher semantics (negative LIMIT is an error). Minimal, localized to the LIMIT block:

```rust
let n_pos = self.pos;
let n = self.parse_integer()?;
if n < 0 {
    return Err(ParseError::new("LIMIT must be a non-negative integer", n_pos));
}
Some(n as u64)
```

## Before / After (live evidence)

Reproduced with a throwaway probe against the test graph (removed before commit):

```
BEFORE  [MATCH (n:FUNCTION) RETURN n.name LIMIT -1]  → rows=[main, helper, validate]   (full set!)
BEFORE  [MATCH (n:FUNCTION) RETURN n.name LIMIT -5]  → rows=[main, helper, validate]   (full set!)
AFTER   [MATCH (n:FUNCTION) RETURN n.name LIMIT -1]  → Err(Parse: LIMIT must be a non-negative integer)
        [MATCH (n:FUNCTION) RETURN n.name LIMIT 0]   → rows=[]                          (unchanged)
        [MATCH (n:FUNCTION) RETURN n.name LIMIT 2]   → 2 rows                           (unchanged)
```

## Tests (TDD red → green)

- `parser_tests::negative_limit_rejected` — `LIMIT -1`/`LIMIT -5` must be parse errors (was: parsed OK).
- `parser_tests::limit_zero_parses` — `LIMIT 0` stays valid (`Some(0)`).
- `integration_tests::negative_limit_does_not_return_full_result_set` — end-to-end via `execute()`: negative LIMIT must error, asserted against a fixture with >1 row so the "returned everything" failure mode is observable.

Confirmed red-for-the-right-reason before the fix (expect_err failed / full set returned), green after.

## Adversarial review

- **Round A (correctness):** `LIMIT 0` → `Some(0)` (0 rows, correct); `LIMIT +5` → non-negative, accepted; `LIMIT 99999999999999999999` (i64 overflow) → existing "invalid integer" error (loud); no LIMIT → `None`. Var-length `*2..5` and negative literals in WHERE unaffected.
- **Round B (fragility):** change is 13 lines in the existing LIMIT block; a comment documents the `as u64` wrap trap for future maintainers. (Pre-existing note: `parser.rs` is ~940 lines and not rustfmt-maintained — out of scope to extract here, consistent with the #343/#344 Cypher-parser PRs.)
- **Round C (class/invariants):** only LIMIT fed a sign to `parse_integer`; class closed. No analysis-pipeline invariant touched.

## Verification

- `cargo test --lib` (rfdb): **870 passed / 0 failed**.
- `cargo clippy --lib`: no errors (pre-existing warnings only, none in the edited range).
- `cargo build --bins`: ok.
- `cargo fmt --check`: my added lines are clean; reported diffs are all pre-existing (crate isn't fmt-maintained).
- Rust-only change → Node CI gate unaffected.

## Source

No open GitHub issue / no Linear in this environment; this is a net-new correctness bug in the same RFDB Cypher-engine series as #340–#346 (each a genuine silent-wrong-answer fix), in a previously-untouched area (LIMIT bound validation).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJWggQZKgDMmz19vMDA2Sm)_