### PR TITLE
fix(rfdb): Kleene three-valued logic for Cypher AND/OR with NULL operands

### DIFF
--- a/packages/rfdb-server/src/cypher/executor.rs
+++ b/packages/rfdb-server/src/cypher/executor.rs
@@ -868,21 +868,41 @@ pub fn eval_expr(expr: &Expr, record: &Record) -> CypherValue {
         }
 
         Expr::And(lhs, rhs) => {
-            let l = eval_expr(lhs, record);
-            if !l.is_truthy() {
+            // Kleene three-valued AND. FALSE dominates (short-circuits even past a
+            // NULL operand: `null AND false = false`); otherwise NULL is contagious
+            // (`true AND null = null`, `null AND true = null`). Collapsing a NULL
+            // operand to `Bool(false)` here would be wrong under `NOT`: it makes
+            // `NOT (null AND true)` become `NOT false = true`, wrongly admitting a
+            // row whose predicate is unknown. See `Expr::Not` below for the
+            // complementary NULL-preserving rule. Non-NULL operands fall through
+            // `kleene_truth` to `is_truthy()`, so their behaviour is unchanged.
+            let l = kleene_truth(&eval_expr(lhs, record));
+            if l == Some(false) {
                 return CypherValue::Bool(false);
             }
-            let r = eval_expr(rhs, record);
-            CypherValue::Bool(r.is_truthy())
+            let r = kleene_truth(&eval_expr(rhs, record));
+            kleene_value(match (l, r) {
+                (_, Some(false)) => Some(false),
+                (Some(true), Some(true)) => Some(true),
+                _ => None,
+            })
         }
 
         Expr::Or(lhs, rhs) => {
-            let l = eval_expr(lhs, record);
-            if l.is_truthy() {
+            // Kleene three-valued OR. TRUE dominates (`null OR true = true`);
+            // otherwise NULL is contagious (`null OR false = null`, `false OR
+            // null = null`). As with AND, collapsing a NULL operand to
+            // `Bool(false)` would wrongly admit rows under `NOT`.
+            let l = kleene_truth(&eval_expr(lhs, record));
+            if l == Some(true) {
                 return CypherValue::Bool(true);
             }
-            let r = eval_expr(rhs, record);
-            CypherValue::Bool(r.is_truthy())
+            let r = kleene_truth(&eval_expr(rhs, record));
+            kleene_value(match (l, r) {
+                (_, Some(true)) => Some(true),
+                (Some(false), Some(false)) => Some(false),
+                _ => None,
+            })
         }
 
         Expr::Not(inner) => {
@@ -1022,6 +1042,29 @@ fn eval_binop(l: &CypherValue, op: BinOp, r: &CypherValue) -> CypherValue {
                 .map(|o| o != std::cmp::Ordering::Less)
                 .unwrap_or(false),
         ),
+    }
+}
+
+/// Classify a Cypher value for Kleene (three-valued) boolean logic.
+///
+/// Returns `None` for NULL (the UNKNOWN truth value) and `Some(bool)` for any
+/// definite value, reusing `is_truthy()` so non-NULL operands keep the engine's
+/// existing loose truthiness (e.g. `Int(0)` → `Some(false)`). Used by the `AND`
+/// and `OR` arms of `eval_expr` so a NULL operand propagates as NULL instead of
+/// collapsing to a definite boolean (which is wrong under `NOT`).
+fn kleene_truth(v: &CypherValue) -> Option<bool> {
+    match v {
+        CypherValue::Null => None,
+        other => Some(other.is_truthy()),
+    }
+}
+
+/// Reconstruct a Cypher value from a Kleene truth: `None` → NULL, `Some(b)` →
+/// `Bool(b)`. Inverse of `kleene_truth` for the definite cases.
+fn kleene_value(t: Option<bool>) -> CypherValue {
+    match t {
+        Some(b) => CypherValue::Bool(b),
+        None => CypherValue::Null,
     }
 }
 

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -1427,6 +1427,96 @@ mod executor_tests {
         assert_eq!(names, vec!["withcat"]);
     }
 
+    /// Three-valued (Kleene) logic for `AND` under `NOT`. `n.category` is NULL
+    /// for the two cat-less nodes, so `n.category CONTAINS 'a'` is NULL there.
+    /// Kleene: `null AND true = null`; `NOT null = null` → excluded. Before the
+    /// fix `AND` collapsed the NULL operand to `Bool(false)` via `is_truthy()`,
+    /// so `NOT (null AND true)` became `NOT false = true` and wrongly admitted
+    /// the two NULL-category rows. `withcat` ("alpha") → `true AND true = true`,
+    /// `NOT true = false` → excluded. Correct result: nothing.
+    #[test]
+    fn filter_not_and_null_operand_excluded() {
+        let names = filtered_names(Expr::Not(Box::new(Expr::And(
+            Box::new(Expr::Contains(
+                Box::new(Expr::Property("n".to_string(), "category".to_string())),
+                Box::new(Expr::Literal(CypherLiteral::Str("a".to_string()))),
+            )),
+            Box::new(Expr::Literal(CypherLiteral::Bool(true))),
+        ))));
+        assert!(
+            names.is_empty(),
+            "NOT (nullPredicate AND true) must exclude NULL-operand rows (Kleene: null AND true = null), got {:?}",
+            names
+        );
+    }
+
+    /// Sibling of `filter_not_and_null_operand_excluded` for `OR`. Kleene:
+    /// `null OR false = null`; `NOT null = null` → excluded. Before the fix
+    /// `OR` collapsed the NULL operand to `Bool(false)`, so `NOT (null OR false)`
+    /// became `NOT false = true` and wrongly admitted the NULL-category rows.
+    #[test]
+    fn filter_not_or_null_operand_excluded() {
+        let names = filtered_names(Expr::Not(Box::new(Expr::Or(
+            Box::new(Expr::Contains(
+                Box::new(Expr::Property("n".to_string(), "category".to_string())),
+                Box::new(Expr::Literal(CypherLiteral::Str("a".to_string()))),
+            )),
+            Box::new(Expr::Literal(CypherLiteral::Bool(false))),
+        ))));
+        assert!(
+            names.is_empty(),
+            "NOT (nullPredicate OR false) must exclude NULL-operand rows (Kleene: null OR false = null), got {:?}",
+            names
+        );
+    }
+
+    /// Guard: FALSE dominates `AND` even past a NULL operand (Kleene:
+    /// `null AND false = false`). So `NOT (anything AND false) = NOT false =
+    /// true` admits every row. Holds before and after the fix — proves the
+    /// truthy/falsy short-circuits are preserved.
+    #[test]
+    fn filter_not_and_false_admits_all() {
+        let names = filtered_names(Expr::Not(Box::new(Expr::And(
+            Box::new(Expr::Contains(
+                Box::new(Expr::Property("n".to_string(), "category".to_string())),
+                Box::new(Expr::Literal(CypherLiteral::Str("a".to_string()))),
+            )),
+            Box::new(Expr::Literal(CypherLiteral::Bool(false))),
+        ))));
+        assert_eq!(names, vec!["nocat_none", "nocat_other", "withcat"]);
+    }
+
+    /// Guard: TRUE dominates `OR` even past a NULL operand (Kleene:
+    /// `null OR true = true`). So `NOT (anything OR true) = NOT true = false`
+    /// admits nothing. Holds before and after the fix.
+    #[test]
+    fn filter_not_or_true_excludes_all() {
+        let names = filtered_names(Expr::Not(Box::new(Expr::Or(
+            Box::new(Expr::Contains(
+                Box::new(Expr::Property("n".to_string(), "category".to_string())),
+                Box::new(Expr::Literal(CypherLiteral::Str("a".to_string()))),
+            )),
+            Box::new(Expr::Literal(CypherLiteral::Bool(true))),
+        ))));
+        assert!(names.is_empty(), "got {:?}", names);
+    }
+
+    /// Guard: a direct (non-negated) `AND` with a NULL operand still EXCLUDES
+    /// the row (NULL is not truthy) and still matches the non-null hit. The bug
+    /// is only observable under `NOT`; top-level `WHERE` filtering is unchanged.
+    /// Holds before and after the fix.
+    #[test]
+    fn filter_and_null_operand_still_excludes_and_matches() {
+        let names = filtered_names(Expr::And(
+            Box::new(Expr::Contains(
+                Box::new(Expr::Property("n".to_string(), "category".to_string())),
+                Box::new(Expr::Literal(CypherLiteral::Str("a".to_string()))),
+            )),
+            Box::new(Expr::Literal(CypherLiteral::Bool(true))),
+        ));
+        assert_eq!(names, vec!["withcat"]);
+    }
+
     #[test]
     fn filter_exported_boolean() {
         let engine = create_test_graph();


### PR DESCRIPTION
## Summary

The `And`/`Or` arms of the Cypher expression evaluator collapsed a **NULL** operand into a definite `Bool(false)` (via `is_truthy()`). At top-level `WHERE` this is invisible — NULL and `false` both make a row fall out — but **under `NOT` it silently admitted rows whose predicate is _unknown_**:

```cypher
MATCH (n:FUNCTION) WHERE NOT (n.category CONTAINS 'a' AND true) RETURN n.name
```

For a node whose `category` is absent, `n.category CONTAINS 'a'` is NULL. The engine evaluated `null AND true` → `Bool(false)`, then `NOT false` → `Bool(true)`, so the **NULL-property row was wrongly returned**. Per Cypher/Neo4j three-valued logic: `null AND true = null`, `NOT null = null` → the row must be **excluded**.

This is the explicitly-filed-but-unfixed sibling of the same NULL-under-`NOT` class already closed for comparisons (#341, `eval_binop`) and string predicates (#348, `Expr::Not`). It's an on-thesis silent-wrong-answer bug in the engine an AI agent queries.

## Spec (BDD)

- **Invariant restored:** Cypher `AND`/`OR` follow Kleene three-valued logic — a NULL operand yields NULL unless the other operand already decides the result (`false` for `AND`, `true` for `OR`).
- **Given** a graph where some nodes lack property `category` (→ NULL)
  **When** `WHERE NOT (n.category CONTAINS 'a' AND true)` runs
  **Then** the NULL-`category` rows are **excluded** (`null AND true = null`, `NOT null = null`), not admitted.
- **And** `WHERE NOT (n.category CONTAINS 'a' OR false)` likewise excludes them (`null OR false = null`).
- **And** FALSE still dominates `AND` and TRUE still dominates `OR` (short-circuit preserved): `NOT (x AND false)` admits all, `NOT (x OR true)` admits none.
- **And** top-level (non-negated) filtering is unchanged: `n.category CONTAINS 'a' AND true` still returns only the populated hit.

## Root cause

`packages/rfdb-server/src/cypher/executor.rs`, `eval_expr`:

```rust
Expr::And(lhs, rhs) => {
    let l = eval_expr(lhs, record);
    if !l.is_truthy() { return CypherValue::Bool(false); } // null -> Bool(false): WRONG under NOT
    let r = eval_expr(rhs, record);
    CypherValue::Bool(r.is_truthy())                        // true AND null -> Bool(false): WRONG
}
```

`is_truthy(Null) == false`, so every NULL operand became a definite `false`. `Expr::Not` (correctly, since #348) preserves NULL — but it never saw a NULL because `And`/`Or` had already swallowed it.

## Fix

Evaluate `AND`/`OR` under Kleene three-valued logic via two small, documented helpers:

```rust
fn kleene_truth(v: &CypherValue) -> Option<bool> { // None = UNKNOWN (NULL)
    match v { CypherValue::Null => None, other => Some(other.is_truthy()) }
}
fn kleene_value(t: Option<bool>) -> CypherValue {
    match t { Some(b) => CypherValue::Bool(b), None => CypherValue::Null }
}
```

`AND`: short-circuit `Some(false)` → `false`; else `(_, false)=>false`, `(true,true)=>true`, else `None`.
`OR`: short-circuit `Some(true)` → `true`; else `(_, true)=>true`, `(false,false)=>false`, else `None`.

Non-NULL operands route through `is_truthy()` exactly as before — **only the NULL cases change**, and only observably under `NOT` (at top-level `WHERE`, `NULL` and `Bool(false)` both exclude).

## Before / After evidence (`cargo test -p rfdb --lib`)

RED before the fix (the two `_excluded` tests):
```
filter_not_and_null_operand_excluded: NOT (nullPredicate AND true) must exclude NULL-operand rows
  got ["nocat_none", "nocat_other"]      # wrongly admitted
filter_not_or_null_operand_excluded:  NOT (nullPredicate OR false) must exclude NULL-operand rows
  got ["nocat_none", "nocat_other"]      # wrongly admitted
test result: FAILED. 3 passed; 2 failed
```

GREEN after:
```
filter_not_and_null_operand_excluded ... ok
filter_not_or_null_operand_excluded ... ok
filter_not_and_false_admits_all ... ok          # guard: FALSE dominates AND
filter_not_or_true_excludes_all ... ok          # guard: TRUE dominates OR
filter_and_null_operand_still_excludes_and_matches ... ok  # guard: top-level WHERE unchanged
filter_and_logic ... ok   filter_or_logic ... ok   filter_not_logic ... ok   # pre-existing regressions
```

Full crate suite:
```
cargo test -p rfdb --lib   ->  test result: ok. 911 passed; 0 failed; 0 ignored
cargo clippy --lib         ->  exit 0 (no new warnings; pre-existing HashSet/tree/axial_to_pixel only)
cargo build --bins         ->  Finished
```
(Tests use the executor AST helper `filtered_names` against the `create_string_metadata_graph` fixture — the same harness the #348 NULL-under-`NOT` tests use — and assert the **set of node names that survive the filter**, i.e. graph shape.)

## Adversarial review

- **Round A — correctness:** full Kleene tables verified: `F∧N=F` (short-circuits before evaluating rhs), `T∧N=N`, `N∧T=N`, `N∧N=N`, `T∨N=T`, `N∨F=N`, `F∨N=N`, `N∨N=N`. Non-NULL/non-bool operands (`Int`, `Str`, `Node`) keep prior loose truthiness via `is_truthy()`. Short-circuit semantics preserved for the dominating operand.
- **Round B — fragility:** `executor.rs` was already >500 lines (pre-existing; splitting it is out of scope, consistent with #345/#348). Added ~40 documented lines; the NULL-preserving coupling with `Expr::Not` is documented at the `And` site so a future "simplify back to `is_truthy()`" reintroduction is guarded. Helpers are pure and total.
- **Round C — class-not-instance:** `ast.rs` defines only `And`/`Or`/`Not` as boolean connectives (no `Xor`). `Not` (#348) and `eval_binop` (#341) already propagate NULL. With `And`/`Or` fixed, the boolean-NULL class is fully closed — no sibling latent bug, no follow-ups.

## Blast radius

Rust-only, isolated to `packages/rfdb-server/src/cypher/{executor,tests}.rs`. No JS/TS, no wire format, no graph-shape changes to stored data — only the truth value of `AND`/`OR` over NULL operands, observable in `WHERE` predicates (and only differs under `NOT`). The CI gate (`.github/workflows/ci.yml`) runs JS suites only; no JS/TS files are touched.

## Source

In-env triage: 0 open GitHub issues, no Linear MCP this run (github + Enox only). This is the filed-but-unfixed sibling follow-up of #341/#348, recorded in the autonomous web-session RFDB-Cypher-correctness intake series in Enox.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Khvhudc4b71GJc1D8vJbbY)_