### PR TITLE
fix(rfdb): datalog edge(X,X)/incoming(X,X) enforce self-loop equality

### DIFF
--- a/packages/rfdb-server/src/datalog/eval.rs
+++ b/packages/rfdb-server/src/datalog/eval.rs
@@ -82,6 +82,25 @@ impl Bindings {
         self.map.insert(var.to_string(), value);
     }
 
+    /// Bind `var` to `value`, enforcing repeated-variable equality within a
+    /// single atom.
+    ///
+    /// If `var` is unbound, this binds it and returns `true`. If `var` is
+    /// already bound, the new `value` must equal the existing one — otherwise
+    /// the binding is inconsistent and this returns `false` so the caller can
+    /// drop the row. This makes a variable that appears more than once in one
+    /// atom act as an equality join (e.g. `edge(X, X)` = self-loops) instead of
+    /// the later occurrence silently overwriting the earlier one with `set`.
+    pub fn bind_checked(&mut self, var: &str, value: Value) -> bool {
+        match self.map.get(var) {
+            Some(existing) => *existing == value,
+            None => {
+                self.map.insert(var.to_string(), value);
+                true
+            }
+        }
+    }
+
     /// Extend with another bindings, returning None if conflict
     pub fn extend(&self, other: &Bindings) -> Option<Bindings> {
         let mut result = self.clone();
@@ -925,7 +944,11 @@ impl<'a> Evaluator<'a> {
 
                         // Bind dst
                         match dst_term {
-                            Term::Var(var) => b.set(var, Value::Id(e.dst)),
+                            Term::Var(var) => {
+                                if !b.bind_checked(var, Value::Id(e.dst)) {
+                                    return None;
+                                }
+                            }
                             Term::Const(s) => {
                                 if s.parse::<u128>().ok() != Some(e.dst) {
                                     return None;
@@ -937,7 +960,9 @@ impl<'a> Evaluator<'a> {
                         // Bind edge type if variable
                         if let Some(Term::Var(var)) = type_term {
                             if let Some(etype) = e.edge_type {
-                                b.set(var, Value::Str(etype));
+                                if !b.bind_checked(var, Value::Str(etype)) {
+                                    return None;
+                                }
                             }
                         }
 
@@ -974,25 +999,32 @@ impl<'a> Evaluator<'a> {
                         }
                         true
                     })
-                    .map(|e| {
+                    .filter_map(|e| {
                         let mut b = Bindings::new();
 
                         // Bind source variable
                         b.set(src_var, Value::Id(e.src));
 
-                        // Bind destination
+                        // Bind destination. `bind_checked` enforces equality when
+                        // dst is the SAME variable as src — i.e. `edge(X, X)` is a
+                        // self-loop join (keep only e.src == e.dst), not an
+                        // overwrite that would drop the constraint.
                         if let Term::Var(var) = dst_term {
-                            b.set(var, Value::Id(e.dst));
+                            if !b.bind_checked(var, Value::Id(e.dst)) {
+                                return None;
+                            }
                         }
 
                         // Bind edge type if variable
                         if let Some(Term::Var(var)) = type_term {
                             if let Some(etype) = e.edge_type {
-                                b.set(var, Value::Str(etype));
+                                if !b.bind_checked(var, Value::Str(etype)) {
+                                    return None;
+                                }
                             }
                         }
 
-                        b
+                        Some(b)
                     })
                     .collect()
             }
@@ -1024,22 +1056,26 @@ impl<'a> Evaluator<'a> {
                         }
                         true
                     })
-                    .map(|e| {
+                    .filter_map(|e| {
                         let mut b = Bindings::new();
 
                         // Bind destination if variable
                         if let Term::Var(var) = dst_term {
-                            b.set(var, Value::Id(e.dst));
+                            if !b.bind_checked(var, Value::Id(e.dst)) {
+                                return None;
+                            }
                         }
 
                         // Bind edge type if variable
                         if let Some(Term::Var(var)) = type_term {
                             if let Some(etype) = e.edge_type {
-                                b.set(var, Value::Str(etype));
+                                if !b.bind_checked(var, Value::Str(etype)) {
+                                    return None;
+                                }
                             }
                         }
 
-                        b
+                        Some(b)
                     })
                     .collect()
             }
@@ -1080,9 +1116,16 @@ impl<'a> Evaluator<'a> {
                     .filter_map(|e| {
                         let mut b = Bindings::new();
 
-                        // Bind src
+                        // Bind src. `bind_checked` enforces equality when src is
+                        // the SAME variable as the (variable) dst — i.e.
+                        // `incoming(X, X)` is a self-loop join, not an overwrite
+                        // that would drop the e.src == e.dst constraint.
                         match src_term {
-                            Term::Var(var) => b.set(var, Value::Id(e.src)),
+                            Term::Var(var) => {
+                                if !b.bind_checked(var, Value::Id(e.src)) {
+                                    return None;
+                                }
+                            }
                             Term::Const(s) => {
                                 if s.parse::<u128>().ok() != Some(e.src) {
                                     return None;
@@ -1094,7 +1137,9 @@ impl<'a> Evaluator<'a> {
                         // Bind edge type if variable
                         if let Some(Term::Var(var)) = type_term {
                             if let Some(etype) = e.edge_type {
-                                b.set(var, Value::Str(etype));
+                                if !b.bind_checked(var, Value::Str(etype)) {
+                                    return None;
+                                }
                             }
                         }
 
@@ -1128,9 +1173,16 @@ impl<'a> Evaluator<'a> {
                         // Bind dst variable
                         b.set(dst_var, Value::Id(e.dst));
 
-                        // Bind src
+                        // Bind src. `bind_checked` enforces equality when src is
+                        // the SAME variable as the (variable) dst — i.e.
+                        // `incoming(X, X)` is a self-loop join, not an overwrite
+                        // that would drop the e.src == e.dst constraint.
                         match src_term {
-                            Term::Var(var) => b.set(var, Value::Id(e.src)),
+                            Term::Var(var) => {
+                                if !b.bind_checked(var, Value::Id(e.src)) {
+                                    return None;
+                                }
+                            }
                             Term::Const(s) => {
                                 if s.parse::<u128>().ok() != Some(e.src) {
                                     return None;
@@ -1142,7 +1194,9 @@ impl<'a> Evaluator<'a> {
                         // Bind edge type if variable
                         if let Some(Term::Var(var)) = type_term {
                             if let Some(etype) = e.edge_type {
-                                b.set(var, Value::Str(etype));
+                                if !b.bind_checked(var, Value::Str(etype)) {
+                                    return None;
+                                }
                             }
                         }
 
@@ -1181,9 +1235,16 @@ impl<'a> Evaluator<'a> {
                     .filter_map(|e| {
                         let mut b = Bindings::new();
 
-                        // Bind src
+                        // Bind src. `bind_checked` enforces equality when src is
+                        // the SAME variable as the (variable) dst — i.e.
+                        // `incoming(X, X)` is a self-loop join, not an overwrite
+                        // that would drop the e.src == e.dst constraint.
                         match src_term {
-                            Term::Var(var) => b.set(var, Value::Id(e.src)),
+                            Term::Var(var) => {
+                                if !b.bind_checked(var, Value::Id(e.src)) {
+                                    return None;
+                                }
+                            }
                             Term::Const(s) => {
                                 if s.parse::<u128>().ok() != Some(e.src) {
                                     return None;
@@ -1195,7 +1256,9 @@ impl<'a> Evaluator<'a> {
                         // Bind edge type if variable
                         if let Some(Term::Var(var)) = type_term {
                             if let Some(etype) = e.edge_type {
-                                b.set(var, Value::Str(etype));
+                                if !b.bind_checked(var, Value::Str(etype)) {
+                                    return None;
+                                }
                             }
                         }
 

--- a/packages/rfdb-server/src/datalog/eval_explain.rs
+++ b/packages/rfdb-server/src/datalog/eval_explain.rs
@@ -830,7 +830,11 @@ impl<'a> EvaluatorExplain<'a> {
                         let mut b = Bindings::new();
 
                         match dst_term {
-                            Term::Var(var) => b.set(var, Value::Id(e.dst)),
+                            Term::Var(var) => {
+                                if !b.bind_checked(var, Value::Id(e.dst)) {
+                                    return None;
+                                }
+                            }
                             Term::Const(s) => {
                                 if s.parse::<u128>().ok() != Some(e.dst) {
                                     return None;
@@ -841,7 +845,9 @@ impl<'a> EvaluatorExplain<'a> {
 
                         if let Some(Term::Var(var)) = type_term {
                             if let Some(etype) = e.edge_type {
-                                b.set(var, Value::Str(etype));
+                                if !b.bind_checked(var, Value::Str(etype)) {
+                                    return None;
+                                }
                             }
                         }
 
@@ -882,25 +888,32 @@ impl<'a> EvaluatorExplain<'a> {
                         }
                         true
                     })
-                    .map(|e| {
+                    .filter_map(|e| {
                         let mut b = Bindings::new();
 
                         // Bind source variable
                         b.set(src_var, Value::Id(e.src));
 
-                        // Bind destination
+                        // Bind destination. `bind_checked` enforces equality when
+                        // dst is the SAME variable as src — `edge(X, X)` is a
+                        // self-loop join, not an overwrite that drops the
+                        // e.src == e.dst constraint.
                         if let Term::Var(var) = dst_term {
-                            b.set(var, Value::Id(e.dst));
+                            if !b.bind_checked(var, Value::Id(e.dst)) {
+                                return None;
+                            }
                         }
 
                         // Bind edge type if variable
                         if let Some(Term::Var(var)) = type_term {
                             if let Some(etype) = e.edge_type {
-                                b.set(var, Value::Str(etype));
+                                if !b.bind_checked(var, Value::Str(etype)) {
+                                    return None;
+                                }
                             }
                         }
 
-                        b
+                        Some(b)
                     })
                     .collect()
             }
@@ -936,22 +949,26 @@ impl<'a> EvaluatorExplain<'a> {
                         }
                         true
                     })
-                    .map(|e| {
+                    .filter_map(|e| {
                         let mut b = Bindings::new();
 
                         // Bind destination if variable
                         if let Term::Var(var) = dst_term {
-                            b.set(var, Value::Id(e.dst));
+                            if !b.bind_checked(var, Value::Id(e.dst)) {
+                                return None;
+                            }
                         }
 
                         // Bind edge type if variable
                         if let Some(Term::Var(var)) = type_term {
                             if let Some(etype) = e.edge_type {
-                                b.set(var, Value::Str(etype));
+                                if !b.bind_checked(var, Value::Str(etype)) {
+                                    return None;
+                                }
                             }
                         }
 
-                        b
+                        Some(b)
                     })
                     .collect()
             }
@@ -994,7 +1011,11 @@ impl<'a> EvaluatorExplain<'a> {
                         let mut b = Bindings::new();
 
                         match src_term {
-                            Term::Var(var) => b.set(var, Value::Id(e.src)),
+                            Term::Var(var) => {
+                                if !b.bind_checked(var, Value::Id(e.src)) {
+                                    return None;
+                                }
+                            }
                             Term::Const(s) => {
                                 if s.parse::<u128>().ok() != Some(e.src) {
                                     return None;
@@ -1005,7 +1026,9 @@ impl<'a> EvaluatorExplain<'a> {
 
                         if let Some(Term::Var(var)) = type_term {
                             if let Some(etype) = e.edge_type {
-                                b.set(var, Value::Str(etype));
+                                if !b.bind_checked(var, Value::Str(etype)) {
+                                    return None;
+                                }
                             }
                         }
 
@@ -1042,9 +1065,16 @@ impl<'a> EvaluatorExplain<'a> {
                         // Bind dst variable
                         b.set(dst_var, Value::Id(e.dst));
 
-                        // Bind src
+                        // Bind src. `bind_checked` enforces equality when src is
+                        // the SAME variable as the (variable) dst — `incoming(X, X)`
+                        // is a self-loop join, not an overwrite that drops the
+                        // e.src == e.dst constraint.
                         match src_term {
-                            Term::Var(var) => b.set(var, Value::Id(e.src)),
+                            Term::Var(var) => {
+                                if !b.bind_checked(var, Value::Id(e.src)) {
+                                    return None;
+                                }
+                            }
                             Term::Const(s) => {
                                 if s.parse::<u128>().ok() != Some(e.src) {
                                     return None;
@@ -1055,7 +1085,9 @@ impl<'a> EvaluatorExplain<'a> {
 
                         if let Some(Term::Var(var)) = type_term {
                             if let Some(etype) = e.edge_type {
-                                b.set(var, Value::Str(etype));
+                                if !b.bind_checked(var, Value::Str(etype)) {
+                                    return None;
+                                }
                             }
                         }
 
@@ -1100,7 +1132,11 @@ impl<'a> EvaluatorExplain<'a> {
 
                         // Bind src
                         match src_term {
-                            Term::Var(var) => b.set(var, Value::Id(e.src)),
+                            Term::Var(var) => {
+                                if !b.bind_checked(var, Value::Id(e.src)) {
+                                    return None;
+                                }
+                            }
                             Term::Const(s) => {
                                 if s.parse::<u128>().ok() != Some(e.src) {
                                     return None;
@@ -1112,7 +1148,9 @@ impl<'a> EvaluatorExplain<'a> {
                         // Bind edge type if variable
                         if let Some(Term::Var(var)) = type_term {
                             if let Some(etype) = e.edge_type {
-                                b.set(var, Value::Str(etype));
+                                if !b.bind_checked(var, Value::Str(etype)) {
+                                    return None;
+                                }
                             }
                         }
 

--- a/packages/rfdb-server/src/datalog/tests.rs
+++ b/packages/rfdb-server/src/datalog/tests.rs
@@ -5985,3 +5985,186 @@ mod attr_reverse_nested_metadata_tests {
         assert_eq!(ids, vec![2], "reverse nested attr must seed the pipelined generator path");
     }
 }
+
+/// Repeated-variable (self-loop) handling for `edge`/`incoming` enumeration.
+///
+/// A variable that appears in BOTH the src and dst position of a single edge
+/// atom — e.g. `edge(X, X, "CALLS")` ("find recursive functions") — is an
+/// equality join: only edges whose src == dst may match. When the shared
+/// variable is still unbound (the atom acts as a generator), the per-edge
+/// binding builder must enforce that equality, not silently overwrite the
+/// earlier binding with the later endpoint.
+mod repeated_var_tests {
+    use super::*;
+    use crate::graph::{GraphEngineV2, GraphStore};
+    use crate::storage::{NodeRecord, EdgeRecord};
+
+    /// Graph with two genuine self-loops and two ordinary edges:
+    ///   1 -> 2  CALLS
+    ///   2 -> 3  CALLS
+    ///   4 -> 4  CALLS        (recursive function — a real self-loop)
+    ///   1 -> 1  REFERENCES   (self-loop of a different type)
+    fn setup_self_loop_graph() -> GraphEngineV2 {
+        let mut engine = GraphEngineV2::create_ephemeral();
+        let mk = |id: u128| NodeRecord {
+            id,
+            node_type: Some("FUNCTION".to_string()),
+            name: Some(format!("fn_{}", id)),
+            file: Some("t.js".to_string()),
+            file_id: 0,
+            name_offset: 0,
+            version: "main".into(),
+            exported: false,
+            replaces: None,
+            deleted: false,
+            metadata: None,
+            semantic_id: None,
+        };
+        engine.add_nodes(vec![mk(1), mk(2), mk(3), mk(4)]);
+        let e = |src: u128, dst: u128, t: &str| EdgeRecord {
+            src,
+            dst,
+            edge_type: Some(t.to_string()),
+            version: "main".into(),
+            metadata: None,
+            deleted: false,
+        };
+        engine.add_edges(
+            vec![
+                e(1, 2, "CALLS"),
+                e(2, 3, "CALLS"),
+                e(4, 4, "CALLS"),
+                e(1, 1, "REFERENCES"),
+            ],
+            false,
+        );
+        engine
+    }
+
+    fn ids_of(results: &[Bindings], var: &str) -> Vec<u128> {
+        let mut v: Vec<u128> = results
+            .iter()
+            .filter_map(|b| b.get(var).and_then(|val| val.as_id()))
+            .collect();
+        v.sort_unstable();
+        v.dedup();
+        v
+    }
+
+    #[test]
+    fn test_edge_repeated_var_typed_self_loop_only() {
+        let engine = setup_self_loop_graph();
+        let ev = Evaluator::new(&engine);
+        // edge(X, X, "CALLS") — only the 4->4 recursive CALLS edge qualifies.
+        let results = ev
+            .eval_query(&parse_query(r#"edge(X, X, "CALLS")"#).unwrap())
+            .unwrap();
+        assert_eq!(
+            ids_of(&results, "X"),
+            vec![4],
+            "edge(X, X, \"CALLS\") must return only the self-loop source, not every CALLS edge"
+        );
+    }
+
+    #[test]
+    fn test_edge_repeated_var_untyped_self_loops() {
+        let engine = setup_self_loop_graph();
+        let ev = Evaluator::new(&engine);
+        // edge(X, X) — both self-loops (4->4 CALLS and 1->1 REFERENCES).
+        let results = ev
+            .eval_query(&parse_query(r#"edge(X, X)"#).unwrap())
+            .unwrap();
+        assert_eq!(
+            ids_of(&results, "X"),
+            vec![1, 4],
+            "edge(X, X) must return exactly the self-loop nodes"
+        );
+    }
+
+    #[test]
+    fn test_incoming_repeated_var_typed_self_loop_only() {
+        let engine = setup_self_loop_graph();
+        let ev = Evaluator::new(&engine);
+        // incoming(X, X, "CALLS") — reverse view, same single self-loop.
+        let results = ev
+            .eval_query(&parse_query(r#"incoming(X, X, "CALLS")"#).unwrap())
+            .unwrap();
+        assert_eq!(
+            ids_of(&results, "X"),
+            vec![4],
+            "incoming(X, X, \"CALLS\") must return only the self-loop node"
+        );
+    }
+
+    #[test]
+    fn test_incoming_repeated_var_untyped_self_loops() {
+        let engine = setup_self_loop_graph();
+        let ev = Evaluator::new(&engine);
+        let results = ev
+            .eval_query(&parse_query(r#"incoming(X, X)"#).unwrap())
+            .unwrap();
+        assert_eq!(
+            ids_of(&results, "X"),
+            vec![1, 4],
+            "incoming(X, X) must return exactly the self-loop nodes"
+        );
+    }
+
+    #[test]
+    fn test_edge_distinct_vars_unaffected() {
+        // Regression guard: distinct src/dst variables still enumerate every edge.
+        let engine = setup_self_loop_graph();
+        let ev = Evaluator::new(&engine);
+        let results = ev
+            .eval_query(&parse_query(r#"edge(X, Y, "CALLS")"#).unwrap())
+            .unwrap();
+        // (1,2), (2,3), (4,4) — three CALLS edges.
+        assert_eq!(results.len(), 3, "distinct-var enumeration must be unchanged");
+    }
+
+    #[test]
+    fn test_edge_repeated_var_bound_path_still_correct() {
+        // When X is already bound before the edge atom, evaluation goes through
+        // the Const-src branch (which already filters dst == src correctly).
+        // This guards that the fix does not regress the already-correct path.
+        let engine = setup_self_loop_graph();
+        let ev = Evaluator::new(&engine);
+        let results = ev
+            .eval_query(
+                &parse_query(r#"node(X, "FUNCTION"), edge(X, X, "CALLS")"#).unwrap(),
+            )
+            .unwrap();
+        assert_eq!(
+            ids_of(&results, "X"),
+            vec![4],
+            "bound-var self-loop path must remain correct"
+        );
+    }
+
+    #[test]
+    fn test_explain_edge_repeated_var_matches_plain() {
+        use crate::datalog::eval_explain::EvaluatorExplain;
+        let engine = setup_self_loop_graph();
+        let plain = Evaluator::new(&engine);
+        let plain_results = plain
+            .eval_query(&parse_query(r#"edge(X, X, "CALLS")"#).unwrap())
+            .unwrap();
+        assert_eq!(ids_of(&plain_results, "X"), vec![4]);
+
+        let mut explain = EvaluatorExplain::new(&engine, true);
+        let explain_result = explain
+            .eval_query(&parse_query(r#"edge(X, X, "CALLS")"#).unwrap())
+            .unwrap();
+        let mut explain_ids: Vec<u128> = explain_result
+            .bindings
+            .iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.parse::<u128>().ok()))
+            .collect();
+        explain_ids.sort_unstable();
+        explain_ids.dedup();
+        assert_eq!(
+            explain_ids, vec![4],
+            "explain evaluator must match plain for repeated-var self-loop"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

A variable that appears in **both endpoints** of a single `edge`/`incoming` atom — e.g. `edge(X, X, "CALLS")` (the natural way to ask *"which functions call themselves?"*) — is an **equality join**: only edges whose `src == dst` may match. In the **enumeration path** (the atom acting as a generator, the shared variable still unbound), the per-edge binding builder set the variable twice with raw `b.set`, so the **dst binding silently overwrote the src binding** and the self-loop constraint was dropped. `edge(X, X, "CALLS")` returned **every CALLS edge** instead of only the self-loops — an on-thesis silent-wrong-answer in the engine an AI agent queries.

Same RFDB Datalog-builtins correctness series as #359/#361/#362/#363 (each a genuine silent-wrong-answer), in a previously-untouched seam: single-atom **repeated-variable** binding in the `edge`/`incoming` enumeration path. The two-atom self-join (`edge(M,C,T1), edge(C,M,T2)`) was already fixed (REG-503, hash-join path); this is its single-atom dual.

## Spec (BDD)

- **Invariant restored:** a variable repeated across the endpoints of one `edge`/`incoming` atom is an equality constraint — `edge(X, X)` enumerates only self-loops (`src == dst`), it does not overwrite the binding.
- **Given** edges `1→2 CALLS`, `2→3 CALLS`, `4→4 CALLS` (a recursive function), `1→1 REFERENCES`
  **When** `edge(X, X, "CALLS")`
  **Then** `X = {4}` — **not** `{2, 3, 4}` (every CALLS destination).
- **And** `edge(X, X)` (untyped) → `{1, 4}` (both self-loops); `incoming(X, X, "CALLS")` → `{4}`; `incoming(X, X)` → `{1, 4}`.
- **And (regression):** `edge(X, Y, "CALLS")` (distinct vars) still enumerates all 3 edges; `node(X,"FUNCTION"), edge(X, X, "CALLS")` (X bound first) still returns `{4}`.
- **And** the `--explain` evaluator returns the same rows as the plain evaluator.

## Root cause

`packages/rfdb-server/src/datalog/eval.rs`, `eval_edge` (`Term::Var(src_var)` arm):

```rust
b.set(src_var, Value::Id(e.src));
if let Term::Var(var) = dst_term {
    b.set(var, Value::Id(e.dst));   // src_var == dst var ("X") → OVERWRITES src with dst
}
```

For `edge(X, X)` the shared `X` is set to `e.src`, then unconditionally re-set to `e.dst`, so `X = e.dst` for **every** edge and the `e.src == e.dst` constraint vanishes. Same shape in `eval_incoming` (`incoming(X, X)` overwrote with `e.src`) and in the `EvaluatorExplain` twin. Reachable whenever the atom runs with the shared variable **unbound** (standalone / first-literal generator); evaluation falls to the non-hash enumeration path (`current.len() < HASH_JOIN_THRESHOLD`).

## Fix

Add `Bindings::bind_checked(var, value)` — binds an unbound var, but requires **equality** when the var is already bound, returning `false` (drop the row) on conflict. Route every variable-binding site in `eval_edge`/`eval_incoming` (all three `src`/`dst`/`wildcard` modes) through it, in **both** the plain `Evaluator` and the `EvaluatorExplain` twin. `Value` is `Id(u128)` vs `Str(String)` with derived `PartialEq`, so the self-loop check (`Id(src) == Id(dst)`) is exact.

Untouched (already correct):
- **Hash-join fast paths** (`eval_edge_hash_join`/`eval_incoming_hash_join`) already honor already-bound vars (REG-503, `existing != dst_id → continue`); for `node(X,…), edge(X,X)` the join key `X` is bound, so it filters `dst == src` correctly.
- **Bound-var path:** when `X` is bound before the atom, substitution yields a `Const` src and the `Const`-src branch already filters `dst == src`.

## Before / After (live `cargo test`, fixture above)

RED before the fix:
```
test_edge_repeated_var_typed_self_loop_only      left: [2, 3, 4]  right: [4]
test_edge_repeated_var_untyped_self_loops        left: [1,2,3,4]  right: [1, 4]
test_incoming_repeated_var_typed_self_loop_only  left: [1, 2, 4]  right: [4]
test_incoming_repeated_var_untyped_self_loops    left: [1, 2, 4]  right: [1, 4]
test_explain_edge_repeated_var_matches_plain     left: [2, 3, 4]  right: [4]
test_edge_distinct_vars_unaffected ... ok            # guard: distinct vars unchanged
test_edge_repeated_var_bound_path_still_correct ... ok  # guard: bound path unchanged
```
GREEN after — `datalog::tests::repeated_var_tests`: **7 passed; 0 failed**.

Full gate (Rust-only, isolated to the `rfdb` crate):
```
cargo test --lib datalog::   -> ok. 238 passed; 0 failed
cargo test --lib             -> ok. 962 passed; 0 failed   (was 955 + 7 new)
cargo clippy --lib           -> no new warnings (only pre-existing option_as_ref_deref on untouched get_*_edges lines)
cargo build --bins           -> Finished
rustfmt --check (edited regions) -> clean (crate not fmt-maintained; pre-existing import-order drift untouched)
```

## Adversarial review

- **Round A — correctness:** genuine self-loop `4→4` kept; ordinary edges (`1→2`, `2→3`) and a cycle `100↔101` (not a self-loop) correctly excluded from `edge(X,X)`; empty/orphan graphs → empty; distinct-var enumeration byte-identical; bound-var path unchanged; `id == type` collisions (`edge(X,Y,X)`) drop (`Id` ≠ `Str`, semantically correct — no edge's type equals its source's numeric id); explain twin pinned to plain.
- **Round B — fragility:** `eval.rs`/`eval_explain.rs` are pre-existing >500-line files (splitting out of scope, consistent with the series). The repeated-var = equality invariant is centralized in one documented `Bindings::bind_checked` helper and re-stated at each self-loop site, guarding a future "simplify back to `set`" reintroduction.
- **Round C — class-not-instance:** the class is "single-atom repeated variable enforced as equality, not silent `set`-overwrite." Fixed in `eval_edge` (3 branches) + `eval_incoming` (3 branches) across **both** evaluator twins; the hash-join dual was already closed (REG-503). **Noted degenerate sibling (not fixed):** `node(X, X)` (id == type) has the same `set`-overwrite shape, but it is a semantically-empty query — a node's `u128` id can never equal its type string, so no realistic agent query hits it; the same `bind_checked` helper would close it trivially as a follow-up if desired.

## Blast radius

Rust-only, inside `packages/rfdb-server/src/datalog/{eval,eval_explain,tests}.rs`. No JS/TS, no wire format, no stored-graph-shape change — only the row set of `edge`/`incoming` queries that **repeat a variable across endpoints with that variable unbound** (previously returned all edges, now returns only self-loops). The JS-only CI gate is unaffected.

## Source

In-env triage this run: **0 open GitHub issues**, no Linear MCP (github + Enox only). Net-new correctness bug found by reading the live Datalog builtins (Evidence Rule: RED→GREEN `cargo test` graph-shape assertions against an in-memory `GraphEngineV2`). Recorded in the autonomous web-session RFDB-Datalog-correctness intake series in Enox.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3KsQmHnpBdg9fhGGdLNwf)_