### PR TITLE
fix(rfdb): three-valued logic for Cypher string predicates under NOT (NULL operand)

### DIFF
--- a/packages/rfdb-server/src/cypher/executor.rs
+++ b/packages/rfdb-server/src/cypher/executor.rs
@@ -858,39 +858,33 @@ pub fn eval_expr(expr: &Expr, record: &Record) -> CypherValue {
         }
 
         Expr::Not(inner) => {
+            // Three-valued logic: NOT NULL is NULL, not TRUE. Without this, a
+            // predicate that evaluates to NULL (e.g. a string predicate against
+            // an absent property) would be flipped to a definite TRUE and
+            // wrongly admit the row in `WHERE NOT ...`.
             let v = eval_expr(inner, record);
-            CypherValue::Bool(!v.is_truthy())
+            match v {
+                CypherValue::Null => CypherValue::Null,
+                _ => CypherValue::Bool(!v.is_truthy()),
+            }
         }
 
         Expr::Contains(lhs, rhs) => {
             let l = eval_expr(lhs, record);
             let r = eval_expr(rhs, record);
-            match (&l, &r) {
-                (CypherValue::Str(a), CypherValue::Str(b)) => CypherValue::Bool(a.contains(b.as_str())),
-                _ => CypherValue::Bool(false),
-            }
+            eval_string_predicate(l, r, |a, b| a.contains(b))
         }
 
         Expr::StartsWith(lhs, rhs) => {
             let l = eval_expr(lhs, record);
             let r = eval_expr(rhs, record);
-            match (&l, &r) {
-                (CypherValue::Str(a), CypherValue::Str(b)) => {
-                    CypherValue::Bool(a.starts_with(b.as_str()))
-                }
-                _ => CypherValue::Bool(false),
-            }
+            eval_string_predicate(l, r, |a, b| a.starts_with(b))
         }
 
         Expr::EndsWith(lhs, rhs) => {
             let l = eval_expr(lhs, record);
             let r = eval_expr(rhs, record);
-            match (&l, &r) {
-                (CypherValue::Str(a), CypherValue::Str(b)) => {
-                    CypherValue::Bool(a.ends_with(b.as_str()))
-                }
-                _ => CypherValue::Bool(false),
-            }
+            eval_string_predicate(l, r, |a, b| a.ends_with(b))
         }
 
         Expr::IsNull(inner) => {
@@ -921,6 +915,30 @@ pub fn eval_expr(expr: &Expr, record: &Record) -> CypherValue {
 }
 
 // ─── Helper functions ───────────────────────────────────────────────────────
+
+/// Evaluate a Cypher string predicate (CONTAINS / STARTS WITH / ENDS WITH)
+/// over already-evaluated operands, applying three-valued logic.
+///
+/// Semantics (matching Neo4j):
+/// - if EITHER operand is NULL, the result is NULL (so that `NOT pred` stays
+///   NULL and the row is excluded, rather than being flipped to a definite
+///   TRUE and wrongly admitted);
+/// - if both operands are strings, return `Bool(test(a, b))`;
+/// - any other (non-NULL, non-string) combination yields `Bool(false)`,
+///   preserving the engine's prior behavior for type mismatches.
+fn eval_string_predicate(
+    lhs: CypherValue,
+    rhs: CypherValue,
+    test: impl Fn(&str, &str) -> bool,
+) -> CypherValue {
+    if matches!(lhs, CypherValue::Null) || matches!(rhs, CypherValue::Null) {
+        return CypherValue::Null;
+    }
+    match (&lhs, &rhs) {
+        (CypherValue::Str(a), CypherValue::Str(b)) => CypherValue::Bool(test(a, b)),
+        _ => CypherValue::Bool(false),
+    }
+}
 
 /// Convert a CypherLiteral to a CypherValue.
 fn literal_to_value(lit: &CypherLiteral) -> CypherValue {

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -1054,6 +1054,145 @@ mod executor_tests {
         assert!(filter.next().unwrap().is_none());
     }
 
+    /// Graph with a STRING metadata property `category` that is genuinely
+    /// present on one FUNCTION node ("withcat" = "alpha") and absent (NULL) on
+    /// two others ("nocat_none" has no metadata; "nocat_other" has metadata
+    /// without the key). Used to exercise three-valued logic of the string
+    /// predicates under NOT — `semanticId` cannot be used because NodeScan
+    /// synthesizes a non-NULL semanticId for every node.
+    fn create_string_metadata_graph() -> GraphEngineV2 {
+        let mut engine = GraphEngineV2::create_ephemeral();
+        engine.add_nodes(vec![
+            NodeRecord {
+                id: 1,
+                node_type: Some("FUNCTION".to_string()),
+                name: Some("withcat".to_string()),
+                file: Some("src/a.js".to_string()),
+                file_id: 0,
+                name_offset: 0,
+                version: "main".into(),
+                exported: true,
+                replaces: None,
+                deleted: false,
+                metadata: Some(r#"{"category": "alpha"}"#.to_string()),
+                semantic_id: None,
+            },
+            NodeRecord {
+                id: 2,
+                node_type: Some("FUNCTION".to_string()),
+                name: Some("nocat_none".to_string()),
+                file: Some("src/b.js".to_string()),
+                file_id: 0,
+                name_offset: 0,
+                version: "main".into(),
+                exported: false,
+                replaces: None,
+                deleted: false,
+                metadata: None,
+                semantic_id: None,
+            },
+            NodeRecord {
+                id: 3,
+                node_type: Some("FUNCTION".to_string()),
+                name: Some("nocat_other".to_string()),
+                file: Some("src/c.js".to_string()),
+                file_id: 0,
+                name_offset: 0,
+                version: "main".into(),
+                exported: false,
+                replaces: None,
+                deleted: false,
+                metadata: Some(r#"{"other": 1}"#.to_string()),
+                semantic_id: None,
+            },
+        ]);
+        engine
+    }
+
+    /// Collect FUNCTION node names that pass `predicate` against the
+    /// string-metadata fixture, sorted.
+    fn filtered_names(predicate: Expr) -> Vec<String> {
+        let engine = create_string_metadata_graph();
+        let limits = default_limits();
+        let scan = NodeScan::new(
+            &engine,
+            Some("n".to_string()),
+            vec!["FUNCTION".to_string()],
+            vec![],
+            &limits,
+        );
+        let mut filter = Filter::new(Box::new(scan), predicate);
+        let mut names = Vec::new();
+        while let Some(rec) = filter.next().unwrap() {
+            if let CypherValue::Str(s) = rec.get("n").unwrap().property("name") {
+                names.push(s);
+            }
+        }
+        names.sort();
+        names
+    }
+
+    /// Regression (three-valued logic): `WHERE NOT n.<prop> CONTAINS 'x'` must
+    /// EXCLUDE nodes whose property is NULL (absent), matching Cypher/Neo4j
+    /// semantics. Before the fix, CONTAINS returned `Bool(false)` for a NULL
+    /// operand, and `NOT Bool(false)` is `Bool(true)`, so the row was wrongly
+    /// admitted. Correct: `null CONTAINS 'x' = null`, `NOT null = null` (excluded).
+    ///
+    /// `NOT category CONTAINS 'a'` matches NOTHING: "withcat" ("alpha") contains
+    /// 'a' (NOT -> false), and the two NULL-category nodes stay NULL.
+    #[test]
+    fn filter_not_contains_null_property_excluded() {
+        let names = filtered_names(Expr::Not(Box::new(Expr::Contains(
+            Box::new(Expr::Property("n".to_string(), "category".to_string())),
+            Box::new(Expr::Literal(CypherLiteral::Str("a".to_string()))),
+        ))));
+        assert!(
+            names.is_empty(),
+            "NOT CONTAINS on a NULL property must exclude null-valued rows, got {:?}",
+            names
+        );
+    }
+
+    /// Sibling of `filter_not_contains_null_property_excluded` for STARTS WITH.
+    #[test]
+    fn filter_not_starts_with_null_property_excluded() {
+        let names = filtered_names(Expr::Not(Box::new(Expr::StartsWith(
+            Box::new(Expr::Property("n".to_string(), "category".to_string())),
+            Box::new(Expr::Literal(CypherLiteral::Str("al".to_string()))),
+        ))));
+        assert!(
+            names.is_empty(),
+            "NOT STARTS WITH on a NULL property must exclude null-valued rows, got {:?}",
+            names
+        );
+    }
+
+    /// Sibling of `filter_not_contains_null_property_excluded` for ENDS WITH.
+    #[test]
+    fn filter_not_ends_with_null_property_excluded() {
+        let names = filtered_names(Expr::Not(Box::new(Expr::EndsWith(
+            Box::new(Expr::Property("n".to_string(), "category".to_string())),
+            Box::new(Expr::Literal(CypherLiteral::Str("ha".to_string()))),
+        ))));
+        assert!(
+            names.is_empty(),
+            "NOT ENDS WITH on a NULL property must exclude null-valued rows, got {:?}",
+            names
+        );
+    }
+
+    /// Guard against over-correction: a direct (non-negated) CONTAINS on a NULL
+    /// property still EXCLUDES the row (NULL is not truthy) and still matches the
+    /// non-null hit. Passes both before and after the fix.
+    #[test]
+    fn filter_contains_null_property_still_excludes_and_matches() {
+        let names = filtered_names(Expr::Contains(
+            Box::new(Expr::Property("n".to_string(), "category".to_string())),
+            Box::new(Expr::Literal(CypherLiteral::Str("a".to_string()))),
+        ));
+        assert_eq!(names, vec!["withcat"]);
+    }
+
     #[test]
     fn filter_exported_boolean() {
         let engine = create_test_graph();
@@ -1634,6 +1773,52 @@ mod executor_tests {
             &rec,
         );
         assert_eq!(result, CypherValue::Bool(true));
+    }
+
+    /// Three-valued logic for the string predicates and `NOT`: a NULL operand
+    /// yields NULL (not `Bool(false)`), and `NOT NULL` stays NULL (not
+    /// `Bool(true)`). This is the mechanism behind `WHERE NOT x CONTAINS 'y'`
+    /// correctly excluding rows where `x` is NULL.
+    #[test]
+    fn eval_expr_string_predicates_null_operand_yields_null() {
+        let rec = Record::new(); // empty record: Variable("x") evaluates to NULL
+
+        for pred in [
+            Expr::Contains(
+                Box::new(Expr::Variable("x".to_string())),
+                Box::new(Expr::Literal(CypherLiteral::Str("y".to_string()))),
+            ),
+            Expr::StartsWith(
+                Box::new(Expr::Variable("x".to_string())),
+                Box::new(Expr::Literal(CypherLiteral::Str("y".to_string()))),
+            ),
+            Expr::EndsWith(
+                Box::new(Expr::Variable("x".to_string())),
+                Box::new(Expr::Literal(CypherLiteral::Str("y".to_string()))),
+            ),
+        ] {
+            assert_eq!(eval_expr(&pred, &rec), CypherValue::Null);
+            // NOT NULL must remain NULL (three-valued logic), not flip to true.
+            let negated = Expr::Not(Box::new(pred));
+            assert_eq!(eval_expr(&negated, &rec), CypherValue::Null);
+        }
+
+        // The NULL guard fires on EITHER operand: a NULL right-hand side too.
+        let rhs_null = Expr::Contains(
+            Box::new(Expr::Literal(CypherLiteral::Str("abc".to_string()))),
+            Box::new(Expr::Variable("x".to_string())),
+        );
+        assert_eq!(eval_expr(&rhs_null, &rec), CypherValue::Null);
+    }
+
+    /// `NOT` on a definite boolean is unchanged: only the NULL arm is special.
+    #[test]
+    fn eval_expr_not_on_boolean_unchanged() {
+        let rec = Record::new();
+        let t = Expr::Not(Box::new(Expr::Literal(CypherLiteral::Bool(true))));
+        assert_eq!(eval_expr(&t, &rec), CypherValue::Bool(false));
+        let f = Expr::Not(Box::new(Expr::Literal(CypherLiteral::Bool(false))));
+        assert_eq!(eval_expr(&f, &rec), CypherValue::Bool(true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`WHERE NOT n.prop CONTAINS 'x'` (and `STARTS WITH` / `ENDS WITH`) silently **admitted nodes whose property is NULL/absent** — a wrong-answer bug in the RFDB Cypher engine. This is the sibling follow-up **explicitly filed but left unfixed by PR #341** ("Contains/StartsWith/EndsWith return Bool(false) on NULL → wrong under NOT").

No GitHub issue / Linear ticket exists for this (0 open GH issues; web env has no Linear MCP). Source is the documented follow-up backlog of the #337–#347 Cypher-correctness sweep.

## Spec

**Invariant restored:** Cypher three-valued logic — a string predicate against a NULL operand evaluates to NULL (not `false`), and `NOT NULL = NULL`, so the row is excluded.

**Given** a FUNCTION node whose `category` property is absent (NULL)
**When** the query is `WHERE NOT n.category CONTAINS 'a'`
**Then** the node is **excluded** (Neo4j: `null CONTAINS 'a' = null`, `NOT null = null`), not admitted.

## Root cause (current HEAD, `packages/rfdb-server/src/cypher/executor.rs`)

Two sites, both required:

1. `Contains`/`StartsWith`/`EndsWith` (lines ~865–894) returned `Bool(false)` for *any* non-`(Str,Str)` pair, **including a NULL operand**.
2. `Not(inner)` (lines ~860–863) returned `Bool(!is_truthy(v))`, so `Not(Null) → is_truthy(Null)=false → Bool(true)`.

Combined under `NOT`:
```
Contains(Null, 'x') → Bool(false) → Not → Bool(true) → row ADMITTED  (wrong)
```
The direct (non-negated) form was already observably correct (`null` and `false` both drop the row), which is why only the `NOT` case exposes the bug.

## Fix

- New helper `eval_string_predicate(l, r, test)`: returns `Null` when **either** operand is `Null`; `Bool(test(a,b))` for two strings; `Bool(false)` for other type mismatches (prior behavior preserved). Removes the 3× duplicated match.
- `Not` now propagates NULL (`Null → Null`); the boolean arm is unchanged.

Mirrors the NULL-guard precedent of PR #341 (comparison ops). Both changes are necessary — the predicate must produce `Null` *and* `Not` must preserve it.

## Before / After evidence

New tests fail **red for the right reason** before the fix:
```
test eval_expr_string_predicates_null_operand_yields_null ... FAILED
  left: Bool(false)   right: Null
test filter_not_contains_null_property_excluded   ... FAILED
test filter_not_starts_with_null_property_excluded ... FAILED
test filter_not_ends_with_null_property_excluded   ... FAILED
test result: FAILED. 2 passed; 4 failed
```
Green after the fix:
```
test filter_not_contains_null_property_excluded             ... ok
test filter_not_starts_with_null_property_excluded          ... ok
test filter_not_ends_with_null_property_excluded            ... ok
test filter_contains_null_property_still_excludes_and_matches ... ok
test eval_expr_string_predicates_null_operand_yields_null   ... ok
test eval_expr_not_on_boolean_unchanged                     ... ok
test result: ok. 873 passed; 0 failed   (867 pre-existing + 6 new)
```
`cargo clippy -p rfdb --lib` → exit 0. Added code is rustfmt-clean in isolation (the crate has pre-existing fmt drift unrelated to this change).

## Adversarial review

- **Round A (correctness):** both operands NULL → `Null` (guard fires on either side, covered by `rhs_null` assertion); empty-pattern `"x".contains("")` and Unicode unchanged; non-null non-string still `Bool(false)` (unchanged). `Not` boolean arm verified unchanged (`eval_expr_not_on_boolean_unchanged`).
- **Round B (structure):** 3 duplicated match arms collapsed into one documented helper; no file growth of concern; no new god-file.
- **Round C (class, not instance):** fixed the whole string-predicate class via one helper + the `Not` 3VL change. **Testing trap found:** `NodeScan` synthesizes a non-NULL `semanticId` (`name@file`) for every node, so `semanticId` cannot exercise NULL-property behavior — the fixture uses a genuinely-absent metadata **string** field (`create_string_metadata_graph`).

## Blast radius

`eval_expr` `Not`/string-predicate arms feed Filter/Project/Sort/HashAggregate. The only behavioral change is when a sub-expression evaluates to `Null`: previously `NOT` yielded a definite `true`, now `Null` (correctly dropped in WHERE; correctly `null` in projections). No other call sites touched.

## Follow-ups (filed, intentionally out of scope to keep this focused)

- `AND`/`OR` collapse `Null` via `is_truthy` rather than full Kleene 3VL, so `NOT (nullExpr AND true)` is still incorrect under nesting.
- Non-null, non-string operands still return `Bool(false)` where Neo4j returns `null`.
- `eval_binop` has no NULL short-circuit in this base (`d01c08a`) — that is open PR #341. This `Not` fix **complements** #341: once merged, comparisons-under-`NOT` also become correct. Same base, disjoint code regions, no conflict.

🤖 Autonomous fix. Owner reviews — auto-merge intentionally not armed.

---
_Generated by [Claude Code](https://claude.ai/code/session_011nH3iTMGatcmPcxeHw8vsA)_