### PR TITLE
fix(rfdb): bind anonymous Cypher start node so relationship traversal works

### DIFF
--- a/packages/rfdb-server/src/cypher/planner.rs
+++ b/packages/rfdb-server/src/cypher/planner.rs
@@ -24,10 +24,27 @@ pub fn plan<'a>(
 ) -> Result<Box<dyn Operator + 'a>, CypherError> {
     let pattern = &query.match_clause.pattern;
 
+    // The start node's effective variable name. For an anonymous start node
+    // (`MATCH ()-[:CALLS]->(g)`) we synthesize `__anon_0` — the same name the
+    // segment loop below uses for unnamed nodes (`__anon_{i+1}`). This name is
+    // used for BOTH the `NodeScan` binding and `prev_var` so they always agree.
+    let start_var = pattern
+        .start
+        .variable
+        .clone()
+        .unwrap_or_else(|| "__anon_0".to_string());
+
     // 1. Start with NodeScan for the first node pattern.
+    //
+    // The scan must always bind the start node under `start_var`, even when the
+    // pattern node is anonymous: a downstream `Expand` resolves its source node
+    // by looking up `start_var` in the record. If `NodeScan` produced an unbound
+    // record (as it did when the start node had no explicit variable), `Expand`
+    // failed with "variable '__anon_0' is not a node". Binding here mirrors how
+    // anonymous DESTINATION nodes are already bound by `Expand`.
     let mut op: Box<dyn Operator + 'a> = Box::new(NodeScan::new(
         engine,
-        pattern.start.variable.clone(),
+        Some(start_var.clone()),
         pattern.start.labels.clone(),
         pattern.start.properties.clone(),
         limits,
@@ -35,11 +52,7 @@ pub fn plan<'a>(
 
     // Track the "current" variable name so Expand knows which record field
     // holds the source node. Start with the first node pattern's variable.
-    let mut prev_var = pattern
-        .start
-        .variable
-        .clone()
-        .unwrap_or_else(|| "__anon_0".to_string());
+    let mut prev_var = start_var;
 
     // 2. Chain Expand/VarLengthExpand for each segment.
     for (i, (rel, node)) in pattern.segments.iter().enumerate() {

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -2459,6 +2459,85 @@ mod integration_tests {
         );
     }
 
+    // ── Anonymous start node + relationship ─────────────────────────────────
+    //
+    // Regression: a pattern whose FIRST node is anonymous (`MATCH ()-[:CALLS]->(g)`)
+    // must still traverse edges. The planner synthesizes the source variable
+    // `__anon_0` for the unnamed start node, but `NodeScan` only bound a record
+    // field when the node had an explicit variable — so the produced record was
+    // empty and `Expand` failed with "variable '__anon_0' is not a node".
+    // Anonymous DESTINATION nodes were already bound (by `Expand`), so the gap
+    // was specific to the start node. These cover outgoing, incoming, and the
+    // edge-counting query (`MATCH ()-[r]->() RETURN COUNT(*)`) that surfaced it.
+
+    #[test]
+    fn anonymous_start_node_outgoing_traverses() {
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH ()-[:CALLS]->(g) RETURN g.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        // CALLS edges: main->helper, main->validate, helper->validate.
+        // Targets (g): helper, validate, validate.
+        assert_eq!(result.row_count, 3);
+        let names = collect_string_column(&result, 0);
+        assert_eq!(names, vec!["helper", "validate", "validate"]);
+    }
+
+    #[test]
+    fn anonymous_start_node_incoming_traverses() {
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH ()<-[:CALLS]-(caller) RETURN caller.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        // Same CALLS edges read backwards — callers (sources): main, main, helper.
+        assert_eq!(result.row_count, 3);
+        let names = collect_string_column(&result, 0);
+        assert_eq!(names, vec!["helper", "main", "main"]);
+    }
+
+    #[test]
+    fn anonymous_start_node_count_edges() {
+        // The exact dogfooding query that exposed the bug: counting edges with
+        // both endpoints anonymous.
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH ()-[:CALLS]->() RETURN COUNT(*) AS total",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        assert_eq!(result.columns, vec!["total"]);
+        assert_eq!(result.row_count, 1);
+        assert_eq!(result.rows[0][0], serde_json::json!(3));
+    }
+
+    #[test]
+    fn anonymous_start_node_var_length_traverses() {
+        // The same root cause affected `VarLengthExpand` (it resolves its source
+        // node identically to `Expand`). A single-hop `*1..1` exercises that
+        // operator deterministically (no BFS-dedup ambiguity).
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH ()-[:CALLS*1..1]->(g) RETURN g.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        assert_eq!(result.row_count, 3);
+        let names = collect_string_column(&result, 0);
+        assert_eq!(names, vec!["helper", "validate", "validate"]);
+    }
+
     #[test]
     fn where_clause() {
         let engine = create_test_graph();


### PR DESCRIPTION
## Summary

A Cypher `MATCH` pattern whose **first node is anonymous** — e.g. `MATCH ()-[:CALLS]->(g) RETURN g.name` — failed at execution with:

```
Execution error: variable '__anon_0' is not a node
```

The planner synthesizes the source-variable name `__anon_0` for an unnamed start node, but `NodeScan` only wrote a record binding when the node had an **explicit** variable (`executor.rs:210-212`). So the start record was empty and `Expand` could not resolve its source (`executor.rs:349-357`). Anonymous **destination** nodes were already bound (by `Expand`, `executor.rs:332-334`), so the gap was specific to the *start* node — an asymmetry.

This breaks a whole class of common, on-thesis agent queries — *"what does anything call?"*, counting edges (`MATCH ()-[r]->() RETURN COUNT(*)`), reverse lookups (`MATCH ()<-[:CALLS]-(caller)`). It's a silent-failure bug in the engine an AI agent queries.

## Spec (BDD)

- **Invariant restored:** the start node of a `MATCH` pattern is always bound in the produced record, whether or not it has an explicit variable — so relationship operators can resolve their source node.
- **Given** a graph with `CALLS` edges `main→helper`, `main→validate`, `helper→validate`
  **When** `MATCH ()-[:CALLS]->(g) RETURN g.name` runs
  **Then** it returns the three targets `[helper, validate, validate]`, **not** an execution error.
- **And** `MATCH ()<-[:CALLS]-(caller) RETURN caller.name` returns the sources `[helper, main, main]`.
- **And** `MATCH ()-[:CALLS]->() RETURN COUNT(*)` returns `3` (the exact dogfooding query that surfaced the bug).
- **And** named start nodes (`MATCH (f:FUNCTION)-[:CALLS]->(g)`) are unchanged.

## Root cause

`packages/rfdb-server/src/cypher/planner.rs` — the planner passed `pattern.start.variable.clone()` (an `Option`, `None` for anonymous nodes) to `NodeScan`, while separately computing `prev_var = ...unwrap_or("__anon_0")` for the `Expand` source. When the start node was anonymous the two disagreed: the scan bound nothing, `prev_var` was `__anon_0`, and `Expand`/`VarLengthExpand` failed looking up `__anon_0`.

## Fix

Derive the start node's effective variable name **once** (with the same `__anon_0` fallback the segment chain already uses for unnamed nodes) and use it for **both** the `NodeScan` binding and `prev_var`, so they always agree:

```rust
let start_var = pattern.start.variable.clone()
    .unwrap_or_else(|| "__anon_0".to_string());

let mut op = Box::new(NodeScan::new(engine, Some(start_var.clone()), ...));
let mut prev_var = start_var;
```

A single planner change fixes both relationship operators — `Expand` and `VarLengthExpand` resolve their source identically (`executor.rs:349` / `executor.rs:503`). The named-start path is byte-for-byte equivalent to before (`Some(name)` either way).

## Before / After evidence (`cargo test -p rfdb --lib`)

RED before the fix (fix reverted via `git stash`, new tests kept):

```
test cypher::tests::integration_tests::anonymous_start_node_outgoing_traverses  ... FAILED
test cypher::tests::integration_tests::anonymous_start_node_incoming_traverses  ... FAILED
test cypher::tests::integration_tests::anonymous_start_node_count_edges         ... FAILED
test cypher::tests::integration_tests::anonymous_start_node_var_length_traverses... FAILED
called `Result::unwrap()` on an `Err` value: Execution("variable '__anon_0' is not a node")
test result: FAILED. 0 passed; 4 failed; 917 filtered out
```

GREEN after:

```
test cypher::tests::integration_tests::anonymous_start_node_outgoing_traverses  ... ok
test cypher::tests::integration_tests::anonymous_start_node_incoming_traverses  ... ok
test cypher::tests::integration_tests::anonymous_start_node_count_edges         ... ok
test cypher::tests::integration_tests::anonymous_start_node_var_length_traverses... ok
```

Full gate (Rust-only change, isolated to the `rfdb` crate):

```
cargo test -p rfdb --lib    ->  test result: ok. 921 passed; 0 failed; 0 ignored
cargo clippy --lib          ->  no new warnings (pre-existing HashSet/tree only; none in planner.rs)
cargo build --bins          ->  Finished
```

Tests go through the integration `execute()` path (parse → plan → execute) and assert **graph shape** (the set/multiset of returned names), not internal details — using the existing `create_test_graph` fixture.

## Adversarial review

- **Round A — correctness:** named start node unchanged (`Some(name)` identical to prior behavior; all 917 pre-existing tests pass). Outgoing, incoming, var-length (`*1..1`, deterministic — no BFS-dedup ambiguity), and aggregate `COUNT(*)` over a fully-anonymous pattern all covered. Single-node `MATCH () RETURN COUNT(*)` (no relationship) is unaffected — the extra binding is harmless and the aggregate counts input rows regardless of bindings.
- **Round B — fragility:** the change *removes* a latent inconsistency — previously the `NodeScan` variable and `prev_var` were derived from two separate expressions that could (and did) diverge; now a single `start_var` feeds both, documented at the site. `planner.rs` stays well under 500 lines (≈295). The `__anon_N` collision risk with a user literally naming a variable `__anon_0` pre-exists for destination nodes and is unchanged here (out of scope).
- **Round C — class-not-instance:** the identical "is not a node" source-lookup exists in both `Expand` (executor.rs:349) and `VarLengthExpand` (executor.rs:503); a test pins each. The start node is the only `NodeScan`; destinations are bound by the expand operators. The class is fully closed with one fix — no sibling latent site, no follow-ups.

## Blast radius

Rust-only, isolated to `packages/rfdb-server/src/cypher/{planner,tests}.rs`. No JS/TS, no wire format, no stored-graph-shape changes — only whether an anonymous-start pattern executes (previously it errored). The CI `Tests` job (`.github/workflows/ci.yml`) gates JS suites only; no JS/TS files are touched.

## Source

In-env triage: 0 open GitHub issues, no Linear MCP this run (github + Enox only). Net-new correctness bug in the same RFDB Cypher-engine series as #340–#354, in a previously-untouched area (the planner's start-node binding). Distinct from all open PRs (#345/#346/#347/#351/#352 — ORDER BY / LIMIT / AND-OR-NULL). Recorded under the autonomous web-session RFDB-Cypher-correctness intake series in Enox.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3jD8e7KTDyeTShXvw261j)_