### PR TITLE
fix(rfdb): datalog attr(X, "a.b", V) reverse lookup resolves nested metadata paths

### DIFF
--- a/packages/rfdb-server/src/datalog/eval.rs
+++ b/packages/rfdb-server/src/datalog/eval.rs
@@ -467,12 +467,14 @@ impl<'a> Evaluator<'a> {
                 {
                     let id_var = id_var.clone();
                     match attr_name.as_str() {
-                        // First-class columns AttrQuery cannot express. These must
-                        // route through the shared reverse helper (same as
-                        // eval_attr) — `attr_to_query` would mis-route them to a
-                        // metadata filter that silently matches nothing. They are
-                        // O(1)/O(n) and emitted as a single chunk; symmetry with
-                        // the non-generator path matters more than streaming here.
+                        // First-class columns AttrQuery cannot express (id /
+                        // semantic_id / version), AND dotted nested metadata keys
+                        // the flat index cannot match: both must route through the
+                        // shared reverse helper for forward/reverse symmetry —
+                        // `attr_to_query` would mis-route them to a flat metadata
+                        // filter that silently matches nothing. Emitted as a single
+                        // chunk (O(1)/O(n)); symmetry with the non-generator path
+                        // matters more than streaming here.
                         "id" | "semantic_id" | "version" => {
                             let ids = Self::reverse_attr_lookup(
                                 self.engine,
@@ -486,7 +488,20 @@ impl<'a> Evaluator<'a> {
                             }).collect();
                             callback(bindings);
                         }
-                        // name/file/type/exported + metadata: indexed, chunked.
+                        name if name.contains('.') => {
+                            let ids = Self::reverse_attr_lookup(
+                                self.engine,
+                                attr_name,
+                                expected_value,
+                            );
+                            let bindings: Vec<Bindings> = ids.iter().map(|&id| {
+                                let mut b = Bindings::new();
+                                b.set(&id_var, Value::Id(id));
+                                b
+                            }).collect();
+                            callback(bindings);
+                        }
+                        // name/file/type/exported + FLAT metadata: indexed, chunked.
                         _ => {
                             let query = Self::attr_to_query(attr_name, expected_value);
                             self.engine.find_by_attr_chunked(&query, chunk_size, &mut |ids| {
@@ -1337,8 +1352,41 @@ impl<'a> Evaluator<'a> {
                 .into_iter()
                 .filter(|id| engine.get_node(*id).map(|n| n.version).as_deref() == Some(value))
                 .collect(),
+            // Nested dotted metadata path (e.g. "config.port"). The forward path
+            // (`eval_attr`) resolves these via `get_metadata_value`
+            // (metadata["config"]["port"]), but the index-backed `find_by_attr` /
+            // `metadata_matches` only matches FLAT keys (`parsed.get("config.port")`),
+            // so a dotted key reverses to nothing while the forward dual resolves
+            // it — a silent forward/reverse asymmetry (same class as the
+            // semantic_id/version/id gap above). Scan the node set with the SAME
+            // `get_metadata_value` the forward path uses, so the two directions
+            // cannot disagree (O(n), consistent with the other reverse lookups).
+            // Flat keys keep the fast index path in the arm below.
+            name if name.contains('.') => Self::reverse_metadata_scan(engine, name, value),
             _ => engine.find_by_attr(&Self::attr_to_query(attr_name, value)),
         }
+    }
+
+    /// Reverse-lookup node ids whose metadata resolves `attr_name` to `value`,
+    /// using the exact same `get_metadata_value` resolution the forward `attr`
+    /// path uses (exact flat key first, then nested dotted path). This keeps the
+    /// reverse direction symmetric with the forward direction for dotted metadata
+    /// keys that the flat `find_by_attr` index cannot express. O(n) over the node
+    /// set, consistent with the documented cost of `attr()` reverse lookups.
+    fn reverse_metadata_scan(engine: &dyn GraphStore, attr_name: &str, value: &str) -> Vec<u128> {
+        engine
+            .find_by_attr(&AttrQuery::default())
+            .into_iter()
+            .filter(|id| {
+                engine
+                    .get_node(*id)
+                    .and_then(|n| n.metadata)
+                    .and_then(|m| serde_json::from_str::<serde_json::Value>(&m).ok())
+                    .and_then(|j| crate::datalog::utils::get_metadata_value(&j, attr_name))
+                    .as_deref()
+                    == Some(value)
+            })
+            .collect()
     }
 
     /// Evaluate attr_edge(Src, Dst, EdgeType, AttrName, Value) predicate - access edge metadata

--- a/packages/rfdb-server/src/datalog/eval_explain.rs
+++ b/packages/rfdb-server/src/datalog/eval_explain.rs
@@ -1346,8 +1346,33 @@ impl<'a> EvaluatorExplain<'a> {
                 .into_iter()
                 .filter(|id| engine.get_node(*id).map(|n| n.version).as_deref() == Some(value))
                 .collect(),
+            // Nested dotted metadata path — twin of
+            // `Evaluator::reverse_attr_lookup`'s nested-path arm (keep in sync).
+            // The flat `find_by_attr` index cannot match dotted keys that the
+            // forward `get_metadata_value` resolves, so scan with the same
+            // resolver to keep forward/reverse symmetric.
+            name if name.contains('.') => Self::reverse_metadata_scan(engine, name, value),
             _ => engine.find_by_attr(&Self::attr_to_query(attr_name, value)),
         }
+    }
+
+    /// Reverse-lookup node ids whose metadata resolves `attr_name` to `value`
+    /// via the forward `get_metadata_value` resolution. Twin of
+    /// `Evaluator::reverse_metadata_scan` (keep in sync).
+    fn reverse_metadata_scan(engine: &dyn GraphStore, attr_name: &str, value: &str) -> Vec<u128> {
+        engine
+            .find_by_attr(&AttrQuery::default())
+            .into_iter()
+            .filter(|id| {
+                engine
+                    .get_node(*id)
+                    .and_then(|n| n.metadata)
+                    .and_then(|m| serde_json::from_str::<serde_json::Value>(&m).ok())
+                    .and_then(|j| crate::datalog::utils::get_metadata_value(&j, attr_name))
+                    .as_deref()
+                    == Some(value)
+            })
+            .collect()
     }
 
     /// Evaluate path(Src, Dst) predicate using BFS

--- a/packages/rfdb-server/src/datalog/tests.rs
+++ b/packages/rfdb-server/src/datalog/tests.rs
@@ -5826,3 +5826,162 @@ mod numeric_cmp_tests {
         assert_eq!(result[2].atom().predicate(), "gt");
     }
 }
+
+
+// ============================================================================
+// attr() reverse lookup — nested metadata dotted paths (forward/reverse symmetry)
+//
+// The forward path `attr(id, "a.b", V)` resolves nested dotted metadata paths
+// via `get_metadata_value` (metadata["a"]["b"]). The reverse path
+// `attr(X, "a.b", "v")` routed dotted keys through `metadata_filters`, which
+// only matches FLAT keys (`parsed.get("a.b")`), so it silently returned nothing
+// while the forward dual resolved it — a silent forward/reverse asymmetry of
+// the same class as the semantic_id/version/id reverse gap (RFD-48). These
+// tests pin the restored symmetry; flat-key reverse is unchanged.
+// ============================================================================
+
+mod attr_reverse_nested_metadata_tests {
+    use super::*;
+    use crate::graph::{GraphEngineV2, GraphStore};
+    use crate::storage::NodeRecord;
+    use crate::datalog::eval::Evaluator;
+    use crate::datalog::eval_explain::EvaluatorExplain;
+
+    fn setup_nested_metadata_graph() -> GraphEngineV2 {
+        let mut engine = GraphEngineV2::create_ephemeral();
+        engine.add_nodes(vec![
+            NodeRecord {
+                id: 1,
+                node_type: Some("SERVICE".to_string()),
+                name: Some("db".to_string()),
+                file: Some("db.js".to_string()),
+                file_id: 0, name_offset: 0,
+                version: "main".into(),
+                exported: false, replaces: None, deleted: false,
+                metadata: Some(r#"{"config":{"port":"5432"},"tier":"data"}"#.to_string()),
+                semantic_id: None,
+            },
+            NodeRecord {
+                id: 2,
+                node_type: Some("SERVICE".to_string()),
+                name: Some("cache".to_string()),
+                file: Some("cache.js".to_string()),
+                file_id: 0, name_offset: 0,
+                version: "main".into(),
+                exported: false, replaces: None, deleted: false,
+                metadata: Some(r#"{"config":{"port":"6379"},"tier":"data"}"#.to_string()),
+                semantic_id: None,
+            },
+        ]);
+        engine
+    }
+
+    // Reverse: attr(X, "config.port", "5432") must find node 1, mirroring the
+    // forward attr(1, "config.port", V) = "5432".
+    #[test]
+    fn test_eval_attr_reverse_nested_metadata() {
+        let engine = setup_nested_metadata_graph();
+        let ev = Evaluator::new(&engine);
+
+        let results = ev.query_atom(&Atom::new("attr", vec![
+            Term::var("X"),
+            Term::constant("config.port"),
+            Term::constant("5432"),
+        ])).unwrap();
+
+        let ids: Vec<u128> = results.iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+            .collect();
+        assert_eq!(ids, vec![1], "reverse nested config.port=5432 must return node 1");
+    }
+
+    // Forward/reverse symmetry over a nested dotted path: the value forward
+    // returns for node 2's config.port, fed back to reverse, returns node 2.
+    #[test]
+    fn test_eval_attr_nested_forward_reverse_symmetry() {
+        let engine = setup_nested_metadata_graph();
+        let ev = Evaluator::new(&engine);
+
+        let fwd = ev.query_atom(&Atom::new("attr", vec![
+            Term::constant("2"),
+            Term::constant("config.port"),
+            Term::var("V"),
+        ])).unwrap();
+        assert_eq!(fwd.len(), 1);
+        let value = match fwd[0].get("V").unwrap() {
+            Value::Str(s) => s.clone(),
+            other => panic!("expected Str, got {:?}", other),
+        };
+        assert_eq!(value, "6379");
+
+        let rev = ev.query_atom(&Atom::new("attr", vec![
+            Term::var("X"),
+            Term::constant("config.port"),
+            Term::constant(&value),
+        ])).unwrap();
+        let ids: Vec<u128> = rev.iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+            .collect();
+        assert_eq!(ids, vec![2], "forward nested value must reverse to node 2");
+    }
+
+    // A nested path value that no node has → empty.
+    #[test]
+    fn test_eval_attr_reverse_nested_no_match() {
+        let engine = setup_nested_metadata_graph();
+        let ev = Evaluator::new(&engine);
+        let results = ev.query_atom(&Atom::new("attr", vec![
+            Term::var("X"),
+            Term::constant("config.port"),
+            Term::constant("9999"),
+        ])).unwrap();
+        assert!(results.is_empty(), "unknown nested value must yield no rows");
+    }
+
+    // Regression: flat metadata key reverse lookup is unchanged.
+    #[test]
+    fn test_eval_attr_reverse_flat_metadata_still_works() {
+        let engine = setup_nested_metadata_graph();
+        let ev = Evaluator::new(&engine);
+        let results = ev.query_atom(&Atom::new("attr", vec![
+            Term::var("X"),
+            Term::constant("tier"),
+            Term::constant("data"),
+        ])).unwrap();
+        let mut ids: Vec<u128> = results.iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec![1, 2], "flat metadata reverse must still match both nodes");
+    }
+
+    // EvaluatorExplain twin must agree with Evaluator on the reverse nested lookup.
+    #[test]
+    fn test_eval_attr_reverse_nested_explain() {
+        let engine = setup_nested_metadata_graph();
+        let mut ev = EvaluatorExplain::new(&engine, false);
+        let result = ev.eval_query(&parse_query(
+            r#"attr(X, "config.port", "5432")"#
+        ).unwrap()).unwrap();
+        assert_eq!(result.bindings.len(), 1);
+        assert_eq!(result.bindings[0].get("X"), Some(&"1".to_string()));
+    }
+
+    // The pipelined generator path (eval_generator_chunked) has its OWN copy of
+    // the reverse-attr routing. A conjunction whose only valid seed is the
+    // reverse nested attr lookup routes through it (neq is a filter that needs X
+    // already bound, so the reorderer places the reverse attr first as the
+    // generator) — exercising the generator-path copy, not eval_attr.
+    #[test]
+    fn test_eval_attr_reverse_nested_as_generator() {
+        let engine = setup_nested_metadata_graph();
+        let ev = Evaluator::new(&engine);
+        let results = ev.eval_query(&parse_query(
+            r#"attr(X, "config.port", "6379"), neq(X, "0")"#
+        ).unwrap()).unwrap();
+        let ids: Vec<u128> = results.iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+            .collect();
+        assert_eq!(ids, vec![2], "reverse nested attr must seed the pipelined generator path");
+    }
+}


### PR DESCRIPTION
## Summary

The Datalog `attr` builtin was **asymmetric across forward/reverse for nested dotted metadata paths**. The forward path `attr(id, "config.port", V)` resolves a nested dotted key via `get_metadata_value` (`metadata["config"]["port"]`), but the reverse path `attr(X, "config.port", "5432")` routed dotted keys through the index-backed `find_by_attr` / `metadata_matches`, which only matches **FLAT** keys (`parsed.get("config.port")`). So a dotted nested key reversed to **nothing** while the forward dual resolved it — an on-thesis silent-wrong-answer in the engine an AI agent queries ("which node has `config.port = 5432`?" → confidently empty).

This is a net-new correctness bug of the **same class** as the `semantic_id` / `version` / `id` reverse gap already closed in #361 (RFD-48): first-class/forward-only resolution that the reverse path silently failed to mirror. It is in a previously-untouched corner (nested metadata path resolution) of the actively-developed Datalog builtins vein (#357/#359/#361/#362).

## Spec (BDD)

- **Invariant restored:** `attr(X, F, V)` (reverse) is the exact dual of `attr(id, F, V)` (forward) for every field `F`, including nested dotted metadata paths — a node reverses iff the forward path resolves `F` to `V` on it.
- **Given** node 1 with metadata `{"config":{"port":"5432"}}`
  **When** `attr(X, "config.port", "5432")`
  **Then** `X = {1}` — **not** empty (mirrors forward `attr(1, "config.port", V) = "5432"`).
- **And** the value forward returns for a node's `config.port`, fed back to the reverse lookup, returns that same node (round-trip symmetry).
- **And (regression)** flat metadata keys (`attr(X, "tier", "data")`) and first-class fields are unchanged.
- **And** a nested value no node has → empty.

## Root cause

`packages/rfdb-server/src/datalog/eval.rs`, `Evaluator::reverse_attr_lookup` (and its `EvaluatorExplain` twin, and the pipelined `eval_generator_chunked` attr branch):

```rust
match attr_name {
    "id" => ...,            // first-class (added in #361)
    "semantic_id" => ...,   // first-class
    "version" => ...,       // first-class
    _ => engine.find_by_attr(&Self::attr_to_query(attr_name, value)),  // <- flat-only
}
```

`attr_to_query` maps any non-first-class field to `metadata_filters = [(name, value)]`, and `metadata_matches` does `parsed.get(name)` — a **flat** key lookup. The forward path uses `get_metadata_value`, which tries the exact flat key **then** traverses a nested dotted path. So `"config.port"` resolved forward (nested) but matched nothing in reverse (flat `get("config.port")` → `None`).

## Fix

Route dotted metadata keys (`name.contains('.')`) through a new `reverse_metadata_scan` helper that selects nodes using the **same** `get_metadata_value` resolution the forward path uses — so the two directions cannot drift apart. Flat keys keep the fast `find_by_attr` index path. O(n) over the node set, consistent with the documented cost (and existing implementation) of the `semantic_id`/`version` reverse lookups.

Applied at all **three** sites that share the routing:
1. `Evaluator::reverse_attr_lookup` (`eval.rs`)
2. `EvaluatorExplain::reverse_attr_lookup` (`eval_explain.rs`) — twin, kept in sync
3. `Evaluator::eval_generator_chunked` attr branch (`eval.rs`) — dotted keys now route through `reverse_attr_lookup` as a single chunk, exactly like `id`/`semantic_id`/`version` (the generator path is a separate copy of the reverse routing). `EvaluatorExplain` has no generator path.

## Before / After (live, `cargo test`, ephemeral graph node 1 = `{"config":{"port":"5432"}}`)

In-env probe **before** the fix (Evidence Rule — live `query_atom`):
```
FWD attr(1, "config.port", V)        -> ["5432"]   # forward resolves nested path
REV attr(X, "config.port", "5432")   -> []          # BUG — should be [1]
REV attr(X, "tier", "data")          -> [1, 2]      # flat key control: correct both ways
```

The 6 new tests, **RED before / GREEN after**:
```
test ...attr_reverse_nested_metadata_tests::test_eval_attr_reverse_nested_metadata ... ok        # REV "config.port"=5432 -> {1}
test ...::test_eval_attr_nested_forward_reverse_symmetry ... ok                                    # fwd value round-trips to {2}
test ...::test_eval_attr_reverse_nested_explain ... ok                                             # EvaluatorExplain twin agrees
test ...::test_eval_attr_reverse_nested_as_generator ... ok                                        # pipelined generator-path seed
test ...::test_eval_attr_reverse_nested_no_match ... ok                                            # unknown nested value -> []
test ...::test_eval_attr_reverse_flat_metadata_still_works ... ok                                  # flat-key regression guard
```
(Before the fix the 4 positive tests failed with `left: [] / 0`, `right: [1] / [2] / 1` — red for the right reason; the 2 control tests passed both before and after.)

Full gate (Rust-only, isolated to the `rfdb` crate):
```
cargo test --lib datalog::   -> ok. 231 passed; 0 failed
cargo test --lib             -> ok. 955 passed; 0 failed
cargo clippy --lib           -> no new warnings (none in the edited regions; 25 pre-existing crate-wide hunks only)
cargo build --bins           -> Finished
```
(`rfdb` is not rustfmt-maintained — 25 pre-existing fmt hunks exist in `eval.rs` alone; the new arm at line 497 matches the byte-identical sibling arm at 481. Consistent with prior RFDB PRs #345/#348/#356/#357/#359.)

## Adversarial review

- **Round A — correctness:** dotted key that *also* exists as a literal flat key (`get_metadata_value` tries exact-first then nested → my scan uses the same fn, so it matches either, symmetric with forward); node with `metadata: None` (and_then chain → no match); malformed metadata JSON (parse fails → no match, graceful); nested path resolving to an object/array (`get_metadata_value` → `None` → no match, identical to forward); no-match and round-trip pinned by tests.
- **Round B — fragility:** `eval.rs`/`eval_explain.rs` are pre-existing >500-line files (splitting out of scope, consistent with prior RFDB PRs). The one real coupling — reverse must agree with forward — is structurally eliminated: both directions resolve through the **same** `get_metadata_value`. The matching logic has a single source of truth (`reverse_metadata_scan` / `reverse_attr_lookup`); the generator path delegates to it rather than re-implementing. The Evaluator↔EvaluatorExplain twin duplication is documented "keep in sync" at both sites (matching the existing convention for these mirrored evaluators).
- **Round C — class-not-instance:** audited the `attr()` reverse routing for the full forward/reverse symmetry class. First-class columns (`id`/`semantic_id`/`version`) were closed by #361; flat metadata keys were already symmetric (verified live, regression-guarded); nested dotted paths were the remaining gap, now closed at all 3 sites. `attr_edge` (edge metadata) is **forward-only** (no reverse lookup exists), so it has no dual to disagree with. No analysis-pipeline invariant touched.

## Sibling latent issues found (out of scope — filed, not fixed)

- **`numeric_cmp` (`gt`/`lt`/`gte`/`lte`) parses operands as `f64`** — comparing two u128 hash node IDs that differ only in low bits both round to the **same** `f64` (verified live: `lt(a, a+1)` → 0 rows, expected 1), so `lt`/`gt` over node IDs is broken for the distinct-pair-dedup idiom. Documented as an f64-domain limitation (the builtin is intended for numeric *metadata*); a proper fix needs integer-aware comparison and is a separate design decision.
- **Cypher `WHERE` on nested metadata properties** likely shares the same flat-only `metadata_matches` limitation (storage layer, `shard.rs`) — a different engine/area, kept separate per the convention of these focused PRs.

## Blast radius

Rust-only, inside `packages/rfdb-server/src/datalog/{eval,eval_explain,tests}.rs`. No JS/TS, no wire format, no stored-graph-shape change — only the row set of reverse `attr(X, "<dotted.key>", V)` queries (previously always empty). The JS-only CI gate (`.github/workflows/ci.yml`) is unaffected; full datalog (231) + lib (955) suites green.

## Source

In-env triage this run: **0 open GitHub issues**, no Linear MCP (github + Enox only). Net-new correctness bug found by empirically probing the live Datalog engine (Evidence Rule: live `query_atom` against a built `rfdb`), in the Datalog-builtins forward/reverse-symmetry vein flagged after #361. Recorded in the autonomous web-session RFDB-correctness intake series in Enox.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNZFyzbKEpiJQ9icffmKZX)_