### PR TITLE
rfdb: consolidate 7 reviewed Cypher/Datalog fixes (#345,347,351,352,356,360,365) + fix #346 test build

### DIFF
--- a/packages/rfdb-server/src/cypher/executor.rs
+++ b/packages/rfdb-server/src/cypher/executor.rs
@@ -868,21 +868,41 @@ pub fn eval_expr(expr: &Expr, record: &Record) -> CypherValue {
         }
 
         Expr::And(lhs, rhs) => {
-            let l = eval_expr(lhs, record);
-            if !l.is_truthy() {
+            // Kleene three-valued AND. FALSE dominates (short-circuits even past a
+            // NULL operand: `null AND false = false`); otherwise NULL is contagious
+            // (`true AND null = null`, `null AND true = null`). Collapsing a NULL
+            // operand to `Bool(false)` here would be wrong under `NOT`: it makes
+            // `NOT (null AND true)` become `NOT false = true`, wrongly admitting a
+            // row whose predicate is unknown. See `Expr::Not` below for the
+            // complementary NULL-preserving rule. Non-NULL operands fall through
+            // `kleene_truth` to `is_truthy()`, so their behaviour is unchanged.
+            let l = kleene_truth(&eval_expr(lhs, record));
+            if l == Some(false) {
                 return CypherValue::Bool(false);
             }
-            let r = eval_expr(rhs, record);
-            CypherValue::Bool(r.is_truthy())
+            let r = kleene_truth(&eval_expr(rhs, record));
+            kleene_value(match (l, r) {
+                (_, Some(false)) => Some(false),
+                (Some(true), Some(true)) => Some(true),
+                _ => None,
+            })
         }
 
         Expr::Or(lhs, rhs) => {
-            let l = eval_expr(lhs, record);
-            if l.is_truthy() {
+            // Kleene three-valued OR. TRUE dominates (`null OR true = true`);
+            // otherwise NULL is contagious (`null OR false = null`, `false OR
+            // null = null`). As with AND, collapsing a NULL operand to
+            // `Bool(false)` would wrongly admit rows under `NOT`.
+            let l = kleene_truth(&eval_expr(lhs, record));
+            if l == Some(true) {
                 return CypherValue::Bool(true);
             }
-            let r = eval_expr(rhs, record);
-            CypherValue::Bool(r.is_truthy())
+            let r = kleene_truth(&eval_expr(rhs, record));
+            kleene_value(match (l, r) {
+                (_, Some(true)) => Some(true),
+                (Some(false), Some(false)) => Some(false),
+                _ => None,
+            })
         }
 
         Expr::Not(inner) => {
@@ -1022,6 +1042,29 @@ fn eval_binop(l: &CypherValue, op: BinOp, r: &CypherValue) -> CypherValue {
                 .map(|o| o != std::cmp::Ordering::Less)
                 .unwrap_or(false),
         ),
+    }
+}
+
+/// Classify a Cypher value for Kleene (three-valued) boolean logic.
+///
+/// Returns `None` for NULL (the UNKNOWN truth value) and `Some(bool)` for any
+/// definite value, reusing `is_truthy()` so non-NULL operands keep the engine's
+/// existing loose truthiness (e.g. `Int(0)` → `Some(false)`). Used by the `AND`
+/// and `OR` arms of `eval_expr` so a NULL operand propagates as NULL instead of
+/// collapsing to a definite boolean (which is wrong under `NOT`).
+fn kleene_truth(v: &CypherValue) -> Option<bool> {
+    match v {
+        CypherValue::Null => None,
+        other => Some(other.is_truthy()),
+    }
+}
+
+/// Reconstruct a Cypher value from a Kleene truth: `None` → NULL, `Some(b)` →
+/// `Bool(b)`. Inverse of `kleene_truth` for the definite cases.
+fn kleene_value(t: Option<bool>) -> CypherValue {
+    match t {
+        Some(b) => CypherValue::Bool(b),
+        None => CypherValue::Null,
     }
 }
 

--- a/packages/rfdb-server/src/cypher/executor.rs
+++ b/packages/rfdb-server/src/cypher/executor.rs
@@ -629,9 +629,7 @@ impl<'a> Sort<'a> {
             for (expr, dir) in order_by {
                 let va = eval_expr(expr, a);
                 let vb = eval_expr(expr, b);
-                let cmp = va
-                    .partial_cmp_values(&vb)
-                    .unwrap_or(std::cmp::Ordering::Equal);
+                let cmp = order_cmp(&va, &vb);
                 let cmp = match dir {
                     SortDir::Asc => cmp,
                     SortDir::Desc => cmp.reverse(),
@@ -921,6 +919,32 @@ pub fn eval_expr(expr: &Expr, record: &Record) -> CypherValue {
 }
 
 // ─── Helper functions ───────────────────────────────────────────────────────
+
+/// Ordering comparator for `ORDER BY`, applied in the *ascending* direction
+/// (callers reverse it for `DESC`).
+///
+/// Implements Cypher/Neo4j ordering semantics for NULL: a null value is
+/// considered **greater than** any non-null value, so it sorts LAST under
+/// ascending order and FIRST under descending order (see the Neo4j Cypher
+/// manual, "Ordering null"). This deliberately differs from
+/// [`CypherValue::partial_cmp_values`], which treats null as the smallest
+/// value — that comparator is shared with WHERE-clause comparisons
+/// (`eval_binop`) and must not change. ORDER BY needs its own null rule, so
+/// it lives here rather than in the shared value comparator.
+///
+/// Non-null, mutually-incomparable values (e.g. a Str vs an Int, or two
+/// Node values) fall back to `Ordering::Equal`, preserving the prior
+/// best-effort behaviour for heterogeneous columns.
+fn order_cmp(a: &CypherValue, b: &CypherValue) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    match (a, b) {
+        (CypherValue::Null, CypherValue::Null) => Ordering::Equal,
+        // null is greater than any non-null value -> sorts last ascending.
+        (CypherValue::Null, _) => Ordering::Greater,
+        (_, CypherValue::Null) => Ordering::Less,
+        _ => a.partial_cmp_values(b).unwrap_or(Ordering::Equal),
+    }
+}
 
 /// Convert a CypherLiteral to a CypherValue.
 fn literal_to_value(lit: &CypherLiteral) -> CypherValue {

--- a/packages/rfdb-server/src/cypher/executor.rs
+++ b/packages/rfdb-server/src/cypher/executor.rs
@@ -427,7 +427,15 @@ impl<'a> VarLengthExpand<'a> {
         };
 
         while let Some((node_id, depth)) = queue.pop_front() {
-            if depth >= self.min_depth && depth > 0 {
+            // Emit a node once its depth reaches the lower bound. `depth >=
+            // min_depth` alone is correct for every bound: for the usual
+            // `min_depth >= 1` it already excludes the start node (depth 0), and
+            // for a ZERO lower bound (`*0` / `*0..N`) it includes the start node
+            // bound to itself — the openCypher zero-length path. A prior `&&
+            // depth > 0` guard unconditionally dropped depth 0, silently omitting
+            // the start node from `*0` patterns (e.g. the `-[:CONTAINS*0..]->`
+            // "self-or-descendants" idiom).
+            if depth >= self.min_depth {
                 result.push(node_id);
             }
             if depth >= self.max_depth {

--- a/packages/rfdb-server/src/cypher/executor.rs
+++ b/packages/rfdb-server/src/cypher/executor.rs
@@ -1001,7 +1001,11 @@ fn edge_record_to_value(edge: &EdgeRecord) -> CypherValue {
 }
 
 /// Format a RETURN expression as a column name.
-fn format_return_expr(expr: &Expr) -> String {
+///
+/// `pub(crate)` so the planner can reconstruct the exact group-key column names
+/// produced by `HashAggregate` when rewriting `ORDER BY` expressions (an
+/// aggregate query sorts over these produced columns, not the raw pattern).
+pub(crate) fn format_return_expr(expr: &Expr) -> String {
     match expr {
         Expr::Property(var, prop) => format!("{}.{}", var, prop),
         Expr::Variable(v) => v.clone(),

--- a/packages/rfdb-server/src/cypher/parser.rs
+++ b/packages/rfdb-server/src/cypher/parser.rs
@@ -353,7 +353,21 @@ impl<'a> Parser<'a> {
 
         let limit = if self.keyword_ahead("LIMIT") {
             self.expect_keyword("LIMIT")?;
-            Some(self.parse_integer()? as u64)
+            // `parse_integer` accepts an optional leading sign, so a negative
+            // LIMIT would otherwise parse to a negative i64 and then wrap to a
+            // huge u64 via `as u64` (e.g. -1 → u64::MAX), making the Limit
+            // operator effectively unbounded — the query would silently return
+            // the entire result set instead of erroring. Reject it explicitly so
+            // a bad bound surfaces as a parse error, not wrong data.
+            let n_pos = self.pos;
+            let n = self.parse_integer()?;
+            if n < 0 {
+                return Err(ParseError::new(
+                    "LIMIT must be a non-negative integer",
+                    n_pos,
+                ));
+            }
+            Some(n as u64)
         } else {
             None
         };

--- a/packages/rfdb-server/src/cypher/planner.rs
+++ b/packages/rfdb-server/src/cypher/planner.rs
@@ -143,11 +143,22 @@ pub fn plan<'a>(
 
     if has_aggregates {
         let (group_keys, aggregates) = split_return_items(&query.return_clause);
+
+        // Rewrite ORDER BY to reference the columns HashAggregate produces.
+        // Post-aggregation the original node bindings are gone and aggregate
+        // calls are not re-evaluated, so Sort must reference the produced
+        // column names. Done BEFORE the groups/aggregates are moved into the
+        // operator below.
+        let order_by = query
+            .order_by
+            .as_ref()
+            .map(|ob| rewrite_order_by_for_aggregates(ob, &group_keys, &aggregates));
+
         op = Box::new(HashAggregate::new(op, group_keys, aggregates, limits));
 
-        // Sort after aggregate (operates on named columns).
-        if let Some(ref order_by) = query.order_by {
-            op = Box::new(Sort::new(op, order_by.clone(), limits));
+        // Sort after aggregate (operates on the produced named columns).
+        if let Some(order_by) = order_by {
+            op = Box::new(Sort::new(op, order_by, limits));
         }
     } else {
         // Sort before Project (operates on full node records).
@@ -198,6 +209,96 @@ fn split_return_items(ret: &ReturnClause) -> (Vec<ReturnItem>, Vec<AggregateItem
     }
 
     (group_keys, aggregates)
+}
+
+/// The column name `HashAggregate` produces for a group-key RETURN item.
+///
+/// MUST stay identical to the key `HashAggregate::materialize` inserts for the
+/// same item (`alias` else `format_return_expr(expr)`), so that an `ORDER BY`
+/// expression rewritten to `Variable(name)` resolves to the right column.
+fn group_key_name(item: &ReturnItem) -> String {
+    item.alias
+        .clone()
+        .unwrap_or_else(|| format_return_expr(&item.expr))
+}
+
+/// Rewrite the `ORDER BY` expressions of an aggregate query so they reference
+/// the columns the `HashAggregate` operator emits.
+///
+/// In an aggregate query the `Sort` operator runs *after* `HashAggregate`,
+/// whose output records carry only the produced columns: one per group key
+/// (keyed by [`group_key_name`]) and one per aggregate (keyed by its alias).
+/// The original `ORDER BY` AST instead holds the raw pattern expressions:
+///
+/// - `ORDER BY n.file` is a `Property("n", "file")`, but `n` no longer exists
+///   in the post-aggregation record (only the string column `"n.file"` does),
+///   so `eval_expr` would yield `NULL` and the rows would not sort.
+/// - `ORDER BY COUNT(*)` is a `FunctionCall`, which `eval_expr` returns `NULL`
+///   for (aggregates are not re-evaluated post-aggregation), again no sort.
+///
+/// This rewrite maps any `ORDER BY` term that matches a RETURN item — by
+/// structural equality for group keys, by function name + argument for
+/// aggregates — to a `Variable` referencing that item's produced column, so
+/// `Sort` reads the already-computed value. Terms that match nothing (e.g. an
+/// alias already referenced directly, or an expression not in RETURN) are left
+/// unchanged.
+fn rewrite_order_by_for_aggregates(
+    order_by: &[(Expr, SortDir)],
+    group_keys: &[ReturnItem],
+    aggregates: &[AggregateItem],
+) -> Vec<(Expr, SortDir)> {
+    order_by
+        .iter()
+        .map(|(expr, dir)| (rewrite_order_expr(expr, group_keys, aggregates), *dir))
+        .collect()
+}
+
+/// Recursively rewrite a single `ORDER BY` expression. See
+/// [`rewrite_order_by_for_aggregates`] for the rationale.
+fn rewrite_order_expr(
+    expr: &Expr,
+    group_keys: &[ReturnItem],
+    aggregates: &[AggregateItem],
+) -> Expr {
+    // An aggregate call that also appears in RETURN -> its produced column.
+    if let Expr::FunctionCall(name, args) = expr {
+        if is_aggregate_function(name) {
+            let func = name.to_uppercase();
+            let arg = args.first().cloned().unwrap_or(Expr::Star);
+            if let Some(agg) = aggregates
+                .iter()
+                .find(|a| a.function == func && a.arg == arg)
+            {
+                return Expr::Variable(agg.alias.clone());
+            }
+        }
+    }
+
+    // A group-key expression that appears in RETURN -> its produced column.
+    if let Some(gk) = group_keys.iter().find(|g| g.expr == *expr) {
+        return Expr::Variable(group_key_name(gk));
+    }
+
+    // Recurse into compound expressions so combinations resolve too.
+    match expr {
+        Expr::BinaryOp(l, op, r) => Expr::BinaryOp(
+            Box::new(rewrite_order_expr(l, group_keys, aggregates)),
+            *op,
+            Box::new(rewrite_order_expr(r, group_keys, aggregates)),
+        ),
+        Expr::And(l, r) => Expr::And(
+            Box::new(rewrite_order_expr(l, group_keys, aggregates)),
+            Box::new(rewrite_order_expr(r, group_keys, aggregates)),
+        ),
+        Expr::Or(l, r) => Expr::Or(
+            Box::new(rewrite_order_expr(l, group_keys, aggregates)),
+            Box::new(rewrite_order_expr(r, group_keys, aggregates)),
+        ),
+        Expr::Not(inner) => {
+            Expr::Not(Box::new(rewrite_order_expr(inner, group_keys, aggregates)))
+        }
+        other => other.clone(),
+    }
 }
 
 /// Format an expression for use in a generated alias.

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -1427,6 +1427,96 @@ mod executor_tests {
         assert_eq!(names, vec!["withcat"]);
     }
 
+    /// Three-valued (Kleene) logic for `AND` under `NOT`. `n.category` is NULL
+    /// for the two cat-less nodes, so `n.category CONTAINS 'a'` is NULL there.
+    /// Kleene: `null AND true = null`; `NOT null = null` → excluded. Before the
+    /// fix `AND` collapsed the NULL operand to `Bool(false)` via `is_truthy()`,
+    /// so `NOT (null AND true)` became `NOT false = true` and wrongly admitted
+    /// the two NULL-category rows. `withcat` ("alpha") → `true AND true = true`,
+    /// `NOT true = false` → excluded. Correct result: nothing.
+    #[test]
+    fn filter_not_and_null_operand_excluded() {
+        let names = filtered_names(Expr::Not(Box::new(Expr::And(
+            Box::new(Expr::Contains(
+                Box::new(Expr::Property("n".to_string(), "category".to_string())),
+                Box::new(Expr::Literal(CypherLiteral::Str("a".to_string()))),
+            )),
+            Box::new(Expr::Literal(CypherLiteral::Bool(true))),
+        ))));
+        assert!(
+            names.is_empty(),
+            "NOT (nullPredicate AND true) must exclude NULL-operand rows (Kleene: null AND true = null), got {:?}",
+            names
+        );
+    }
+
+    /// Sibling of `filter_not_and_null_operand_excluded` for `OR`. Kleene:
+    /// `null OR false = null`; `NOT null = null` → excluded. Before the fix
+    /// `OR` collapsed the NULL operand to `Bool(false)`, so `NOT (null OR false)`
+    /// became `NOT false = true` and wrongly admitted the NULL-category rows.
+    #[test]
+    fn filter_not_or_null_operand_excluded() {
+        let names = filtered_names(Expr::Not(Box::new(Expr::Or(
+            Box::new(Expr::Contains(
+                Box::new(Expr::Property("n".to_string(), "category".to_string())),
+                Box::new(Expr::Literal(CypherLiteral::Str("a".to_string()))),
+            )),
+            Box::new(Expr::Literal(CypherLiteral::Bool(false))),
+        ))));
+        assert!(
+            names.is_empty(),
+            "NOT (nullPredicate OR false) must exclude NULL-operand rows (Kleene: null OR false = null), got {:?}",
+            names
+        );
+    }
+
+    /// Guard: FALSE dominates `AND` even past a NULL operand (Kleene:
+    /// `null AND false = false`). So `NOT (anything AND false) = NOT false =
+    /// true` admits every row. Holds before and after the fix — proves the
+    /// truthy/falsy short-circuits are preserved.
+    #[test]
+    fn filter_not_and_false_admits_all() {
+        let names = filtered_names(Expr::Not(Box::new(Expr::And(
+            Box::new(Expr::Contains(
+                Box::new(Expr::Property("n".to_string(), "category".to_string())),
+                Box::new(Expr::Literal(CypherLiteral::Str("a".to_string()))),
+            )),
+            Box::new(Expr::Literal(CypherLiteral::Bool(false))),
+        ))));
+        assert_eq!(names, vec!["nocat_none", "nocat_other", "withcat"]);
+    }
+
+    /// Guard: TRUE dominates `OR` even past a NULL operand (Kleene:
+    /// `null OR true = true`). So `NOT (anything OR true) = NOT true = false`
+    /// admits nothing. Holds before and after the fix.
+    #[test]
+    fn filter_not_or_true_excludes_all() {
+        let names = filtered_names(Expr::Not(Box::new(Expr::Or(
+            Box::new(Expr::Contains(
+                Box::new(Expr::Property("n".to_string(), "category".to_string())),
+                Box::new(Expr::Literal(CypherLiteral::Str("a".to_string()))),
+            )),
+            Box::new(Expr::Literal(CypherLiteral::Bool(true))),
+        ))));
+        assert!(names.is_empty(), "got {:?}", names);
+    }
+
+    /// Guard: a direct (non-negated) `AND` with a NULL operand still EXCLUDES
+    /// the row (NULL is not truthy) and still matches the non-null hit. The bug
+    /// is only observable under `NOT`; top-level `WHERE` filtering is unchanged.
+    /// Holds before and after the fix.
+    #[test]
+    fn filter_and_null_operand_still_excludes_and_matches() {
+        let names = filtered_names(Expr::And(
+            Box::new(Expr::Contains(
+                Box::new(Expr::Property("n".to_string(), "category".to_string())),
+                Box::new(Expr::Literal(CypherLiteral::Str("a".to_string()))),
+            )),
+            Box::new(Expr::Literal(CypherLiteral::Bool(true))),
+        ));
+        assert_eq!(names, vec!["withcat"]);
+    }
+
     #[test]
     fn filter_exported_boolean() {
         let engine = create_test_graph();

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -219,6 +219,30 @@ mod parser_tests {
     }
 
     #[test]
+    fn limit_zero_parses() {
+        // LIMIT 0 is a valid (if pointless) non-negative bound.
+        let q = parse_cypher("MATCH (n:FUNCTION) RETURN n.name LIMIT 0").unwrap();
+        assert_eq!(q.limit, Some(0));
+    }
+
+    #[test]
+    fn negative_limit_rejected() {
+        // A negative LIMIT must be a parse error, not silently wrapped to a huge
+        // u64 (which would behave as "no limit" and return the entire result set).
+        let err = parse_cypher("MATCH (n:FUNCTION) RETURN n.name LIMIT -1")
+            .expect_err("LIMIT -1 must be rejected");
+        let msg = format!("{}", err).to_lowercase();
+        assert!(
+            msg.contains("limit") && msg.contains("non-negative"),
+            "expected a clear non-negative LIMIT error, got: {}",
+            msg
+        );
+
+        // Larger negative values are rejected the same way.
+        assert!(parse_cypher("MATCH (n:FUNCTION) RETURN n.name LIMIT -5").is_err());
+    }
+
+    #[test]
     fn full_complex_query() {
         let q = parse_cypher(
             "MATCH (f:FUNCTION)-[:CALLS]->(g) WHERE f.name = 'main' RETURN g.name, g.file LIMIT 5",
@@ -2458,5 +2482,41 @@ mod integration_tests {
         .unwrap();
         assert_eq!(result.columns, vec!["f.name", "calls"]);
         assert!(result.row_count >= 1);
+    }
+
+    #[test]
+    fn negative_limit_does_not_return_full_result_set() {
+        // Regression: `LIMIT -1` was parsed to i64 -1 then cast `as u64`, yielding
+        // u64::MAX — so the Limit operator never stopped and the query silently
+        // returned EVERY row instead of erroring. An agent that computes a limit
+        // and accidentally passes a negative value would get the whole graph back
+        // dressed up as a capped result. The fix rejects negative LIMIT at parse
+        // time, so execution surfaces a loud error rather than wrong data.
+        let engine = create_test_graph();
+
+        // Baseline: there is more than one FUNCTION node, so an unbounded scan
+        // returns multiple rows. This makes the "returned everything" failure
+        // mode observable.
+        let all = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        assert!(
+            all.row_count > 1,
+            "fixture must have >1 FUNCTION node for this test to be meaningful"
+        );
+
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.name LIMIT -1",
+            EvalLimits::none(),
+        );
+        assert!(
+            result.is_err(),
+            "negative LIMIT must error, not return {} rows",
+            result.map(|r| r.row_count).unwrap_or(0)
+        );
     }
 }

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -2027,6 +2027,44 @@ mod executor_tests {
         assert_eq!(names, vec!["internal"]);
     }
 
+    /// Zero-length path: `min_depth = max_depth = 0` binds the destination to
+    /// the START node itself (Cypher `*0` semantics). Was dropped by the
+    /// `&& depth > 0` guard in `bfs`, which excluded depth 0 even for min 0.
+    #[test]
+    fn var_length_expand_zero_depth_yields_start() {
+        let engine = create_test_graph();
+        let limits = default_limits();
+
+        let scan = NodeScan::new(
+            &engine,
+            Some("a".to_string()),
+            vec!["FUNCTION".to_string()],
+            vec![("name".to_string(), Expr::Literal(CypherLiteral::Str("main".to_string())))],
+            &limits,
+        );
+
+        let mut expand = VarLengthExpand::new(
+            Box::new(scan),
+            &engine,
+            "a".to_string(),
+            Some("b".to_string()),
+            vec!["CALLS".to_string()],
+            Direction::Outgoing,
+            0,
+            0,
+            &limits,
+        );
+
+        let mut names = Vec::new();
+        while let Some(rec) = expand.next().unwrap() {
+            if let CypherValue::Str(s) = rec.get("b").unwrap().property("name") {
+                names.push(s);
+            }
+        }
+        // Only the start node "main" — zero hops, no traversal.
+        assert_eq!(names, vec!["main"]);
+    }
+
     // ── eval_expr unit tests ────────────────────────────────────────────
 
     #[test]
@@ -3576,6 +3614,107 @@ mod integration_tests {
         .unwrap();
 
         assert_eq!(collect_string_column(&result, 0), vec!["it's"]);
+    }
+
+    // ── Zero-length variable-length paths (`*0`, `*0..N`) ────────────────────
+    //
+    // openCypher/Neo4j: a variable-length pattern with a lower bound of 0
+    // includes the ZERO-length path, which binds the destination variable to
+    // the START node itself (the node is "reachable from itself in 0 hops").
+    // `VarLengthExpand::bfs` dropped depth-0 unconditionally (`&& depth > 0`),
+    // so `*0` / `*0..N` silently omitted the start node — a silent-wrong-answer
+    // for the common "self-or-descendants" idiom (e.g. `-[:CONTAINS*0..]->`).
+
+    /// `*0` is exactly the zero-length path: x is bound to the start node and
+    /// nothing else. Was: empty result.
+    #[test]
+    fn var_length_zero_exact_returns_start_node() {
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION {name: 'main'})-[:CALLS*0]->(x) RETURN x.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        assert_eq!(collect_string_column(&result, 0), vec!["main"]);
+    }
+
+    /// `*0..1` = the start node (0 hops) PLUS its direct CALLS targets (1 hop).
+    /// main -> helper, main -> validate, so the set is {main, helper, validate}.
+    /// Was: {helper, validate} (start node missing).
+    #[test]
+    fn var_length_zero_to_one_includes_start_and_neighbors() {
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION {name: 'main'})-[:CALLS*0..1]->(x) RETURN x.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        assert_eq!(
+            collect_string_column(&result, 0),
+            vec!["helper", "main", "validate"]
+        );
+    }
+
+    /// A destination label/property filter still applies to the zero-length
+    /// match: `(x:CLASS)` excludes the FUNCTION start node, so `*0..1` here
+    /// yields nothing (main has no CALLS edge to a CLASS, and main itself is
+    /// not a CLASS).
+    #[test]
+    fn var_length_zero_respects_destination_label_filter() {
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION {name: 'main'})-[:CALLS*0..1]->(x:CLASS) RETURN x.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        assert!(
+            result.rows.is_empty(),
+            "zero-length match must honor destination label filter, got {:?}",
+            result.rows
+        );
+    }
+
+    /// Regression guard: a NON-zero lower bound must STILL exclude the start
+    /// node. Removing the buggy `&& depth > 0` must not leak the start node into
+    /// `*1..N` queries (depth 0 < min_depth already excludes it).
+    #[test]
+    fn var_length_min_one_still_excludes_start_node() {
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION {name: 'main'})-[:CALLS*1..2]->(x) RETURN x.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        // 1 hop: helper, validate. 2 hops: validate (via helper). De-duped set
+        // excludes "main" — the start node must not appear for a min>=1 path.
+        assert_eq!(
+            collect_string_column(&result, 0),
+            vec!["helper", "validate"]
+        );
+    }
+
+    /// Headline idiom: `*0..` ("the node itself plus everything reachable").
+    /// From "main" over CALLS this is {main, helper, validate} — the start node
+    /// included via the zero-length path. Also proves the unbounded BFS still
+    /// terminates (visited-set de-dup) with a zero lower bound. Was: start node
+    /// missing.
+    #[test]
+    fn var_length_zero_unbounded_includes_self_and_all_reachable() {
+        let engine = create_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION {name: 'main'})-[:CALLS*0..]->(x) RETURN x.name",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        assert_eq!(
+            collect_string_column(&result, 0),
+            vec!["helper", "main", "validate"]
+        );
     }
 
 }

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -2459,4 +2459,111 @@ mod integration_tests {
         assert_eq!(result.columns, vec!["f.name", "calls"]);
         assert!(result.row_count >= 1);
     }
+
+    // ── ORDER BY in aggregate queries (sort by aggregate / group-key expr) ──
+
+    /// Three files with distinct grouped SUMs, laid out so that the group
+    /// insertion order (a.js, m.js, z.js — ascending node id) matches NONE of
+    /// the sorted orders we assert below. This makes the tests fail reliably
+    /// when ORDER BY silently no-ops (rows fall back to insertion order),
+    /// regardless of the storage scan order.
+    ///
+    /// Grouped SUM(lineCount): a.js=10, m.js=100, z.js=1.
+    fn order_by_agg_graph() -> GraphEngineV2 {
+        let mut engine = GraphEngineV2::create_ephemeral();
+        let mk = |id: u128, file: &str, lc: i64| NodeRecord {
+            id,
+            node_type: Some("FUNCTION".to_string()),
+            name: Some(format!("f{}", id)),
+            file: Some(file.to_string()),
+            file_id: 0,
+            name_offset: 0,
+            version: "main".into(),
+            exported: true,
+            replaces: None,
+            deleted: false,
+            metadata: Some(format!(r#"{{"lineCount": {}}}"#, lc)),
+            semantic_id: None,
+        };
+        engine.add_nodes(vec![
+            mk(20, "a.js", 5),
+            mk(21, "a.js", 5),
+            mk(22, "m.js", 100),
+            mk(23, "z.js", 1),
+        ]);
+        engine
+    }
+
+    #[test]
+    fn order_by_aggregate_expression_sorts_groups() {
+        // ORDER BY <aggregate function> in an aggregate query must sort by the
+        // computed aggregate. The Sort operator runs on HashAggregate output
+        // (columns keyed "n.file" / "total"); evaluating the raw FunctionCall
+        // expr returns NULL post-aggregation, so without a rewrite every row
+        // compares equal and the result stays in group-insertion order.
+        let engine = order_by_agg_graph();
+
+        let asc = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.file, SUM(n.lineCount) AS total ORDER BY SUM(n.lineCount) ASC",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        let asc_totals: Vec<i64> = asc.rows.iter().map(|r| r[1].as_i64().unwrap()).collect();
+        let asc_files: Vec<&str> = asc.rows.iter().map(|r| r[0].as_str().unwrap()).collect();
+        assert_eq!(asc_totals, vec![1, 10, 100], "totals must be ascending");
+        assert_eq!(asc_files, vec!["z.js", "a.js", "m.js"]);
+
+        let desc = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.file, SUM(n.lineCount) AS total ORDER BY SUM(n.lineCount) DESC",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        let desc_totals: Vec<i64> = desc.rows.iter().map(|r| r[1].as_i64().unwrap()).collect();
+        assert_eq!(desc_totals, vec![100, 10, 1], "totals must be descending");
+    }
+
+    #[test]
+    fn order_by_aliased_aggregate_sorts_groups() {
+        // ORDER BY the aggregate's alias must also sort (this already worked via
+        // the Variable lookup path, but is asserted to lock in the behavior).
+        let engine = order_by_agg_graph();
+        let res = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.file, SUM(n.lineCount) AS total ORDER BY total DESC",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        let totals: Vec<i64> = res.rows.iter().map(|r| r[1].as_i64().unwrap()).collect();
+        assert_eq!(totals, vec![100, 10, 1]);
+    }
+
+    #[test]
+    fn order_by_group_key_property_in_aggregate_query() {
+        // Sibling case: ORDER BY a group-key PROPERTY (n.file) in an aggregate
+        // query. Post-aggregation node `n` is gone and the column is keyed
+        // "n.file"; the raw Property("n","file") expr looked up absent var `n`,
+        // yielding NULL and no sort. Assert both directions so insertion order
+        // (which equals at most one of them) cannot satisfy both.
+        let engine = order_by_agg_graph();
+
+        let asc = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.file, SUM(n.lineCount) AS total ORDER BY n.file ASC",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        let asc_files: Vec<&str> = asc.rows.iter().map(|r| r[0].as_str().unwrap()).collect();
+        assert_eq!(asc_files, vec!["a.js", "m.js", "z.js"]);
+
+        let desc = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.file, SUM(n.lineCount) AS total ORDER BY n.file DESC",
+            EvalLimits::none(),
+        )
+        .unwrap();
+        let desc_files: Vec<&str> = desc.rows.iter().map(|r| r[0].as_str().unwrap()).collect();
+        assert_eq!(desc_files, vec!["z.js", "m.js", "a.js"]);
+    }
 }

--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -2346,6 +2346,54 @@ mod integration_tests {
         assert_eq!(result.rows[0][0], serde_json::json!(30));
     }
 
+    // ── ORDER BY null ordering (Cypher/Neo4j semantics) ─────────────────
+    //
+    // Cypher treats null as GREATER than any non-null value for ordering:
+    // nulls sort LAST in ascending order and FIRST in descending order
+    // (Neo4j Cypher manual, "Ordering null"). The numeric fixture has one
+    // node (`d`) with no `lineCount`, so `n.lineCount` is NULL for it.
+
+    #[test]
+    fn order_by_nulls_last_ascending() {
+        let engine = create_numeric_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.name, n.lineCount ORDER BY n.lineCount",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        let names: Vec<&str> = result
+            .rows
+            .iter()
+            .map(|row| row[0].as_str().unwrap())
+            .collect();
+        // a=10, b=20, c=30 ascending, then d (NULL lineCount) LAST.
+        assert_eq!(names, vec!["a", "b", "c", "d"]);
+        // The trailing row really is the NULL one (projects to JSON null).
+        assert_eq!(result.rows[3][1], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn order_by_nulls_first_descending() {
+        let engine = create_numeric_test_graph();
+        let result = execute(
+            &engine,
+            "MATCH (n:FUNCTION) RETURN n.name, n.lineCount ORDER BY n.lineCount DESC",
+            EvalLimits::none(),
+        )
+        .unwrap();
+
+        let names: Vec<&str> = result
+            .rows
+            .iter()
+            .map(|row| row[0].as_str().unwrap())
+            .collect();
+        // d (NULL lineCount) FIRST, then c=30, b=20, a=10 descending.
+        assert_eq!(names, vec!["d", "c", "b", "a"]);
+        assert_eq!(result.rows[0][1], serde_json::Value::Null);
+    }
+
     #[test]
     fn sum_aggregate_grouped() {
         // Two groups by file, each with distinct numeric sums.

--- a/packages/rfdb-server/src/datalog/eval.rs
+++ b/packages/rfdb-server/src/datalog/eval.rs
@@ -1427,6 +1427,47 @@ impl<'a> Evaluator<'a> {
                     vec![Bindings::new()]
                 }
             }
+            // path(X, "dst") - REVERSE reachability: enumerate every node that
+            // can REACH dst (its ancestor set). The directed dual of the
+            // (Const, Var) forward arm. Previously this fell through to the
+            // catch-all and silently returned NO rows, so an agent asking "what
+            // reaches / depends on dst" via `path(X, dst)` got a confidently
+            // empty answer instead of the real ancestors — an on-thesis
+            // silent-wrong-answer.
+            (Term::Var(var), Term::Const(dst_str)) => {
+                let dst_id = match dst_str.parse::<u128>() {
+                    Ok(id) => id,
+                    Err(_) => return vec![],
+                };
+
+                self.path_reaches(dst_id)
+                    .into_iter()
+                    .map(|id| {
+                        let mut b = Bindings::new();
+                        b.set(var, Value::Id(id));
+                        b
+                    })
+                    .collect()
+            }
+            // path(_, "dst") - does ANY node reach dst? Dual of (Const, _).
+            (Term::Wildcard, Term::Const(dst_str)) => {
+                let dst_id = match dst_str.parse::<u128>() {
+                    Ok(id) => id,
+                    Err(_) => return vec![],
+                };
+
+                if self.path_reaches(dst_id).is_empty() {
+                    vec![]
+                } else {
+                    vec![Bindings::new()]
+                }
+            }
+            // Remaining modes have NO constant endpoint (both src and dst are
+            // Var/Wildcard). Answering them would require materializing all-pairs
+            // reachability (O(N·E)) and is intentionally unsupported — `path`
+            // needs at least one bound endpoint, exactly as the forward arms
+            // require a bound source. In a conjunctive query the pipeline binds
+            // one endpoint from a preceding generator atom before `path` runs.
             _ => vec![],
         }
     }
@@ -1448,6 +1489,36 @@ impl<'a> Evaluator<'a> {
             return Vec::new();
         }
         self.engine.bfs(&frontier, 100, &[])
+    }
+
+    /// Set of nodes that can REACH `dst_id` via AT LEAST ONE edge — the ancestor
+    /// set queried by `path(X, dst)` (the reverse of [`Self::path_reachable`]).
+    ///
+    /// Mirrors `path_reachable` exactly, but walks INCOMING edges backward: BFS
+    /// is seeded from `dst_id`'s direct predecessors (the depth-1 frontier)
+    /// rather than `dst_id` itself, so `dst_id` appears here ONLY when a real
+    /// edge path loops back to it (a genuine cycle). This keeps the reverse arms
+    /// consistent with the forward arms and with the irreflexive `path(A, A)`
+    /// self-rule (see the `test_eval_path_self_*` tests). It reuses the shared
+    /// `traversal::bfs` with a backward-neighbour closure — the same primitive
+    /// `GraphStore::bfs` uses forward — so the two directions cannot drift apart.
+    fn path_reaches(&self, dst_id: u128) -> Vec<u128> {
+        // Direct predecessors of `node`: the sources of its (non-deleted)
+        // incoming edges. The backward analogue of `GraphStore::neighbors`.
+        let predecessors = |node: u128| -> Vec<u128> {
+            self.engine
+                .get_incoming_edges(node, None)
+                .into_iter()
+                .filter(|e| !e.deleted)
+                .map(|e| e.src)
+                .collect()
+        };
+
+        let frontier = predecessors(dst_id);
+        if frontier.is_empty() {
+            return Vec::new();
+        }
+        crate::graph::traversal::bfs(&frontier, 100, predecessors)
     }
 
     /// Evaluate neq(X, Y) - inequality constraint

--- a/packages/rfdb-server/src/datalog/eval.rs
+++ b/packages/rfdb-server/src/datalog/eval.rs
@@ -55,6 +55,42 @@ impl Value {
     }
 }
 
+/// Compare two numeric operand strings for the gt/lt/gte/lte builtins.
+///
+/// Integer operands are compared EXACTLY. This matters because operands are
+/// frequently u128 node IDs (and large integer metadata such as timestamps or
+/// byte offsets), which overflow f64's 53-bit mantissa — parsing those as f64
+/// would collapse distinct values onto the same float and silently drop or admit
+/// rows (e.g. `lt(A, B)` between two IDs differing only in low bits returns
+/// false; `gte(A, B)` returns true). `i128` is tried first (covers negative
+/// metadata and IDs up to i128::MAX); `u128` second (covers hash IDs above
+/// i128::MAX). Only genuinely fractional operands fall back to `f64`.
+///
+/// Returns `None` when either operand is non-numeric, when an `f64` comparison
+/// is undefined (NaN), or when `op` is not a recognised comparison — callers
+/// treat any `None`/`Some(false)` as a non-passing constraint (empty result).
+pub(crate) fn numeric_compare(left: &str, right: &str, op: &str) -> Option<bool> {
+    use std::cmp::Ordering;
+
+    let ordering: Ordering = if let (Ok(l), Ok(r)) = (left.parse::<i128>(), right.parse::<i128>()) {
+        l.cmp(&r)
+    } else if let (Ok(l), Ok(r)) = (left.parse::<u128>(), right.parse::<u128>()) {
+        l.cmp(&r)
+    } else {
+        let l: f64 = left.parse().ok()?;
+        let r: f64 = right.parse().ok()?;
+        l.partial_cmp(&r)? // None on NaN → graceful non-pass
+    };
+
+    Some(match op {
+        "gt" => ordering == Ordering::Greater,
+        "lt" => ordering == Ordering::Less,
+        "gte" => ordering != Ordering::Less,
+        "lte" => ordering != Ordering::Greater,
+        _ => return None,
+    })
+}
+
 /// Variable bindings
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Bindings {
@@ -1659,7 +1695,9 @@ impl<'a> Evaluator<'a> {
 
     /// Evaluate gt/lt/gte/lte(X, Y) - numeric comparison constraints
     /// Both arguments must be bound (either constants or bound variables).
-    /// Values are parsed as f64; non-numeric strings produce empty result (graceful failure).
+    /// Integer operands (including u128 node IDs) are compared exactly via
+    /// [`numeric_compare`]; non-numeric strings produce an empty result
+    /// (graceful failure).
     fn eval_numeric_cmp(&self, atom: &Atom) -> Vec<Bindings> {
         let args = atom.args();
         if args.len() < 2 {
@@ -1676,28 +1714,9 @@ impl<'a> Evaluator<'a> {
             _ => return vec![],
         };
 
-        let left: f64 = match left_str.parse() {
-            Ok(v) => v,
-            Err(_) => return vec![],
-        };
-
-        let right: f64 = match right_str.parse() {
-            Ok(v) => v,
-            Err(_) => return vec![],
-        };
-
-        let pass = match atom.predicate() {
-            "gt" => left > right,
-            "lt" => left < right,
-            "gte" => left >= right,
-            "lte" => left <= right,
-            _ => return vec![],
-        };
-
-        if pass {
-            vec![Bindings::new()]
-        } else {
-            vec![]
+        match numeric_compare(left_str, right_str, atom.predicate()) {
+            Some(true) => vec![Bindings::new()],
+            _ => vec![],
         }
     }
 

--- a/packages/rfdb-server/src/datalog/eval_explain.rs
+++ b/packages/rfdb-server/src/datalog/eval_explain.rs
@@ -16,6 +16,7 @@ use crate::datalog::types::*;
 use crate::datalog::eval::{Value, Bindings, EvalLimits};
 use super::utils::reorder_literals;
 use super::eval::HASH_JOIN_THRESHOLD;
+use super::eval::numeric_compare;
 
 /// Statistics collected during query execution
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -1511,7 +1512,10 @@ impl<'a> EvaluatorExplain<'a> {
         }
     }
 
-    /// Evaluate gt/lt/gte/lte(X, Y) - numeric comparison constraints
+    /// Evaluate gt/lt/gte/lte(X, Y) - numeric comparison constraints.
+    /// Integer operands (including u128 node IDs) are compared exactly via the
+    /// shared [`numeric_compare`] helper (kept in sync with the non-explain
+    /// `Evaluator`); non-numeric strings produce an empty result.
     fn eval_numeric_cmp(&mut self, atom: &Atom) -> Vec<Bindings> {
         let args = atom.args();
         if args.len() < 2 {
@@ -1528,28 +1532,9 @@ impl<'a> EvaluatorExplain<'a> {
             _ => return vec![],
         };
 
-        let left: f64 = match left_str.parse() {
-            Ok(v) => v,
-            Err(_) => return vec![],
-        };
-
-        let right: f64 = match right_str.parse() {
-            Ok(v) => v,
-            Err(_) => return vec![],
-        };
-
-        let pass = match atom.predicate() {
-            "gt" => left > right,
-            "lt" => left < right,
-            "gte" => left >= right,
-            "lte" => left <= right,
-            _ => return vec![],
-        };
-
-        if pass {
-            vec![Bindings::new()]
-        } else {
-            vec![]
+        match numeric_compare(left_str, right_str, atom.predicate()) {
+            Some(true) => vec![Bindings::new()],
+            _ => vec![],
         }
     }
 

--- a/packages/rfdb-server/src/datalog/tests.rs
+++ b/packages/rfdb-server/src/datalog/tests.rs
@@ -693,6 +693,105 @@ mod eval_tests {
         assert_eq!(results.len(), 1, "node on a cycle MUST have a path to itself");
     }
 
+    // ── path() REVERSE reachability: path(X, dst) enumerates ancestors ──
+    //
+    // The directed dual of path(src, X). `path(X, "dst")` must return every node
+    // that can REACH dst (its ancestor set). Before the fix these (Var/Wildcard
+    // source, Const dest) arms fell through to the catch-all and silently
+    // returned NO rows — so "what reaches / depends on dst" answered empty.
+
+    #[test]
+    fn test_eval_path_reverse_enumerates_ancestors() {
+        // Graph: 1 -> 4 -> 2 (CALLS); node 3 is an orphan.
+        // path(X, "2") = nodes that reach 2 = {1, 4}.
+        let engine = setup_test_graph();
+        let evaluator = Evaluator::new(&engine);
+        let query = Atom::new("path", vec![Term::var("X"), Term::constant("2")]);
+        let mut ids: Vec<u128> = evaluator
+            .query_atom(&query)
+            .unwrap()
+            .iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec![1, 4], "reverse path must enumerate ancestors of 2");
+    }
+
+    #[test]
+    fn test_eval_path_reverse_no_ancestors_is_empty() {
+        // Node 1 is a root: nothing reaches it → path(X, "1") is empty.
+        let engine = setup_test_graph();
+        let evaluator = Evaluator::new(&engine);
+        let query = Atom::new("path", vec![Term::var("X"), Term::constant("1")]);
+        let results = evaluator.query_atom(&query).unwrap();
+        assert_eq!(results.len(), 0, "a root node has no ancestors");
+    }
+
+    #[test]
+    fn test_eval_path_reverse_wildcard_existence() {
+        let engine = setup_test_graph();
+        let evaluator = Evaluator::new(&engine);
+        // path(_, "2") - something reaches 2 → exactly one success row.
+        let reach2 = Atom::new("path", vec![Term::Wildcard, Term::constant("2")]);
+        assert_eq!(evaluator.query_atom(&reach2).unwrap().len(), 1);
+        // path(_, "1") - nothing reaches 1 → no rows.
+        let reach1 = Atom::new("path", vec![Term::Wildcard, Term::constant("1")]);
+        assert_eq!(evaluator.query_atom(&reach1).unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_eval_path_reverse_includes_cyclic_self() {
+        // 100 <-> 101 cycle. Ancestors of 100: 101 reaches it directly, and 100
+        // reaches itself via the cycle → {100, 101}. Mirrors the forward
+        // test_eval_path_var_includes_cyclic_self.
+        let engine = setup_cycle_graph();
+        let evaluator = Evaluator::new(&engine);
+        let query = Atom::new("path", vec![Term::var("X"), Term::constant("100")]);
+        let mut ids: Vec<u128> = evaluator
+            .query_atom(&query)
+            .unwrap()
+            .iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec![100, 101], "cyclic reverse enumeration includes self (100) and peer (101)");
+    }
+
+    #[test]
+    fn test_eval_path_reverse_via_parsed_query() {
+        // End-to-end through parse_query + eval_query (not just query_atom),
+        // exercising the full pipeline for a single reverse-path literal.
+        let engine = setup_test_graph();
+        let evaluator = Evaluator::new(&engine);
+        let literals = parse_query("path(X, \"2\")").unwrap();
+        let mut ids: Vec<u128> = evaluator
+            .eval_query(&literals)
+            .unwrap()
+            .iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+            .collect();
+        ids.sort();
+        assert_eq!(ids, vec![1, 4]);
+    }
+
+    #[test]
+    fn test_eval_path_reverse_in_conjunction() {
+        // The real-world shape: "which FUNCTIONs reach node 2?". `reorder_literals`
+        // must place the reverse-path atom first (it provides X via the constant
+        // dst), then the node generator filters. Ancestors of 2 = {1, 4}; only 4
+        // is a FUNCTION (1 is queue:publish).
+        let engine = setup_test_graph();
+        let evaluator = Evaluator::new(&engine);
+        let literals = parse_query("path(X, \"2\"), node(X, \"FUNCTION\")").unwrap();
+        let ids: Vec<u128> = evaluator
+            .eval_query(&literals)
+            .unwrap()
+            .iter()
+            .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+            .collect();
+        assert_eq!(ids, vec![4], "only FUNCTION ancestor of node 2 is node 4");
+    }
+
     #[test]
     fn test_eval_path_var_includes_cyclic_self() {
         // Enumerating reachable nodes from a cyclic node must include the node

--- a/packages/rfdb-server/src/datalog/tests.rs
+++ b/packages/rfdb-server/src/datalog/tests.rs
@@ -5827,6 +5827,146 @@ mod numeric_cmp_tests {
     }
 }
 
+// ============================================================================
+// numeric_cmp(gt/lt/gte/lte) — integer-exact comparison of large operands
+//
+// The comparison parsed both operands as f64. f64 has a 53-bit mantissa, so any
+// integer above 2^53 (e.g. u128 node IDs, large timestamps / byte offsets stored
+// as metadata) loses precision: two DISTINCT values that differ only in low bits
+// round to the SAME f64. That made `lt(A, B)` return FALSE for distinct IDs
+// (silently dropping rows — e.g. the canonical symmetric-pair-dedup idiom
+// `edge(A,B), edge(B,A), lt(A,B)` lost every pair) and `gte(A, B)` return TRUE
+// for distinct IDs (false positive). These tests pin integer-exact comparison;
+// genuinely fractional operands still fall back to f64.
+// ============================================================================
+
+mod numeric_cmp_u128_precision_tests {
+    use super::*;
+    use crate::graph::{GraphEngineV2, GraphStore};
+    use crate::storage::{NodeRecord, EdgeRecord};
+    use crate::datalog::eval::{Evaluator, Value};
+    use crate::datalog::eval_explain::EvaluatorExplain;
+
+    // 2^60 and 2^60 + 1 — both <= i128::MAX, both round to the SAME f64
+    // (2^60 is exactly representable, 2^60 + 1 is not).
+    const BIG: &str = "1152921504606846976";
+    const BIG_PLUS_1: &str = "1152921504606846977";
+
+    // 2^127 and 2^127 + 1 — both > i128::MAX but < u128::MAX, also f64-equal.
+    // Exercises the u128 fallback (these do not parse as i128).
+    const HUGE: &str = "170141183460469231731687303715884105728";
+    const HUGE_PLUS_1: &str = "170141183460469231731687303715884105729";
+
+    fn cmp(op: &str, a: &str, b: &str) -> usize {
+        let engine = GraphEngineV2::create_ephemeral();
+        let evaluator = Evaluator::new(&engine);
+        let query = Atom::new(op, vec![Term::constant(a), Term::constant(b)]);
+        evaluator.query_atom(&query).unwrap().len()
+    }
+
+    // lt(2^60, 2^60+1) must be TRUE — distinct IDs must not collapse under f64.
+    #[test]
+    fn test_lt_large_ids_not_collapsed() {
+        assert_eq!(cmp("lt", BIG, BIG_PLUS_1), 1, "2^60 < 2^60+1 must hold");
+    }
+
+    // gt(2^60+1, 2^60) must be TRUE.
+    #[test]
+    fn test_gt_large_ids_not_collapsed() {
+        assert_eq!(cmp("gt", BIG_PLUS_1, BIG), 1, "2^60+1 > 2^60 must hold");
+    }
+
+    // gte/lte must NOT treat distinct large IDs as equal (false-positive guard).
+    #[test]
+    fn test_gte_lte_distinct_large_ids_not_falsely_equal() {
+        // 2^60 is strictly less than 2^60+1, so neither >= nor (reversed) <= holds.
+        assert_eq!(cmp("gte", BIG, BIG_PLUS_1), 0, "2^60 >= 2^60+1 must be false");
+        assert_eq!(cmp("lte", BIG_PLUS_1, BIG), 0, "2^60+1 <= 2^60 must be false");
+        // The genuinely-equal case still passes.
+        assert_eq!(cmp("gte", BIG, BIG), 1, "2^60 >= 2^60 must hold");
+        assert_eq!(cmp("lte", BIG, BIG), 1, "2^60 <= 2^60 must hold");
+    }
+
+    // u128 operands above i128::MAX (do not parse as i128) compared exactly.
+    #[test]
+    fn test_cmp_u128_above_i128_max() {
+        assert_eq!(cmp("lt", HUGE, HUGE_PLUS_1), 1, "2^127 < 2^127+1 must hold");
+        assert_eq!(cmp("gt", HUGE_PLUS_1, HUGE), 1, "2^127+1 > 2^127 must hold");
+        assert_eq!(cmp("gte", HUGE, HUGE_PLUS_1), 0, "2^127 >= 2^127+1 must be false");
+    }
+
+    // Regression: fractional and negative operands still work via the f64 fallback.
+    #[test]
+    fn test_float_and_negative_comparisons_still_work() {
+        assert_eq!(cmp("gt", "1000.5", "1000"), 1, "1000.5 > 1000");
+        assert_eq!(cmp("lt", "5", "5.5"), 1, "5 < 5.5 (mixed int/float)");
+        assert_eq!(cmp("gt", "5", "-10"), 1, "5 > -10 (negative)");
+        assert_eq!(cmp("lt", "-10", "5"), 1, "-10 < 5");
+        assert_eq!(cmp("gt", "abc", "100"), 0, "non-numeric → empty");
+    }
+
+    // Realistic end-to-end: the symmetric-pair-dedup idiom over two nodes whose
+    // u128 IDs round to the same f64. `lt(A, B)` must keep the one canonical pair.
+    #[test]
+    fn test_symmetric_pair_dedup_idiom_large_ids() {
+        let a: u128 = BIG.parse().unwrap();
+        let b: u128 = BIG_PLUS_1.parse().unwrap();
+        let mut engine = GraphEngineV2::create_ephemeral();
+        engine.add_nodes(vec![
+            NodeRecord {
+                id: a,
+                node_type: Some("FUNCTION".to_string()),
+                name: Some("alpha".to_string()),
+                file: Some("a.js".to_string()),
+                file_id: 0, name_offset: 0,
+                version: "main".into(),
+                exported: false, replaces: None, deleted: false,
+                metadata: None, semantic_id: None,
+            },
+            NodeRecord {
+                id: b,
+                node_type: Some("FUNCTION".to_string()),
+                name: Some("beta".to_string()),
+                file: Some("b.js".to_string()),
+                file_id: 0, name_offset: 0,
+                version: "main".into(),
+                exported: false, replaces: None, deleted: false,
+                metadata: None, semantic_id: None,
+            },
+        ]);
+        engine.add_edges(vec![
+            EdgeRecord { src: a, dst: b, edge_type: Some("CALLS".to_string()),
+                version: "main".into(), metadata: None, deleted: false },
+            EdgeRecord { src: b, dst: a, edge_type: Some("CALLS".to_string()),
+                version: "main".into(), metadata: None, deleted: false },
+        ], false);
+
+        let mut evaluator = Evaluator::new(&engine);
+        let rule = parse_rule(
+            r#"mutual(A, B) :- edge(A, B, "CALLS"), edge(B, A, "CALLS"), lt(A, B)."#
+        ).unwrap();
+        evaluator.add_rule(rule);
+
+        let results = evaluator.query(&parse_atom("mutual(A, B)").unwrap()).unwrap();
+        // Exactly one canonical ordered pair (a < b); not zero (collapsed by f64),
+        // not two (both directions admitted).
+        assert_eq!(results.len(), 1, "dedup must keep exactly one ordered pair");
+        assert_eq!(results[0].get("A"), Some(&Value::Id(a)));
+        assert_eq!(results[0].get("B"), Some(&Value::Id(b)));
+    }
+
+    // EvaluatorExplain twin must agree: lt(2^60, 2^60+1) yields one row.
+    #[test]
+    fn test_numeric_cmp_large_ids_explain_parity() {
+        let engine = GraphEngineV2::create_ephemeral();
+        let mut ev = EvaluatorExplain::new(&engine, false);
+        let result = ev.eval_query(
+            &parse_query(&format!(r#"lt("{}", "{}")"#, BIG, BIG_PLUS_1)).unwrap()
+        ).unwrap();
+        assert_eq!(result.bindings.len(), 1, "explain twin must also pass lt on distinct large IDs");
+    }
+}
+
 
 // ============================================================================
 // attr() reverse lookup — nested metadata dotted paths (forward/reverse symmetry)

--- a/packages/rfdb-server/src/datalog/utils.rs
+++ b/packages/rfdb-server/src/datalog/utils.rs
@@ -236,16 +236,31 @@ fn positive_can_place_and_provides(
             (true, provides)
         }
         "path" => {
-            // path(src, dst) — requires the first arg (source) bound. Unlike the
-            // edge predicates, `eval_path` only supports a Const/bound source
-            // (BFS from an unbound source is not a scan), so it cannot full-scan.
+            // path(src, dst) — placeable when AT LEAST ONE endpoint is *concrete*
+            // (a Const or an already-bound Var; a Wildcard does NOT count):
+            //   - src concrete → forward BFS, providing a free dst var
+            //     (`eval_path` (Const, Var/Wildcard/Const) arms);
+            //   - dst concrete → reverse BFS over incoming edges, providing a
+            //     free src var (`eval_path` (Var/Wildcard, Const) arms).
+            // A fully-unbound pair (both Var/Wildcard) is all-pairs reachability
+            // (O(N·E)) and is unsupported — `eval_path` returns nothing for it —
+            // so reorder must NOT report it as placeable, otherwise it would
+            // claim to bind a variable it never produces. This classification
+            // mirrors the supported `eval_path` modes exactly.
             if args.is_empty() {
                 return (true, HashSet::new());
             }
-            let can_place = is_bound_or_const(&args[0], bound);
+            let concrete = |t: &Term| match t {
+                Term::Const(_) => true,
+                Term::Var(v) => bound.contains(v),
+                Term::Wildcard => false,
+            };
+            let can_place = concrete(&args[0]) || args.get(1).is_some_and(concrete);
             let mut provides = HashSet::new();
             if can_place {
-                for arg in args.iter().skip(1) {
+                // Whichever side was free becomes bound once the (directional)
+                // BFS runs, so report every free Var arg.
+                for arg in args.iter() {
                     if let Term::Var(v) = arg {
                         if !bound.contains(v) {
                             provides.insert(v.clone());


### PR DESCRIPTION
Consolidated integration of 7 small, individually-reviewed-SAFE `fix(rfdb)` PRs that all append tests to the shared multi-module `cypher/tests.rs` / `datalog/tests.rs` and therefore mutually conflict. Merged together here (each `--no-ff`, tests de-interleaved into the correct submodule), full suite green.

**Bundled PRs** (each reviewed SAFE_TO_MERGE, evidence in their threads):
- #345 — aggregate-query `ORDER BY` sorts by produced columns
- #347 — reject negative Cypher `LIMIT`
- #351 — `ORDER BY` places NULLs last (ASC) / first (DESC)
- #352 — `AND`/`OR` Kleene three-valued logic with NULL operands
- #356 — include start node in zero-length var-length paths (`*0`/`*0..N`)
- #360 — Datalog `path(X,dst)`/`path(_,dst)` reverse reachability
- #365 — Datalog `gt/lt/gte/lte` compare integers exactly (no f64 collapse of u128 IDs)

**Also fixes a latent test-compile break on `main`:** #346 (b35af97b) landed 4 `order_by_alias_*_non_aggregate` tests inside `mod return_star_tests`, which calls `create_test_graph()` — a helper that module does not define (base drift after #340–349). `cargo test` would not compile on main. Relocated those 4 tests into `mod integration_tests` (which defines the helper).

**Verification:** `cargo test --lib` → **998 passed, 0 failed** (+24 over main). All conflicts were clean production auto-merges or test-append de-interleaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)