### PR TITLE
fix(rfdb): reject unsupported scalar functions in WHERE / ORDER BY / pattern props (silent-wrong-answer)

### DIFF
--- a/packages/rfdb-server/src/cypher/planner.rs
+++ b/packages/rfdb-server/src/cypher/planner.rs
@@ -116,19 +116,40 @@ pub fn plan<'a>(
     //   HashAggregate already produces named columns, so Sort works on those.
     //   No separate Project is needed after HashAggregate.
 
-    // Reject non-aggregate functions in RETURN. The executor implements only
-    // aggregate functions (COUNT/SUM/AVG/MIN/MAX); a scalar function such as
-    // toUpper(...) must fail loudly here rather than be silently routed through
-    // HashAggregate (which would mislabel it as an aggregate) or projected to
-    // NULL. Scalar-function support is a separate feature.
+    // Reject unsupported (non-aggregate) scalar functions in every clause whose
+    // expressions the engine evaluates. The executor implements only the aggregate
+    // functions (COUNT/SUM/AVG/MIN/MAX); any other function name (e.g. `toUpper`,
+    // `toLower`, `type`, `length`) is NOT implemented and `eval_expr` evaluates it
+    // to NULL. Left unguarded that produces silent wrong answers:
+    //   - RETURN toUpper(n.name)            → mislabeled as an aggregate / NULL column
+    //   - WHERE  toUpper(n.name) = 'X'      → `NULL = 'X'` = NULL → every row dropped
+    //                                         (an empty result that looks like "no match")
+    //   - ORDER BY toUpper(n.name)          → every sort key NULL → silent no-op sort
+    // So each such clause must fail loudly here. Scalar-function support is a
+    // separate feature; until it exists, an unsupported call is an error, not a
+    // confidently-wrong result.
     for item in &query.return_clause.items {
-        if let Expr::FunctionCall(name, _) = &item.expr {
-            if !is_aggregate_function(name) {
-                return Err(CypherError::Plan(format!(
-                    "Unsupported function '{}' in RETURN (supported: COUNT, SUM, AVG, MIN, MAX)",
-                    name
-                )));
-            }
+        reject_unsupported_functions(&item.expr, "RETURN")?;
+    }
+    if let Some(ref where_expr) = query.where_clause {
+        reject_unsupported_functions(where_expr, "WHERE")?;
+    }
+    if let Some(ref order_by) = query.order_by {
+        for (expr, _) in order_by {
+            reject_unsupported_functions(expr, "ORDER BY")?;
+        }
+    }
+    // Inline pattern property values are evaluated too — the start node's via
+    // `NodeScan::matches_properties` (`eval_literal_expr`) and each segment node's
+    // via a synthesized `Filter` (`eval_expr`). A function call there is the same
+    // silent-NULL trap (e.g. `MATCH (n {name: toUpper('x')})` would match only
+    // NULL-named nodes), so validate those values as well.
+    for (_, val) in &pattern.start.properties {
+        reject_unsupported_functions(val, "node pattern properties")?;
+    }
+    for (_, node) in &pattern.segments {
+        for (_, val) in &node.properties {
+            reject_unsupported_functions(val, "node pattern properties")?;
         }
     }
 
@@ -164,6 +185,52 @@ pub fn plan<'a>(
     }
 
     Ok(op)
+}
+
+/// Recursively reject any unsupported (non-aggregate) function call anywhere in
+/// `expr`, returning a [`CypherError::Plan`] that names the offending function
+/// and the `clause` it appears in.
+///
+/// The engine only implements the aggregate functions (COUNT/SUM/AVG/MIN/MAX);
+/// every other function name evaluates to NULL in `eval_expr`, which silently
+/// corrupts WHERE filters, ORDER BY keys, and RETURN columns. This walk catches
+/// such calls before execution — including ones buried inside compound
+/// predicates (e.g. `NOT (toLower(x) = 'y' AND ...)`) — so the query fails
+/// loudly instead of returning a confidently-wrong empty/unsorted result.
+///
+/// Aggregate function calls are left intact: they are legitimate in RETURN (and
+/// in ORDER BY of an aggregate query), and are routed through `HashAggregate`.
+/// Their arguments are still walked, so a scalar function nested inside an
+/// aggregate (e.g. `COUNT(toUpper(x))`) is also rejected.
+fn reject_unsupported_functions(expr: &Expr, clause: &str) -> Result<(), CypherError> {
+    match expr {
+        Expr::FunctionCall(name, args) => {
+            if !is_aggregate_function(name) {
+                return Err(CypherError::Plan(format!(
+                    "Unsupported function '{}' in {} (supported: COUNT, SUM, AVG, MIN, MAX); \
+                     scalar functions are not implemented",
+                    name, clause
+                )));
+            }
+            for arg in args {
+                reject_unsupported_functions(arg, clause)?;
+            }
+            Ok(())
+        }
+        Expr::BinaryOp(lhs, _, rhs)
+        | Expr::And(lhs, rhs)
+        | Expr::Or(lhs, rhs)
+        | Expr::Contains(lhs, rhs)
+        | Expr::StartsWith(lhs, rhs)
+        | Expr::EndsWith(lhs, rhs) => {
+            reject_unsupported_functions(lhs, clause)?;
+            reject_unsupported_functions(rhs, clause)
+        }
+        Expr::Not(inner) | Expr::IsNull(inner) | Expr::IsNotNull(inner) => {
+            reject_unsupported_functions(inner, clause)
+        }
+        Expr::Property(_, _) | Expr::Literal(_) | Expr::Variable(_) | Expr::Star => Ok(()),
+    }
 }
 
 /// Split ReturnClause items into group keys (non-aggregate) and aggregate items.

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -3145,6 +3145,136 @@ mod integration_tests {
         assert!(result.row_count >= 1);
     }
 
+    // ── Unsupported scalar functions in WHERE / ORDER BY must fail loudly ──────
+    //
+    // The RETURN path already rejects unsupported scalar functions (see
+    // `scalar_function_in_return_rejected_not_mislabeled_aggregate`). WHERE and
+    // ORDER BY had no equivalent guard: a function the engine does not implement
+    // (e.g. `toUpper`) evaluated to NULL in `eval_expr`, so a predicate like
+    // `WHERE toUpper(n.name) = 'MAIN'` became `NULL = 'MAIN'` → NULL → not truthy
+    // → every row silently dropped (an empty result that LOOKS like "no matches"),
+    // and `ORDER BY toUpper(n.name)` made every sort key NULL → a silent no-op
+    // sort. On-thesis silent-wrong-answer: the engine an AI agent queries must
+    // fail loudly here, never return a confidently-wrong empty/unsorted result.
+
+    #[test]
+    fn where_unsupported_scalar_function_rejected_not_silent_empty() {
+        // `toUpper` is not implemented. The matching node ("main") exists, so a
+        // correct engine either evaluates the function or errors — it must NOT
+        // silently return zero rows.
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) WHERE toUpper(n.name) = 'MAIN' RETURN n.name",
+            EvalLimits::none(),
+        );
+        assert!(
+            result.is_err(),
+            "unsupported scalar function in WHERE must error, not silently \
+             return rows; got {:?}",
+            result
+        );
+        let msg = format!("{:?}", result.unwrap_err()).to_lowercase();
+        assert!(
+            !msg.contains("aggregate"),
+            "scalar function must not be reported as an aggregate; got: {}",
+            msg
+        );
+        assert!(
+            msg.contains("toupper") || msg.contains("function"),
+            "error should name the unsupported function; got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn where_unsupported_scalar_function_nested_under_not_rejected() {
+        // The guard must walk the whole predicate tree, not just the top node:
+        // a scalar function buried under NOT/AND must still be rejected.
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) WHERE NOT (toLower(n.name) = 'main' AND n.exported = true) RETURN n.name",
+            EvalLimits::none(),
+        );
+        assert!(
+            result.is_err(),
+            "unsupported scalar function nested in WHERE must error; got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn order_by_unsupported_scalar_function_rejected() {
+        // `ORDER BY toUpper(n.name)` would make every sort key NULL → silent
+        // no-op sort. Must error instead.
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.name ORDER BY toUpper(n.name)",
+            EvalLimits::none(),
+        );
+        assert!(
+            result.is_err(),
+            "unsupported scalar function in ORDER BY must error; got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn where_supported_string_predicate_still_works() {
+        // Regression guard: CONTAINS is a built-in predicate (Expr::Contains),
+        // NOT a FunctionCall, so the new guard must leave it untouched.
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) WHERE n.name CONTAINS 'ain' RETURN n.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        let names: Vec<String> = result
+            .rows
+            .iter()
+            .map(|r| r[0].as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(names, vec!["main".to_string()]);
+    }
+
+    #[test]
+    fn inline_pattern_property_unsupported_function_rejected() {
+        // `MATCH (n {name: toUpper('main')})` would evaluate the value to NULL
+        // and match only NULL-named nodes → silent empty. Must error instead.
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION {name: toUpper('main')}) RETURN n.name",
+            EvalLimits::none(),
+        );
+        assert!(
+            result.is_err(),
+            "unsupported scalar function in inline pattern property must error; got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn order_by_aggregate_in_aggregate_query_not_rejected() {
+        // Regression guard: an AGGREGATE function (COUNT) in ORDER BY of an
+        // aggregate query is legitimate and must NOT be rejected by the
+        // scalar-function guard.
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (f:FUNCTION)-[:CALLS]->(g) RETURN f.name, COUNT(g) AS calls ORDER BY COUNT(g)",
+            EvalLimits::none(),
+        );
+        assert!(
+            result.is_ok(),
+            "aggregate function in ORDER BY must be allowed; got {:?}",
+            result
+        );
+    }
+
     // ── GROUP BY key must distinguish value types (value_to_group_key) ─────
     //
     // `value_to_group_key` must map two values to the SAME bucket iff they are


### PR DESCRIPTION
## Summary

The Cypher planner already **rejects** unsupported (non-aggregate) scalar functions in `RETURN` (`planner.rs:124`, tested by `scalar_function_in_return_rejected_not_mislabeled_aggregate`). But `WHERE`, `ORDER BY`, and **inline pattern property values** had **no equivalent guard**. The executor implements only the aggregate functions (`COUNT/SUM/AVG/MIN/MAX`); every other function name (`toUpper`, `toLower`, `type`, `length`, …) is parsed into `Expr::FunctionCall` and silently evaluated to **NULL** by `eval_expr` (`executor.rs:928-939`). Unguarded, that produces confidently-wrong results:

- `WHERE toUpper(n.name) = 'X'` → `NULL = 'X'` = NULL → not truthy → **every row dropped** (an empty result that *looks* like "no match")
- `WHERE NOT (toLower(n.name) = 'main' AND …)` → predicate NULL → under NOT silently **admits every row**
- `ORDER BY toUpper(n.name)` → every sort key NULL → **silent no-op sort**
- `MATCH (n {name: toUpper('x')})` → inline value → NULL → matches only **NULL-named** nodes

This is an on-thesis silent-wrong-answer bug in the engine an AI agent queries — the same class as RFD-70 ("unsupported aggregate must fail loudly, not silently return a count") and the same asymmetry the RETURN guard already closed. Same Cypher-correctness series as the open #345/#346/#347/#351/#352, in a **previously-unguarded** area (no overlap: those are And/Or, ORDER BY rewrite/null-order, LIMIT).

## Spec (BDD)

- **Invariant restored:** an unsupported (non-aggregate) function call in any evaluated clause **fails loudly** (`CypherError::Plan`) rather than evaluating to NULL and corrupting the result.
- **Given** a graph where node `main` exists, **When** `MATCH (n:FUNCTION) WHERE toUpper(n.name) = 'MAIN' RETURN n.name` runs, **Then** the engine returns an error naming the function — **not** an empty (`row_count: 0`) result.
- **And** the guard walks the whole predicate tree: a scalar function nested under `NOT`/`AND` (or inside an aggregate's args, e.g. `COUNT(toUpper(x))`) is also rejected.
- **And** `ORDER BY toUpper(n.name)` and `MATCH (n {name: toUpper('x')})` are rejected.
- **And** legitimate usage is unchanged: built-in predicates (`CONTAINS`/`STARTS WITH`/`ENDS WITH`), aggregates in `RETURN` (`COUNT(g)`), and aggregates in `ORDER BY` of an aggregate query (`ORDER BY COUNT(g)`) all still work.

## Root cause

`packages/rfdb-server/src/cypher/planner.rs` validated only `RETURN` items, and only at the **top level**. `eval_expr` returns `NULL` for any `FunctionCall` that isn't `COUNT` (`executor.rs:928-939`), and `Filter`/`Sort`/`NodeScan::matches_properties` consume those NULLs without complaint.

## Fix

A single recursive, total helper `reject_unsupported_functions(expr, clause)` (exhaustive `match` over every `Expr` variant → adding a new variant forces a compile error here). Applied to: every `RETURN` item, the `WHERE` expr, every `ORDER BY` term, and every inline pattern property value (start node + each segment node). Aggregate calls are left intact (routed through `HashAggregate`); their **arguments are still walked**.

Rust-only, isolated to `cypher/planner.rs` (+ tests). `planner.rs` 211 → 270 lines (< 500). No wire/format/graph-shape change — only turns a silently-wrong result into a loud `Plan` error for queries that were already broken.

## Before / After evidence (`cargo test --manifest-path packages/rfdb-server/Cargo.toml --lib`)

RED before the fix (the new tests), with the smoking gun captured verbatim:
```
where_unsupported_scalar_function_rejected_not_silent_empty
  ... got Ok(CypherResult { columns: ["n.name"], rows: [], row_count: 0 })   # silent empty
where_unsupported_scalar_function_nested_under_not_rejected
  ... got Ok(CypherResult { ... rows: [validate, helper, main], row_count: 3 })  # silently admits all
order_by_unsupported_scalar_function_rejected
  ... got Ok(CypherResult { ... rows: [helper, validate, main] })  # unsorted no-op
test result: FAILED. 50 passed; 3 failed
```

GREEN after:
```
test cypher::tests::integration_tests::where_unsupported_scalar_function_rejected_not_silent_empty ... ok
test cypher::tests::integration_tests::where_unsupported_scalar_function_nested_under_not_rejected ... ok
test cypher::tests::integration_tests::order_by_unsupported_scalar_function_rejected ... ok
test cypher::tests::integration_tests::inline_pattern_property_unsupported_function_rejected ... ok
test cypher::tests::integration_tests::where_supported_string_predicate_still_works ... ok          # regression guard
test cypher::tests::integration_tests::order_by_aggregate_in_aggregate_query_not_rejected ... ok    # regression guard
test cypher::tests::integration_tests::scalar_function_in_return_rejected_not_mislabeled_aggregate ... ok  # pre-existing, message-compat

test result: ok. 917 passed; 0 failed; 0 ignored
```

Full gate (Rust-only change → JS CI suites unaffected, no JS/TS touched):
```
cargo test  --manifest-path packages/rfdb-server/Cargo.toml --lib  →  ok. 917 passed; 0 failed
cargo clippy --manifest-path packages/rfdb-server/Cargo.toml --lib →  exit 0 (no new warnings; pre-existing found_any / tree / axial_to_pixel only)
```
(`cargo fmt --check` drift is pre-existing and crate-wide — the crate isn't rustfmt-maintained, consistent with #343/#344/#347/#348; my added lines follow surrounding style.)

## Adversarial review

- **Round A — correctness:** unknown fn in WHERE → error; nested under `NOT`/`AND` → error (recursion); ORDER BY → error; inline pattern prop → error; `COUNT(toUpper(x))` → error (args walked). Regression guards prove `CONTAINS` (an `Expr::Contains`, not a `FunctionCall`), `RETURN COUNT(g)`, and `ORDER BY COUNT(g)` are untouched. Function names are uppercased by the parser; the error message contains the name and the word "function" and avoids the substring "aggregate" (keeps the pre-existing RETURN-rejection test green).
- **Round B — fragility:** helper is pure/total; the **exhaustive match** is the guard — a future `Expr` variant won't compile until its function-bearing sub-exprs are decided. `planner.rs` stays < 500 lines. Documented for agents.
- **Round C — class-not-instance:** enumerated every `eval_expr` feed site: `Filter`(WHERE) ✓, `Filter`(label — synthesized `Property = Str` literal, never a fn) ✓ safe, `Filter`(inline property) ✓, `Project`(RETURN) ✓, `Sort`(ORDER BY) ✓, `HashAggregate`(group keys + agg args, via RETURN recursion) ✓. Class fully closed.

### Sibling found, deferred (out of scope)
Aggregate functions **misused in WHERE** (e.g. `WHERE COUNT(*) > 0`, which Cypher forbids) still evaluate to NULL rather than erroring — a distinct "aggregate-misuse" concern, pre-existing and not worsened here. Recommend a separate fix.

## Blast radius

Rust-only, `cypher/planner.rs` (+ tests). Only affects queries that already contained an unsupported function call (previously silently wrong) — those now return a clear `Plan` error. No change to any query that doesn't use an unimplemented function.

## Source

In-env triage: 0 open GitHub issues, no Linear MCP this run (github + Enox only). Net-new silent-wrong-answer found by dogfooding the RFDB Cypher engine; same correctness series as #34x–#35x, previously-unguarded clauses. Recorded in the autonomous web-session RFDB-Cypher-correctness intake series in Enox.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8a9BCc4r9MxRTReEhN4V2)_