### PR TITLE
fix(rfdb): reverse attr(X, semantic_id/id/version, V) lookup returns matching nodes

### DIFF
--- a/packages/rfdb-server/src/datalog/eval.rs
+++ b/packages/rfdb-server/src/datalog/eval.rs
@@ -460,16 +460,40 @@ impl<'a> Evaluator<'a> {
                 if let (Term::Var(id_var), Term::Const(attr_name), Term::Const(expected_value)) =
                     (&args[0], &args[1], &args[2])
                 {
-                    let query = Self::attr_to_query(attr_name, expected_value);
                     let id_var = id_var.clone();
-                    self.engine.find_by_attr_chunked(&query, chunk_size, &mut |ids| {
-                        let bindings: Vec<Bindings> = ids.iter().map(|&id| {
-                            let mut b = Bindings::new();
-                            b.set(&id_var, Value::Id(id));
-                            b
-                        }).collect();
-                        callback(bindings)
-                    });
+                    match attr_name.as_str() {
+                        // First-class columns AttrQuery cannot express. These must
+                        // route through the shared reverse helper (same as
+                        // eval_attr) — `attr_to_query` would mis-route them to a
+                        // metadata filter that silently matches nothing. They are
+                        // O(1)/O(n) and emitted as a single chunk; symmetry with
+                        // the non-generator path matters more than streaming here.
+                        "id" | "semantic_id" | "version" => {
+                            let ids = Self::reverse_attr_lookup(
+                                self.engine,
+                                attr_name,
+                                expected_value,
+                            );
+                            let bindings: Vec<Bindings> = ids.iter().map(|&id| {
+                                let mut b = Bindings::new();
+                                b.set(&id_var, Value::Id(id));
+                                b
+                            }).collect();
+                            callback(bindings);
+                        }
+                        // name/file/type/exported + metadata: indexed, chunked.
+                        _ => {
+                            let query = Self::attr_to_query(attr_name, expected_value);
+                            self.engine.find_by_attr_chunked(&query, chunk_size, &mut |ids| {
+                                let bindings: Vec<Bindings> = ids.iter().map(|&id| {
+                                    let mut b = Bindings::new();
+                                    b.set(&id_var, Value::Id(id));
+                                    b
+                                }).collect();
+                                callback(bindings)
+                            });
+                        }
+                    }
                 }
             }
             _ => {}
@@ -1180,8 +1204,7 @@ impl<'a> Evaluator<'a> {
         if let (Term::Var(id_var), Term::Const(attr_name), Term::Const(expected_value)) =
             (id_term, attr_term, value_term)
         {
-            let query = Self::attr_to_query(attr_name, expected_value);
-            let ids = self.engine.find_by_attr(&query);
+            let ids = Self::reverse_attr_lookup(self.engine, attr_name, expected_value);
             return ids
                 .into_iter()
                 .map(|id| {
@@ -1273,6 +1296,44 @@ impl<'a> Evaluator<'a> {
             _ => query.metadata_filters = vec![(attr_name.to_string(), value.to_string())],
         }
         query
+    }
+
+    /// Reverse `attr(X, F, V)` lookup: find node ids whose field `F` equals `V`.
+    ///
+    /// This is the dual of the forward path in `eval_attr` and MUST stay
+    /// symmetric with it. `name`/`file`/`type`/`exported` are expressible as an
+    /// `AttrQuery` and use the index-accelerated `find_by_attr`. But
+    /// `semantic_id`/`id`/`version` are first-class node columns that
+    /// `AttrQuery` cannot express — routing them through `metadata_filters` (as
+    /// `attr_to_query` does) silently matches nothing, because they are NOT in
+    /// the node's metadata JSON. The forward path reads them off `NodeRecord`
+    /// directly, so the reverse path must too, or the two directions disagree
+    /// (a silent wrong answer). They are handled here:
+    /// - `id`: O(1) existence check (the value *is* the node id).
+    /// - `semantic_id`/`version`: scan the node set (O(n), consistent with the
+    ///   documented O(n) cost of `attr()` reverse lookups).
+    ///
+    /// Any other field name is treated as a metadata key, unchanged.
+    fn reverse_attr_lookup(engine: &dyn GraphStore, attr_name: &str, value: &str) -> Vec<u128> {
+        match attr_name {
+            "id" => match value.parse::<u128>() {
+                Ok(id) if engine.get_node(id).is_some() => vec![id],
+                _ => vec![],
+            },
+            "semantic_id" => engine
+                .find_by_attr(&AttrQuery::default())
+                .into_iter()
+                .filter(|id| {
+                    engine.get_node(*id).and_then(|n| n.semantic_id).as_deref() == Some(value)
+                })
+                .collect(),
+            "version" => engine
+                .find_by_attr(&AttrQuery::default())
+                .into_iter()
+                .filter(|id| engine.get_node(*id).map(|n| n.version).as_deref() == Some(value))
+                .collect(),
+            _ => engine.find_by_attr(&Self::attr_to_query(attr_name, value)),
+        }
     }
 
     /// Evaluate attr_edge(Src, Dst, EdgeType, AttrName, Value) predicate - access edge metadata

--- a/packages/rfdb-server/src/datalog/eval_explain.rs
+++ b/packages/rfdb-server/src/datalog/eval_explain.rs
@@ -1134,8 +1134,7 @@ impl<'a> EvaluatorExplain<'a> {
             (id_term, attr_term, value_term)
         {
             self.stats.find_by_type_calls += 1;
-            let query = Self::attr_to_query(attr_name, expected_value);
-            let ids = self.engine.find_by_attr(&query);
+            let ids = Self::reverse_attr_lookup(self.engine, attr_name, expected_value);
             self.stats.nodes_visited += ids.len();
             return ids
                 .into_iter()
@@ -1317,6 +1316,33 @@ impl<'a> EvaluatorExplain<'a> {
             _ => query.metadata_filters = vec![(attr_name.to_string(), value.to_string())],
         }
         query
+    }
+
+    /// Reverse `attr(X, F, V)` lookup — twin of `Evaluator::reverse_attr_lookup`
+    /// (keep both in sync). Restores forward/reverse symmetry for the
+    /// first-class columns `semantic_id`/`id`/`version`, which `AttrQuery`
+    /// cannot express and which `metadata_filters` would silently miss. See the
+    /// doc comment on `Evaluator::reverse_attr_lookup` for the full rationale.
+    fn reverse_attr_lookup(engine: &dyn GraphStore, attr_name: &str, value: &str) -> Vec<u128> {
+        match attr_name {
+            "id" => match value.parse::<u128>() {
+                Ok(id) if engine.get_node(id).is_some() => vec![id],
+                _ => vec![],
+            },
+            "semantic_id" => engine
+                .find_by_attr(&AttrQuery::default())
+                .into_iter()
+                .filter(|id| {
+                    engine.get_node(*id).and_then(|n| n.semantic_id).as_deref() == Some(value)
+                })
+                .collect(),
+            "version" => engine
+                .find_by_attr(&AttrQuery::default())
+                .into_iter()
+                .filter(|id| engine.get_node(*id).map(|n| n.version).as_deref() == Some(value))
+                .collect(),
+            _ => engine.find_by_attr(&Self::attr_to_query(attr_name, value)),
+        }
     }
 
     /// Evaluate path(Src, Dst) predicate using BFS

--- a/packages/rfdb-server/src/datalog/tests.rs
+++ b/packages/rfdb-server/src/datalog/tests.rs
@@ -4303,6 +4303,173 @@ mod attr_first_class_field_tests {
         assert_eq!(result.bindings.len(), 1);
         assert_eq!(result.bindings[0].get("X"), Some(&"10".to_string()));
     }
+
+    // ------------------------------------------------------------------
+    // Reverse lookup for first-class fields version / semantic_id / id.
+    //
+    // RFD-48 added FORWARD `attr(id, F, V)` support for these (tested
+    // above), but the REVERSE path `attr(X, F, V)` routed every non-
+    // name/file/type/exported field through `metadata_filters`, which
+    // only matches the node's metadata JSON. semantic_id / id / version
+    // are first-class columns (NOT in metadata JSON), so reverse lookup
+    // silently returned nothing — asymmetric with forward, a silent
+    // wrong answer for the most fundamental "find the node with this
+    // semantic_id" query. These tests pin the restored symmetry.
+    // ------------------------------------------------------------------
+
+    // Reverse lookup: attr(X, "semantic_id", "...") finds the node by its
+    // canonical identifier. Must mirror the forward test above.
+    #[test]
+    fn test_eval_attr_reverse_semantic_id() {
+        let engine = setup_attr_field_graph();
+        let evaluator = Evaluator::new(&engine);
+
+        let query = Atom::new("attr", vec![
+            Term::var("X"),
+            Term::constant("semantic_id"),
+            Term::constant("lib.js->FUNCTION->exportedFn"),
+        ]);
+        let results = evaluator.query_atom(&query).unwrap();
+        let ids: Vec<u128> = results.iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+            .collect();
+        assert_eq!(ids, vec![10], "reverse semantic_id must return node 10");
+    }
+
+    // Reverse lookup with a semantic_id that no node has → empty.
+    #[test]
+    fn test_eval_attr_reverse_semantic_id_no_match() {
+        let engine = setup_attr_field_graph();
+        let evaluator = Evaluator::new(&engine);
+
+        let query = Atom::new("attr", vec![
+            Term::var("X"),
+            Term::constant("semantic_id"),
+            Term::constant("does.js->NONE->missing"),
+        ]);
+        let results = evaluator.query_atom(&query).unwrap();
+        assert!(results.is_empty(), "unknown semantic_id must yield no rows");
+    }
+
+    // Forward/reverse symmetry: the value forward returns for node 10's
+    // semantic_id, fed back into the reverse lookup, must return node 10.
+    #[test]
+    fn test_eval_attr_semantic_id_forward_reverse_symmetry() {
+        let engine = setup_attr_field_graph();
+        let evaluator = Evaluator::new(&engine);
+
+        // Forward: get node 10's semantic_id value.
+        let fwd = evaluator.query_atom(&Atom::new("attr", vec![
+            Term::constant("10"),
+            Term::constant("semantic_id"),
+            Term::var("V"),
+        ])).unwrap();
+        let value = match fwd[0].get("V").unwrap() {
+            Value::Str(s) => s.clone(),
+            other => panic!("expected Str, got {:?}", other),
+        };
+
+        // Reverse: that value must resolve back to exactly node 10.
+        let rev = evaluator.query_atom(&Atom::new("attr", vec![
+            Term::var("X"),
+            Term::constant("semantic_id"),
+            Term::constant(&value),
+        ])).unwrap();
+        let ids: Vec<u128> = rev.iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+            .collect();
+        assert_eq!(ids, vec![10], "forward semantic_id value must reverse to node 10");
+    }
+
+    // Reverse lookup: attr(X, "id", "20") binds X to that node (O(1) by id).
+    #[test]
+    fn test_eval_attr_reverse_id() {
+        let engine = setup_attr_field_graph();
+        let evaluator = Evaluator::new(&engine);
+
+        let query = Atom::new("attr", vec![
+            Term::var("X"),
+            Term::constant("id"),
+            Term::constant("20"),
+        ]);
+        let results = evaluator.query_atom(&query).unwrap();
+        let ids: Vec<u128> = results.iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+            .collect();
+        assert_eq!(ids, vec![20], "reverse id must return exactly node 20");
+    }
+
+    // Reverse lookup: attr(X, "id", "<nonexistent>") → empty (node absent).
+    #[test]
+    fn test_eval_attr_reverse_id_no_match() {
+        let engine = setup_attr_field_graph();
+        let evaluator = Evaluator::new(&engine);
+
+        let query = Atom::new("attr", vec![
+            Term::var("X"),
+            Term::constant("id"),
+            Term::constant("99999"),
+        ]);
+        let results = evaluator.query_atom(&query).unwrap();
+        assert!(results.is_empty(), "unknown id must yield no rows");
+    }
+
+    // Reverse lookup: attr(X, "version", "main") returns every node at
+    // that version (both fixture nodes are version "main").
+    #[test]
+    fn test_eval_attr_reverse_version() {
+        let engine = setup_attr_field_graph();
+        let evaluator = Evaluator::new(&engine);
+
+        let query = Atom::new("attr", vec![
+            Term::var("X"),
+            Term::constant("version"),
+            Term::constant("main"),
+        ]);
+        let results = evaluator.query_atom(&query).unwrap();
+        let mut ids: Vec<u128> = results.iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec![10, 20], "reverse version must return both nodes");
+    }
+
+    // The pipelined GENERATOR path (eval_generator_chunked) is a SEPARATE copy
+    // of the reverse-attr lookup. A conjunction whose only valid seed is a
+    // reverse semantic_id lookup routes through it. `neq` is a filter (needs X
+    // already bound), so the reorderer must place the reverse `attr` first as
+    // the generator — exercising the generator-path copy, not eval_attr.
+    #[test]
+    fn test_eval_attr_reverse_semantic_id_as_generator() {
+        let engine = setup_attr_field_graph();
+        let evaluator = Evaluator::new(&engine);
+
+        let literals = parse_query(
+            r#"attr(X, "semantic_id", "lib.js->FUNCTION->exportedFn"), neq(X, "0")"#
+        ).unwrap();
+
+        let results = evaluator.eval_query(&literals).unwrap();
+        let ids: Vec<u128> = results.iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+            .collect();
+        assert_eq!(ids, vec![10], "reverse semantic_id must seed the pipelined generator path");
+    }
+
+    // EvaluatorExplain mirror for reverse semantic_id — both evaluators
+    // must agree (the explain twin shares the same attr logic).
+    #[test]
+    fn test_eval_attr_reverse_semantic_id_explain() {
+        let engine = setup_attr_field_graph();
+        let mut evaluator = EvaluatorExplain::new(&engine, false);
+
+        let literals = parse_query(
+            r#"attr(X, "semantic_id", "app.js->IMPORT->React")"#
+        ).unwrap();
+
+        let result = evaluator.eval_query(&literals).unwrap();
+        assert_eq!(result.bindings.len(), 1);
+        assert_eq!(result.bindings[0].get("X"), Some(&"20".to_string()));
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Datalog `attr(X, F, V)` **reverse** lookup (X unbound, find nodes whose field `F` = `V`) silently returned **no rows** for the first-class node columns `semantic_id`, `id`, and `version` — while the **forward** direction `attr(id, F, V)` reads them correctly. The most fundamental graph query an AI agent makes — *"find the node with this `semantic_id`"* (Grafema's canonical `grafema://` identifier) — confidently returned empty. An on-thesis silent-wrong-answer in the engine the agent queries.

This **completes the forward/reverse symmetry that RFD-48 introduced for the forward direction only** (`attr_first_class_field_tests` already covered forward `semantic_id`/`id`/`version`, and reverse only for `exported`). Net-new Datalog correctness bug found by dogfooding the builtins (the productive vein flagged after #357/#359 closed `path/2`/`incoming`); a previously-untouched area, no overlap with the open RFDB PRs (#345/#346/#347/#351/#352/#356/#360).

## Spec (BDD)

- **Invariant restored:** reverse `attr(X, F, V)` returns exactly the nodes for which forward `attr(id, F, V)` succeeds — the two directions agree for every field the forward path supports.
- **Given** nodes `10` (`semantic_id = "lib.js->FUNCTION->exportedFn"`, version `main`) and `20` (`semantic_id = "app.js->IMPORT->React"`, version `main`)
  **When** `attr(X, "semantic_id", "lib.js->FUNCTION->exportedFn")`
  **Then** `X = {10}` — **not** empty.
- **And** `attr(X, "id", "20") = {20}`; an absent id → empty.
- **And** `attr(X, "version", "main") = {10, 20}`.
- **And** the value forward returns for node 10's `semantic_id`, fed back into the reverse lookup, returns exactly `{10}` (round-trip symmetry).
- **And** an unknown `semantic_id` → empty (no false positives).
- **And** the same holds when reverse `attr` **seeds a conjunction** (pipelined generator path) and via the `EvaluatorExplain` twin.

## Root cause

`packages/rfdb-server/src/datalog/eval.rs` — the reverse branch of `eval_attr` (and the `"attr"` arm of `eval_generator_chunked`, the pipelined seed path) routed the field through `attr_to_query`:

```rust
fn attr_to_query(attr_name: &str, value: &str) -> AttrQuery {
    match attr_name {
        "name" => ..., "file" => ..., "type" => ..., "exported" => ...,
        _ => query.metadata_filters = vec[(attr_name.to_string(), value.to_string())],
    }
}
```

`semantic_id`/`id`/`version` fell into the `_` arm → a `metadata_filters` entry. But `find_by_attr`/`matches_attr_filters` (`storage_v2/shard.rs:1117`) match `metadata_filters` only against the node's **metadata JSON**. These three are **first-class `NodeRecord` columns**, not metadata keys, so the filter matched nothing. The forward path reads them straight off `NodeRecord` (`eval_attr`, lines 1217–1224) — hence the asymmetry. `AttrQuery` has no field for them, which is why a prior triage note parked this as "needs storage extension"; the fix lives entirely in the Datalog layer, which already has `get_node` access.

## Fix

A shared `reverse_attr_lookup` helper restores symmetry without touching the wire format or storage:

```rust
fn reverse_attr_lookup(engine: &dyn GraphStore, attr_name: &str, value: &str) -> Vec<u128> {
    match attr_name {
        "id" => match value.parse::<u128>() {           // O(1): the value IS the id
            Ok(id) if engine.get_node(id).is_some() => vec[id],
            _ => vec[],
        },
        "semantic_id" => engine.find_by_attr(&AttrQuery::default()).into_iter()
            .filter(|id| engine.get_node(*id).and_then(|n| n.semantic_id).as_deref() == Some(value))
            .collect(),                                  // O(n) scan (documented attr() cost)
        "version" => engine.find_by_attr(&AttrQuery::default()).into_iter()
            .filter(|id| engine.get_node(*id).map(|n| n.version).as_deref() == Some(value))
            .collect(),
        _ => engine.find_by_attr(&Self::attr_to_query(attr_name, value)),  // unchanged index path
    }
}
```

`name`/`file`/`type`/`exported`/metadata keep the index-accelerated `find_by_attr` path; only the three mis-routed first-class columns change. `version` matches via `get_node` (NOT the deprecated `AttrQuery.version` field the v2 engine ignores). Applied to **both** the non-generator path (`eval_attr`) and the generator path (`eval_generator_chunked`), in **both** `Evaluator` and `EvaluatorExplain` (twins kept in sync, documented).

## Before / After (live `cargo test`, fixture: node 10 / node 20)

**RED before** the fix — the new reverse tests:
```
test_eval_attr_reverse_semantic_id            left: []  right: [10]
test_eval_attr_reverse_id                     left: []  right: [20]
test_eval_attr_reverse_version                left: []  right: [10, 20]
test_eval_attr_reverse_semantic_id_explain    bindings: 0  (expected 1)
test_eval_attr_reverse_semantic_id_as_generator  left: []  right: [10]   # pipelined seed path
```
**GREEN after:**
```
test_eval_attr_reverse_semantic_id ... ok
test_eval_attr_reverse_semantic_id_no_match ... ok
test_eval_attr_semantic_id_forward_reverse_symmetry ... ok
test_eval_attr_reverse_id ... ok
test_eval_attr_reverse_id_no_match ... ok
test_eval_attr_reverse_version ... ok
test_eval_attr_reverse_semantic_id_as_generator ... ok
test_eval_attr_reverse_semantic_id_explain ... ok
```

Full gate (Rust-only, isolated to the `rfdb` crate):
```
cargo test --lib            -> ok. 944 passed; 0 failed; 0 ignored
cargo test --lib datalog::  -> ok. 220 passed; 0 failed
cargo clippy --lib          -> Finished (exit 0; no new warnings — pre-existing crate-wide only, none in edited files)
rustfmt --check             -> edited regions clean (crate is not fmt-maintained; pre-existing import/brace drift untouched)
```

## Adversarial review

- **Round A — correctness:** no-match (`semantic_id`/`id`) → empty; non-numeric `id` (parse fails) → empty; node with `semantic_id = None` → filtered out; **duplicate** `semantic_id` across nodes → all returned (correct dual of forward); `version` matched via `get_node`, sidestepping the deprecated-and-ignored `AttrQuery.version` field; a metadata key literally named `semantic_id`/`id`/`version` is now treated as the first-class column in **both** directions, matching the forward path's match-arm precedence (forward never reads metadata for these names).
- **Round B — fragility:** `eval.rs`/`eval_explain.rs` are pre-existing >500-line god-files (splitting out of scope, consistent with prior RFDB PRs). The twin-sync coupling is documented on the explain copy; the forward/reverse-symmetry coupling and the O(n)-scan cost are documented on the canonical helper (cost matches `KNOWN_LIMITATIONS`' "Datalog `attr()` … O(n) scan").
- **Round C — class-not-instance:** the class = first-class `NodeRecord` columns the forward path reads but `AttrQuery` can't express = `{id, semantic_id, version}` (forward also reads name/file/type/exported, which `AttrQuery` *does* express). All three fixed across **both** reverse paths (non-generator `eval_attr` + generator `eval_generator_chunked`) and **both** evaluators. Every `attr_to_query` call site audited. The sibling generator-path copy was found via Round C and is fixed + regression-pinned (`test_eval_attr_reverse_semantic_id_as_generator`).

## Blast radius

Rust-only, inside `packages/rfdb-server/src/datalog/{eval,eval_explain,tests}.rs`. No JS/TS, no wire format, no stored-graph-shape change — only the row set of reverse `attr(X, F, V)` queries where `F ∈ {semantic_id, id, version}` (previously always empty). The JS-only CI gate is unaffected. The reorderer (`utils.rs`) already placed reverse `attr` correctly for any field, so no planning change was needed.

## Follow-up (out of scope, not filed yet)

Reverse `semantic_id`/`version` is an O(n) scan with O(n) `get_node` clones. For very large graphs a real fix would add a `semantic_id` secondary index (or extend `find_by_attr`/`AttrQuery` + wire format). Deferred to keep this PR a single correctness slice; performance matches the documented `attr()` reverse-lookup cost.

## Source

In-env triage this run: **0 open GitHub issues**, no Linear MCP (github + Enox only). Net-new Datalog correctness bug found by empirically probing the live engine (Evidence Rule: TDD RED→GREEN `cargo test` against a built `rfdb`), in the autonomous web-session RFDB-correctness intake series recorded in Enox.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTeD6QPTaDH3MH6mG452ZZ)_