### PR TITLE
fix(rfdb): include start node in zero-length Cypher var-length paths (*0 / *0..N)

### DIFF
--- a/packages/rfdb-server/src/cypher/executor.rs
+++ b/packages/rfdb-server/src/cypher/executor.rs
@@ -427,7 +427,15 @@ impl<'a> VarLengthExpand<'a> {
         };
 
         while let Some((node_id, depth)) = queue.pop_front() {
-            if depth >= self.min_depth && depth > 0 {
+            // Emit a node once its depth reaches the lower bound. `depth >=
+            // min_depth` alone is correct for every bound: for the usual
+            // `min_depth >= 1` it already excludes the start node (depth 0), and
+            // for a ZERO lower bound (`*0` / `*0..N`) it includes the start node
+            // bound to itself — the openCypher zero-length path. A prior `&&
+            // depth > 0` guard unconditionally dropped depth 0, silently omitting
+            // the start node from `*0` patterns (e.g. the `-[:CONTAINS*0..]->`
+            // "self-or-descendants" idiom).
+            if depth >= self.min_depth {
                 result.push(node_id);
             }
             if depth >= self.max_depth {

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -2027,6 +2027,44 @@ mod executor_tests {
         assert_eq!(names, vec!["internal"]);
     }
 
+    /// Zero-length path: `min_depth = max_depth = 0` binds the destination to
+    /// the START node itself (Cypher `*0` semantics). Was dropped by the
+    /// `&& depth > 0` guard in `bfs`, which excluded depth 0 even for min 0.
+    #[test]
+    fn var_length_expand_zero_depth_yields_start() {
+        let engine = create_test_graph();
+        let limits = default_limits();
+
+        let scan = NodeScan::new(
+            &engine,
+            Some("a".to_string()),
+            vec!["FUNCTION".to_string()],
+            vec![("name".to_string(), Expr::Literal(CypherLiteral::Str("main".to_string())))],
+            &limits,
+        );
+
+        let mut expand = VarLengthExpand::new(
+            Box::new(scan),
+            &engine,
+            "a".to_string(),
+            Some("b".to_string()),
+            vec!["CALLS".to_string()],
+            Direction::Outgoing,
+            0,
+            0,
+            &limits,
+        );
+
+        let mut names = Vec::new();
+        while let Some(rec) = expand.next().unwrap() {
+            if let CypherValue::Str(s) = rec.get("b").unwrap().property("name") {
+                names.push(s);
+            }
+        }
+        // Only the start node "main" — zero hops, no traversal.
+        assert_eq!(names, vec!["main"]);
+    }
+
     // ── eval_expr unit tests ────────────────────────────────────────────
 
     #[test]
@@ -3576,6 +3614,107 @@ mod integration_tests {
         .unwrap();
 
         assert_eq!(collect_string_column(&result, 0), vec!["it's"]);
+    }
+
+    // ── Zero-length variable-length paths (`*0`, `*0..N`) ────────────────────
+    //
+    // openCypher/Neo4j: a variable-length pattern with a lower bound of 0
+    // includes the ZERO-length path, which binds the destination variable to
+    // the START node itself (the node is "reachable from itself in 0 hops").
+    // `VarLengthExpand::bfs` dropped depth-0 unconditionally (`&& depth > 0`),
+    // so `*0` / `*0..N` silently omitted the start node — a silent-wrong-answer
+    // for the common "self-or-descendants" idiom (e.g. `-[:CONTAINS*0..]->`).
+
+    /// `*0` is exactly the zero-length path: x is bound to the start node and
+    /// nothing else. Was: empty result.
+    #[test]
+    fn var_length_zero_exact_returns_start_node() {
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION {name: 'main'})-[:CALLS*0]->(x) RETURN x.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        assert_eq!(collect_string_column(&result, 0), vec!["main"]);
+    }
+
+    /// `*0..1` = the start node (0 hops) PLUS its direct CALLS targets (1 hop).
+    /// main -> helper, main -> validate, so the set is {main, helper, validate}.
+    /// Was: {helper, validate} (start node missing).
+    #[test]
+    fn var_length_zero_to_one_includes_start_and_neighbors() {
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION {name: 'main'})-[:CALLS*0..1]->(x) RETURN x.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        assert_eq!(
+            collect_string_column(&result, 0),
+            vec!["helper", "main", "validate"]
+        );
+    }
+
+    /// A destination label/property filter still applies to the zero-length
+    /// match: `(x:CLASS)` excludes the FUNCTION start node, so `*0..1` here
+    /// yields nothing (main has no CALLS edge to a CLASS, and main itself is
+    /// not a CLASS).
+    #[test]
+    fn var_length_zero_respects_destination_label_filter() {
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION {name: 'main'})-[:CALLS*0..1]->(x:CLASS) RETURN x.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        assert!(
+            result.rows.is_empty(),
+            "zero-length match must honor destination label filter, got {:?}",
+            result.rows
+        );
+    }
+
+    /// Regression guard: a NON-zero lower bound must STILL exclude the start
+    /// node. Removing the buggy `&& depth > 0` must not leak the start node into
+    /// `*1..N` queries (depth 0 < min_depth already excludes it).
+    #[test]
+    fn var_length_min_one_still_excludes_start_node() {
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION {name: 'main'})-[:CALLS*1..2]->(x) RETURN x.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        // 1 hop: helper, validate. 2 hops: validate (via helper). De-duped set
+        // excludes "main" — the start node must not appear for a min>=1 path.
+        assert_eq!(
+            collect_string_column(&result, 0),
+            vec!["helper", "validate"]
+        );
+    }
+
+    /// Headline idiom: `*0..` ("the node itself plus everything reachable").
+    /// From "main" over CALLS this is {main, helper, validate} — the start node
+    /// included via the zero-length path. Also proves the unbounded BFS still
+    /// terminates (visited-set de-dup) with a zero lower bound. Was: start node
+    /// missing.
+    #[test]
+    fn var_length_zero_unbounded_includes_self_and_all_reachable() {
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION {name: 'main'})-[:CALLS*0..]->(x) RETURN x.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        assert_eq!(
+            collect_string_column(&result, 0),
+            vec!["helper", "main", "validate"]
+        );
     }
 
 }


### PR DESCRIPTION
## Summary

A Cypher variable-length pattern with a **zero lower bound** (`*0`, `*0..N`, `*0..`) silently **omitted the start node**. Per openCypher/Neo4j, a zero-length variable-length path binds the destination variable to the **start node itself** (a node is reachable from itself in 0 hops). This is the basis of the very common *"self-or-descendants"* idiom, e.g. `MATCH (root)-[:CONTAINS*0..]->(x)` to get a node **plus** everything it contains. The engine dropped the `x = root` row — an on-thesis silent-wrong-answer for an AI agent traversing containment/call hierarchies.

This is a net-new correctness bug in the same RFDB Cypher hardening series as #340–#355. It's a sibling of #344 (which fixed *parsing* of `*`, `*N`, `*N..` — the parser already produces `(0, …)` for `*0`), but in a **previously-untouched area**: the `VarLengthExpand` BFS *execution* semantics. (The "BFS shortest-path node de-dup" follow-up noted in #344 is a separate, deliberately-out-of-scope design choice and is **not** touched here.)

## Spec (BDD)

- **Invariant restored:** a zero lower bound includes the zero-length path — the destination variable is bound to the start node itself.
- **Given** `main -[:CALLS]-> helper`, `main -[:CALLS]-> validate`, `helper -[:CALLS]-> validate`
  **When** `MATCH (n:FUNCTION {name:'main'})-[:CALLS*0]->(x) RETURN x.name`
  **Then** the result is `["main"]` (zero hops, no traversal) — **not** empty.
- **And** `*0..1` returns `{main, helper, validate}` (start + 1-hop) — not `{helper, validate}`.
- **And** `*0..` returns `{main, helper, validate}` (start + all reachable, de-duped, terminating).
- **And** a destination label filter still applies to the zero-length match: `*0..1 ->(x:CLASS)` excludes the FUNCTION start node.
- **And (regression):** a non-zero lower bound `*1..2` **still excludes** the start node.

## Root cause

`packages/rfdb-server/src/cypher/executor.rs`, `VarLengthExpand::bfs`:

```rust
while let Some((node_id, depth)) = queue.pop_front() {
    if depth >= self.min_depth && depth > 0 {   // <-- `&& depth > 0` drops the start node
        result.push(node_id);
    }
    ...
}
```

`bfs` enqueues `(start_id, 0)`. The `&& depth > 0` clause unconditionally suppressed the depth-0 emission, so the start node was never produced — even when `min_depth == 0`. The guard was **redundant** for the usual `min_depth >= 1` (where `depth >= min_depth` already excludes depth 0) and **wrong** for `min_depth == 0`. The clause also contradicted `bfs`'s own doc comment ("collecting node IDs at depths `[min_depth, max_depth]`").

## Fix

Drop the buggy clause — `depth >= self.min_depth` alone is correct for **every** bound:

```rust
// for min_depth >= 1: depth 0 < min_depth, so the start node is excluded.
// for min_depth == 0: depth 0 >= 0, so the start node is included (zero-length path).
if depth >= self.min_depth {
    result.push(node_id);
}
```

One-line logic change + a documented comment so a future "re-add `depth > 0`" cannot silently reintroduce the bug.

## Before / After (live `cargo test`, fixture: main→helper, main→validate, helper→validate)

RED before the fix:
```
var_length_zero_exact_returns_start_node            left: []                       right: ["main"]
var_length_zero_to_one_includes_start_and_neighbors left: ["helper","validate"]    right: ["helper","main","validate"]
var_length_expand_zero_depth_yields_start           FAILED (start node dropped)
```

GREEN after:
```
test ...::var_length_zero_exact_returns_start_node ... ok
test ...::var_length_zero_to_one_includes_start_and_neighbors ... ok
test ...::var_length_zero_unbounded_includes_self_and_all_reachable ... ok
test ...::var_length_expand_zero_depth_yields_start ... ok
test ...::var_length_min_one_still_excludes_start_node ... ok               # regression guard
test ...::var_length_zero_respects_destination_label_filter ... ok         # filter guard
```

Full gate (Rust-only change, isolated to the `rfdb` crate):
```
cargo test -p rfdb --lib   -> test result: ok. 927 passed; 0 failed; 0 ignored
cargo clippy --lib         -> Finished (no new warnings; pre-existing only, none in the edited range)
rustfmt --check            -> no new drift in the edited regions (crate is not fmt-maintained; pre-existing drift untouched)
```

## Adversarial review

- **Round A — correctness:** verified `*0`→[start]; `*0..1`→start+1-hop; `*0..` (unbounded, with de-dup) terminates and includes start+all reachable; `*1..N` and `*2..N` unchanged (existing `var_length_expand_min_2` still green). Repeated variable `(a)-[:R*0]->(a)`: depth-0 `nid == a`'s binding, so the repeated-variable constraint admits it (correct zero-length self-match). Destination label/property filters (synthesized by the planner after the expand) still apply to the zero-length row.
- **Round B — fragility:** `executor.rs` is already >500 lines (pre-existing god-file; splitting is out of scope, consistent with #345/#348/#351/#352). Net change is removing one clause + a doc comment explaining why `depth >= min_depth` alone is correct, guarding against a future re-introduction.
- **Round C — class-not-instance:** `VarLengthExpand::bfs` is the **sole** operator with a `min_depth` / zero-length notion — fixed-length `Expand` is always exactly one hop and has no depth-0 path. The class is fully closed; no sibling latent site, no follow-ups. Parser side already handles `*0`/`*0..`/`*0..N` (`parse_var_length`), so no parser change is needed.

## Blast radius

Rust-only, inside `packages/rfdb-server/src/cypher/{executor,tests}.rs`. No JS/TS, no wire format, no stored-graph-shape change — only the row set of variable-length queries with a **zero** lower bound (everything else byte-identical). The JS-only CI gate (`.github/workflows/ci.yml`) is unaffected.

## Source

In-env triage this run: **0 open GitHub issues**; no Linear MCP (github + Enox only). Net-new correctness bug found by empirically probing the live Cypher engine (Evidence Rule: live `execute()` queries against a built `rfdb`), recorded under the autonomous web-session RFDB-Cypher-correctness intake series in Enox.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2NUuDUGA1qAu351Jnvggi)_