### PR TITLE
fix(rfdb): datalog negation hash join honors constant non-key endpoint

### DIFF
--- a/packages/rfdb-server/src/datalog/eval.rs
+++ b/packages/rfdb-server/src/datalog/eval.rs
@@ -288,14 +288,19 @@ impl<'a> Evaluator<'a> {
                 }
             }
 
-            // Check if hash join applies for negation edge/incoming literals
+            // Check if hash join applies for negation edge/incoming literals.
+            // The fast path is only sound when the non-key endpoint is a Wildcard
+            // (see negation_hash_join_sound); a constant/bound endpoint must be
+            // honored, so fall through to the per-binding path in that case.
             if let Literal::Negative(atom) = literal {
                 if let Some((join_var, key_pos)) = self.should_hash_join(atom, &bound_vars, current.len()) {
-                    current = self.eval_negation_hash_join(atom, &current, &join_var, key_pos);
-                    if current.is_empty() {
-                        break;
+                    if super::utils::negation_hash_join_sound(atom, key_pos) {
+                        current = self.eval_negation_hash_join(atom, &current, &join_var, key_pos);
+                        if current.is_empty() {
+                            break;
+                        }
+                        continue;
                     }
-                    continue;
                 }
             }
 
@@ -1856,14 +1861,19 @@ impl<'a> Evaluator<'a> {
                 }
             }
 
-            // Check if hash join applies for negation edge/incoming literals
+            // Check if hash join applies for negation edge/incoming literals.
+            // The fast path is only sound when the non-key endpoint is a Wildcard
+            // (see negation_hash_join_sound); a constant/bound endpoint must be
+            // honored, so fall through to the per-binding path in that case.
             if let Literal::Negative(atom) = literal {
                 if let Some((join_var, key_pos)) = self.should_hash_join(atom, &bound_vars, current.len()) {
-                    current = self.eval_negation_hash_join(atom, &current, &join_var, key_pos);
-                    if current.is_empty() {
-                        break;
+                    if super::utils::negation_hash_join_sound(atom, key_pos) {
+                        current = self.eval_negation_hash_join(atom, &current, &join_var, key_pos);
+                        if current.is_empty() {
+                            break;
+                        }
+                        continue;
                     }
-                    continue;
                 }
             }
 

--- a/packages/rfdb-server/src/datalog/eval_explain.rs
+++ b/packages/rfdb-server/src/datalog/eval_explain.rs
@@ -264,24 +264,29 @@ impl<'a> EvaluatorExplain<'a> {
                 }
             }
 
-            // Check if hash join applies for negation edge/incoming literals
+            // Check if hash join applies for negation edge/incoming literals.
+            // The fast path is only sound when the non-key endpoint is a Wildcard
+            // (see negation_hash_join_sound); a constant/bound endpoint must be
+            // honored, so fall through to the per-binding path in that case.
             if let Literal::Negative(atom) = literal {
                 if let Some((join_var, key_pos)) = self.should_hash_join(atom, &bound_vars, current.len()) {
-                    let start = Instant::now();
-                    current = self.eval_negation_hash_join(atom, &current, &join_var, key_pos);
-                    let duration = start.elapsed();
-                    self.record_step(
-                        "hash_join_negation",
-                        atom.predicate(),
-                        atom.args(),
-                        current.len(),
-                        duration,
-                        Some(format!("key_var={}, key_pos={}", join_var, key_pos)),
-                    );
-                    if current.is_empty() {
-                        break;
+                    if super::utils::negation_hash_join_sound(atom, key_pos) {
+                        let start = Instant::now();
+                        current = self.eval_negation_hash_join(atom, &current, &join_var, key_pos);
+                        let duration = start.elapsed();
+                        self.record_step(
+                            "hash_join_negation",
+                            atom.predicate(),
+                            atom.args(),
+                            current.len(),
+                            duration,
+                            Some(format!("key_var={}, key_pos={}", join_var, key_pos)),
+                        );
+                        if current.is_empty() {
+                            break;
+                        }
+                        continue;
                     }
-                    continue;
                 }
             }
 
@@ -1766,24 +1771,29 @@ impl<'a> EvaluatorExplain<'a> {
                 }
             }
 
-            // Check if hash join applies for negation edge/incoming literals
+            // Check if hash join applies for negation edge/incoming literals.
+            // The fast path is only sound when the non-key endpoint is a Wildcard
+            // (see negation_hash_join_sound); a constant/bound endpoint must be
+            // honored, so fall through to the per-binding path in that case.
             if let Literal::Negative(atom) = literal {
                 if let Some((join_var, key_pos)) = self.should_hash_join(atom, &bound_vars, current.len()) {
-                    let start = Instant::now();
-                    current = self.eval_negation_hash_join(atom, &current, &join_var, key_pos);
-                    let duration = start.elapsed();
-                    self.record_step(
-                        "hash_join_negation",
-                        atom.predicate(),
-                        atom.args(),
-                        current.len(),
-                        duration,
-                        Some(format!("key_var={}, key_pos={}", join_var, key_pos)),
-                    );
-                    if current.is_empty() {
-                        break;
+                    if super::utils::negation_hash_join_sound(atom, key_pos) {
+                        let start = Instant::now();
+                        current = self.eval_negation_hash_join(atom, &current, &join_var, key_pos);
+                        let duration = start.elapsed();
+                        self.record_step(
+                            "hash_join_negation",
+                            atom.predicate(),
+                            atom.args(),
+                            current.len(),
+                            duration,
+                            Some(format!("key_var={}, key_pos={}", join_var, key_pos)),
+                        );
+                        if current.is_empty() {
+                            break;
+                        }
+                        continue;
                     }
-                    continue;
                 }
             }
 

--- a/packages/rfdb-server/src/datalog/tests.rs
+++ b/packages/rfdb-server/src/datalog/tests.rs
@@ -5316,6 +5316,147 @@ mod hash_join_tests {
         assert_eq!(results.len(), db_count,
             "should find {} functions calling DB queries", db_count);
     }
+
+    // ------------------------------------------------------------------------
+    // Negation hash join: a constant (or bound-var) NON-KEY endpoint must be
+    // honored.
+    //
+    // `eval_negation_hash_join` keys its existence set on a single endpoint
+    // (`key_pos`). For `\+ edge(X, "d", "T")` the constant dst "d" was silently
+    // dropped once the binding count crossed HASH_JOIN_THRESHOLD, collapsing the
+    // literal into `\+ edge(X, _, "T")` ("X has NO outgoing T edge") — a
+    // threshold-dependent silent wrong answer. These tests pin the correct
+    // per-edge semantics across all three evaluation loops (process_literals,
+    // eval_rule_body_with, and the explain twin), in both edge directions.
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_hash_join_negation_const_dst_via_eval_query() {
+        // In setup_hash_join_graph, FUNCTION i calls CALL node (n+i). Targeting
+        // the CALL node of function 1 means ONLY function 1 calls it, so
+        // `\+ edge(X, "<n+1>", "CALLS")` must match every function EXCEPT 1.
+        let n = HASH_JOIN_THRESHOLD + 10;
+        let engine = setup_hash_join_graph(n);
+        let target = (n + 1) as u128;
+
+        let evaluator = Evaluator::new(&engine);
+        let literals = parse_query(&format!(
+            "node(X, \"FUNCTION\"), \\+ edge(X, \"{}\", \"CALLS\")",
+            target
+        )).unwrap();
+        let results = evaluator.eval_query(&literals).unwrap();
+
+        let ids: HashSet<u128> = results.iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+            .collect();
+
+        assert_eq!(ids.len(), n - 1,
+            "negation with a const dst must exclude ONLY the caller of that dst");
+        assert!(!ids.contains(&1), "fn 1 calls the target dst -> excluded");
+        assert!(ids.contains(&2), "fn 2 does not call the target dst -> included");
+    }
+
+    #[test]
+    fn test_hash_join_negation_const_dst_via_rule() {
+        // Same property through a derived rule (eval_rule_body_with path).
+        let n = HASH_JOIN_THRESHOLD + 10;
+        let engine = setup_hash_join_graph(n);
+        let target = (n + 1) as u128;
+
+        let mut evaluator = Evaluator::new(&engine);
+        let rule = parse_rule(&format!(
+            "no_call_to(X) :- node(X, \"FUNCTION\"), \\+ edge(X, \"{}\", \"CALLS\").",
+            target
+        )).unwrap();
+        evaluator.add_rule(rule);
+
+        let goal = parse_atom("no_call_to(X)").unwrap();
+        let results = evaluator.query(&goal).unwrap();
+
+        let ids: HashSet<u128> = results.iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+            .collect();
+        assert_eq!(ids.len(), n - 1,
+            "derived-rule negation with a const dst must honor the dst");
+        assert!(!ids.contains(&1), "fn 1 calls the target dst -> excluded");
+    }
+
+    #[test]
+    fn test_hash_join_negation_const_src_incoming() {
+        // incoming sibling: `\+ incoming(C, "1", "CALLS")` = "no CALLS edge from
+        // node 1 into C". Only CALL node (n+1) has node 1 as its caller, so every
+        // other CALL node must match.
+        let n = HASH_JOIN_THRESHOLD + 10;
+        let engine = setup_hash_join_graph(n);
+
+        let evaluator = Evaluator::new(&engine);
+        let literals = parse_query(
+            "node(C, \"CALL\"), \\+ incoming(C, \"1\", \"CALLS\")"
+        ).unwrap();
+        let results = evaluator.eval_query(&literals).unwrap();
+
+        let ids: HashSet<u128> = results.iter()
+            .filter_map(|b| b.get("C").and_then(|v| v.as_id()))
+            .collect();
+        assert_eq!(ids.len(), n - 1,
+            "only the CALL node called by node 1 must be excluded");
+        assert!(!ids.contains(&((n + 1) as u128)), "CALL n+1 is called by node 1 -> excluded");
+        assert!(ids.contains(&((n + 2) as u128)), "CALL n+2 is called by node 2 -> included");
+    }
+
+    #[test]
+    fn test_hash_join_negation_const_dst_explain_parity() {
+        // The explain twin must agree with the standard evaluator.
+        let n = HASH_JOIN_THRESHOLD + 10;
+        let engine = setup_hash_join_graph(n);
+        let target = (n + 1) as u128;
+
+        let mut explain = EvaluatorExplain::new(&engine, false);
+        let literals = parse_query(&format!(
+            "node(X, \"FUNCTION\"), \\+ edge(X, \"{}\", \"CALLS\")",
+            target
+        )).unwrap();
+        let result = explain.eval_query(&literals).unwrap();
+
+        let ids: HashSet<u128> = result.bindings.iter()
+            .filter_map(|b| b.get("X").and_then(|s| s.parse::<u128>().ok()))
+            .collect();
+        assert_eq!(ids.len(), n - 1, "explain twin must honor the const dst too");
+        assert!(!ids.contains(&1), "fn 1 calls the target dst -> excluded");
+    }
+
+    #[test]
+    fn test_hash_join_negation_wildcard_still_fast_path() {
+        // Regression guard: the wildcard non-key endpoint is the ONLY sound
+        // fast-path case and must keep working — `\+ edge(X, _, "CALLS")`.
+        let n = HASH_JOIN_THRESHOLD + 10;
+        let mut engine = setup_hash_join_graph(n);
+        let mut orphans = Vec::new();
+        for i in (2 * n + 1)..=(2 * n + 5) {
+            orphans.push(NodeRecord {
+                id: i as u128,
+                node_type: Some("FUNCTION".to_string()),
+                name: Some(format!("orphan_{}", i)),
+                file: Some("test.js".to_string()),
+                file_id: 0,
+                name_offset: 0,
+                version: "main".into(),
+                exported: false,
+                replaces: None,
+                deleted: false,
+                metadata: None,
+                semantic_id: None,
+            });
+        }
+        engine.add_nodes(orphans);
+
+        let evaluator = Evaluator::new(&engine);
+        let literals = parse_query(
+            "node(X, \"FUNCTION\"), \\+ edge(X, _, \"CALLS\")"
+        ).unwrap();
+        let results = evaluator.eval_query(&literals).unwrap();
+        assert_eq!(results.len(), 5, "only the 5 orphan functions have no CALLS edge");
+    }
 }
 
 // ============================================================================

--- a/packages/rfdb-server/src/datalog/utils.rs
+++ b/packages/rfdb-server/src/datalog/utils.rs
@@ -300,6 +300,29 @@ fn is_bound_or_const(term: &Term, bound: &HashSet<String>) -> bool {
     }
 }
 
+/// Whether the negation hash-join fast path is sound for `atom`, given that its
+/// existence set is keyed on the endpoint at `key_pos`.
+///
+/// `eval_negation_hash_join` builds a set of node ids for ONE endpoint
+/// (`key_pos`) and rejects every binding whose key is in that set. That
+/// correctly models `\+ edge(X, _, "T")` ("X has no outgoing T edge") only when
+/// the OTHER endpoint is unconstrained — i.e. a `Wildcard`. When the other
+/// endpoint is a `Const` (or an already-bound `Var`), the negation refers to a
+/// SPECIFIC edge — `\+ edge(X, "d", "T")` means "X has no T edge *to d*", not
+/// "X has no T edge at all" — which a single-endpoint existence set cannot
+/// express. In that case this returns `false` so the literal falls through to
+/// the per-binding path (`substitute_atom` + `eval_edge`/`eval_incoming`), which
+/// filters on both endpoints. Without this guard the constant was silently
+/// dropped once the binding count crossed the hash-join threshold, producing a
+/// threshold-dependent wrong answer.
+///
+/// `key_pos` is always 0 or 1 (per `should_hash_join`), so the other endpoint is
+/// the remaining one of `args[0]`/`args[1]`.
+pub(crate) fn negation_hash_join_sound(atom: &super::types::Atom, key_pos: usize) -> bool {
+    let other_pos = if key_pos == 0 { 1 } else { 0 };
+    matches!(atom.args().get(other_pos), Some(Term::Wildcard))
+}
+
 /// Collect all free Var names from args (Var names not yet in bound).
 fn free_vars(args: &[Term], bound: &HashSet<String>) -> HashSet<String> {
     args.iter()


### PR DESCRIPTION
## Summary

The Datalog **negation** hash-join fast path silently dropped a constant (or already-bound) value at the **non-key endpoint** of an `edge`/`incoming` literal. `\+ edge(X, "d", "T")` ("X has no `T` edge **to d**") was collapsed into `\+ edge(X, _, "T")` ("X has no `T` edge **at all**") — but **only once the binding count crossed `HASH_JOIN_THRESHOLD` (16)**. Below the threshold the per-binding path is correct; above it the answer flips. A query's truth therefore depended on graph size — an on-thesis, threshold-dependent **silent wrong answer** in the engine an AI agent queries.

Net-new correctness bug found by code-reading the negation hash-join path, in an area none of the open RFDB PRs (#345–#360) touch. It is the negation-side analogue of the already-fixed positive self-join shared-var bug (`rfdb-datalog-hash-join-shared-var`); the positive path was hardened, the negation path was not.

## Spec (BDD)

- **Invariant restored:** the negation hash-join fast path computes the same row set as the per-binding path. A non-key endpoint that is a `Const` (or bound `Var`) constrains a **specific** edge and must be honored.
- **Given** a graph where FUNCTION `i` calls CALL node `n+i` (so only function `1` calls `n+1`)
  **When** `node(X, "FUNCTION"), \+ edge(X, "<n+1>", "CALLS")` runs with > 16 functions
  **Then** every function **except** function `1` matches (`n-1` rows) — **not** zero.
- **And** the incoming dual `node(C, "CALL"), \+ incoming(C, "1", "CALLS")` excludes only the CALL node node `1` points to.
- **And (regression):** the wildcard form `\+ edge(X, _, "CALLS")` ("no outgoing CALLS edge") still uses the fast path and is unchanged.

## Root cause

`packages/rfdb-server/src/datalog/eval.rs` — `eval_negation_hash_join` builds an existence set from **one** endpoint and never filters by the other:

```rust
let exists: HashSet<u128> = match (atom.predicate(), key_pos) {
    ("edge", 0)     => edges.iter().map(|e| e.src).collect(), // ALL srcs of "T" edges
    ("edge", 1)     => edges.iter().map(|e| e.dst).collect(),
    ("incoming", 0) => edges.iter().map(|e| e.dst).collect(),
    ("incoming", 1) => edges.iter().map(|e| e.src).collect(),
    _ => return current.to_vec(),
};
// keep binding iff key NOT in exists  -> ignores the OTHER endpoint entirely
```

The dispatch sites (`process_literals`, `eval_rule_body_with`, and both `EvaluatorExplain` loops) took this fast path for **any** `should_hash_join` hit, regardless of whether the non-key endpoint was a `Wildcard`, a `Const`, or a bound `Var`. The correct per-binding path (`substitute_atom` + `eval_edge`/`eval_incoming`) **does** check the const endpoint (`eval.rs:909-913`, `eval.rs:1066-1070`), so the two paths disagreed above the threshold. (Positive hash join is unaffected — `eval_edge_hash_join`/`eval_incoming_hash_join` already filter the non-key endpoint at `eval.rs:581` / `eval.rs:657`.)

## Fix

A single documented helper gates the fast path:

```rust
// utils.rs
pub(crate) fn negation_hash_join_sound(atom: &Atom, key_pos: usize) -> bool {
    let other_pos = if key_pos == 0 { 1 } else { 0 };
    matches!(atom.args().get(other_pos), Some(Term::Wildcard))
}
```

The single-endpoint existence set only models `\+ edge(X, _, "T")` correctly, i.e. when the other endpoint is unconstrained (`Wildcard`). For a `Const`/bound-`Var` other endpoint the literal falls through to the per-binding path, which filters on **both** endpoints. The reorderer requires all negative-literal vars to be bound, so the non-key endpoint is always `Wildcard | Const | bound Var` — the gate handles all three. Applied identically to all four dispatch sites; the eval/explain twins stay in lockstep.

## Before / After (live `cargo test`, fixture: FUNCTION `i` → CALL `n+i` via CALLS, `n = 26`)

The 4 new tests are **RED before / GREEN after** — pre-fix each returned `0` rows where `25` are correct (the exact "collapsed to wildcard" symptom):

```
test_hash_join_negation_const_dst_via_eval_query     left: 0  right: 25   # FAILED (pre-fix)
test_hash_join_negation_const_dst_via_rule           left: 0  right: 25   # FAILED (pre-fix)
test_hash_join_negation_const_src_incoming           left: 0  right: 25   # FAILED (pre-fix)
test_hash_join_negation_const_dst_explain_parity     left: 0  right: 25   # FAILED (pre-fix)
```

After the fix:

```
running 7 tests
test ...::test_hash_join_negation_const_dst_via_eval_query ... ok
test ...::test_hash_join_negation_const_dst_via_rule ... ok
test ...::test_hash_join_negation_const_src_incoming ... ok
test ...::test_hash_join_negation_const_dst_explain_parity ... ok
test ...::test_hash_join_negation_correctness ... ok            # pre-existing wildcard
test ...::test_hash_join_negation_dst_position ... ok           # pre-existing wildcard
test ...::test_hash_join_negation_wildcard_still_fast_path ... ok   # new regression guard
test result: ok. 7 passed; 0 failed
```

Full gate (Rust-only, isolated to the `rfdb` crate):

```
cargo test --lib datalog::   -> ok. 225 passed; 0 failed
cargo test --lib             -> ok. 949 passed; 0 failed   (was 945, +4 new)
cargo clippy --lib           -> exit 0 (no new warnings; the only diffs in the edited
                                datalog files are pre-existing, none at changed lines)
cargo build --bins           -> Finished
```

## Adversarial review

- **Round A — correctness:** verified all key/other-endpoint combinations: `edge` key_pos 0 + const dst (fixed), `edge` key_pos 1 + const src (`\+ edge("c", Y, "T")` → fall-through), `incoming` key_pos 0 + const src (fixed), both-endpoints-bound `\+ edge(X, Y, "T")` (other endpoint is a bound Var → fall-through → correct), and `Wildcard` other endpoint in both directions (fast path retained, two pre-existing tests + one new guard). 2-arg negation (`args.len() < 3`) never reaches the fast path (`should_hash_join` returns `None`). `args.get(other_pos)` is always `Some` because `should_hash_join` already requires a 3-arg edge/incoming literal.
- **Round B — fragility:** the soundness rule is centralized in one documented `pub(crate)` helper (instead of inlined four times); the "single-endpoint existence set" coupling is explained at the helper and referenced at every call site, guarding against a future "just call the fast path" regression. `eval.rs` / `eval_explain.rs` are pre-existing >500-line files (splitting out of scope, consistent with prior RFDB PRs); the crate is not rustfmt-maintained (pre-existing drift left untouched).
- **Round C — class-not-instance:** **all four** negation dispatch sites fixed (2 in `eval.rs`, 2 in the explain twin). Positive hash join already handles the non-key endpoint and is left alone. The reorderer constraint bounds the endpoint shapes, so the class is fully closed; no sibling latent site, no follow-ups.

## Blast radius

Rust-only, inside `packages/rfdb-server/src/datalog/{utils,eval,eval_explain,tests}.rs`. No JS/TS, no wire format, no stored-graph-shape change — only the row set of negated `edge`/`incoming` literals with a **constant/bound non-key endpoint** above the hash-join threshold (previously over-removed). The JS-only CI gate (`.github/workflows/ci.yml`) is unaffected; no JS/TS files touched.

## Source

In-env triage this run: **0 open GitHub issues**, no Linear MCP (github + Enox only). Net-new correctness bug; the RFDB Datalog-builtins vein flagged in prior intake notes (after #357/#359/#360/#361). Recorded in the autonomous web-session RFDB-correctness intake series in Enox.

---
_Generated by [Claude Code](https://claude.ai/code/session_017azkwo6Lq1aRP7gXPoe4Ft)_