### PR TITLE
fix(util): resolve extensionless & directory re-export sources in packageApiEnricher

### DIFF
--- a/packages/util/src/enrichers/packageApiEnricher.ts
+++ b/packages/util/src/enrichers/packageApiEnricher.ts
@@ -136,7 +136,7 @@ export async function enrichPackageApis(
       //     job). If the source is outside the indexed graph, we still emit the
       //     node but increment exportsWithoutHandler.
       const targetId = reExportSource
-        ? await findDefinitionTarget(client, exportedName, resolveRelative(barrel, reExportSource))
+        ? await resolveReExportTarget(client, exportedName, resolveRelative(barrel, reExportSource))
         : await findDefinitionTarget(client, exportedName, barrel);
 
       const nodeMeta: Record<string, unknown> = {
@@ -275,11 +275,16 @@ async function findDefinitionTarget(
 }
 
 /**
- * Resolve a relative re-export source (`./foo/index.js`, `../bar.ts`) against
- * the barrel's file path. Mirrors ManifestGenerator.resolveSourcePath but
- * without TypeScript-specific extension tweaks: we deliberately try the source
- * verbatim AND with a `.ts` swap, since the JS analyzer emits `.js` paths even
- * for source TypeScript.
+ * Normalize a relative re-export source (`./foo`, `./foo.js`, `./sub`, `../bar`)
+ * into a logical base path relative to the barrel. Non-relative sources
+ * (bare/scoped specifiers like `@scope/pkg`) are returned verbatim — they don't
+ * map to an in-graph file and resolve to no HANDLES target.
+ *
+ * This deliberately does NOT pick a file extension: extension/index expansion
+ * happens in {@link candidateFiles}, because a single specifier can map to a
+ * `.ts`, `.tsx`, `.js`, … file, or a directory `index.*`, and the analyzer
+ * indexes source TypeScript as `.ts` even when the specifier is `.js` or
+ * extensionless.
  */
 function resolveRelative(fromFile: string, source: string): string {
   if (!source.startsWith('.')) return source;
@@ -294,11 +299,62 @@ function resolveRelative(fromFile: string, source: string): string {
     if (p === '..') stack.pop();
     else if (p !== '.' && p !== '') stack.push(p);
   }
-  resolved = (resolved.startsWith('/') ? '/' : '') + stack.join('/');
-  // The analyzer indexes source TypeScript as .ts; barrels typically reference
-  // siblings via `./foo.js` thanks to ESM. Try .ts before falling through.
-  if (resolved.endsWith('.js')) return resolved.replace(/\.js$/, '.ts');
-  return resolved;
+  return (resolved.startsWith('/') ? '/' : '') + stack.join('/');
+}
+
+/** Source-file extensions a re-export specifier may resolve to, TS-first. */
+const REEXPORT_EXTENSIONS: readonly string[] = ['.ts', '.tsx', '.js', '.mjs', '.cjs'];
+/** Directory index file names, TS-first. */
+const REEXPORT_INDEX_FILES: readonly string[] = REEXPORT_EXTENSIONS.map(e => `index${e}`);
+const KNOWN_EXT_RE = /\.(?:ts|tsx|js|mjs|cjs|jsx)$/;
+
+/**
+ * Expand a normalized re-export base path into the candidate graph file paths
+ * it may correspond to, ordered by likelihood (verbatim first when the
+ * specifier already carries a known extension, otherwise TS source files before
+ * the directory `index.*` forms).
+ *
+ * The analyzer stores `EXPORT_BINDING.source` as the verbatim `from '...'`
+ * string. Source TypeScript commonly uses the extensionless (`./foo`) or
+ * ESM `.js` (`./foo.js`) form, while the real graph node lives in `foo.ts`,
+ * so a single fixed extension can never cover every layout.
+ */
+function candidateFiles(resolved: string): string[] {
+  const out: string[] = [];
+  const push = (p: string): void => {
+    if (!out.includes(p)) out.push(p);
+  };
+
+  if (KNOWN_EXT_RE.test(resolved)) {
+    // e.g. './foo.js' → try foo.js verbatim, then TS/JS siblings of foo.*
+    push(resolved);
+    const base = resolved.replace(KNOWN_EXT_RE, '');
+    for (const ext of REEXPORT_EXTENSIONS) push(base + ext);
+  } else {
+    // e.g. './foo' or './sub' → file-with-extension first, then directory index
+    for (const ext of REEXPORT_EXTENSIONS) push(resolved + ext);
+    push(resolved);
+    for (const idx of REEXPORT_INDEX_FILES) push(`${resolved}/${idx}`);
+  }
+  return out;
+}
+
+/**
+ * Resolve a re-export's HANDLES target by trying each candidate file the
+ * normalized source path may map to, returning the first definition found.
+ * Returns null when no candidate file holds a matching definition — callers
+ * treat that as an unresolved re-export (`exportsWithoutHandler`).
+ */
+async function resolveReExportTarget(
+  client: RFDBClient,
+  name: string,
+  resolvedSource: string,
+): Promise<string | null> {
+  for (const file of candidateFiles(resolvedSource)) {
+    const id = await findDefinitionTarget(client, name, file);
+    if (id) return id;
+  }
+  return null;
 }
 
 /** ---------------------------------------------------------------------------

--- a/test/unit/packageApiEnricher.test.js
+++ b/test/unit/packageApiEnricher.test.js
@@ -243,6 +243,118 @@ describe('packageApiEnricher', () => {
     }
   });
 
+  it('extensionless re-export source resolves to the .ts definition', async () => {
+    // The JS analyzer stores EXPORT_BINDING.source as the verbatim `from '...'`
+    // specifier. For source TypeScript, the common form is extensionless
+    // (`export { foo } from './foo'`). The resolver must expand './foo' to the
+    // real graph file `foo.ts` — a `.js→.ts` swap alone never fires here.
+    const barrel = 'packages/pkg-a/src/index.ts';
+    const defFile = 'packages/pkg-a/src/foo.ts';
+    await seedBarrelModule(backend, barrel);
+    await seedBarrelModule(backend, defFile);
+
+    await backend.addNode({
+      id: 'test::eb-foo',
+      type: 'EXPORT_BINDING',
+      name: 'foo',
+      file: barrel,
+      exported: true,
+      exportedName: 'foo',
+      source: './foo', // extensionless
+    });
+    await backend.addNode({
+      id: 'test::fn-foo',
+      type: 'FUNCTION',
+      name: 'foo',
+      file: defFile,
+    });
+
+    const result = await enrichPackageApis(client);
+
+    assert.equal(result.apiNodesCreated, 1);
+    assert.equal(result.handlesEdgesCreated, 1, 'extensionless source must resolve to a HANDLES target');
+    assert.equal(result.exportsWithoutHandler, 0);
+
+    const apiNodes = [];
+    for await (const wn of client.queryNodes({ type: 'package:export' })) apiNodes.push(wn);
+    assert.equal(apiNodes.length, 1);
+
+    const has = await getEdges(client, apiNodes[0].id, 'HANDLES');
+    assert.equal(has.length, 1, 'one HANDLES edge expected');
+    const target = await client.getNode(String(has[0].dst));
+    assert.equal(target.nodeType, 'FUNCTION');
+    assert.equal(target.name, 'foo');
+  });
+
+  it('directory re-export source resolves to the directory index file', async () => {
+    // `export { bar } from './sub'` where ./sub is a directory must resolve to
+    // its index file (`./sub/index.ts`).
+    const barrel = 'packages/pkg-a/src/index.ts';
+    const defFile = 'packages/pkg-a/src/sub/index.ts';
+    await seedBarrelModule(backend, barrel);
+    await seedBarrelModule(backend, defFile);
+
+    await backend.addNode({
+      id: 'test::eb-bar',
+      type: 'EXPORT_BINDING',
+      name: 'bar',
+      file: barrel,
+      exported: true,
+      exportedName: 'bar',
+      source: './sub', // directory
+    });
+    await backend.addNode({
+      id: 'test::fn-bar',
+      type: 'FUNCTION',
+      name: 'bar',
+      file: defFile,
+    });
+
+    const result = await enrichPackageApis(client);
+
+    assert.equal(result.handlesEdgesCreated, 1, 'directory source must resolve via index file');
+    assert.equal(result.exportsWithoutHandler, 0);
+
+    const apiNodes = [];
+    for await (const wn of client.queryNodes({ type: 'package:export' })) apiNodes.push(wn);
+    const has = await getEdges(client, apiNodes[0].id, 'HANDLES');
+    assert.equal(has.length, 1, 'one HANDLES edge expected');
+    const target = await client.getNode(String(has[0].dst));
+    assert.equal(target.name, 'bar');
+  });
+
+  it('extensionless source pointing nowhere still increments exportsWithoutHandler (no false resolve)', async () => {
+    // Adversarial: a same-named definition exists in an UNRELATED file. The
+    // resolver must NOT resolve to it — candidate expansion stays scoped to the
+    // re-export source path, and fuzzyNameFallback is disabled.
+    const barrel = 'packages/pkg-a/src/index.ts';
+    const unrelated = 'packages/pkg-a/src/elsewhere.ts';
+    await seedBarrelModule(backend, barrel);
+    await seedBarrelModule(backend, unrelated);
+
+    await backend.addNode({
+      id: 'test::eb-missing',
+      type: 'EXPORT_BINDING',
+      name: 'missing',
+      file: barrel,
+      exported: true,
+      exportedName: 'missing',
+      source: './missing', // no ./missing.* file in graph
+    });
+    await backend.addNode({
+      id: 'test::fn-missing',
+      type: 'FUNCTION',
+      name: 'missing',
+      file: unrelated, // same name, wrong file
+    });
+
+    const result = await enrichPackageApis(client);
+
+    assert.equal(result.apiNodesCreated, 1);
+    assert.equal(result.handlesEdgesCreated, 0, 'must not falsely resolve to unrelated file');
+    assert.equal(result.exportsWithoutHandler, 1);
+  });
+
   it('idempotent: running twice does not duplicate nodes or HANDLES edges', async () => {
     const barrel = 'packages/pkg-a/src/index.ts';
     const defFile = 'packages/pkg-a/src/foo.ts';


### PR DESCRIPTION
## Source

Sibling latent follow-up, explicitly filed (not fixed) by the parallel ManifestGenerator re-export fix (branch `claude/vigilant-lamport-jd7t7`, recorded in Enox `grafema` domain, 2026-06-08): *"packageApiEnricher.resolveRelative only does .js→.ts swap, no extensionless/index expansion → under-resolves extensionless re-exports."* No GitHub/Linear ticket exists for it (Linear unavailable this run). This PR fixes that sibling; it does **not** touch `ManifestGenerator` (the parallel session's scope).

## Spec

**Invariant restored:** every monorepo-barrel re-export whose definition is present in the graph must get a `HANDLES` edge to that definition, regardless of how the `from '...'` specifier is written; `exportsWithoutHandler` counts only genuinely-unresolvable re-exports.

**Given** a barrel `packages/pkg/src/index.ts` with `EXPORT_BINDING.source` …
- **When** the source is extensionless (`./foo`) and the definition lives in `./foo.ts`
  **Then** a `HANDLES` edge is emitted and `exportsWithoutHandler` stays 0.
- **When** the source is a directory (`./sub`) and the definition lives in `./sub/index.ts`
  **Then** it resolves via the directory index file.
- **When** the source points nowhere (`./missing`) but a same-named symbol exists in an unrelated file
  **Then** no edge is emitted (`exportsWithoutHandler++`) — no false resolve.

## Root cause

`resolveRelative` (packages/util/src/enrichers/packageApiEnricher.ts) only did a trailing `.js`→`.ts` swap. The JS analyzer stores `EXPORT_BINDING.source` as the verbatim `from '...'` string, and source TypeScript is indexed as `.ts`, so:
- extensionless `./foo` → looked up file `…/foo` (no extension) ≠ graph node `…/foo.ts`
- directory `./sub` → looked up `…/sub` ≠ `…/sub/index.ts`

Both fell through to no `HANDLES` edge. `findDefinitionTarget` already sets `fuzzyNameFallback:false`, so this is pure path under-resolution, never mis-resolution.

## Fix

`resolveRelative` now only normalizes the path. New `candidateFiles()` expands the base (TS-first) into file forms (`.ts/.tsx/.js/.mjs/.cjs`) and directory-index forms (`index.*`); `resolveReExportTarget()` returns the first in-graph definition. Verbatim is tried first when the specifier already carries a known extension (preserves the compiled-JS layout). +50 LOC; file 333→388 (<500). Mirrors the `candidateFiles` shape used by the parallel ManifestGenerator fix. Not reusing `moduleResolution.ts` is deliberate: that helper does filesystem `existsSync` lookups and returns one path — here candidates must match **graph** node `file` fields, a different layer.

## Before / After (live test, real RFDB via `createTestDatabase`)

New cases were RED before the fix, GREEN after:

```
# BEFORE (impl unchanged, new tests added)
# pass 6  # fail 2
  FAIL: extensionless re-export source resolves to the .ts definition
        extensionless source must resolve to a HANDLES target
  FAIL: directory re-export source resolves to the directory index file
        directory source must resolve via index file

# AFTER (fix applied)
# tests 8  # pass 8  # fail 0
ALL TESTS PASSED
```

## Adversarial review

- **Round A — correctness:** extensionless ✓, directory-index ✓, existing `.js` form ✓ (5 prior tests still green), non-relative `@scope/pkg` → no match → `exportsWithoutHandler` ✓, trailing-slash `./sub/` normalizes to `./sub` ✓. File form is tried before directory index (correct TS resolution priority). Adversarial unresolved-but-same-name case asserts **no false resolve** (`fuzzyNameFallback:false`).
- **Round B — fragility:** local helper instead of coupling graph resolution to the filesystem-based `moduleResolution.ts`; new functions documented for agents; file <500 lines.
- **Round C — class-not-instance:** grepped all `.js→.ts`-only swaps. `generator.ts:258` = ManifestGenerator (parallel session's primary fix — left untouched). `analyzeAction.ts:632` = deterministic `dist/index.js`→`src/index.ts` package.json-entry mapping, a different concern. Other resolvers route through `moduleResolution.ts` which already has full extension+index expansion.

## Verification gate

```
pnpm build       → all packages OK
pnpm typecheck   → 0 errors
pnpm lint        → 0 errors
./scripts/test.sh → tests 697  pass 697  fail 0  (was 695; +2 new)
```

## Blast radius

`enrichPackageApis` is the only caller; `resolveRelative`/`candidateFiles`/`resolveReExportTarget` are module-private. Behaviour change is strictly additive — previously-unresolved extensionless/directory re-exports now gain `HANDLES` edges; all previously-resolved cases are unchanged.

## Follow-ups (not in scope)

- ManifestGenerator extensionless/index expansion — already handled on `claude/vigilant-lamport-jd7t7`.

https://claude.ai/code/session_016Vzc2uAVFwQZzs6SDXuqwx

---
_Generated by [Claude Code](https://claude.ai/code/session_016Vzc2uAVFwQZzs6SDXuqwx)_