### PR TITLE
fix(rfdb): datalog numeric_cmp compares integer operands exactly (no f64 collapse)

### DIFF
--- a/packages/rfdb-server/src/datalog/eval.rs
+++ b/packages/rfdb-server/src/datalog/eval.rs
@@ -55,6 +55,42 @@ impl Value {
     }
 }
 
+/// Compare two numeric operand strings for the gt/lt/gte/lte builtins.
+///
+/// Integer operands are compared EXACTLY. This matters because operands are
+/// frequently u128 node IDs (and large integer metadata such as timestamps or
+/// byte offsets), which overflow f64's 53-bit mantissa — parsing those as f64
+/// would collapse distinct values onto the same float and silently drop or admit
+/// rows (e.g. `lt(A, B)` between two IDs differing only in low bits returns
+/// false; `gte(A, B)` returns true). `i128` is tried first (covers negative
+/// metadata and IDs up to i128::MAX); `u128` second (covers hash IDs above
+/// i128::MAX). Only genuinely fractional operands fall back to `f64`.
+///
+/// Returns `None` when either operand is non-numeric, when an `f64` comparison
+/// is undefined (NaN), or when `op` is not a recognised comparison — callers
+/// treat any `None`/`Some(false)` as a non-passing constraint (empty result).
+pub(crate) fn numeric_compare(left: &str, right: &str, op: &str) -> Option<bool> {
+    use std::cmp::Ordering;
+
+    let ordering: Ordering = if let (Ok(l), Ok(r)) = (left.parse::<i128>(), right.parse::<i128>()) {
+        l.cmp(&r)
+    } else if let (Ok(l), Ok(r)) = (left.parse::<u128>(), right.parse::<u128>()) {
+        l.cmp(&r)
+    } else {
+        let l: f64 = left.parse().ok()?;
+        let r: f64 = right.parse().ok()?;
+        l.partial_cmp(&r)? // None on NaN → graceful non-pass
+    };
+
+    Some(match op {
+        "gt" => ordering == Ordering::Greater,
+        "lt" => ordering == Ordering::Less,
+        "gte" => ordering != Ordering::Less,
+        "lte" => ordering != Ordering::Greater,
+        _ => return None,
+    })
+}
+
 /// Variable bindings
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Bindings {
@@ -1659,7 +1695,9 @@ impl<'a> Evaluator<'a> {
 
     /// Evaluate gt/lt/gte/lte(X, Y) - numeric comparison constraints
     /// Both arguments must be bound (either constants or bound variables).
-    /// Values are parsed as f64; non-numeric strings produce empty result (graceful failure).
+    /// Integer operands (including u128 node IDs) are compared exactly via
+    /// [`numeric_compare`]; non-numeric strings produce an empty result
+    /// (graceful failure).
     fn eval_numeric_cmp(&self, atom: &Atom) -> Vec<Bindings> {
         let args = atom.args();
         if args.len() < 2 {
@@ -1676,28 +1714,9 @@ impl<'a> Evaluator<'a> {
             _ => return vec![],
         };
 
-        let left: f64 = match left_str.parse() {
-            Ok(v) => v,
-            Err(_) => return vec![],
-        };
-
-        let right: f64 = match right_str.parse() {
-            Ok(v) => v,
-            Err(_) => return vec![],
-        };
-
-        let pass = match atom.predicate() {
-            "gt" => left > right,
-            "lt" => left < right,
-            "gte" => left >= right,
-            "lte" => left <= right,
-            _ => return vec![],
-        };
-
-        if pass {
-            vec![Bindings::new()]
-        } else {
-            vec![]
+        match numeric_compare(left_str, right_str, atom.predicate()) {
+            Some(true) => vec![Bindings::new()],
+            _ => vec![],
         }
     }
 

--- a/packages/rfdb-server/src/datalog/eval_explain.rs
+++ b/packages/rfdb-server/src/datalog/eval_explain.rs
@@ -16,6 +16,7 @@ use crate::datalog::types::*;
 use crate::datalog::eval::{Value, Bindings, EvalLimits};
 use super::utils::reorder_literals;
 use super::eval::HASH_JOIN_THRESHOLD;
+use super::eval::numeric_compare;
 
 /// Statistics collected during query execution
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -1511,7 +1512,10 @@ impl<'a> EvaluatorExplain<'a> {
         }
     }
 
-    /// Evaluate gt/lt/gte/lte(X, Y) - numeric comparison constraints
+    /// Evaluate gt/lt/gte/lte(X, Y) - numeric comparison constraints.
+    /// Integer operands (including u128 node IDs) are compared exactly via the
+    /// shared [`numeric_compare`] helper (kept in sync with the non-explain
+    /// `Evaluator`); non-numeric strings produce an empty result.
     fn eval_numeric_cmp(&mut self, atom: &Atom) -> Vec<Bindings> {
         let args = atom.args();
         if args.len() < 2 {
@@ -1528,28 +1532,9 @@ impl<'a> EvaluatorExplain<'a> {
             _ => return vec![],
         };
 
-        let left: f64 = match left_str.parse() {
-            Ok(v) => v,
-            Err(_) => return vec![],
-        };
-
-        let right: f64 = match right_str.parse() {
-            Ok(v) => v,
-            Err(_) => return vec![],
-        };
-
-        let pass = match atom.predicate() {
-            "gt" => left > right,
-            "lt" => left < right,
-            "gte" => left >= right,
-            "lte" => left <= right,
-            _ => return vec![],
-        };
-
-        if pass {
-            vec![Bindings::new()]
-        } else {
-            vec![]
+        match numeric_compare(left_str, right_str, atom.predicate()) {
+            Some(true) => vec![Bindings::new()],
+            _ => vec![],
         }
     }
 

--- a/packages/rfdb-server/src/datalog/tests.rs
+++ b/packages/rfdb-server/src/datalog/tests.rs
@@ -5827,6 +5827,146 @@ mod numeric_cmp_tests {
     }
 }
 
+// ============================================================================
+// numeric_cmp(gt/lt/gte/lte) — integer-exact comparison of large operands
+//
+// The comparison parsed both operands as f64. f64 has a 53-bit mantissa, so any
+// integer above 2^53 (e.g. u128 node IDs, large timestamps / byte offsets stored
+// as metadata) loses precision: two DISTINCT values that differ only in low bits
+// round to the SAME f64. That made `lt(A, B)` return FALSE for distinct IDs
+// (silently dropping rows — e.g. the canonical symmetric-pair-dedup idiom
+// `edge(A,B), edge(B,A), lt(A,B)` lost every pair) and `gte(A, B)` return TRUE
+// for distinct IDs (false positive). These tests pin integer-exact comparison;
+// genuinely fractional operands still fall back to f64.
+// ============================================================================
+
+mod numeric_cmp_u128_precision_tests {
+    use super::*;
+    use crate::graph::{GraphEngineV2, GraphStore};
+    use crate::storage::{NodeRecord, EdgeRecord};
+    use crate::datalog::eval::{Evaluator, Value};
+    use crate::datalog::eval_explain::EvaluatorExplain;
+
+    // 2^60 and 2^60 + 1 — both <= i128::MAX, both round to the SAME f64
+    // (2^60 is exactly representable, 2^60 + 1 is not).
+    const BIG: &str = "1152921504606846976";
+    const BIG_PLUS_1: &str = "1152921504606846977";
+
+    // 2^127 and 2^127 + 1 — both > i128::MAX but < u128::MAX, also f64-equal.
+    // Exercises the u128 fallback (these do not parse as i128).
+    const HUGE: &str = "170141183460469231731687303715884105728";
+    const HUGE_PLUS_1: &str = "170141183460469231731687303715884105729";
+
+    fn cmp(op: &str, a: &str, b: &str) -> usize {
+        let engine = GraphEngineV2::create_ephemeral();
+        let evaluator = Evaluator::new(&engine);
+        let query = Atom::new(op, vec![Term::constant(a), Term::constant(b)]);
+        evaluator.query_atom(&query).unwrap().len()
+    }
+
+    // lt(2^60, 2^60+1) must be TRUE — distinct IDs must not collapse under f64.
+    #[test]
+    fn test_lt_large_ids_not_collapsed() {
+        assert_eq!(cmp("lt", BIG, BIG_PLUS_1), 1, "2^60 < 2^60+1 must hold");
+    }
+
+    // gt(2^60+1, 2^60) must be TRUE.
+    #[test]
+    fn test_gt_large_ids_not_collapsed() {
+        assert_eq!(cmp("gt", BIG_PLUS_1, BIG), 1, "2^60+1 > 2^60 must hold");
+    }
+
+    // gte/lte must NOT treat distinct large IDs as equal (false-positive guard).
+    #[test]
+    fn test_gte_lte_distinct_large_ids_not_falsely_equal() {
+        // 2^60 is strictly less than 2^60+1, so neither >= nor (reversed) <= holds.
+        assert_eq!(cmp("gte", BIG, BIG_PLUS_1), 0, "2^60 >= 2^60+1 must be false");
+        assert_eq!(cmp("lte", BIG_PLUS_1, BIG), 0, "2^60+1 <= 2^60 must be false");
+        // The genuinely-equal case still passes.
+        assert_eq!(cmp("gte", BIG, BIG), 1, "2^60 >= 2^60 must hold");
+        assert_eq!(cmp("lte", BIG, BIG), 1, "2^60 <= 2^60 must hold");
+    }
+
+    // u128 operands above i128::MAX (do not parse as i128) compared exactly.
+    #[test]
+    fn test_cmp_u128_above_i128_max() {
+        assert_eq!(cmp("lt", HUGE, HUGE_PLUS_1), 1, "2^127 < 2^127+1 must hold");
+        assert_eq!(cmp("gt", HUGE_PLUS_1, HUGE), 1, "2^127+1 > 2^127 must hold");
+        assert_eq!(cmp("gte", HUGE, HUGE_PLUS_1), 0, "2^127 >= 2^127+1 must be false");
+    }
+
+    // Regression: fractional and negative operands still work via the f64 fallback.
+    #[test]
+    fn test_float_and_negative_comparisons_still_work() {
+        assert_eq!(cmp("gt", "1000.5", "1000"), 1, "1000.5 > 1000");
+        assert_eq!(cmp("lt", "5", "5.5"), 1, "5 < 5.5 (mixed int/float)");
+        assert_eq!(cmp("gt", "5", "-10"), 1, "5 > -10 (negative)");
+        assert_eq!(cmp("lt", "-10", "5"), 1, "-10 < 5");
+        assert_eq!(cmp("gt", "abc", "100"), 0, "non-numeric → empty");
+    }
+
+    // Realistic end-to-end: the symmetric-pair-dedup idiom over two nodes whose
+    // u128 IDs round to the same f64. `lt(A, B)` must keep the one canonical pair.
+    #[test]
+    fn test_symmetric_pair_dedup_idiom_large_ids() {
+        let a: u128 = BIG.parse().unwrap();
+        let b: u128 = BIG_PLUS_1.parse().unwrap();
+        let mut engine = GraphEngineV2::create_ephemeral();
+        engine.add_nodes(vec![
+            NodeRecord {
+                id: a,
+                node_type: Some("FUNCTION".to_string()),
+                name: Some("alpha".to_string()),
+                file: Some("a.js".to_string()),
+                file_id: 0, name_offset: 0,
+                version: "main".into(),
+                exported: false, replaces: None, deleted: false,
+                metadata: None, semantic_id: None,
+            },
+            NodeRecord {
+                id: b,
+                node_type: Some("FUNCTION".to_string()),
+                name: Some("beta".to_string()),
+                file: Some("b.js".to_string()),
+                file_id: 0, name_offset: 0,
+                version: "main".into(),
+                exported: false, replaces: None, deleted: false,
+                metadata: None, semantic_id: None,
+            },
+        ]);
+        engine.add_edges(vec![
+            EdgeRecord { src: a, dst: b, edge_type: Some("CALLS".to_string()),
+                version: "main".into(), metadata: None, deleted: false },
+            EdgeRecord { src: b, dst: a, edge_type: Some("CALLS".to_string()),
+                version: "main".into(), metadata: None, deleted: false },
+        ], false);
+
+        let mut evaluator = Evaluator::new(&engine);
+        let rule = parse_rule(
+            r#"mutual(A, B) :- edge(A, B, "CALLS"), edge(B, A, "CALLS"), lt(A, B)."#
+        ).unwrap();
+        evaluator.add_rule(rule);
+
+        let results = evaluator.query(&parse_atom("mutual(A, B)").unwrap()).unwrap();
+        // Exactly one canonical ordered pair (a < b); not zero (collapsed by f64),
+        // not two (both directions admitted).
+        assert_eq!(results.len(), 1, "dedup must keep exactly one ordered pair");
+        assert_eq!(results[0].get("A"), Some(&Value::Id(a)));
+        assert_eq!(results[0].get("B"), Some(&Value::Id(b)));
+    }
+
+    // EvaluatorExplain twin must agree: lt(2^60, 2^60+1) yields one row.
+    #[test]
+    fn test_numeric_cmp_large_ids_explain_parity() {
+        let engine = GraphEngineV2::create_ephemeral();
+        let mut ev = EvaluatorExplain::new(&engine, false);
+        let result = ev.eval_query(
+            &parse_query(&format!(r#"lt("{}", "{}")"#, BIG, BIG_PLUS_1)).unwrap()
+        ).unwrap();
+        assert_eq!(result.bindings.len(), 1, "explain twin must also pass lt on distinct large IDs");
+    }
+}
+
 
 // ============================================================================
 // attr() reverse lookup — nested metadata dotted paths (forward/reverse symmetry)


### PR DESCRIPTION
## Summary

The Datalog `gt`/`lt`/`gte`/`lte` builtins parsed **both operands as `f64`**. `f64` has a 53-bit mantissa, so any integer above 2^53 — crucially **u128 node IDs**, but also large integer metadata (timestamps, byte offsets) — loses precision: two *distinct* values differing only in low bits round to the **same** float. The comparator then gave silent wrong answers:

- `lt(A, B)` between two distinct IDs returned **false** → rows silently **dropped**. The canonical symmetric-pair-dedup idiom `edge(A,B), edge(B,A), lt(A,B)` (keep one ordered copy of each mutual pair) lost **every** pair.
- `gte(A, B)` / `lte(A, B)` between two distinct IDs returned **true** → a **false positive** (treats distinct IDs as equal).

An AI agent comparing/ordering node IDs in Datalog — a first-class graph query — got confidently wrong results. On-thesis silent-wrong-answer bug in the engine the agent queries.

This is the explicitly-noted-but-unfixed seam flagged by the prior RFDB Datalog intake runs (recorded in Enox after #359 and #364: *"numeric_cmp/neq compare via f64 parse which loses precision on u128 node-id operands"*). It sits in the same Datalog-builtins hardening vein as the merged #359/#361/#362/#363/#364, in a previously-untouched executor path.

## Spec (BDD)

- **Invariant restored:** `gt`/`lt`/`gte`/`lte` compare integer operands **exactly** — distinct integers never collapse, regardless of magnitude (u128 node IDs included). Genuinely fractional operands still compare as `f64`.
- **Given** two node IDs `A = 2^60`, `B = 2^60 + 1` (which round to the same `f64`)
  **When** `lt(A, B)` is evaluated
  **Then** it is **true** (1 row) — not empty.
- **And** `gte(A, B)` is **false** (0 rows) — the distinct IDs are not treated as equal.
- **And** for IDs above `i128::MAX` (e.g. `2^127`, `2^127 + 1`, still `< u128::MAX`), `lt`/`gt`/`gte` are exact.
- **And** the symmetric-pair-dedup idiom `mutual(A,B) :- edge(A,B,"CALLS"), edge(B,A,"CALLS"), lt(A,B)` over two such IDs returns **exactly one** ordered pair (not zero, not both directions).
- **And (regression):** fractional operands (`1000.5 > 1000`, `5 < 5.5`), negative operands (`5 > -10`), and non-numeric operands (`abc` → empty) behave exactly as before.

## Root cause

`packages/rfdb-server/src/datalog/eval.rs`, `eval_numeric_cmp` (and its `EvaluatorExplain` twin in `eval_explain.rs`):

```rust
let left:  f64 = left_str.parse()?;   // u128 id "1152921504606846977" → 1.152921504606847e18
let right: f64 = right_str.parse()?;  // u128 id "1152921504606846976" → 1.152921504606847e18  (EQUAL!)
match op { "lt" => left < right, ... } // false → row dropped
```

Bound variables reach the constraint as `Term::Const(value.as_str())`, and `Value::Id(u128).as_str()` is the **decimal string of the u128** (`eval.rs:52`). So `lt(A, B)` over node-ID-bound vars fed two large decimal strings straight into the lossy `f64` parse.

## Fix

A single shared helper `numeric_compare(left, right, op) -> Option<bool>` (`eval.rs`), used by **both** evaluator twins (kills the two-diverging-copies fragility):

```rust
let ordering = if let (Ok(l), Ok(r)) = (left.parse::<i128>(), right.parse::<i128>()) {
    l.cmp(&r)                       // exact: negatives + IDs up to i128::MAX
} else if let (Ok(l), Ok(r)) = (left.parse::<u128>(), right.parse::<u128>()) {
    l.cmp(&r)                       // exact: hash IDs above i128::MAX
} else {
    left.parse::<f64>().ok()?.partial_cmp(&right.parse::<f64>().ok()?)?  // fractional only
};
```

`i128` first (covers negative metadata and IDs ≤ `i128::MAX`), `u128` second (covers the ~50% of random hash IDs above `i128::MAX`), `f64` only for genuinely fractional operands. Non-numeric / NaN → `None` → graceful empty, identical to before.

## Before / After (live `cargo test`)

RED before the fix — the 6 new tests (1 regression-guard test was already green, proving the f64/negative path is preserved):
```
test result: FAILED. 1 passed; 6 failed
  test_lt_large_ids_not_collapsed            left: 0  right: 1
  test_gt_large_ids_not_collapsed            left: 0  right: 1
  test_gte_lte_distinct_large_ids_not_...    (gte returned 1, expected 0 — false positive)
  test_cmp_u128_above_i128_max               left: 0  right: 1
  test_symmetric_pair_dedup_idiom_large_ids  left: 0  right: 1
  test_numeric_cmp_large_ids_explain_parity  left: 0  right: 1
```
GREEN after:
```
test datalog::tests::numeric_cmp_u128_precision_tests::test_lt_large_ids_not_collapsed ... ok
test ...::test_gt_large_ids_not_collapsed ... ok
test ...::test_gte_lte_distinct_large_ids_not_falsely_equal ... ok
test ...::test_cmp_u128_above_i128_max ... ok
test ...::test_float_and_negative_comparisons_still_work ... ok   # regression guard
test ...::test_symmetric_pair_dedup_idiom_large_ids ... ok        # end-to-end idiom
test ...::test_numeric_cmp_large_ids_explain_parity ... ok        # explain-twin parity
test result: ok. 18 passed; 0 failed   (numeric_cmp filter)
```

Full gate (Rust-only, isolated to the `rfdb` crate):
```
cargo test --lib datalog::   -> ok. 245 passed; 0 failed   (was 238; +7 new)
cargo test --lib             -> ok. 969 passed; 0 failed   (was 962; +7 new)
cargo clippy --lib           -> exit 0, no new warnings (none in the edited regions)
rustfmt --check              -> edited code regions clean; only pre-existing import-block
                                drift remains (crate is not fmt-maintained, consistent with
                                prior RFDB PRs)
```

## Adversarial review

- **Round A — correctness:** `i128` exactness for negatives + IDs ≤ i128::MAX; `u128` exactness for IDs above i128::MAX (the ~half of random hash IDs that overflow i128); mixed int/float (`5 < 5.5`) and pure float (`1000.5 > 1000`) via the `f64` fallback; equal operands (`gte(x,x)`/`lte(x,x)` = true) preserved; non-numeric → empty; NaN → `partial_cmp` `None` → empty (same outward behaviour as the old `f64` `>`/`>=`). `gte`/`lte` expressed as `!= Less` / `!= Greater` so equality is admitted exactly once.
- **Round B — structural fragility:** the two evaluator copies (`Evaluator` + `EvaluatorExplain`) previously held duplicate `f64` logic; both now route through the single `pub(crate) numeric_compare`, so they cannot drift (the same de-duplication strategy as `HASH_JOIN_THRESHOLD`). `eval.rs`/`eval_explain.rs` are pre-existing >500-line files; splitting is out of scope, consistent with #359/#362/#364. The helper is pure, total, and documented for agents.
- **Round C — class-not-instance:** audited the sibling string-comparison builtins. `neq` (eval.rs:1632) compares operands **as strings** (`left_val != right_val`) — exact for IDs, no precision loss, correct as-is. `starts_with`/`ends_with`/`contains` are string ops with no numeric domain. `numeric_cmp` was the **sole** builtin parsing IDs through `f64`; the class is fully closed. The explain twin is fixed in the same change (parity test pins it).

## Blast radius

Rust-only, inside `packages/rfdb-server/src/datalog/{eval,eval_explain,tests}.rs`. No JS/TS, no wire format, no stored-graph-shape change — only the truth value of `gt`/`lt`/`gte`/`lte` over **integer operands larger than 2^53** (everything fractional/small is byte-identical). The CI gate (`.github/workflows/ci.yml`) runs JS suites only and is unaffected.

## Source

In-env triage this run: **0 open GitHub issues**, no Linear MCP (github + Enox only). Net-new Datalog correctness bug; the seam was explicitly flagged-but-deferred by prior intake runs (Enox notes after #359/#364). Recorded in the autonomous web-session RFDB-correctness intake series.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sr4GiudzSyuyrWprE84FHh)_