### PR TITLE
feat(rust-analyzer): emit Rust `union` declarations into the graph

### DIFF
--- a/packages/grafema-orchestrator/src/rust_analyzer.rs
+++ b/packages/grafema-orchestrator/src/rust_analyzer.rs
@@ -487,7 +487,7 @@ fn walk_item(item: &syn::Item, ctx: &mut Ctx) {
         syn::Item::ExternCrate(_) => {}
         syn::Item::ForeignMod(_) => {}
         syn::Item::Macro(_) => {}
-        syn::Item::Union(_) => {} // TODO: treat like struct
+        syn::Item::Union(u) => walk_union(u, ctx),
         syn::Item::TraitAlias(_) => {}
         syn::Item::Verbatim(_) => {}
         _ => panic!("rust_analyzer: unhandled Item variant: {}", item_variant_name(item)),
@@ -708,6 +708,72 @@ fn walk_struct(s: &syn::ItemStruct, ctx: &mut Ctx) {
 
     // Fields
     for field in &s.fields {
+        if let Some(ident) = &field.ident {
+            let fname = ident.to_string();
+            let (fl, fc) = ctx.span_line_col(ident.span());
+            let field_id = semantic_id(&ctx.file, "RECORD_FIELD", &fname, Some(&node_id), None);
+            let mut field_meta = HashMap::new();
+            let type_str = type_to_name(&field.ty);
+            if type_str != "<type>" {
+                field_meta.insert("typeAnnotation".to_string(), serde_json::Value::String(type_str));
+            }
+            ctx.emit_declaration(GraphNode {
+                id: field_id.clone(),
+                node_type: "RECORD_FIELD".to_string(),
+                name: fname,
+                file: ctx.file.clone(),
+                line: fl, column: fc,
+                end_line: ctx.span_end_line_col(ident.span()).0, end_column: ctx.span_end_line_col(ident.span()).1,
+                exported: false,
+                metadata: field_meta,
+                extra: HashMap::new(),
+            });
+            ctx.emit_edge(GraphEdge {
+                src: node_id.clone(), dst: field_id,
+                edge_type: "HAS_FIELD".to_string(),
+                metadata: HashMap::new(),
+            });
+        }
+    }
+}
+
+/// Walk a Rust `union` declaration.
+///
+/// Unions are struct-like aggregate types with the same named-field layout, so
+/// we model them as STRUCT nodes — this lets every struct-aware query, the
+/// layout pass, and the city-map placeable-type list pick them up without
+/// introducing a new node type (which would have to be kept in sync across
+/// `analyzer.rs`, `layout/loader.rs`, and the GUI's placeable set). The
+/// union/struct distinction is preserved in `metadata.declKind = "union"`.
+fn walk_union(u: &syn::ItemUnion, ctx: &mut Ctx) {
+    let ident = u.ident.to_string();
+    let (line, col) = ctx.span_line_col(u.ident.span());
+    let is_exported = is_pub(&u.vis);
+    let node_id = semantic_id(&ctx.file, "STRUCT", &ident, None, None);
+
+    ctx.emit_declaration(GraphNode {
+        id: node_id.clone(),
+        node_type: "STRUCT".to_string(),
+        name: ident.clone(),
+        file: ctx.file.clone(),
+        line, column: col,
+        end_line: ctx.span_end_line_col(u.ident.span()).0, end_column: ctx.span_end_line_col(u.ident.span()).1,
+        exported: is_exported,
+        metadata: HashMap::from([
+            Ctx::meta_text("visibility", vis_to_text(&u.vis)),
+            Ctx::meta_text("declKind", "union"),
+        ]),
+        extra: HashMap::new(),
+    });
+
+    if is_exported {
+        ctx.exports.push(ExportInfo {
+            name: ident, node_id: node_id.clone(), kind: "union".to_string(), source: None,
+        });
+    }
+
+    // Fields — a union always has named fields.
+    for field in &u.fields.named {
         if let Some(ident) = &field.ident {
             let fname = ident.to_string();
             let (fl, fc) = ctx.span_line_col(ident.span());
@@ -1879,6 +1945,32 @@ mod tests {
         assert!(has_node(&fa, "RECORD_FIELD", "bar"));
         assert!(has_node(&fa, "RECORD_FIELD", "baz"));
         assert!(has_edge(&fa, "HAS_FIELD", "STRUCT", "RECORD_FIELD"));
+    }
+
+    #[test]
+    fn test_union_with_fields() {
+        // Rust `union`s are struct-like: same named-field layout, same role as a
+        // declared aggregate type. We emit them as STRUCT nodes (so every
+        // struct-aware query, layout pass, and the city-map placeable list pick
+        // them up without new node-type plumbing) and tag declKind=union so the
+        // union/struct distinction survives in the graph.
+        let fa = parse_and_analyze("pub union MyUnion { pub i: u32, f: f32 }");
+        assert!(has_node(&fa, "STRUCT", "MyUnion"), "union emitted as STRUCT node");
+        assert!(has_node(&fa, "RECORD_FIELD", "i"), "union field i");
+        assert!(has_node(&fa, "RECORD_FIELD", "f"), "union field f");
+        assert!(has_edge(&fa, "HAS_FIELD", "STRUCT", "RECORD_FIELD"), "HAS_FIELD edge");
+
+        let u = fa.nodes.iter()
+            .find(|n| n.node_type == "STRUCT" && n.name == "MyUnion")
+            .unwrap();
+        assert_eq!(u.metadata.get("declKind"), Some(&serde_json::json!("union")), "tagged declKind=union");
+        assert!(u.exported, "pub union is exported");
+
+        // Field type annotations are preserved exactly like struct fields.
+        let i = fa.nodes.iter()
+            .find(|n| n.node_type == "RECORD_FIELD" && n.name == "i")
+            .unwrap();
+        assert_eq!(i.metadata.get("typeAnnotation"), Some(&serde_json::json!("u32")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`walk_item` in the Rust analyzer silently dropped `syn::Item::Union` — it was a no-op marked `// TODO: treat like struct`. As a result **every Rust `union` and all of its fields were missing from the graph**: a whole top-level item kind was invisible to every query, the layout pass, and the city map.

This closes that gap and removes a forbidden in-production `TODO` (per `CLAUDE.md` Forbidden Patterns).

## Spec

**Invariant restored:** every declared Rust aggregate type that the analyzer reaches via `walk_item` produces a graph node. Previously `struct`/`enum` did; `union` did not.

**Given** a Rust file containing `pub union MyUnion { pub i: u32, f: f32 }`
**When** it is analyzed
**Then** the graph contains a `STRUCT` node `MyUnion` (`exported=true`, `metadata.declKind="union"`), `RECORD_FIELD` nodes `i` and `f` (with `typeAnnotation`), and `HAS_FIELD` edges from the union to each field — the same shape a `struct` produces.

## Design

Unions are struct-like aggregates (named fields, declared type, same role). I model them as **`STRUCT` nodes** rather than introducing a new `UNION` node type. Rationale: a new placeable type would have to be kept in sync across three coupled lists that explicitly warn about drift —
- `packages/grafema-orchestrator/src/analyzer.rs:3124` (known node types)
- `packages/grafema-orchestrator/src/layout/loader.rs:71` (layout placeable types)
- `packages/util/src/enrichers/compactionEnricher.ts:633` (GUI `PLACEABLE_TYPES`, with a comment: *"If this drifts from the server-side list… edges with unresolvable endpoints in the viz"*)

Reusing `STRUCT` means unions are immediately queryable, placeable, and displayable with zero new plumbing. The union/struct distinction is preserved losslessly in `metadata.declKind = "union"` (`declKind` is not a reserved metadata key, so it survives RFDB node serialization). The implementation mirrors `walk_struct` (matching the file's existing per-item-walker idiom).

## Before / After (evidence)

**Before** — `walk_item` at `rust_analyzer.rs:490`:
```rust
syn::Item::Union(_) => {} // TODO: treat like struct
```
New test `test_union_with_fields` fails for the right reason against this code:
```
thread '...test_union_with_fields' panicked at src/rust_analyzer.rs:1892:9:
union emitted as STRUCT node
test result: FAILED. 0 passed; 1 failed; ...
```

**After:**
```
test rust_analyzer::tests::test_union_with_fields ... ok
test result: ok. 1 passed; 0 failed; ...
```

## Full gate (actual outputs)

| Gate | Result |
|------|--------|
| `cargo test -p grafema-orchestrator --lib` | `421 passed; 0 failed` (was 420 + 1 new) |
| `cargo test -p rfdb-server --lib` | `998 passed; 0 failed` (unaffected) |
| `./scripts/test.sh` (JS unit) | `694 pass; 0 fail; 0 skipped; 0 todo` |
| `pnpm typecheck` | clean (exit 0) |
| `pnpm lint` | clean (exit 0) |

No new compiler warnings introduced (the 4 pre-existing orchestrator warnings are unrelated and outside `rust_analyzer.rs`).

## Adversarial review

- **Correctness (Round A):** `syn::ItemUnion.fields` is always `FieldsNamed` (Rust unions cannot have unnamed/unit fields), so iterating `u.fields.named` is exhaustive; `field.ident` is always `Some`. Empty/edge bodies are handled (no field loop iterations → node still emitted). Generic unions (`union U<T> { … }`) take the ident `U`, consistent with how `walk_struct` ignores generics. A `struct` and `union` of the same name in one file can't collide because Rust forbids that name clash at compile time.
- **Class-not-instance (Round C):** the fix is at the `walk_item` dispatch point, which is invoked recursively (`walk_mod` → `walk_item`), so unions nested in modules are covered too — not just top-level. No other call site drops the variant. `item_variant_name` still lists `Union` for the unrelated `_ =>` panic path; harmless.
- **Structural (Round B):** `walk_union` duplicates `walk_struct`'s field loop (~25 lines). This matches the file's established standalone-walker convention (`walk_struct`/`walk_enum` don't share either). `rust_analyzer.rs` is a pre-existing 2k-line file; not split here (out of scope).

## Blast radius

Rust-analyzer only. Pure addition for a previously no-op branch; no existing behavior changes. JS/TS packages untouched (verified: diff is a single `.rs` file).

## Notes

- No open GitHub issue / reachable Linear item corresponds to this; it was found by auditing forbidden-pattern (`TODO`) markers in production code per `CLAUDE.md`.
- This repo's own Rust source contains zero `union` declarations, so its self-analysis graph is unchanged. The value is for target codebases that use unions (FFI/systems Rust: `libc`, `windows-rs`, `MaybeUninit`-style), which the analyzer is explicitly meant to cover.

https://claude.ai/code/session_01Ah9CCu82AR8KVsQWjCsMH8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ah9CCu82AR8KVsQWjCsMH8)_