### PR TITLE
fix(rfdb): boundary-safe Cypher keyword probe (UTF-8 panic)

### DIFF
--- a/packages/rfdb-server/src/cypher/parser.rs
+++ b/packages/rfdb-server/src/cypher/parser.rs
@@ -96,18 +96,24 @@ impl<'a> Parser<'a> {
     fn keyword_ahead(&mut self, kw: &str) -> bool {
         self.skip_whitespace();
         let rem = self.remaining();
-        if rem.len() < kw.len() {
+        // `str::get(..kw.len())` returns `None` both when the remaining input
+        // is shorter than the keyword AND when `kw.len()` does not fall on a
+        // UTF-8 char boundary (e.g. a multibyte char straddles that index).
+        // This avoids the panic that a raw `rem[..kw.len()]` byte slice would
+        // hit when non-ASCII input appears where a keyword is probed.
+        let head = match rem.get(..kw.len()) {
+            Some(h) => h,
+            None => return false,
+        };
+        if !head.eq_ignore_ascii_case(kw) {
             return false;
         }
-        if !rem[..kw.len()].eq_ignore_ascii_case(kw) {
-            return false;
+        // Must be followed by non-alphanumeric (word boundary) or end of input.
+        // `kw.len()` is a valid boundary here because `get(..kw.len())` succeeded.
+        match rem[kw.len()..].chars().next() {
+            None => true,
+            Some(next_char) => !next_char.is_alphanumeric() && next_char != '_',
         }
-        // Must be followed by non-alphanumeric (word boundary) or end of input
-        if rem.len() == kw.len() {
-            return true;
-        }
-        let next_char = rem[kw.len()..].chars().next().unwrap();
-        !next_char.is_alphanumeric() && next_char != '_'
     }
 
     /// Consume a keyword (case-insensitive) or return an error.

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -519,6 +519,53 @@ mod parser_tests {
     }
 
     #[test]
+    fn multibyte_char_where_keyword_expected_errors_not_panics() {
+        // A multibyte UTF-8 char sitting where a keyword check happens must
+        // produce a clean ParseError, not panic on a non-char-boundary byte
+        // slice. Here, after `n.name = 'x'` the expression parser probes for
+        // `OR`/`AND` (2/3-byte keywords) against a 3-byte char (好, U+597D).
+        let multibyte = String::from_utf8(vec![0xE5, 0xA5, 0xBD]).unwrap();
+        let query = format!("MATCH (n) WHERE n.name = 'x' {}", multibyte);
+        let err = parse_cypher(&query).unwrap_err();
+        assert!(
+            err.message.contains("expected keyword 'RETURN'"),
+            "unexpected message: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn multibyte_trailing_input_errors_not_panics() {
+        // Trailing multibyte input after a complete query reaches the
+        // `ORDER`/`LIMIT` keyword probes (5-byte keywords) against a 6-byte
+        // run (ααα, three U+03B1). The byte index 5 lands mid-char.
+        let multibyte = String::from_utf8(vec![0xCE, 0xB1, 0xCE, 0xB1, 0xCE, 0xB1]).unwrap();
+        let query = format!("MATCH (n) RETURN n {}", multibyte);
+        let err = parse_cypher(&query).unwrap_err();
+        assert!(
+            err.message.contains("unexpected input after query"),
+            "unexpected message: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn multibyte_immediately_before_real_keyword_still_parses() {
+        // Guard: a legitimate non-ASCII string literal followed by ORDER BY
+        // must still parse — the boundary-safe keyword check must not regress
+        // normal keyword detection.
+        let cyrillic =
+            String::from_utf8(vec![0xD1, 0x82, 0xD0, 0xB5, 0xD1, 0x81, 0xD1, 0x82]).unwrap(); // "тест"
+        let query = format!(
+            "MATCH (n) WHERE n.name = '{}' RETURN n.name ORDER BY n.name LIMIT 5",
+            cyrillic
+        );
+        let q = parse_cypher(&query).unwrap();
+        assert!(q.order_by.is_some());
+        assert_eq!(q.limit, Some(5));
+    }
+
+    #[test]
     fn line_comment_ignored() {
         let q = parse_cypher(
             "// Find all functions\nMATCH (n:FUNCTION) RETURN n.name",


### PR DESCRIPTION
## Summary

The Cypher parser's `keyword_ahead` probe sliced the remaining input with a **byte** slice `rem[..kw.len()]`. When non-ASCII input appears where a keyword is probed and a multibyte UTF-8 character straddles byte index `kw.len()`, the slice lands off a char boundary and **panics** (`byte index N is not a char boundary`), crashing the query-execution thread instead of returning a clean `ParseError`. The pre-existing `rem.len() < kw.len()` guard only handled remainders *shorter* than the keyword — not boundary misalignment when the remainder is long enough.

Reachable from any `execute()` → `parse_cypher()` call (`cypher/mod.rs:32`), so an agent/client query carrying a stray non-ASCII byte at a keyword decision point crashes the RFDB Cypher engine. On-thesis (AI queries the graph): such a query should return an error, not crash.

## Spec

- **Invariant restored:** parsing any input string is total — it returns `Ok(query)` or `Err(ParseError)`, never panics, regardless of UTF-8 content.
- **Acceptance (BDD):**
  - *Given* a Cypher string with a multibyte char where a keyword is probed, *When* parsed, *Then* a `ParseError` is returned (no panic).
  - *Given* a valid query whose string literal contains non-ASCII text followed by real `ORDER BY`/`LIMIT` keywords, *When* parsed, *Then* it parses successfully (no regression in keyword detection).

## Root cause

`packages/rfdb-server/src/cypher/parser.rs` `keyword_ahead` (line ~102):
```rust
if !rem[..kw.len()].eq_ignore_ascii_case(kw) {   // byte slice -> panics off-boundary
```

## Fix

Probe with `str::get(..kw.len())`, which returns `None` for **both** an out-of-range index and a non-char-boundary index. The subsequent `rem[kw.len()..]` is then provably on a boundary (only reached after `get` succeeded).

## Before / After

Baseline (RED) — the new repro tests panic on `parser.rs:102:16`:
```
thread '...' panicked: byte index 5 is not a char boundary; ...
   6: rfdb::cypher::parser::Parser::keyword_ahead at ./src/cypher/parser.rs:102:16
test result: FAILED. 0 passed; 3 failed
```
After fix (GREEN):
```
test ...::multibyte_char_where_keyword_expected_errors_not_panics ... ok
test ...::multibyte_trailing_input_errors_not_panics ... ok
test ...::multibyte_immediately_before_real_keyword_still_parses ... ok
test result: ok. 3 passed; 0 failed
```

## Adversarial review

- **Round A (correctness):** empty input → `get(..n)`=None→false ✓; exact end-of-input match (`rem=="OR"`) → `get(..2)`=Some, `rem[2..]`=None→true ✓ (identical to old behavior); keyword followed by alphanumeric multibyte (`"OR好"`) → false, same as old ✓; straddling char → None→false ("not the keyword") ✓; ASCII case-insensitivity preserved via `eq_ignore_ascii_case`.
- **Round B (fragility):** single-function change, no new coupling; `rem[kw.len()..]` boundary-safety documented inline.
- **Round C (class-not-instance):** audited every byte slice in this parser — line 102 was the only panic-prone one; line 109 depends on it (now safe), line 848's `[1..]` is guarded by an ASCII `-`, and all `input[pos..]`/`input[start..pos]` indices advance via `len_utf8()`. The Datalog parser (`datalog/parser.rs`) detects keywords with `starts_with` and is unaffected. **Class fully closed — no follow-ups filed.**

## Verification

```
cargo test -p rfdb --lib            -> 870 passed; 0 failed
cargo clippy -p rfdb --lib          -> exit 0 (3 pre-existing warnings, none in changed code)
```
Rust-only change; does not affect the Node CI gate. The crate is not `rustfmt`-maintained (pre-existing diffs crate-wide); the added/edited lines are themselves `rustfmt`-clean.

## Blast radius

`keyword_ahead` is the keyword detector for the whole Cypher grammar (`WHERE`/`ORDER`/`LIMIT`/`OR`/`AND`/`NOT`/`IS`/`CONTAINS`/`STARTS`/`ENDS`/`AS`/`ASC`/`DESC`/`TRUE`/`FALSE`/`NULL`). The change only narrows behavior on inputs that previously panicked; all keyword-match outcomes on valid input are unchanged.

https://claude.ai/code/session_01AtwjELywyM3pae9cAmkstC

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtwjELywyM3pae9cAmkstC)_