### PR TITLE
fix(rfdb): datalog path(A,A) is false unless A is on a real cycle

### DIFF
--- a/packages/rfdb-server/src/datalog/eval.rs
+++ b/packages/rfdb-server/src/datalog/eval.rs
@@ -1387,10 +1387,7 @@ impl<'a> Evaluator<'a> {
                     Err(_) => return vec![],
                 };
 
-                // BFS with all edge types, max depth 100
-                let reachable = self.engine.bfs(&[src_id], 100, &[]);
-
-                if reachable.contains(&dst_id) {
+                if self.path_reachable(src_id).contains(&dst_id) {
                     vec![Bindings::new()]
                 } else {
                     vec![]
@@ -1403,11 +1400,8 @@ impl<'a> Evaluator<'a> {
                     Err(_) => return vec![],
                 };
 
-                let reachable = self.engine.bfs(&[src_id], 100, &[]);
-
-                reachable
+                self.path_reachable(src_id)
                     .into_iter()
-                    .filter(|&id| id != src_id) // exclude self
                     .map(|id| {
                         let mut b = Bindings::new();
                         b.set(var, Value::Id(id));
@@ -1422,17 +1416,33 @@ impl<'a> Evaluator<'a> {
                     Err(_) => return vec![],
                 };
 
-                let reachable = self.engine.bfs(&[src_id], 100, &[]);
-
-                // Has path if reaches anything other than self
-                if reachable.iter().any(|&id| id != src_id) {
-                    vec![Bindings::new()]
-                } else {
+                if self.path_reachable(src_id).is_empty() {
                     vec![]
+                } else {
+                    vec![Bindings::new()]
                 }
             }
             _ => vec![],
         }
+    }
+
+    /// Set of nodes reachable from `src_id` via AT LEAST ONE edge (`path/2`
+    /// semantics).
+    ///
+    /// BFS is seeded from `src_id`'s direct neighbours (the depth-1 frontier)
+    /// rather than from `src_id` itself. `GraphStore::bfs` always returns its
+    /// seed nodes in the result, so seeding from `src_id` would make every node
+    /// trivially "reach itself" in zero hops — which is why all three `path/2`
+    /// argument modes must agree on excluding that zero-length self path. Seeding
+    /// from the neighbours instead means `src_id` appears here ONLY when a real
+    /// edge path loops back to it (a genuine cycle). For acyclic sources this is
+    /// identical to "bfs(src) minus src".
+    fn path_reachable(&self, src_id: u128) -> Vec<u128> {
+        let frontier = self.engine.neighbors(src_id, &[]);
+        if frontier.is_empty() {
+            return Vec::new();
+        }
+        self.engine.bfs(&frontier, 100, &[])
     }
 
     /// Evaluate neq(X, Y) - inequality constraint

--- a/packages/rfdb-server/src/datalog/eval_explain.rs
+++ b/packages/rfdb-server/src/datalog/eval_explain.rs
@@ -1334,11 +1334,7 @@ impl<'a> EvaluatorExplain<'a> {
                     Err(_) => return vec![],
                 };
 
-                self.stats.bfs_calls += 1;
-                let reachable = self.engine.bfs(&[src_id], 100, &[]);
-                self.stats.nodes_visited += reachable.len();
-
-                if reachable.contains(&dst_id) {
+                if self.path_reachable(src_id).contains(&dst_id) {
                     vec![Bindings::new()]
                 } else {
                     vec![]
@@ -1350,13 +1346,8 @@ impl<'a> EvaluatorExplain<'a> {
                     Err(_) => return vec![],
                 };
 
-                self.stats.bfs_calls += 1;
-                let reachable = self.engine.bfs(&[src_id], 100, &[]);
-                self.stats.nodes_visited += reachable.len();
-
-                reachable
+                self.path_reachable(src_id)
                     .into_iter()
-                    .filter(|&id| id != src_id)
                     .map(|id| {
                         let mut b = Bindings::new();
                         b.set(var, Value::Id(id));
@@ -1370,18 +1361,30 @@ impl<'a> EvaluatorExplain<'a> {
                     Err(_) => return vec![],
                 };
 
-                self.stats.bfs_calls += 1;
-                let reachable = self.engine.bfs(&[src_id], 100, &[]);
-                self.stats.nodes_visited += reachable.len();
-
-                if reachable.iter().any(|&id| id != src_id) {
-                    vec![Bindings::new()]
-                } else {
+                if self.path_reachable(src_id).is_empty() {
                     vec![]
+                } else {
+                    vec![Bindings::new()]
                 }
             }
             _ => vec![],
         }
+    }
+
+    /// Set of nodes reachable from `src_id` via AT LEAST ONE edge (`path/2`
+    /// semantics). See `Evaluator::path_reachable` for the rationale; BFS is
+    /// seeded from `src_id`'s neighbours so the trivial zero-length self path is
+    /// never counted, while a genuine cycle back to `src_id` still is. Updates
+    /// the explain stats (`bfs_calls`, `nodes_visited`) like the previous code.
+    fn path_reachable(&mut self, src_id: u128) -> Vec<u128> {
+        let frontier = self.engine.neighbors(src_id, &[]);
+        if frontier.is_empty() {
+            return Vec::new();
+        }
+        self.stats.bfs_calls += 1;
+        let reachable = self.engine.bfs(&frontier, 100, &[]);
+        self.stats.nodes_visited += reachable.len();
+        reachable
     }
 
     /// Evaluate neq(X, Y)

--- a/packages/rfdb-server/src/datalog/tests.rs
+++ b/packages/rfdb-server/src/datalog/tests.rs
@@ -625,6 +625,108 @@ mod eval_tests {
         assert_eq!(results.len(), 0); // no path
     }
 
+    /// A->B->A two-node cycle plus an isolated node C, for self-reachability tests.
+    fn setup_cycle_graph() -> GraphEngineV2 {
+        let mut engine = GraphEngineV2::create_ephemeral();
+        let mk = |id: u128, name: &str| NodeRecord {
+            id,
+            node_type: Some("FUNCTION".to_string()),
+            name: Some(name.to_string()),
+            file: Some("c.js".to_string()),
+            file_id: 0,
+            name_offset: 0,
+            version: "main".into(),
+            exported: false,
+            replaces: None,
+            deleted: false,
+            metadata: None,
+            semantic_id: None,
+        };
+        engine.add_nodes(vec![mk(100, "a"), mk(101, "b"), mk(102, "c_isolated")]);
+        engine.add_edges(
+            vec![
+                EdgeRecord { src: 100, dst: 101, edge_type: Some("CALLS".into()), version: "main".into(), metadata: None, deleted: false },
+                EdgeRecord { src: 101, dst: 100, edge_type: Some("CALLS".into()), version: "main".into(), metadata: None, deleted: false },
+            ],
+            false,
+        );
+        engine
+    }
+
+    // ── path() self-reachability (irreflexive: a node reaches itself only via a
+    //    genuine cycle, never via the trivial zero-length self path) ──
+    //
+    // Regression: `path(src, dst)` seeded BFS from `src` itself, and `bfs` returns
+    // the seed in its result set. The (Const, Const) arm did `reachable.contains(dst)`
+    // without excluding that trivial self-presence, so `path(A, A)` was TRUE for
+    // EVERY node — even an isolated node with no edges — contradicting the (Var) and
+    // (Wildcard) arms which both exclude self. Fixed by seeding BFS from src's
+    // neighbours (≥1 hop), so self counts only when a real edge path returns to src.
+
+    #[test]
+    fn test_eval_path_self_isolated_is_false() {
+        // Node 3 in setup_test_graph has NO outgoing edges → no path to itself.
+        let engine = setup_test_graph();
+        let evaluator = Evaluator::new(&engine);
+        let query = Atom::new("path", vec![Term::constant("3"), Term::constant("3")]);
+        let results = evaluator.query_atom(&query).unwrap();
+        assert_eq!(results.len(), 0, "isolated node must NOT have a path to itself");
+    }
+
+    #[test]
+    fn test_eval_path_self_acyclic_is_false() {
+        // Node 1 reaches 4 and 2 but nothing loops back to 1 → no self path.
+        let engine = setup_test_graph();
+        let evaluator = Evaluator::new(&engine);
+        let query = Atom::new("path", vec![Term::constant("1"), Term::constant("1")]);
+        let results = evaluator.query_atom(&query).unwrap();
+        assert_eq!(results.len(), 0, "acyclic node must NOT have a path to itself");
+    }
+
+    #[test]
+    fn test_eval_path_self_cycle_is_true() {
+        // 100 -> 101 -> 100 is a genuine cycle → path(100, 100) holds.
+        let engine = setup_cycle_graph();
+        let evaluator = Evaluator::new(&engine);
+        let query = Atom::new("path", vec![Term::constant("100"), Term::constant("100")]);
+        let results = evaluator.query_atom(&query).unwrap();
+        assert_eq!(results.len(), 1, "node on a cycle MUST have a path to itself");
+    }
+
+    #[test]
+    fn test_eval_path_var_includes_cyclic_self() {
+        // Enumerating reachable nodes from a cyclic node must include the node
+        // itself (it is genuinely reachable via the cycle), alongside its peer.
+        let engine = setup_cycle_graph();
+        let evaluator = Evaluator::new(&engine);
+        let query = Atom::new("path", vec![Term::constant("100"), Term::var("X")]);
+        let mut ids: Vec<u128> = evaluator
+            .query_atom(&query)
+            .unwrap()
+            .iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec![100, 101], "cyclic enumeration must include self (100) and peer (101)");
+    }
+
+    #[test]
+    fn test_eval_path_var_acyclic_excludes_self() {
+        // Regression guard: for an acyclic source, enumeration is unchanged and
+        // never includes the source itself.
+        let engine = setup_test_graph();
+        let evaluator = Evaluator::new(&engine);
+        let query = Atom::new("path", vec![Term::constant("1"), Term::var("X")]);
+        let mut ids: Vec<u128> = evaluator
+            .query_atom(&query)
+            .unwrap()
+            .iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec![2, 4], "acyclic enumeration unchanged: reaches 4 and 2, not self");
+    }
+
     #[test]
     fn test_eval_rule_simple() {
         let engine = setup_test_graph();
@@ -2203,6 +2305,31 @@ mod eval_tests {
 
         assert_eq!(plain_values, explain_values,
             "binding values should match between plain and explain evaluators");
+    }
+
+    /// The explain evaluator has its OWN copy of `eval_path`; pin its
+    /// self-reachability semantics to the same fix as the plain evaluator so the
+    /// duplicated implementations cannot drift (isolated/acyclic self = false,
+    /// cyclic self = true).
+    #[test]
+    fn test_explain_path_self_reachability_matches_plain() {
+        use crate::datalog::eval_explain::EvaluatorExplain;
+
+        // Isolated node 3 (no edges): path(3, 3) must be empty.
+        let engine = setup_test_graph();
+        let mut explain_eval = EvaluatorExplain::new(&engine, true);
+        let isolated = explain_eval
+            .eval_query(&parse_query("path(\"3\", \"3\")").unwrap())
+            .unwrap();
+        assert_eq!(isolated.bindings.len(), 0, "explain: isolated node has no self path");
+
+        // Cyclic node 100 (100->101->100): path(100, 100) must hold.
+        let cycle = setup_cycle_graph();
+        let mut explain_cycle = EvaluatorExplain::new(&cycle, true);
+        let cyclic = explain_cycle
+            .eval_query(&parse_query("path(\"100\", \"100\")").unwrap())
+            .unwrap();
+        assert_eq!(cyclic.bindings.len(), 1, "explain: cyclic node reaches itself");
     }
 
     /// REG-503 parity — wildcard arms.


### PR DESCRIPTION
## Summary

The Datalog `path/2` builtin reported a **path from a node to itself for EVERY node** — including an isolated node with no edges. `path("A", "A")` was always true. This is an on-thesis silent-wrong-answer bug in a reachability primitive an AI agent queries (e.g. "is A reachable from A / is A on a cycle?").

This is a net-new correctness bug, found by dogfooding the Datalog engine (no open GitHub issue; no Linear MCP this run — github + Enox only). It is in a previously-untouched area: the Datalog `path/2` execution semantics (distinct from the recent RFDB **Cypher** hardening series #340–#356, and from the already-merged Datalog hash-join self-join fix).

## Root cause

`packages/rfdb-server/src/datalog/eval.rs`, `eval_path` (and its duplicate in `eval_explain.rs`). `path/2` seeded BFS from the source node itself:

```rust
let reachable = self.engine.bfs(&[src_id], 100, &[]);
```

`GraphStore::bfs` **always returns its seed nodes** in the result (`graph/traversal.rs:28` pushes the seed; `test_bfs_simple_graph` asserts `bfs(&[1],..) == [1,2,3,4]`). The three argument modes then disagreed about that trivial depth-0 self-presence:

- `path(src, X)` (Var) — `.filter(|id| id != src_id) // exclude self`
- `path(src, _)` (Wildcard) — `.any(|id| id != src_id) // reaches anything other than self`
- `path(src, dst)` (Const, Const) — **`reachable.contains(&dst_id)`** — *forgot to exclude self*

So `path(A, A)` returned `true` for every node, even an orphan. The intent is unambiguously **irreflexive** (the other two arms exclude self, and the tested `orphan(X) :- node(X,..), \+ path(X, _)` rule relies on `path(3, _) = false` for the edgeless node 3). The Var arm's blanket `id != src` filter was also wrong in the other direction: it hid **genuine cycles**, so `path(A, X)` could never bind `X` to a cyclic source.

## Spec (BDD)

- **Invariant restored:** `path(src, dst)` holds iff `dst` is reachable from `src` via **at least one edge**. All three argument modes agree; the trivial zero-length self path is never a match.
- **Given** an isolated node `A` (no edges) **When** `path("A","A")` **Then** ∅ (no self path) — previously wrongly `true`.
- **And** an acyclic node `A` (reaches others, nothing loops back) **When** `path("A","A")` **Then** ∅ — previously wrongly `true`.
- **And** a genuine cycle `A->B->A` **When** `path("A","A")` **Then** one result; **And** `path("A", X)` binds `X ∈ {A, B}` (self included via the cycle).
- **And (regression)** for an acyclic source, `path(src, X)` enumeration is unchanged (excludes self), and `path(src, dst)` for a real reachable `dst` is unchanged.

## Fix

A shared `path_reachable(src_id)` helper seeds BFS from the source's **direct neighbours** (the depth-1 frontier) instead of from the source:

```rust
fn path_reachable(&self, src_id: u128) -> Vec<u128> {
    let frontier = self.engine.neighbors(src_id, &[]);
    if frontier.is_empty() { return Vec::new(); }
    self.engine.bfs(&frontier, 100, &[])
}
```

The trivial depth-0 self never counts; a real edge path that loops back to `src` still does (so cyclic self is correctly reported). For acyclic sources this is **identical** to the previous `bfs(src) minus src`. All three arms now route through the helper. `neighbors(id, &[])` is the same outgoing, tombstone-filtered traversal `bfs` uses, so direction/filtering are unchanged. Both copies (`Evaluator` and `EvaluatorExplain`, the latter keeping its `bfs_calls`/`nodes_visited` stats) are fixed.

## Before / After (live `cargo test -p rfdb --lib`)

RED before the fix (3 of the new tests):
```
test_eval_path_self_isolated_is_false   left: 1  right: 0   # orphan node wrongly self-reaches
test_eval_path_self_acyclic_is_false    left: 1  right: 0   # acyclic node wrongly self-reaches
test_eval_path_var_includes_cyclic_self left: [101] right: [100, 101]  # cycle self hidden
test result: FAILED. 4 passed; 3 failed
```
(The cyclic `path(A,A)=true` and acyclic `path(A,X)` excludes-self guards were already green, confirming the fix doesn't regress them.)

GREEN after:
```
test_eval_path_exists ... ok                       # path(1,2) unchanged
test_eval_path_not_exists ... ok                   # path(3,2) unchanged
test_eval_path_self_isolated_is_false ... ok
test_eval_path_self_acyclic_is_false ... ok
test_eval_path_self_cycle_is_true ... ok
test_eval_path_var_includes_cyclic_self ... ok
test_eval_path_var_acyclic_excludes_self ... ok    # regression guard
test_explain_path_self_reachability_matches_plain ... ok  # plain<->explain parity
```

Full gate (Rust-only change, isolated to the `rfdb` crate):
```
cargo test -p rfdb --lib   ->  test result: ok. 927 passed; 0 failed; 0 ignored
cargo clippy -p rfdb --lib ->  no new warnings in datalog/{eval,eval_explain,tests}.rs (pre-existing crate-wide only)
rustfmt --check            ->  no diff in the edited regions (crate is not fmt-maintained; pre-existing drift in benches/ untouched)
```

## Adversarial review

- **Round A — correctness:** isolated → ∅; acyclic self → ∅; cyclic self → present; self-loop edge `A->A` → `neighbors(A)=[A]` → `path(A,A)=true` (a self-loop is a cycle); non-existent src → `neighbors=[]` → ∅ (same as before); multiple neighbours sharing a downstream node → `bfs` dedups; all-tombstoned neighbours → `neighbors` filters them → ∅. The depth cap shifts from "100 from src" to "100 from the frontier" (≤1 extra hop); 100 is a runaway-safety bound, not a semantic depth `path/2` relies on, and the full suite is green.
- **Round B — structural fragility:** `eval.rs` / `eval_explain.rs` are pre-existing large, near-duplicated files (god-file + cross-file duplication out of scope, consistent with the prior series). This change **reduces** intra-file duplication (3 arms now share one helper instead of three copies of bfs+filter) and documents *why* the frontier seeding is required, guarding against a future "simplify back to `bfs(src)`" that would silently reintroduce the bug. A `test_explain_path_self_reachability_matches_plain` parity test pins the two duplicated implementations together.
- **Round C — class-not-instance:** audited every `engine.bfs(&[…])` caller (`rg '\.bfs\('`). The only sites with the trivial-self-then-`contains`/`filter` pattern were the **two** `eval_path` copies — both fixed. The other callers (`graph::reachability`, the `rfdb_server` bfs endpoint, Cypher's own `VarLengthExpand::bfs`) are raw traversal primitives with a deliberately seed-inclusive contract, not the irreflexive `path/2` predicate. Class closed; no follow-ups.

## Blast radius

Rust-only, inside `packages/rfdb-server/src/datalog/{eval,eval_explain,tests}.rs`. No JS/TS, no wire format, no stored-graph-shape change — only the result of the `path/2` Datalog predicate for the self / cyclic cases (every acyclic, non-self query is byte-identical). No CI workflow is tracked in the repo this run; verification is the full `cargo test -p rfdb --lib` suite (927 passing).

## Source

In-env triage this run: **0 open GitHub issues**; no Linear MCP (github + Enox only). The Cypher correctness vein is currently mined out (every wrong-answer I could reproduce maps to an existing open PR — #345/#346/#347/#351/#352/#356 — or the deliberately-parked var-length BFS dedup of #344/#356). This is a distinct, net-new Datalog `path/2` correctness bug, recorded in the autonomous web-session RFDB-correctness intake series in Enox.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Sqm9tSNyrinWu2RxKm1S6)_