### PR TITLE
fix(rfdb): datalog incoming(Dst,Src) enumerates edges like edge(Src,Dst)

### DIFF
--- a/packages/rfdb-server/src/datalog/eval.rs
+++ b/packages/rfdb-server/src/datalog/eval.rs
@@ -1068,7 +1068,12 @@ impl<'a> Evaluator<'a> {
                 let edges = if let Some(edge_type) = type_filter {
                     self.engine.get_edges_by_type(edge_type)
                 } else {
-                    return vec![];
+                    // No edge-type constant: enumerate every edge (full scan),
+                    // binding the dst variable below. Mirrors eval_edge's
+                    // Var(src) arm and this fn's own Wildcard-dst arm. Returning
+                    // empty here silently dropped every row of an untyped
+                    // `incoming(Dst, Src)` enumeration (false negatives).
+                    self.engine.get_all_edges()
                 };
 
                 edges

--- a/packages/rfdb-server/src/datalog/eval_explain.rs
+++ b/packages/rfdb-server/src/datalog/eval_explain.rs
@@ -1019,7 +1019,13 @@ impl<'a> EvaluatorExplain<'a> {
                     self.stats.edges_by_type_calls += 1;
                     self.engine.get_edges_by_type(edge_type)
                 } else {
-                    return vec![];
+                    // Full-scan parity with the plain evaluator's eval_incoming
+                    // Var arm and this fn's own Wildcard-dst arm: returning empty
+                    // here silently dropped every row of an untyped
+                    // `incoming(Dst, Src)` enumeration (false negatives).
+                    self.warnings.push("Full edge scan: consider binding destination node".to_string());
+                    self.stats.all_edges_calls += 1;
+                    self.engine.get_all_edges()
                 };
                 self.stats.edges_traversed += edges.len();
 

--- a/packages/rfdb-server/src/datalog/tests.rs
+++ b/packages/rfdb-server/src/datalog/tests.rs
@@ -855,6 +855,38 @@ mod eval_tests {
     }
 
     #[test]
+    fn test_eval_incoming_untyped_var_dst_enumerates_all_edges() {
+        // incoming(D, S) — unbound dst AND no edge-type constant — must enumerate
+        // every edge (binding D=dst, S=src), mirroring edge(S, D) and incoming's
+        // own Wildcard-dst arm. Returning empty here silently drops every row of
+        // an untyped incoming enumeration (false negatives).
+        let engine = setup_test_graph(); // edges: 1->4, 4->2 (CALLS)
+        let evaluator = Evaluator::new(&engine);
+
+        let query = Atom::new("incoming", vec![Term::var("D"), Term::var("S")]);
+        let mut pairs: Vec<(u128, u128)> = evaluator
+            .query_atom(&query)
+            .unwrap()
+            .iter()
+            .filter_map(|b| Some((b.get("D")?.as_id()?, b.get("S")?.as_id()?)))
+            .collect();
+        pairs.sort();
+        // (dst, src): edge 1->4 => (4,1); edge 4->2 => (2,4)
+        assert_eq!(pairs, vec![(2, 4), (4, 1)]);
+
+        // Symmetry: incoming(D, S) must yield the same (dst,src) set as edge(S, D).
+        let edge_query = Atom::new("edge", vec![Term::var("S"), Term::var("D")]);
+        let mut edge_pairs: Vec<(u128, u128)> = evaluator
+            .query_atom(&edge_query)
+            .unwrap()
+            .iter()
+            .filter_map(|b| Some((b.get("D")?.as_id()?, b.get("S")?.as_id()?)))
+            .collect();
+        edge_pairs.sort();
+        assert_eq!(pairs, edge_pairs, "incoming(D,S) must mirror edge(S,D)");
+    }
+
+    #[test]
     fn test_eval_edge_wildcard_negation() {
         // The original diagnostic query: violation(X) :- node(X, "FUNCTION"), \+ edge(_, X, "CONTAINS").
         // Setup: graph with FUNCTION nodes, some with incoming CONTAINS, some without
@@ -2421,6 +2453,28 @@ mod eval_tests {
     fn test_explain_incoming_wildcard_dst_matches_plain() {
         // incoming(_, X, "CALLS") — Wildcard dst: plain enumerates 2 CALLS edges, binds src.
         assert_explain_parity("incoming(_, X, \"CALLS\")", Some("X"));
+    }
+
+    #[test]
+    fn test_explain_incoming_untyped_var_dst_matches_plain() {
+        // incoming(D, S) — Var dst, NO edge-type constant: the explain evaluator
+        // has its own copy of eval_incoming, so pin the untyped enumeration to
+        // the plain evaluator. Parity alone is insufficient here (both returned 0
+        // before the fix → 0 == 0 would pass), so assert the non-empty count too.
+        use crate::datalog::eval_explain::EvaluatorExplain;
+
+        let engine = setup_test_graph(); // edges: 1->4, 4->2
+        let mut explain_eval = EvaluatorExplain::new(&engine, true);
+        let result = explain_eval
+            .eval_query(&parse_query("incoming(D, S)").unwrap())
+            .unwrap();
+        assert_eq!(
+            result.bindings.len(),
+            2,
+            "explain: untyped incoming(D,S) must enumerate all edges"
+        );
+
+        assert_explain_parity("incoming(D, S)", Some("S"));
     }
 
     #[test]
@@ -3991,10 +4045,16 @@ mod attr_reverse_lookup_tests {
     // Before the fix, both would fail to place (circular dep). After the fix,
     // attr reverse provides X, enabling incoming to be placed.
     #[test]
-    fn test_reorder_attr_reverse_before_incoming() {
+    fn test_reorder_incoming_always_placeable_like_edge() {
         use crate::datalog::utils::reorder_literals;
 
-        // incoming requires X bound; attr reverse lookup provides X
+        // `incoming` is the reverse of `edge` and, like `edge`, is always
+        // placeable (full scan if dst is unbound) — it self-seeds and provides
+        // its free vars. So the reorderer does NOT need to hoist a seed provider
+        // ahead of it: the greedy sort keeps the author's order, placing
+        // `incoming` first. (Previously `incoming` was wrongly treated as
+        // requiring a bound dst, which forced `attr` ahead of it and rejected
+        // standalone `incoming(D, S)` enumerations as circular dependencies.)
         let literals = vec![
             Literal::positive(Atom::new("incoming", vec![
                 Term::var("X"),
@@ -4004,16 +4064,27 @@ mod attr_reverse_lookup_tests {
             Literal::positive(Atom::new("attr", vec![
                 Term::var("X"),
                 Term::constant("name"),
-                Term::constant("orders-pub"),
+                Term::constant("processOrder"),
             ])),
         ];
 
         let ordered = reorder_literals(&literals).unwrap();
+        assert_eq!(ordered[0].atom().predicate(), "incoming",
+            "incoming is always placeable (self-seeds) and stays first");
+        assert_eq!(ordered[1].atom().predicate(), "attr");
 
-        // attr should come first (it provides X via reverse lookup)
-        assert_eq!(ordered[0].atom().predicate(), "attr",
-            "attr reverse lookup should be reordered before incoming");
-        assert_eq!(ordered[1].atom().predicate(), "incoming");
+        // End-to-end: the conjunction is valid and order-independent — it binds
+        // X=dst (processOrder=node 4) and Y=src (node 1) for the CALLS edge 1->4.
+        let engine = setup_reverse_lookup_graph();
+        let evaluator = Evaluator::new(&engine);
+        let results = evaluator
+            .eval_query(&parse_query(
+                r#"incoming(X, Y, "CALLS"), attr(X, "name", "processOrder")"#,
+            ).unwrap())
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].get("X"), Some(&Value::Id(4)));
+        assert_eq!(results[0].get("Y"), Some(&Value::Id(1)));
     }
 
     // End-to-end: attr(X, "name", "orders-pub"), edge(X, Y, "CALLS") works
@@ -4341,19 +4412,55 @@ mod edge_type_index_tests {
     }
 
     #[test]
-    fn test_incoming_unbound_dst_var_type_still_empty() {
-        let engine = setup_edge_type_graph();
+    fn test_incoming_unbound_dst_var_type_enumerates_all_edges() {
+        let engine = setup_edge_type_graph(); // edges: 1->2 CALLS, 3->1 CONTAINS
         let evaluator = Evaluator::new(&engine);
 
-        // incoming(X, Y, T) — both dst and type unbound → degenerate, returns empty
+        // incoming(X, Y, T) — dst, src and type all unbound. With no edge-type
+        // constant the edge-type index (RFD-44) cannot apply, so this falls back
+        // to a full scan and enumerates EVERY edge, binding X=dst, Y=src, T=type.
+        // This is the reverse of edge(Y, X, T) and must agree with it; it used to
+        // silently return empty (a false-negative for an untyped enumeration).
         let query = Atom::new("incoming", vec![
             Term::var("X"),
             Term::var("Y"),
             Term::var("T"),
         ]);
 
-        let results = evaluator.query_atom(&query).unwrap();
-        assert!(results.is_empty(), "incoming with all-unbound should return empty");
+        let mut triples: Vec<(u128, u128, String)> = evaluator
+            .query_atom(&query)
+            .unwrap()
+            .iter()
+            .filter_map(|b| {
+                Some((b.get("X")?.as_id()?, b.get("Y")?.as_id()?, b.get("T")?.as_str()))
+            })
+            .collect();
+        triples.sort();
+        // (dst, src, type): CALLS 1->2 => (2,1,CALLS); CONTAINS 3->1 => (1,3,CONTAINS)
+        assert_eq!(
+            triples,
+            vec![
+                (1, 3, "CONTAINS".to_string()),
+                (2, 1, "CALLS".to_string()),
+            ]
+        );
+
+        // Must mirror edge(Y, X, T) (the same edges, src/dst swapped in binding).
+        let edge_query = Atom::new("edge", vec![
+            Term::var("Y"),
+            Term::var("X"),
+            Term::var("T"),
+        ]);
+        let mut edge_triples: Vec<(u128, u128, String)> = evaluator
+            .query_atom(&edge_query)
+            .unwrap()
+            .iter()
+            .filter_map(|b| {
+                Some((b.get("X")?.as_id()?, b.get("Y")?.as_id()?, b.get("T")?.as_str()))
+            })
+            .collect();
+        edge_triples.sort();
+        assert_eq!(triples, edge_triples, "incoming(X,Y,T) must mirror edge(Y,X,T)");
     }
 }
 

--- a/packages/rfdb-server/src/datalog/utils.rs
+++ b/packages/rfdb-server/src/datalog/utils.rs
@@ -223,8 +223,22 @@ fn positive_can_place_and_provides(
             let provides = free_vars(args, bound);
             (true, provides)
         }
-        "incoming" | "path" => {
-            // incoming(dst, src, type) / path(src, dst) — requires first arg bound
+        "incoming" => {
+            // incoming(dst, src, type) is the reverse of edge(src, dst, type):
+            // both are edge-relation predicates that differ only in argument
+            // order. Like `edge`, `incoming` is always placeable (full scan if
+            // dst is unbound) and provides every free Var arg. Requiring a bound
+            // dst here — while `edge` requires nothing — wrongly rejected
+            // placeable enumerations such as `incoming(D, S)` or
+            // `incoming(D, S, "CALLS")` as circular dependencies, even though the
+            // executor can satisfy them (by edge-type index or full scan).
+            let provides = free_vars(args, bound);
+            (true, provides)
+        }
+        "path" => {
+            // path(src, dst) — requires the first arg (source) bound. Unlike the
+            // edge predicates, `eval_path` only supports a Const/bound source
+            // (BFS from an unbound source is not a scan), so it cannot full-scan.
             if args.is_empty() {
                 return (true, HashSet::new());
             }


### PR DESCRIPTION
## Summary

The Datalog `incoming` builtin is the **reverse of `edge`** — they differ only in argument order (`incoming(dst, src, type)` vs `edge(src, dst, type)`) — yet `incoming` was treated **asymmetrically at two layers**, silently producing **false negatives** for an untyped enumeration. An AI agent issuing `incoming(D, S)` to enumerate the reverse edge relation got either an empty result or a "circular dependency" error, while the equivalent `edge(S, D)` returned every edge. On-thesis silent-wrong-answer in the engine the agent queries.

Net-new correctness bug found by dogfooding the Datalog builtins (the productive vein flagged after #357 closed `path/2`). Same RFDB hardening series as #340–#358, in a previously-untouched area (the `edge`/`incoming` enumeration asymmetry).

## Spec (BDD)

- **Invariant restored:** `incoming(Dst, Src[, Type])` is the reverse of `edge(Src, Dst[, Type])` and must yield the same edge set with `Dst`/`Src` swapped — including when `Dst` is unbound and no edge-type constant is supplied (full scan).
- **Given** edges `1 -[CALLS]-> 4` and `4 -[CALLS]-> 2`
  **When** `incoming(D, S)` runs (unbound dst, no type)
  **Then** it returns `{(D=4,S=1), (D=2,S=4)}` — **not** empty — and equals `edge(S, D)`.
- **And** `incoming(X, Y, T)` (dst, src, type all unbound) enumerates every edge binding the type too, mirroring `edge(Y, X, T)`.
- **And** `incoming(D, S, "CALLS")` (unbound dst, **const** type) is placeable as a standalone goal/rule (was rejected as a circular dependency) and still uses the RFD-44 edge-type **index** (no full scan).
- **And (regression):** `path(src, dst)` still requires a bound source — it cannot full-scan.

## Root cause (two layers)

**1. Query reorderer — `packages/rfdb-server/src/datalog/utils.rs`** (`positive_can_place_and_provides`):
`edge` is *"always placeable (full scan if src unbound)"*, but `incoming` shared an arm with `path` that required `args[0]` (dst) bound. So `incoming(D, S)` — and even `incoming(D, S, "CALLS")`, which the executor *can* satisfy via the edge-type index — was rejected as a `"circular dependency, cannot place"` before reaching the executor (a `Wildcard` dst slipped through only because `is_bound_or_const(Wildcard) == true`).

**2. Executor — `datalog/eval.rs` + its explain twin `eval_explain.rs`** (`eval_incoming`, `Term::Var(dst)` arm):
With no edge-type constant the arm did `return vec[]` instead of falling back to a full scan — even though `eval_edge`'s `Var(src)` arm **and** `eval_incoming`'s own `Wildcard`-dst arm both fall back to `get_all_edges()`. So `incoming(D, S)` returned empty where `edge(S, D)` returned every edge.

## Fix

- **Reorderer:** split `incoming` out of the shared `"incoming" | "path"` arm and give it `edge`'s treatment — always placeable, `provides = free_vars(args)`. `path` keeps the bound-source requirement (`eval_path` only supports a `Const` source; BFS from an unbound source is not a scan).
- **Executor (both copies):** replace `return vec[]` with `get_all_edges()`; the explain twin also pushes the existing `"Full edge scan: consider binding destination node"` warning + bumps `all_edges_calls`, matching its `Wildcard`-dst arm so the cost is surfaced, not hidden.

The RFD-44 const-type index path is **untouched** — `incoming(_, _, "T")` still uses `get_edges_by_type`, never a full scan.

## Before / After (live `cargo test`, fixture: `1->4`, `4->2`, CALLS)

RED before the fix:
```
test_eval_incoming_untyped_var_dst_enumerates_all_edges
  assertion failed: left: []  right: [(2,4),(4,1)]     # executor returned empty

test_explain_incoming_untyped_var_dst_matches_plain
  Err("datalog reorder: circular dependency, cannot place:
       [\"Positive(Atom { predicate: \\\"incoming\\\", args: [Var(\\\"D\\\"), Var(\\\"S\\\")] })\"]")
                                                         # reorderer rejected it outright
```

GREEN after:
```
test datalog::tests::eval_tests::test_eval_incoming_untyped_var_dst_enumerates_all_edges ... ok
test datalog::tests::eval_tests::test_explain_incoming_untyped_var_dst_matches_plain ... ok
test datalog::tests::edge_type_index_tests::test_incoming_unbound_dst_var_type_enumerates_all_edges ... ok
test datalog::tests::attr_reverse_lookup_tests::test_reorder_incoming_always_placeable_like_edge ... ok
```

Full gate (Rust-only change, isolated to the `rfdb` crate):
```
cargo test -p rfdb --lib   -> test result: ok. 936 passed; 0 failed; 0 ignored   (was 934)
cargo clippy --lib         -> no new warnings (pre-existing only; none in edited regions)
cargo build --bins         -> Finished
```

## Tests

- `test_eval_incoming_untyped_var_dst_enumerates_all_edges` — plain: `incoming(D,S)` enumerates all edges and equals `edge(S,D)`.
- `test_incoming_unbound_dst_var_type_enumerates_all_edges` — plain: `incoming(X,Y,T)` (all-unbound, var type) enumerates all edges incl. type, equals `edge(Y,X,T)`. *(rewritten from `..._still_empty`, which pinned the false negative.)*
- `test_explain_incoming_untyped_var_dst_matches_plain` — explain twin parity (count + value set), since parity alone (0==0) couldn't catch the bug.
- `test_reorder_incoming_always_placeable_like_edge` — reorderer leaves `incoming` first (self-seeds) and the conjunction still produces correct results. *(rewritten from `test_reorder_attr_reverse_before_incoming`, which asserted the old "incoming needs a bound dst" ordering.)*

## Adversarial review

- **Round A — correctness:** verified bound-dst (`Const` arm) and `Wildcard`-dst arms unchanged; const-type still index-backed (RFD-44 `test_incoming_unbound_dst_const_type` green, `all_edges_calls == 0`); full-scan arm binds all of dst/src/type, so the reorderer's `free_vars` "provides" set is accurate; negation is unaffected (the reorderer's `Negative` arm still requires all Var args bound). `path` BFS-source requirement preserved (all `path/2` tests, incl. the #357 self-reachability ones, green).
- **Round B — fragility:** `eval.rs`/`eval_explain.rs` are pre-existing >500-line files (splitting out of scope, consistent with the prior PRs in this series); the change is +1 logic line + a doc comment per file explaining why a full-scan fallback (not empty) is correct, guarding against a future "re-add `return vec[]`". The reorderer↔executor coupling (always-placeable ⇒ executor must full-scan) is now identical to `edge` and documented at the reorderer site.
- **Round C — class-not-instance:** audited the whole class — the asymmetry lived at the reorderer + both executor copies; all three fixed. `edge` was already correct (the reference); `path` intentionally kept strict. No `datalog2` engine exists on `main` (it lives on the unmerged `feat/datalog` branch, out of scope). No sibling latent site; no follow-ups filed.

## Blast radius

Rust-only, inside `packages/rfdb-server/src/datalog/{utils,eval,eval_explain,tests}.rs`. No JS/TS, no wire format, no stored-graph-shape change — only newly-correct (non-empty) results for untyped `incoming(...)` enumerations and the placeability of `incoming` goals with an unbound dst. The JS-only CI gate (`.github/workflows/ci.yml`) is unaffected.

## Source

In-env triage this run: **0 open GitHub issues**; no Linear MCP (github + Enox only). Net-new correctness bug found by empirically dogfooding the Datalog builtins (the vein flagged after #357), backed by live `cargo test` on a built `rfdb`. Recorded under the autonomous web-session RFDB-correctness intake series in Enox.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cae5vVUDs5FbZHK77ko3Lm)_