### PR TITLE
fix(rfdb): Cypher ORDER BY places NULLs last (ASC) / first (DESC) per spec

### DIFF
--- a/packages/rfdb-server/src/cypher/executor.rs
+++ b/packages/rfdb-server/src/cypher/executor.rs
@@ -629,9 +629,7 @@ impl<'a> Sort<'a> {
             for (expr, dir) in order_by {
                 let va = eval_expr(expr, a);
                 let vb = eval_expr(expr, b);
-                let cmp = va
-                    .partial_cmp_values(&vb)
-                    .unwrap_or(std::cmp::Ordering::Equal);
+                let cmp = order_cmp(&va, &vb);
                 let cmp = match dir {
                     SortDir::Asc => cmp,
                     SortDir::Desc => cmp.reverse(),
@@ -921,6 +919,32 @@ pub fn eval_expr(expr: &Expr, record: &Record) -> CypherValue {
 }
 
 // ─── Helper functions ───────────────────────────────────────────────────────
+
+/// Ordering comparator for `ORDER BY`, applied in the *ascending* direction
+/// (callers reverse it for `DESC`).
+///
+/// Implements Cypher/Neo4j ordering semantics for NULL: a null value is
+/// considered **greater than** any non-null value, so it sorts LAST under
+/// ascending order and FIRST under descending order (see the Neo4j Cypher
+/// manual, "Ordering null"). This deliberately differs from
+/// [`CypherValue::partial_cmp_values`], which treats null as the smallest
+/// value — that comparator is shared with WHERE-clause comparisons
+/// (`eval_binop`) and must not change. ORDER BY needs its own null rule, so
+/// it lives here rather than in the shared value comparator.
+///
+/// Non-null, mutually-incomparable values (e.g. a Str vs an Int, or two
+/// Node values) fall back to `Ordering::Equal`, preserving the prior
+/// best-effort behaviour for heterogeneous columns.
+fn order_cmp(a: &CypherValue, b: &CypherValue) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    match (a, b) {
+        (CypherValue::Null, CypherValue::Null) => Ordering::Equal,
+        // null is greater than any non-null value -> sorts last ascending.
+        (CypherValue::Null, _) => Ordering::Greater,
+        (_, CypherValue::Null) => Ordering::Less,
+        _ => a.partial_cmp_values(b).unwrap_or(Ordering::Equal),
+    }
+}
 
 /// Convert a CypherLiteral to a CypherValue.
 fn literal_to_value(lit: &CypherLiteral) -> CypherValue {

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -2346,6 +2346,54 @@ mod integration_tests {
         assert_eq!(result.rows[0][0], serde_json::json!(30));
     }
 
+    // ── ORDER BY null ordering (Cypher/Neo4j semantics) ─────────────────
+    //
+    // Cypher treats null as GREATER than any non-null value for ordering:
+    // nulls sort LAST in ascending order and FIRST in descending order
+    // (Neo4j Cypher manual, "Ordering null"). The numeric fixture has one
+    // node (`d`) with no `lineCount`, so `n.lineCount` is NULL for it.
+
+    #[test]
+    fn order_by_nulls_last_ascending() {
+        let engine = create_numeric_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.name, n.lineCount ORDER BY n.lineCount",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        let names: Vec<&str> = result
+            .rows
+            .iter()
+            .map(|row| row[0].as_str().unwrap())
+            .collect();
+        // a=10, b=20, c=30 ascending, then d (NULL lineCount) LAST.
+        assert_eq!(names, vec!["a", "b", "c", "d"]);
+        // The trailing row really is the NULL one (projects to JSON null).
+        assert_eq!(result.rows[3][1], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn order_by_nulls_first_descending() {
+        let engine = create_numeric_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.name, n.lineCount ORDER BY n.lineCount DESC",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        let names: Vec<&str> = result
+            .rows
+            .iter()
+            .map(|row| row[0].as_str().unwrap())
+            .collect();
+        // d (NULL lineCount) FIRST, then c=30, b=20, a=10 descending.
+        assert_eq!(names, vec!["d", "c", "b", "a"]);
+        assert_eq!(result.rows[0][1], serde_json::Value::Null);
+    }
+
     #[test]
     fn sum_aggregate_grouped() {
         // Two groups by file, each with distinct numeric sums.


### PR DESCRIPTION
## Summary

The Cypher `Sort` operator ordered `NULL` as **smaller** than every value, so `ORDER BY x` surfaced rows with a missing / `NULL` property **first** in ascending order (and last in descending) — inverted from Cypher/Neo4j semantics, where *null is treated as greater than any non-null value* (nulls last in ASC, first in DESC; Neo4j Cypher manual, "Ordering null").

In this graph, properties such as `lineCount`, `semantic_id`, and other metadata fields are routinely absent (→ `NULL`), so `ORDER BY n.lineCount` buried the real, populated results under the missing-value rows.

This is a distinct, fully orthogonal Cypher-conformance fix in the same series as the other open `rfdb` PRs (#341 = NULL in WHERE comparisons; #345/#346 = ORDER BY alias/column resolution). None of those touch Sort's NULL ordering.

## Spec (BDD)

- **Invariant restored:** Cypher ORDER BY null ordering — null sorts as greater than any non-null value.
- **Given** a set of nodes where some have a `NULL` value for the sort key
  **When** the result is ordered `ASC` by that key
  **Then** the non-null values come first in ascending order and the `NULL` rows come **last**.
- **Given** the same set
  **When** ordered `DESC`
  **Then** the `NULL` rows come **first**, then non-null values in descending order.

## Root cause

`Sort::materialize` reused `CypherValue::partial_cmp_values`, whose `Null` arms return `Ordering::Less` (`packages/rfdb-server/src/cypher/values.rs:163`). That comparator is **shared** with WHERE-clause comparisons (`eval_binop`, the territory of #341) and must not change. So ORDER BY now uses a dedicated, documented `order_cmp` helper that applies the *null-is-greatest* rule **only** for sorting; `partial_cmp_values` and `eval_binop` are untouched.

```rust
fn order_cmp(a: &CypherValue, b: &CypherValue) -> std::cmp::Ordering {
    match (a, b) {
        (Null, Null) => Equal,
        (Null, _) => Greater,   // null sorts last ascending
        (_, Null) => Less,
        _ => a.partial_cmp_values(b).unwrap_or(Equal),
    }
}
```
Direction (`DESC`) reverses the per-key comparison as before, so nulls correctly flip to first.

## Before / After evidence

Failing test (RED), pre-fix — `ORDER BY n.lineCount` (fixture: a=10, b=20, c=30, d=NULL):
```
assertion `left == right` failed
  left: ["d", "a", "b", "c"]    # NULL first (bug)
 right: ["a", "b", "c", "d"]    # expected: NULL last
```

Post-fix:
```
test cypher::tests::integration_tests::order_by_nulls_last_ascending ... ok
test cypher::tests::integration_tests::order_by_nulls_first_descending ... ok
```

Full crate suite:
```
cargo test --lib   ->  test result: ok. 869 passed; 0 failed; 0 ignored
```
(`cargo fmt --check` clean on the touched file; pre-existing fmt drift in `benches/graph_operations.rs` is unrelated and untouched.)

## Adversarial review

- **Round A — correctness:** multi-key ORDER BY (null in primary → ties fall through to next key; per-key direction independently reverses null placement, matching Cypher); all-null column (stable order preserved via `sort_by`); `Node`/heterogeneous columns (incomparable → `Equal`, prior best-effort behaviour preserved); `NaN` floats (unchanged, `unwrap_or(Equal)`); empty / single-row inputs.
- **Round B — fragility:** the helper is documented specifically to explain *why* it must stay separate from `partial_cmp_values`, so a future "simplification" that re-routes Sort through the shared comparator (and silently reintroduces this bug) is guarded against. `executor.rs` was already >500 lines pre-change; this adds ~25 documented lines and does not create the god-file (splitting it is out of scope).
- **Round C — class-not-instance:** audited every `sort_by` / `partial_cmp_values` use in the crate. All other sorts are concrete-key storage/index/layout sorts (ids, counts, hex coords) with no `NULL` semantics. `Sort` is the **sole** ORDER-BY/`CypherValue` ordering path — the class is fully covered, no sibling latent bug, no follow-ups needed.

## Blast radius

Rust-only change inside the `rfdb` crate (`cypher/executor.rs` + its tests). No JS/TS, no API/wire-format, no graph-shape changes — only the row order of `ORDER BY` queries that contain `NULL` sort-key values. JS CI suites are unaffected (no JS/TS files touched).

Source: in-env triage (no open GitHub issues / no Linear MCP this run); recorded under the autonomous web-session intake series in Enox.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BTe7QGKBSwZ6XrcRMNiGWJ)_