### PR TITLE
fix(rfdb): Cypher RETURN * projects bound variables instead of NULL

### DIFF
--- a/packages/rfdb-server/src/cypher/mod.rs
+++ b/packages/rfdb-server/src/cypher/mod.rs
@@ -15,7 +15,7 @@ pub use ast::*;
 pub use parser::{parse_cypher, ParseError};
 pub use values::{CypherValue, Record};
 pub use executor::{Operator, eval_expr};
-pub use planner::plan;
+pub use planner::{expand_return_star, plan};
 
 use crate::graph::GraphStore;
 use crate::datalog::EvalLimits;
@@ -29,7 +29,10 @@ pub fn execute(
     query_str: &str,
     limits: EvalLimits,
 ) -> Result<CypherResult, CypherError> {
-    let query = parse_cypher(query_str)?;
+    let mut query = parse_cypher(query_str)?;
+    // Expand `RETURN *` into explicit per-variable items BEFORE both planning and
+    // column derivation, so the operator tree and the result header agree.
+    expand_return_star(&mut query)?;
     let mut op = plan(&query, engine, &limits)?;
 
     let columns = query

--- a/packages/rfdb-server/src/cypher/planner.rs
+++ b/packages/rfdb-server/src/cypher/planner.rs
@@ -200,6 +200,89 @@ pub fn plan<'a>(
     Ok(op)
 }
 
+/// Expand a `RETURN *` wildcard into one explicit return item per variable bound
+/// by the MATCH pattern, in pattern-declaration order.
+///
+/// `RETURN *` is a core Cypher idiom — "give me every variable in scope". The
+/// parser produces it as a top-level [`Expr::Star`] return item (distinct from
+/// `count(*)`, where the `Star` is nested inside a [`Expr::FunctionCall`]'s
+/// arguments and is therefore left untouched here). Without expansion the
+/// executor's `eval_expr` evaluates a bare `Expr::Star` to `NULL`, so the query
+/// silently returns a single column literally named `*` holding `NULL` instead
+/// of the bound nodes/relationships — an on-thesis silent-wrong-answer.
+///
+/// This MUST run before both the planner and the column-name derivation in
+/// `execute`, so that the operator tree and the result header agree on the
+/// expanded set of columns.
+///
+/// Behaviour:
+/// - The wildcard expands to the pattern's **named** variables only — the start
+///   node, then for each segment its relationship variable (if named) followed
+///   by its destination node variable (if named) — preserving declaration order
+///   and de-duplicating. Anonymous pattern elements (`()`, `-[:T]->`) contribute
+///   nothing, mirroring Cypher (they are not in scope).
+/// - `RETURN *` with **no** named variable in the pattern is an error (nothing to
+///   project), rather than a confidently-empty/NULL result.
+/// - `RETURN * AS x` is rejected: aliasing the wildcard is not valid Cypher.
+/// - Non-wildcard return items (including `count(*)`) are passed through
+///   unchanged, so `RETURN *, count(x)` expands the `*` and keeps the aggregate.
+pub fn expand_return_star(query: &mut CypherQuery) -> Result<(), CypherError> {
+    // Fast path: nothing to do unless a top-level `*` return item is present.
+    let has_star = query
+        .return_clause
+        .items
+        .iter()
+        .any(|item| matches!(item.expr, Expr::Star));
+    if !has_star {
+        return Ok(());
+    }
+
+    // Collect named variables in pattern-declaration order, de-duplicated.
+    let pattern = &query.match_clause.pattern;
+    let mut named: Vec<String> = Vec::new();
+    let mut push_unique = |v: &Option<String>, named: &mut Vec<String>| {
+        if let Some(name) = v {
+            if !named.iter().any(|n| n == name) {
+                named.push(name.clone());
+            }
+        }
+    };
+    push_unique(&pattern.start.variable, &mut named);
+    for (rel, node) in &pattern.segments {
+        push_unique(&rel.variable, &mut named);
+        push_unique(&node.variable, &mut named);
+    }
+
+    let mut expanded: Vec<ReturnItem> = Vec::with_capacity(query.return_clause.items.len());
+    for item in &query.return_clause.items {
+        if matches!(item.expr, Expr::Star) {
+            if item.alias.is_some() {
+                return Err(CypherError::Plan(
+                    "RETURN * cannot be aliased (`RETURN * AS ...` is invalid)".to_string(),
+                ));
+            }
+            if named.is_empty() {
+                return Err(CypherError::Plan(
+                    "RETURN * requires at least one named variable in the MATCH pattern".to_string(),
+                ));
+            }
+            for var in &named {
+                expanded.push(ReturnItem {
+                    expr: Expr::Variable(var.clone()),
+                    // Alias to the variable name so the column header is `n`, not
+                    // the formatted expression — matching `RETURN n`.
+                    alias: Some(var.clone()),
+                });
+            }
+        } else {
+            expanded.push(item.clone());
+        }
+    }
+
+    query.return_clause.items = expanded;
+    Ok(())
+}
+
 /// Recursively reject any unsupported (non-aggregate) function call anywhere in
 /// `expr`, returning a [`CypherError::Plan`] that names the offending function
 /// and the `clause` it appears in.

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -3579,3 +3579,133 @@ mod integration_tests {
     }
 
 }
+
+
+// ─── RETURN * (project all named variables) ──────────────────────────────────
+//
+// `RETURN *` is a core Cypher idiom: it projects every variable bound in the
+// MATCH pattern. Before the fix it parsed to a single `Expr::Star` return item
+// that `eval_expr` evaluated to NULL, so `MATCH (n:CLASS) RETURN *` silently
+// returned one column literally named "*" holding NULL instead of the node `n`
+// — an on-thesis silent-wrong-answer for an AI agent querying the graph.
+mod return_star_tests {
+    use super::*;
+    use crate::graph::GraphEngineV2;
+    use crate::storage::{NodeRecord, EdgeRecord};
+    use crate::datalog::EvalLimits;
+
+    fn mkn(id: u128, ntype: &str, name: &str) -> NodeRecord {
+        NodeRecord {
+            id, node_type: Some(ntype.to_string()), name: Some(name.to_string()),
+            file: Some("src/m.js".to_string()), file_id: 0, name_offset: 0,
+            version: "main".into(), exported: true, replaces: None, deleted: false,
+            metadata: None, semantic_id: None,
+        }
+    }
+    fn mke(src: u128, dst: u128, t: &str) -> EdgeRecord {
+        EdgeRecord {
+            src, dst, edge_type: Some(t.to_string()),
+            version: "main".into(), deleted: false, metadata: None,
+        }
+    }
+    fn graph() -> GraphEngineV2 {
+        let mut e = GraphEngineV2::create_ephemeral();
+        e.add_nodes(vec![
+            mkn(10, "CLASS", "User"),
+            mkn(11, "FUNCTION", "main"),
+            mkn(12, "FUNCTION", "helper"),
+            mkn(13, "FUNCTION", "validate"),
+        ]);
+        e.add_edges(vec![
+            mke(11, 12, "CALLS"),
+            mke(11, 13, "CALLS"),
+        ], false);
+        e
+    }
+
+    fn obj_name(v: &serde_json::Value) -> String {
+        v.get("name").and_then(|n| n.as_str()).unwrap_or("<none>").to_string()
+    }
+
+    #[test]
+    fn return_star_projects_single_named_node_variable() {
+        let e = graph();
+        let r = execute(&e, "MATCH (n:CLASS) RETURN *", EvalLimits::none()).unwrap();
+        // Column is the variable name `n`, NOT the literal "*".
+        assert_eq!(r.columns, vec!["n"]);
+        assert_eq!(r.row_count, 1);
+        // The value is the whole node object, not NULL.
+        assert!(r.rows[0][0].is_object(), "expected node object, got {:?}", r.rows[0][0]);
+        assert_eq!(obj_name(&r.rows[0][0]), "User");
+    }
+
+    #[test]
+    fn return_star_projects_all_named_variables_in_pattern_order() {
+        let e = graph();
+        let r = execute(
+            &e,
+            "MATCH (a:FUNCTION {name:'main'})-[:CALLS]->(b:FUNCTION) RETURN *",
+            EvalLimits::none(),
+        ).unwrap();
+        assert_eq!(r.columns, vec!["a", "b"]);
+        assert_eq!(r.row_count, 2);
+        for row in &r.rows {
+            assert_eq!(obj_name(&row[0]), "main");
+            assert!(["helper", "validate"].contains(&obj_name(&row[1]).as_str()));
+        }
+    }
+
+    #[test]
+    fn return_star_includes_relationship_variable() {
+        let e = graph();
+        let r = execute(
+            &e,
+            "MATCH (a:FUNCTION {name:'main'})-[r:CALLS]->(b) RETURN *",
+            EvalLimits::none(),
+        ).unwrap();
+        assert_eq!(r.columns, vec!["a", "r", "b"]);
+        assert_eq!(r.row_count, 2);
+    }
+
+    #[test]
+    fn return_star_with_no_named_variables_errors() {
+        let e = graph();
+        // No named variable anywhere in the pattern → `RETURN *` has nothing to project.
+        let r = execute(&e, "MATCH ()-[:CALLS]->() RETURN *", EvalLimits::none());
+        assert!(r.is_err(), "RETURN * with no named variables must error, got {:?}", r);
+    }
+
+    #[test]
+    fn return_star_aliased_errors() {
+        let e = graph();
+        // `RETURN * AS x` is not valid Cypher.
+        let r = execute(&e, "MATCH (n:CLASS) RETURN * AS x", EvalLimits::none());
+        assert!(r.is_err(), "RETURN * AS x must error, got {:?}", r);
+    }
+
+    #[test]
+    fn return_star_with_order_by_and_limit() {
+        let e = graph();
+        // Sort runs before Project, so ORDER BY on a star-projected variable's
+        // property must still work (the full record is in scope at Sort time).
+        let r = execute(
+            &e,
+            "MATCH (n:FUNCTION) RETURN * ORDER BY n.name ASC LIMIT 2",
+            EvalLimits::none(),
+        ).unwrap();
+        assert_eq!(r.columns, vec!["n"]);
+        assert_eq!(r.row_count, 2);
+        assert_eq!(obj_name(&r.rows[0][0]), "helper");
+        assert_eq!(obj_name(&r.rows[1][0]), "main");
+    }
+
+    #[test]
+    fn count_star_still_works_after_star_expansion() {
+        let e = graph();
+        // Regression guard: count(*) must NOT be treated as RETURN *.
+        let r = execute(&e, "MATCH (n:FUNCTION) RETURN count(*) AS c", EvalLimits::none()).unwrap();
+        assert_eq!(r.columns, vec!["c"]);
+        assert_eq!(r.row_count, 1);
+        assert_eq!(r.rows[0][0], serde_json::json!(3));
+    }
+}


### PR DESCRIPTION
## Summary

`RETURN *` — a **core, extremely common Cypher idiom** ("give me every variable in scope") — silently returned garbage. The parser produced it as a top-level `Expr::Star` return item, which the executor's `eval_expr` evaluates to **NULL**. So:

```
MATCH (n:CLASS) RETURN *      → columns = ["*"],  rows = [[null]]      (BUG)
MATCH (n:CLASS) RETURN n      → columns = ["n"],  rows = [[{User…}]]   (correct)
```

The query "succeeds" but hands an AI agent a single column literally named `*` holding NULL instead of the matched node — a textbook on-thesis **silent-wrong-answer** ("AI should query the graph, not read code"). It is a net-new correctness bug in the same RFDB Cypher hardening series as #340–#357, in a previously-untouched area (RETURN-clause wildcard expansion).

## Spec (BDD)

- **Invariant restored:** a top-level `RETURN *` projects every variable bound by the MATCH pattern (its value, e.g. the whole node/relationship), never a NULL column named `*`.
- **Given** `MATCH (n:CLASS)` **When** `RETURN *` **Then** one column `n` whose value is the node object — **not** a column `*` = NULL.
- **And** `MATCH (a)-[:CALLS]->(b) RETURN *` → columns `[a, b]` (pattern-declaration order).
- **And** a named relationship is included: `(a)-[r:CALLS]->(b) RETURN *` → `[a, r, b]`.
- **And** `RETURN * ORDER BY n.name LIMIT 2` still sorts/limits (Sort runs before Project, full record in scope).
- **And (loud-not-silent):** `MATCH ()-[:CALLS]->() RETURN *` (no named variable) and `RETURN * AS x` (invalid) now **error** instead of returning confidently-wrong data — matching the #354 "fail loudly" philosophy.
- **And (regression):** `count(*)` is unchanged (its `*` is nested inside a `FunctionCall`, not a top-level item).

## Root cause

`packages/rfdb-server/src/cypher/`:
- `parser.rs:906` parses a bare `*` to `Expr::Star`.
- `executor.rs:941` — `eval_expr(Expr::Star) → CypherValue::Null`.
- `mod.rs:84` `format_expr(Expr::Star) → "*"`.

So a top-level `RETURN *` item yielded one column named `*` = NULL. Nothing ever expanded the wildcard to the in-scope variables.

## Fix

A new `expand_return_star(&mut CypherQuery)` (`planner.rs`) rewrites a top-level `Expr::Star` return item into one `Expr::Variable(v)` item per **named** pattern variable — start node, then each segment's relationship variable (if named) and destination variable (if named) — in declaration order, de-duplicated (so `(a)-[:R]->(a) RETURN *` yields `a` once). Anonymous elements (`()`, `-[:T]->`) contribute nothing, mirroring Cypher scope rules.

It runs in `execute()` **before both** `plan()` and the column-name derivation, so the operator tree and the result header agree. `count(*)` is left intact (its `Star` is a `FunctionCall` argument, never a top-level item). Empty-scope `RETURN *` and aliased `RETURN * AS x` return a `CypherError::Plan`.

## Before / After (live `cargo test`, fixture: CLASS User; FUNCTION main/helper/validate; main→helper, main→validate)

**RED before** (5 tests):
```
return_star_projects_single_named_node_variable  left: ["*"]            right: ["n"]
return_star_projects_all_named_variables…        left: ["*"]            right: ["a","b"]
return_star_includes_relationship_variable       left: ["*"]            right: ["a","r","b"]
return_star_with_no_named_variables_errors        got Ok(cols ["*"], [[null]])  (wanted Err)
return_star_aliased_errors                        got Ok(cols ["x"], [[null]])  (wanted Err)
```

**GREEN after:**
```
test …::return_star_projects_single_named_node_variable ... ok
test …::return_star_projects_all_named_variables_in_pattern_order ... ok
test …::return_star_includes_relationship_variable ... ok
test …::return_star_with_order_by_and_limit ... ok
test …::return_star_with_no_named_variables_errors ... ok
test …::return_star_aliased_errors ... ok
test …::count_star_still_works_after_star_expansion ... ok   # regression guard
```

Full gate (Rust-only, isolated to the `rfdb` crate):
```
cargo test  --lib   → ok. 934 passed; 0 failed; 0 ignored
cargo clippy --lib  → no new warnings (55 pre-existing only; none in the edited files)
cargo build --bins  → Finished
```
Tests go through `cypher::execute()` — the exact function the server binary calls (`rfdb_server.rs:1603`), so they cover the production query path.

## Adversarial review

- **Round A — correctness:** single node var; multiple vars; named relationship var; repeated variable `(a)-[:R]->(a)` de-dupes to one `a`; `RETURN * ORDER BY … LIMIT` (Sort-before-Project, full record in scope); aggregate path untouched (`count(*)`); empty-scope and aliased wildcard both error loudly. Star nested in `count(*)` is a `FunctionCall` arg, so the top-level `matches!(item.expr, Expr::Star)` check never touches it.
- **Round B — fragility:** `planner.rs` is 374 lines (< 500). The fix is one pure AST→AST function with an agent-facing doc comment; the ordering of expansion (start → rel → dst, deduped, declaration order) is documented so it can't silently drift. The "run before plan() AND before column derivation" coupling is documented at the `execute()` call site.
- **Round C — class-not-instance:** the bug class is "a bare `Expr::Star` reaches `eval_expr` and silently becomes NULL". `execute()` is the **only** Cypher entry point (`grep`: `cypher::execute` has one external caller, `rfdb_server.rs:1603`; `plan()` has no caller outside `execute`), so expanding at `execute()` closes the realistic class. A bare `*` in `WHERE`/`ORDER BY` is invalid Cypher (not a realistic query) and out of scope.

## Sibling finding (separate class, follow-up — NOT fixed here)

Duplicate RETURN aliases corrupt data: `MATCH (n:CLASS) RETURN n.name AS x, n.file AS x` returns `["src/m.js","src/m.js"]` (the second `x` overwrites the first in the `Project` `HashMap<col,val>`, then both columns read the same key). Different mechanism (Project record keying), rarer (Neo4j rejects duplicate aliases). Filed for a separate focused PR to keep this one single-concern.

## Blast radius

Rust-only, inside `packages/rfdb-server/src/cypher/{mod,planner,tests}.rs`. No JS/TS, no wire format, no stored-graph-shape change — only the column set/values of queries that use a top-level `RETURN *` (previously a NULL column; now the bound variables). The JS-only CI gate (`.github/workflows/ci.yml`) is unaffected.

## Source

In-env triage this run: **0 open GitHub issues**; no Linear MCP (github + Enox only). Found by empirically probing the live Cypher engine (Evidence Rule: live `execute()` queries against a built `rfdb`); recorded under the autonomous web-session RFDB-Cypher-correctness intake series in Enox.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNYNt2hFY5ybQ74Sp1ZeC7)_