### PR TITLE
fix(rfdb): repair broken cypher test build (undefined create_test_graph)

### DIFF
--- a/packages/rfdb-server/src/cypher/tests.rs
+++ b/packages/rfdb-server/src/cypher/tests.rs
@@ -3720,14 +3720,14 @@ mod return_star_tests {
     // and the ORDER BY silently no-ops. The fix rewrites alias references in
     // ORDER BY to the underlying RETURN expression so Sort can evaluate them.
     //
-    // The three FUNCTION nodes are inserted as main, helper, validate (id
-    // 10,11,12). Alphabetical ASC is helper,main,validate and DESC is
-    // validate,main,helper — neither equals insertion order, so a no-op sort
-    // cannot satisfy either assertion.
+    // The module's `graph()` helper inserts FUNCTION nodes main, helper,
+    // validate (id 11,12,13) in that order. Alphabetical ASC is
+    // helper,main,validate and DESC is validate,main,helper — neither equals
+    // insertion order, so a no-op sort cannot satisfy either assertion.
 
     #[test]
     fn order_by_alias_ascending_non_aggregate() {
-        let engine = create_test_graph();
+        let engine = graph();
         let result = execute(
             &engine,
             "MATCH (n:FUNCTION) RETURN n.name AS nm ORDER BY nm",
@@ -3746,7 +3746,7 @@ mod return_star_tests {
 
     #[test]
     fn order_by_alias_descending_non_aggregate() {
-        let engine = create_test_graph();
+        let engine = graph();
         let result = execute(
             &engine,
             "MATCH (n:FUNCTION) RETURN n.name AS nm ORDER BY nm DESC",
@@ -3766,7 +3766,7 @@ mod return_star_tests {
     #[test]
     fn order_by_alias_with_limit_non_aggregate() {
         // The alias rewrite must compose with LIMIT: sort first, then take 2.
-        let engine = create_test_graph();
+        let engine = graph();
         let result = execute(
             &engine,
             "MATCH (n:FUNCTION) RETURN n.name AS nm ORDER BY nm DESC LIMIT 2",
@@ -3786,7 +3786,7 @@ mod return_star_tests {
     fn order_by_plain_property_still_works_non_aggregate() {
         // Regression guard: ORDER BY a raw property (no alias indirection) must
         // keep working — the rewrite must leave non-alias terms untouched.
-        let engine = create_test_graph();
+        let engine = graph();
         let result = execute(
             &engine,
             "MATCH (n:FUNCTION) RETURN n.name AS nm ORDER BY n.name DESC",


### PR DESCRIPTION
## Summary

The rfdb lib **test target does not compile on `main`** (HEAD `b35af97`). PR #346
("resolve RETURN aliases in non-aggregate ORDER BY") added four
`order_by_alias_*_non_aggregate` tests into the `return_star_tests` module, but
they call `create_test_graph()` — a helper that exists only in the
`executor_tests` and `integration_tests` modules, **not** in `return_star_tests`.
Result: `cargo test -p rfdb-server` fails to build (E0425 ×4), so the *entire*
Rust unit suite is red.

It slipped through because the CI gate (CONTRIBUTING §"What runs in CI") only runs
the **pnpm** suites; the Rust tests (`cargo test -p rfdb-server`) are a manual step
and were never compiled in CI.

This is a no-PR-was-needed find — there are **0 open GitHub issues** and no Linear
MCP in this environment; the bug was found while dogfooding the RFDB query engine
for the next correctness seam (see "Note on the #365 follow-up lead" below).

## Spec (BDD)

- **Invariant restored:** the rfdb lib test target compiles; `cargo test -p rfdb-server --lib` is green.
- **Given** the four `order_by_alias_*_non_aggregate` tests in `return_star_tests`
  **When** the test target is compiled
  **Then** there is no `cannot find function create_test_graph` error.
- **And** all four tests pass and are *meaningful*: the module's `graph()` helper
  inserts FUNCTION nodes in order main, helper, validate — which differs from every
  asserted order (ASC helper/main/validate, DESC validate/main/helper, LIMIT-2
  validate/main), so a no-op sort cannot vacuously satisfy them.

## Fix

Call the module's existing `graph()` helper instead of the undefined
`create_test_graph()`. `graph()` already inserts exactly the FUNCTION nodes these
tests need — main(11), helper(12), validate(13) — plus a CLASS User(10) that the
`MATCH (n:FUNCTION)` filter excludes. Reusing the in-scope helper avoids
duplicating a third `create_test_graph` definition. The block comment is corrected
to match the real ids (11,12,13; the old comment said 10,11,12).

8 lines changed, test-only; no production code touched.

## Evidence (before → after)

**Before** (`cargo test -p rfdb-server --lib --no-run`):
```
error[E0425]: cannot find function `create_test_graph` in this scope
  --> src/cypher/tests.rs:3730:22   (and 3749, 3769, 3789)
error: could not compile `rfdb` (lib test) due to 4 previous errors
```

**After**:
```
Finished `test` profile ... in 17.81s        # was 4 compile errors
test cypher::tests::return_star_tests::order_by_alias_ascending_non_aggregate ... ok
test cypher::tests::return_star_tests::order_by_alias_descending_non_aggregate ... ok
test cypher::tests::return_star_tests::order_by_alias_with_limit_non_aggregate ... ok
test cypher::tests::return_star_tests::order_by_plain_property_still_works_non_aggregate ... ok
test result: ok. 966 passed; 0 failed; 0 ignored
```
All test targets (lib + bins + 9 integration tests) now compile.

## Adversarial review

- **Round A — correctness.** `graph()` yields the three FUNCTION nodes the tests
  assert on; insertion order (main,helper,validate) ≠ any asserted order, so the
  tests genuinely exercise the #346 alias-rewrite path rather than passing
  vacuously. All four green.
- **Round B — structural.** Reused the existing module-local helper rather than
  copy-pasting a third `create_test_graph`; no new code, no duplication.
- **Round C — class-not-instance.** The class is "a test referencing an
  out-of-scope helper, breaking the test build." Compiling **all** rfdb test
  targets produces zero remaining `cannot find` errors, so the single instance is
  the whole class.

## Blast radius

Test-only change in `packages/rfdb-server/src/cypher/tests.rs`. No production code,
no wire/graph-shape change. The pnpm CI gate is unaffected.

## Follow-up (not in scope here)

The root systemic gap is that **`cargo test -p rfdb-server` is not part of the CI
gate**, so a non-compiling Rust test suite can merge unnoticed. Worth adding a Rust
test (or at least `--no-run` compile) job to `.github/workflows/ci.yml`. Filing
separately rather than scope-creeping this fix.

### Note on the #365 follow-up lead (refuted)

The Enox note after #365 flagged a candidate seam: *"Cypher numeric comparisons in
eval_binop may have the same f64-vs-u128-id precision issue."* Verified and
**refuted** with evidence: `n.id` is exposed as `CypherValue::Str` (values.rs:40,
lexicographic), integer literals parse as `Int(i64)` (parser.rs:372), integer
metadata parses as `Int` (values.rs:71), and `Int`-vs-`Int` comparison is exact
i64 (values.rs:156). The f64 path in `partial_cmp_values` only triggers on **mixed**
Int/Float operands, which requires a genuinely fractional operand — so there is no
silent large-integer collapse in the Cypher engine. (Recorded in Enox.)

https://claude.ai/code/session_01KE9whcSTFuXJtRje6xmQXG

---
_Generated by [Claude Code](https://claude.ai/code/session_01KE9whcSTFuXJtRje6xmQXG)_