### PR TITLE
fix(rfdb): datalog path(X, dst) computes reverse reachability instead of returning empty

### DIFF
--- a/packages/rfdb-server/src/datalog/eval.rs
+++ b/packages/rfdb-server/src/datalog/eval.rs
@@ -1427,6 +1427,47 @@ impl<'a> Evaluator<'a> {
                     vec![Bindings::new()]
                 }
             }
+            // path(X, "dst") - REVERSE reachability: enumerate every node that
+            // can REACH dst (its ancestor set). The directed dual of the
+            // (Const, Var) forward arm. Previously this fell through to the
+            // catch-all and silently returned NO rows, so an agent asking "what
+            // reaches / depends on dst" via `path(X, dst)` got a confidently
+            // empty answer instead of the real ancestors — an on-thesis
+            // silent-wrong-answer.
+            (Term::Var(var), Term::Const(dst_str)) => {
+                let dst_id = match dst_str.parse::<u128>() {
+                    Ok(id) => id,
+                    Err(_) => return vec![],
+                };
+
+                self.path_reaches(dst_id)
+                    .into_iter()
+                    .map(|id| {
+                        let mut b = Bindings::new();
+                        b.set(var, Value::Id(id));
+                        b
+                    })
+                    .collect()
+            }
+            // path(_, "dst") - does ANY node reach dst? Dual of (Const, _).
+            (Term::Wildcard, Term::Const(dst_str)) => {
+                let dst_id = match dst_str.parse::<u128>() {
+                    Ok(id) => id,
+                    Err(_) => return vec![],
+                };
+
+                if self.path_reaches(dst_id).is_empty() {
+                    vec![]
+                } else {
+                    vec![Bindings::new()]
+                }
+            }
+            // Remaining modes have NO constant endpoint (both src and dst are
+            // Var/Wildcard). Answering them would require materializing all-pairs
+            // reachability (O(N·E)) and is intentionally unsupported — `path`
+            // needs at least one bound endpoint, exactly as the forward arms
+            // require a bound source. In a conjunctive query the pipeline binds
+            // one endpoint from a preceding generator atom before `path` runs.
             _ => vec![],
         }
     }
@@ -1448,6 +1489,36 @@ impl<'a> Evaluator<'a> {
             return Vec::new();
         }
         self.engine.bfs(&frontier, 100, &[])
+    }
+
+    /// Set of nodes that can REACH `dst_id` via AT LEAST ONE edge — the ancestor
+    /// set queried by `path(X, dst)` (the reverse of [`Self::path_reachable`]).
+    ///
+    /// Mirrors `path_reachable` exactly, but walks INCOMING edges backward: BFS
+    /// is seeded from `dst_id`'s direct predecessors (the depth-1 frontier)
+    /// rather than `dst_id` itself, so `dst_id` appears here ONLY when a real
+    /// edge path loops back to it (a genuine cycle). This keeps the reverse arms
+    /// consistent with the forward arms and with the irreflexive `path(A, A)`
+    /// self-rule (see the `test_eval_path_self_*` tests). It reuses the shared
+    /// `traversal::bfs` with a backward-neighbour closure — the same primitive
+    /// `GraphStore::bfs` uses forward — so the two directions cannot drift apart.
+    fn path_reaches(&self, dst_id: u128) -> Vec<u128> {
+        // Direct predecessors of `node`: the sources of its (non-deleted)
+        // incoming edges. The backward analogue of `GraphStore::neighbors`.
+        let predecessors = |node: u128| -> Vec<u128> {
+            self.engine
+                .get_incoming_edges(node, None)
+                .into_iter()
+                .filter(|e| !e.deleted)
+                .map(|e| e.src)
+                .collect()
+        };
+
+        let frontier = predecessors(dst_id);
+        if frontier.is_empty() {
+            return Vec::new();
+        }
+        crate::graph::traversal::bfs(&frontier, 100, predecessors)
     }
 
     /// Evaluate neq(X, Y) - inequality constraint

--- a/packages/rfdb-server/src/datalog/tests.rs
+++ b/packages/rfdb-server/src/datalog/tests.rs
@@ -693,6 +693,105 @@ mod eval_tests {
         assert_eq!(results.len(), 1, "node on a cycle MUST have a path to itself");
     }
 
+    // ── path() REVERSE reachability: path(X, dst) enumerates ancestors ──
+    //
+    // The directed dual of path(src, X). `path(X, "dst")` must return every node
+    // that can REACH dst (its ancestor set). Before the fix these (Var/Wildcard
+    // source, Const dest) arms fell through to the catch-all and silently
+    // returned NO rows — so "what reaches / depends on dst" answered empty.
+
+    #[test]
+    fn test_eval_path_reverse_enumerates_ancestors() {
+        // Graph: 1 -> 4 -> 2 (CALLS); node 3 is an orphan.
+        // path(X, "2") = nodes that reach 2 = {1, 4}.
+        let engine = setup_test_graph();
+        let evaluator = Evaluator::new(&engine);
+        let query = Atom::new("path", vec![Term::var("X"), Term::constant("2")]);
+        let mut ids: Vec<u128> = evaluator
+            .query_atom(&query)
+            .unwrap()
+            .iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec![1, 4], "reverse path must enumerate ancestors of 2");
+    }
+
+    #[test]
+    fn test_eval_path_reverse_no_ancestors_is_empty() {
+        // Node 1 is a root: nothing reaches it → path(X, "1") is empty.
+        let engine = setup_test_graph();
+        let evaluator = Evaluator::new(&engine);
+        let query = Atom::new("path", vec![Term::var("X"), Term::constant("1")]);
+        let results = evaluator.query_atom(&query).unwrap();
+        assert_eq!(results.len(), 0, "a root node has no ancestors");
+    }
+
+    #[test]
+    fn test_eval_path_reverse_wildcard_existence() {
+        let engine = setup_test_graph();
+        let evaluator = Evaluator::new(&engine);
+        // path(_, "2") - something reaches 2 → exactly one success row.
+        let reach2 = Atom::new("path", vec![Term::Wildcard, Term::constant("2")]);
+        assert_eq!(evaluator.query_atom(&reach2).unwrap().len(), 1);
+        // path(_, "1") - nothing reaches 1 → no rows.
+        let reach1 = Atom::new("path", vec![Term::Wildcard, Term::constant("1")]);
+        assert_eq!(evaluator.query_atom(&reach1).unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_eval_path_reverse_includes_cyclic_self() {
+        // 100 <-> 101 cycle. Ancestors of 100: 101 reaches it directly, and 100
+        // reaches itself via the cycle → {100, 101}. Mirrors the forward
+        // test_eval_path_var_includes_cyclic_self.
+        let engine = setup_cycle_graph();
+        let evaluator = Evaluator::new(&engine);
+        let query = Atom::new("path", vec![Term::var("X"), Term::constant("100")]);
+        let mut ids: Vec<u128> = evaluator
+            .query_atom(&query)
+            .unwrap()
+            .iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec![100, 101], "cyclic reverse enumeration includes self (100) and peer (101)");
+    }
+
+    #[test]
+    fn test_eval_path_reverse_via_parsed_query() {
+        // End-to-end through parse_query + eval_query (not just query_atom),
+        // exercising the full pipeline for a single reverse-path literal.
+        let engine = setup_test_graph();
+        let evaluator = Evaluator::new(&engine);
+        let literals = parse_query("path(X, \"2\")").unwrap();
+        let mut ids: Vec<u128> = evaluator
+            .eval_query(&literals)
+            .unwrap()
+            .iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec![1, 4]);
+    }
+
+    #[test]
+    fn test_eval_path_reverse_in_conjunction() {
+        // The real-world shape: "which FUNCTIONs reach node 2?". `reorder_literals`
+        // must place the reverse-path atom first (it provides X via the constant
+        // dst), then the node generator filters. Ancestors of 2 = {1, 4}; only 4
+        // is a FUNCTION (1 is queue:publish).
+        let engine = setup_test_graph();
+        let evaluator = Evaluator::new(&engine);
+        let literals = parse_query("path(X, \"2\"), node(X, \"FUNCTION\")").unwrap();
+        let ids: Vec<u128> = evaluator
+            .eval_query(&literals)
+            .unwrap()
+            .iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+            .collect();
+        assert_eq!(ids, vec![4], "only FUNCTION ancestor of node 2 is node 4");
+    }
+
     #[test]
     fn test_eval_path_var_includes_cyclic_self() {
         // Enumerating reachable nodes from a cyclic node must include the node

--- a/packages/rfdb-server/src/datalog/utils.rs
+++ b/packages/rfdb-server/src/datalog/utils.rs
@@ -236,16 +236,31 @@ fn positive_can_place_and_provides(
             (true, provides)
         }
         "path" => {
-            // path(src, dst) — requires the first arg (source) bound. Unlike the
-            // edge predicates, `eval_path` only supports a Const/bound source
-            // (BFS from an unbound source is not a scan), so it cannot full-scan.
+            // path(src, dst) — placeable when AT LEAST ONE endpoint is *concrete*
+            // (a Const or an already-bound Var; a Wildcard does NOT count):
+            //   - src concrete → forward BFS, providing a free dst var
+            //     (`eval_path` (Const, Var/Wildcard/Const) arms);
+            //   - dst concrete → reverse BFS over incoming edges, providing a
+            //     free src var (`eval_path` (Var/Wildcard, Const) arms).
+            // A fully-unbound pair (both Var/Wildcard) is all-pairs reachability
+            // (O(N·E)) and is unsupported — `eval_path` returns nothing for it —
+            // so reorder must NOT report it as placeable, otherwise it would
+            // claim to bind a variable it never produces. This classification
+            // mirrors the supported `eval_path` modes exactly.
             if args.is_empty() {
                 return (true, HashSet::new());
             }
-            let can_place = is_bound_or_const(&args[0], bound);
+            let concrete = |t: &Term| match t {
+                Term::Const(_) => true,
+                Term::Var(v) => bound.contains(v),
+                Term::Wildcard => false,
+            };
+            let can_place = concrete(&args[0]) || args.get(1).is_some_and(concrete);
             let mut provides = HashSet::new();
             if can_place {
-                for arg in args.iter().skip(1) {
+                // Whichever side was free becomes bound once the (directional)
+                // BFS runs, so report every free Var arg.
+                for arg in args.iter() {
                     if let Term::Var(v) = arg {
                         if !bound.contains(v) {
                             provides.insert(v.clone());


### PR DESCRIPTION
## Summary

The Datalog `path` builtin silently returned **no rows** for every *reverse* query — `path(X, "dst")` ("which nodes can **reach** dst") and `path(_, "dst")` ("does anything reach dst"). `eval_path` only implemented the three **bound-source** modes (`path(Const, …)`); every Var/Wildcard-source mode fell through to a catch-all `_ => vec[]`. So an AI agent asking the first-class code-graph question *"what reaches / depends on X"* via `path(Caller, X)` got a confidently-empty answer — an on-thesis silent-wrong-answer in the engine the agent queries.

This is a net-new correctness bug in an actively-developed area (`path` was just touched by #357 for the `path(A,A)` self-rule), in a region none of the open RFDB PRs (#345–#356) touch.

## Spec (BDD)

- **Invariant restored:** `path(X, dst)` is the directed dual of `path(src, X)` — it enumerates dst's **ancestor set** (every node from which a ≥1-edge directed path reaches dst), with the same irreflexive self-semantics (dst itself appears only via a genuine cycle).
- **Given** `1 → 4 → 2` (CALLS) and an orphan node `3`
  **When** `path(X, "2")`
  **Then** `X ∈ {1, 4}` — **not** empty.
- **And** `path(_, "2")` succeeds (something reaches 2); `path(X, "1")` / `path(_, "1")` are empty (node 1 is a root).
- **And** on a `100 ↔ 101` cycle, `path(X, "100") = {100, 101}` (peer + self-via-cycle) — mirroring the forward `path("100", X)`.
- **And** `path(X, "2"), node(X, "FUNCTION")` returns `{4}` (the reorderer places the reverse-path atom first, binding `X`, then the generator filters).

## Root cause

`packages/rfdb-server/src/datalog/eval.rs`, `eval_path`:

```rust
match (src_term, dst_term) {
    (Term::Const(src), Term::Const(dst)) => { /* exists */ }
    (Term::Const(src), Term::Var(v))     => { /* forward enumerate */ }
    (Term::Const(src), Term::Wildcard)   => { /* forward exists */ }
    _ => vec[],   // <-- (Var, Const), (Wildcard, Const) … all silently empty
}
```

And `reorder_literals` (`datalog/utils.rs`) classified `path` as placeable only when **`args[0]` (source)** was bound — so even after adding the executor arms, a conjunctive reverse query was rejected as a *"circular dependency"* (the reorderer didn't know `path` could now produce the source var from a constant dst).

## Fix

- **`eval_path`** — add the two reverse arms `(Var, Const)` and `(Wildcard, Const)`, backed by a new `path_reaches(dst)` helper. It **mirrors `path_reachable` exactly** but walks **incoming** edges, reusing the same shared `traversal::bfs` primitive that `GraphStore::bfs` uses forward (seeded from dst's depth-1 predecessors, depth cap 100) — so the two directions cannot drift apart, and the irreflexive `path(A,A)` rule is preserved. The remaining fully-unbound modes (both endpoints Var/Wildcard ⇒ all-pairs O(N·E)) stay unsupported, documented.
- **`reorder_literals`** — classify `path` as placeable when **either** endpoint is *concrete* (Const or bound Var — Wildcard does **not** count, matching the executor's Const-dst requirement), providing whichever endpoint was free. This makes reverse path usable in conjunctive queries and also closes a **pre-existing latent** case where `path(_, X)` claimed to bind `X` while the executor returned empty.

## Before / After (live `cargo test`, fixture `1 → 4 → 2`, orphan `3`)

In-env probe **before** the fix:
```
path(X, 2) -> []          # BUG — ancestors of 2 are {1, 4}
path(_, 2) -> len 0       # BUG — 1 and 4 reach 2
path(X, 1) -> []          # correct — node 1 is a root
```
RED before / GREEN after — the new `test_eval_path_reverse_*` tests:
```
test_eval_path_reverse_enumerates_ancestors ... ok   # {1, 4}
test_eval_path_reverse_no_ancestors_is_empty ... ok   # root → []
test_eval_path_reverse_wildcard_existence ... ok      # path(_,2)=1 row, path(_,1)=0
test_eval_path_reverse_includes_cyclic_self ... ok    # cycle → {100, 101}
test_eval_path_reverse_via_parsed_query ... ok        # parse_query + eval_query
test_eval_path_reverse_in_conjunction ... ok          # path(X,2), node(X,FUNCTION) → {4}
```

Full gate (Rust-only, isolated to the `rfdb` crate):
```
cargo test --lib datalog::   -> ok. 218 passed; 0 failed
cargo test --lib             -> ok. 941+ passed; 0 failed
cargo clippy --lib           -> no new warnings (none in the edited files; pre-existing crate-wide only)
cargo fmt --check            -> edited files clean (pre-existing drift in benches/graph_operations.rs untouched)
```

## Adversarial review

- **Round A — correctness:** empty/no-ancestor (root → `[]`), genuine cycle (self included via the cycle, never the zero-length self path), acyclic dst (self excluded), deleted incoming edges filtered, fan-in dedup (shared `traversal::bfs` visited-set), unparsable Const dst → `[]` (same as forward), depth cap 100 identical to forward. The reverse irreflexive semantics are pinned by `test_eval_path_reverse_includes_cyclic_self` and `_no_ancestors_is_empty`.
- **Round B — fragility:** `eval.rs` is a pre-existing >500-line file (splitting out of scope, consistent with prior RFDB PRs). The one real coupling — reverse must stay consistent with forward — is structurally eliminated: both directions go through the **same** `traversal::bfs` (documented at `path_reaches`). The reorder↔executor coupling (reorder's `path` classification must match the executor's supported modes) is documented at the reorder site.
- **Round C — class-not-instance:** `path` was the only directionally-asymmetric reachability builtin (`edge`/`incoming` are mutual reverses and already full-scan both ways; `attr` already has forward+reverse). The reorder fix additionally closes the sibling latent `path(_, X)` / `path(_, _)` "claims to bind but returns empty" inconsistency (now a loud reorder error rather than a silent-wrong bind). No analysis-pipeline invariant touched.

## Blast radius

Rust-only, inside `packages/rfdb-server/src/datalog/{eval,utils,tests}.rs`. No JS/TS, no wire format, no stored-graph-shape change — only the row set of `path` queries with an **unbound source + constant dest** (previously always empty). The JS-only CI gate is unaffected. `eval_path` is reached solely via the `eval_atom` dispatch; `reorder_literals` solely via `eval_query`; full datalog + lib suites green.

## Source

In-env triage this run: **0 open GitHub issues**, no Linear MCP (github + Enox only). Net-new correctness bug found by empirically probing the live Datalog engine (Evidence Rule: live `query_atom` / `eval_query` against a built `rfdb`). Recorded in the autonomous web-session RFDB-correctness intake series in Enox.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vfj8swdWUaHLWx1YCXi4Qz)_