### PR TITLE
fix(rfdb): Cypher ordering comparison on incomparable types yields NULL (3-valued logic)

### DIFF
--- a/packages/rfdb-server/src/cypher/executor.rs
+++ b/packages/rfdb-server/src/cypher/executor.rs
@@ -1002,26 +1002,25 @@ fn eval_binop(l: &CypherValue, op: BinOp, r: &CypherValue) -> CypherValue {
     match op {
         BinOp::Eq => CypherValue::Bool(l == r),
         BinOp::Neq => CypherValue::Bool(l != r),
-        BinOp::Lt => CypherValue::Bool(
-            l.partial_cmp_values(r)
-                .map(|o| o == std::cmp::Ordering::Less)
-                .unwrap_or(false),
-        ),
-        BinOp::Gt => CypherValue::Bool(
-            l.partial_cmp_values(r)
-                .map(|o| o == std::cmp::Ordering::Greater)
-                .unwrap_or(false),
-        ),
-        BinOp::Lte => CypherValue::Bool(
-            l.partial_cmp_values(r)
-                .map(|o| o != std::cmp::Ordering::Greater)
-                .unwrap_or(false),
-        ),
-        BinOp::Gte => CypherValue::Bool(
-            l.partial_cmp_values(r)
-                .map(|o| o != std::cmp::Ordering::Less)
-                .unwrap_or(false),
-        ),
+        // Ordering operators follow three-valued logic for INCOMPARABLE operands.
+        // `partial_cmp_values` returns `None` when the two non-NULL operands cannot
+        // be ordered against each other (e.g. String vs Int, Bool vs number, Node,
+        // or a NaN float). Per Cypher/Neo4j this is UNKNOWN → NULL, not a definite
+        // `false`: a previous `.unwrap_or(false)` here meant `NOT (Str < Int)`
+        // flipped to a definite `true` and wrongly admitted the row in `WHERE`.
+        // (NULL operands are already short-circuited to NULL at the top of this fn,
+        // so they never reach `partial_cmp_values`; this guard covers only the
+        // non-NULL-but-incomparable case — the sibling of #341/#348/#352.)
+        BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte => match l.partial_cmp_values(r) {
+            Some(ord) => CypherValue::Bool(match op {
+                BinOp::Lt => ord == std::cmp::Ordering::Less,
+                BinOp::Gt => ord == std::cmp::Ordering::Greater,
+                BinOp::Lte => ord != std::cmp::Ordering::Greater,
+                BinOp::Gte => ord != std::cmp::Ordering::Less,
+                _ => unreachable!("outer arm restricts op to ordering comparisons"),
+            }),
+            None => CypherValue::Null,
+        },
     }
 }
 

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -1427,6 +1427,94 @@ mod executor_tests {
         assert_eq!(names, vec!["withcat"]);
     }
 
+    /// Three-valued logic for ORDER-style comparisons over INCOMPARABLE (but
+    /// non-NULL) operands. In the fixture, `withcat.category` is the string
+    /// `"alpha"`. Comparing a String against an Int (`n.category < 5`) is
+    /// incomparable, so per Cypher/Neo4j it must evaluate to NULL — not a
+    /// definite `false`. Under `NOT`, NULL stays NULL and the row is EXCLUDED.
+    ///
+    /// Before the fix `eval_binop` returned `Bool(false)` for incomparable
+    /// operands (`partial_cmp_values(..).unwrap_or(false)`), so
+    /// `NOT (Str < Int)` became `NOT false = true` and wrongly admitted
+    /// `withcat`. This is the incomparable-type sibling of the NULL-operand
+    /// guard (#341) and the string-predicate / AND-OR NULL fixes (#348/#352).
+    ///
+    /// `NOT (category < 5)` must match NOTHING: `withcat` → `Str < Int` = NULL →
+    /// `NOT NULL` = NULL (excluded); the two NULL-category nodes → `null < 5` =
+    /// NULL → excluded.
+    #[test]
+    fn filter_not_lt_incomparable_types_excluded() {
+        let names = filtered_names(Expr::Not(Box::new(Expr::BinaryOp(
+            Box::new(Expr::Property("n".to_string(), "category".to_string())),
+            BinOp::Lt,
+            Box::new(Expr::Literal(CypherLiteral::Int(5))),
+        ))));
+        assert!(
+            names.is_empty(),
+            "NOT (String < Int) is incomparable -> NULL -> NOT NULL = NULL; row must be excluded, got {:?}",
+            names
+        );
+    }
+
+    /// Sibling of `filter_not_lt_incomparable_types_excluded` for `>=`.
+    /// `NOT (category >= 5)` over `withcat` (`"alpha"` vs Int) must also be
+    /// NULL → excluded, not `NOT false = true`.
+    #[test]
+    fn filter_not_gte_incomparable_types_excluded() {
+        let names = filtered_names(Expr::Not(Box::new(Expr::BinaryOp(
+            Box::new(Expr::Property("n".to_string(), "category".to_string())),
+            BinOp::Gte,
+            Box::new(Expr::Literal(CypherLiteral::Int(5))),
+        ))));
+        assert!(
+            names.is_empty(),
+            "NOT (String >= Int) is incomparable -> NULL; row must be excluded, got {:?}",
+            names
+        );
+    }
+
+    /// Guard against over-correction: a direct (non-negated) incomparable
+    /// ordering still EXCLUDES the row (NULL is not truthy). Passes both before
+    /// (false) and after (NULL) the fix — confirms top-level WHERE is unchanged.
+    #[test]
+    fn filter_lt_incomparable_types_still_excludes() {
+        let names = filtered_names(Expr::BinaryOp(
+            Box::new(Expr::Property("n".to_string(), "category".to_string())),
+            BinOp::Lt,
+            Box::new(Expr::Literal(CypherLiteral::Int(5))),
+        ));
+        assert!(
+            names.is_empty(),
+            "String < Int is incomparable -> not truthy; row must be excluded, got {:?}",
+            names
+        );
+    }
+
+    /// Guard: valid SAME-type ordering still works after the fix. String vs
+    /// String (`category < 'b'`) is comparable: `"alpha" < "b"` is true, so
+    /// `withcat` matches; the NULL-category nodes are excluded.
+    #[test]
+    fn filter_lt_same_type_strings_still_matches() {
+        let names = filtered_names(Expr::BinaryOp(
+            Box::new(Expr::Property("n".to_string(), "category".to_string())),
+            BinOp::Lt,
+            Box::new(Expr::Literal(CypherLiteral::Str("b".to_string()))),
+        ));
+        assert_eq!(names, vec!["withcat"]);
+    }
+
+    /// Guard: valid numeric ordering still works. `nocat_other` has `other = 1`
+    /// (Int); `other > 0` is comparable and true, so it matches.
+    #[test]
+    fn filter_gt_same_type_numbers_still_matches() {
+        let names = filtered_names(Expr::BinaryOp(
+            Box::new(Expr::Property("n".to_string(), "other".to_string())),
+            BinOp::Gt,
+            Box::new(Expr::Literal(CypherLiteral::Int(0))),
+        ));
+        assert_eq!(names, vec!["nocat_other"]);
+    }
+
     #[test]
     fn filter_exported_boolean() {
         let engine = create_test_graph();


### PR DESCRIPTION
## Summary

The Cypher ordering operators (`<`, `>`, `<=`, `>=`) in `eval_binop` collapsed a comparison between two **non-NULL but incomparable** operands (e.g. `String` vs `Int`) into a definite `Bool(false)` via `partial_cmp_values(..).unwrap_or(false)`. Per Cypher/Neo4j three-valued logic this comparison is **UNKNOWN → NULL**.

Invisible at top-level `WHERE` (both `NULL` and `false` drop the row) but **wrong under `NOT`**: `NOT (Str < Int)` evaluated `NOT false = true` and **wrongly admitted** the row. On-thesis silent-wrong-answer bug in the engine an AI agent queries.

This is the **incomparable-non-NULL sibling** of the same three-valued-logic class already closed for NULL operands (#341, same function), string predicates (#348, `Expr::Not`), and AND/OR Kleene logic (#352). #341 only guarded the case where an operand **is** NULL (top of `eval_binop`); the incomparable-but-non-NULL case still reached the ordering arms and hit `unwrap_or(false)`.

## Spec (BDD)

- **Invariant restored:** an ordering comparison (`<`/`>`/`<=`/`>=`) between two values that cannot be ordered against each other (different types, or NaN) is `NULL`, not `false`.
- **Given** a `FUNCTION` node whose `category` is the string `"alpha"`
  **When** `WHERE NOT (n.category < 5)` runs
  **Then** the row is **excluded** (`Str < Int` = NULL → `NOT NULL` = NULL), not admitted via `NOT false = true`.
- **And** `WHERE NOT (n.category >= 5)` likewise excludes it.
- **And** top-level (non-negated) `WHERE n.category < 5` is unchanged — still excluded (NULL is not truthy; previously `false`, also not truthy).
- **And** valid same-type ordering is unchanged: `n.category < 'b'` matches `"alpha"`; `n.other > 0` matches the `other = 1` node.

## Root cause

`packages/rfdb-server/src/cypher/executor.rs`, `eval_binop`:

```rust
BinOp::Lt => CypherValue::Bool(
    l.partial_cmp_values(r)
        .map(|o| o == std::cmp::Ordering::Less)
        .unwrap_or(false),   // incomparable -> Bool(false): WRONG under NOT
),
```

`partial_cmp_values` returns `None` for incomparable non-NULL operands (`Int` vs `Str`, `Bool` vs number, `Node`, NaN). `unwrap_or(false)` turned that UNKNOWN into a definite `false`, which `Expr::Not` (correct since #348) then flipped to a definite `true`.

## Fix

Route the four ordering operators through one match on `partial_cmp_values`; `None` → `CypherValue::Null`:

```rust
BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte => match l.partial_cmp_values(r) {
    Some(ord) => CypherValue::Bool(match op {
        BinOp::Lt => ord == std::cmp::Ordering::Less,
        BinOp::Gt => ord == std::cmp::Ordering::Greater,
        BinOp::Lte => ord != std::cmp::Ordering::Greater,
        BinOp::Gte => ord != std::cmp::Ordering::Less,
        _ => unreachable!("outer arm restricts op to ordering comparisons"),
    }),
    None => CypherValue::Null,   // incomparable types / NaN -> UNKNOWN
},
```

`Eq`/`Neq` are unaffected (they use `==`/`!=`). NULL operands are still short-circuited to `NULL` at the top of the function, so they never reach this arm — **only the non-NULL-incomparable case changes**, and only observably under `NOT`. The coupling with three-valued logic is documented at the site so a future "simplify back to `unwrap_or(false)`" is guarded.

## Before / After evidence (`cargo test -p rfdb --lib`)

RED before the fix (the two `NOT`-wrapped tests), confirmed for the right reason:
```
filter_not_lt_incomparable_types_excluded
  panicked: NOT (String < Int) ... row must be excluded, got ["withcat"]   # wrongly admitted
filter_not_gte_incomparable_types_excluded
  panicked: ... got ["withcat"]
test result: FAILED. 2 passed; 2 failed
```
(the 2 that passed RED: the non-negated guard `filter_lt_incomparable_types_still_excludes`, already correct, and an unrelated aggregate test matching the `incomparable` filter.)

GREEN after:
```
filter_not_lt_incomparable_types_excluded ... ok
filter_not_gte_incomparable_types_excluded ... ok
filter_lt_incomparable_types_still_excludes ... ok   # guard: top-level WHERE unchanged
filter_lt_same_type_strings_still_matches ... ok     # guard: valid Str ordering intact
filter_gt_same_type_numbers_still_matches ... ok     # guard: valid Int ordering intact
```

Full crate suite + build:
```
cargo test -p rfdb --lib   -> test result: ok. 911 passed; 0 failed; 0 ignored
cargo build --bins         -> Finished
cargo clippy --lib / rustfmt --check  -> no new warnings/diffs on touched code
                                         (only pre-existing import-order in executor.rs head
                                          and benches/graph_operations.rs drift, as in #351/#352)
```
Tests assert **graph shape** (the set of FUNCTION node names surviving the filter) via the `create_string_metadata_graph` fixture + `filtered_names` helper — the same harness the #348/#352 three-valued-logic tests use.

## Adversarial review

- **Round A — correctness:** NULL operands short-circuit to NULL before this arm (unchanged, #341). Incomparable non-NULL (`Str`↔`Int`, `Bool`↔number, `Node`, NaN) → NULL (now correct). Same-type comparable (`Int/Int`, `Float/Float`, `Int↔Float`, `Str/Str`, `Bool/Bool`) → `partial_cmp_values` returns `Some`, computed identically to before; `Lte = !Greater`, `Gte = !Less` verified incl. the `Equal` case. `Bool`-vs-`Bool` ordering is unchanged (it was always `Some`, never hit `unwrap_or`). NaN is unreachable from JSON metadata (serde_json never emits NaN); the NULL it now yields is the more-correct UNKNOWN and is documented.
- **Round B — fragility:** `executor.rs` was already >1000 lines (pre-existing god-file; splitting is out of scope, consistent with #345/#348/#352). Net ~+10 documented lines; `unreachable!()` is sound because the outer arm restricts `op` to the four ordering variants.
- **Round C — class-not-instance:** audited every `partial_cmp_values` / `unwrap_or(false)` site in the crate. `eval_binop` was the **sole** comparison-predicate site collapsing incomparable types to `false`. The only other executor `partial_cmp_values` use is the Sort/`ORDER BY` path (`unwrap_or(Ordering::Equal)`, line ~661) — a *sorting* context whose NULL-ordering is the separate open PR #351, intentionally untouched. Remaining `unwrap_or(false)` hits are unrelated config/env booleans. Class fully closed; no follow-ups.

## Blast radius

Rust-only, isolated to `packages/rfdb-server/src/cypher/{executor,tests}.rs`. No JS/TS, no wire format, no stored-graph-shape changes — only the truth value of `<`/`>`/`<=`/`>=` over incomparable operands, observable in `WHERE` and only differing under `NOT`. The CI gate (`.github/workflows/ci.yml`) runs JS suites only; no JS/TS files are touched.

## Source

In-env triage: 0 open GitHub issues, no Linear MCP this run (github + Enox only). Net-new correctness bug found by dogfooding the RFDB Cypher engine — the filed-but-unfixed incomparable-type sibling of the #341/#348/#352 three-valued-logic series, recorded in the autonomous web-session RFDB-Cypher-correctness intake series in Enox.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaChMnDQ4byoiR2HYtUimt)_