### PR TITLE
fix(rfdb): align attr() reverse metadata match with forward for null/object/array

### DIFF
--- a/packages/rfdb-server/src/datalog/tests.rs
+++ b/packages/rfdb-server/src/datalog/tests.rs
@@ -6225,6 +6225,147 @@ mod attr_reverse_nested_metadata_tests {
     }
 }
 
+// ============================================================================
+// attr() reverse lookup — non-primitive flat metadata values (null/object/array)
+//
+// The forward path `attr(id, "k", V)` resolves a flat metadata value via
+// `get_metadata_value` → `value_to_string`, which returns `None` for JSON
+// null/object/array (only String/Number/Bool are exact-matchable primitives),
+// so forward yields no row for these. The reverse path `attr(X, "k", "v")`
+// for a flat key routes through the index-backed `find_by_attr` →
+// `metadata_matches`, whose exact-match arm stringified ANY value (`Null` →
+// `"null"`, objects → order-dependent compact JSON), so it matched rows the
+// forward direction rejects — a silent forward/reverse asymmetry of the same
+// class as the semantic_id/version/id and nested-dotted reverse gaps. The fix
+// makes `metadata_matches` mirror `value_to_string` (null/object/array never
+// match), restoring symmetry on the flat-key fast path. These tests pin it.
+// ============================================================================
+
+mod attr_reverse_nonprimitive_metadata_tests {
+    use super::*;
+    use crate::graph::{GraphEngineV2, GraphStore};
+    use crate::storage::NodeRecord;
+    use crate::datalog::eval::Evaluator;
+    use crate::datalog::eval_explain::EvaluatorExplain;
+
+    // One node carrying a JSON null, object, and array alongside a plain string
+    // metadata value. The string value is the symmetric control.
+    fn setup_nonprimitive_metadata_graph() -> GraphEngineV2 {
+        let mut engine = GraphEngineV2::create_ephemeral();
+        engine.add_nodes(vec![NodeRecord {
+            id: 1,
+            node_type: Some("SERVICE".to_string()),
+            name: Some("svc".to_string()),
+            file: Some("svc.js".to_string()),
+            file_id: 0,
+            name_offset: 0,
+            version: "main".into(),
+            exported: false,
+            replaces: None,
+            deleted: false,
+            metadata: Some(
+                r#"{"flag":null,"obj":{"a":1},"arr":[1,2],"label":"alpha"}"#.to_string(),
+            ),
+            semantic_id: None,
+        }]);
+        engine
+    }
+
+    fn reverse_ids(ev: &Evaluator, key: &str, value: &str) -> Vec<u128> {
+        ev.query_atom(&Atom::new(
+            "attr",
+            vec![Term::var("X"), Term::constant(key), Term::constant(value)],
+        ))
+        .unwrap()
+        .iter()
+        .filter_map(|b| b.get("X").and_then(|v| v.as_id()))
+        .collect()
+    }
+
+    fn forward_rows(ev: &Evaluator, key: &str) -> usize {
+        ev.query_atom(&Atom::new(
+            "attr",
+            vec![Term::constant("1"), Term::constant(key), Term::var("V")],
+        ))
+        .unwrap()
+        .len()
+    }
+
+    // Forward direction: null/object/array values are not extractable primitives,
+    // so forward `attr(1, k, V)` binds nothing. This is the semantics the reverse
+    // direction must mirror.
+    #[test]
+    fn test_forward_attr_nonprimitive_metadata_yields_nothing() {
+        let engine = setup_nonprimitive_metadata_graph();
+        let ev = Evaluator::new(&engine);
+        assert_eq!(forward_rows(&ev, "flag"), 0, "forward null value must bind nothing");
+        assert_eq!(forward_rows(&ev, "obj"), 0, "forward object value must bind nothing");
+        assert_eq!(forward_rows(&ev, "arr"), 0, "forward array value must bind nothing");
+    }
+
+    // Reverse direction must agree: querying for the stringified null/object/array
+    // must NOT match, because the forward direction rejects these values. Before
+    // the fix, `metadata_matches` stringified them and returned node 1.
+    #[test]
+    fn test_reverse_attr_null_metadata_no_match() {
+        let engine = setup_nonprimitive_metadata_graph();
+        let ev = Evaluator::new(&engine);
+        assert!(
+            reverse_ids(&ev, "flag", "null").is_empty(),
+            "reverse attr(X, flag, \"null\") must not match a JSON null (forward rejects it)"
+        );
+    }
+
+    #[test]
+    fn test_reverse_attr_object_metadata_no_match() {
+        let engine = setup_nonprimitive_metadata_graph();
+        let ev = Evaluator::new(&engine);
+        // The compact serialization the old code compared against.
+        assert!(
+            reverse_ids(&ev, "obj", r#"{"a":1}"#).is_empty(),
+            "reverse attr on a JSON object value must not match (forward rejects it)"
+        );
+    }
+
+    #[test]
+    fn test_reverse_attr_array_metadata_no_match() {
+        let engine = setup_nonprimitive_metadata_graph();
+        let ev = Evaluator::new(&engine);
+        assert!(
+            reverse_ids(&ev, "arr", "[1,2]").is_empty(),
+            "reverse attr on a JSON array value must not match (forward rejects it)"
+        );
+    }
+
+    // Regression: a primitive (string) flat metadata value still round-trips
+    // forward → reverse. The fast index path must be unchanged for primitives.
+    #[test]
+    fn test_reverse_attr_primitive_metadata_still_matches() {
+        let engine = setup_nonprimitive_metadata_graph();
+        let ev = Evaluator::new(&engine);
+        assert_eq!(forward_rows(&ev, "label"), 1, "forward string value binds");
+        assert_eq!(
+            reverse_ids(&ev, "label", "alpha"),
+            vec![1],
+            "reverse string flat metadata must still match node 1"
+        );
+    }
+
+    // EvaluatorExplain twin must agree: reverse null lookup yields no rows.
+    #[test]
+    fn test_reverse_attr_null_metadata_explain_parity() {
+        let engine = setup_nonprimitive_metadata_graph();
+        let mut ev = EvaluatorExplain::new(&engine, false);
+        let result = ev
+            .eval_query(&parse_query(r#"attr(X, "flag", "null")"#).unwrap())
+            .unwrap();
+        assert!(
+            result.bindings.is_empty(),
+            "explain twin must also reject reverse null match"
+        );
+    }
+}
+
 /// Repeated-variable (self-loop) handling for `edge`/`incoming` enumeration.
 ///
 /// A variable that appears in BOTH the src and dst position of a single edge

--- a/packages/rfdb-server/src/storage_v2/shard.rs
+++ b/packages/rfdb-server/src/storage_v2/shard.rs
@@ -1054,7 +1054,17 @@ impl Shard {
                         serde_json::Value::String(s) => s.clone(),
                         serde_json::Value::Bool(b) => b.to_string(),
                         serde_json::Value::Number(n) => n.to_string(),
-                        other => other.to_string(),
+                        // Null / Object / Array are not exact-matchable primitives.
+                        // The forward `attr()` read path (datalog
+                        // get_metadata_value → value_to_string) returns None for
+                        // these and yields no match, so the reverse/filter path must
+                        // too. Stringifying them here (Null → "null", objects →
+                        // order-dependent compact JSON) let reverse lookups match
+                        // rows the forward direction rejects — a silent
+                        // forward/reverse asymmetry. Mirror value_to_string.
+                        serde_json::Value::Null
+                        | serde_json::Value::Object(_)
+                        | serde_json::Value::Array(_) => return false,
                     };
                     if v_str != *value {
                         return false;


### PR DESCRIPTION
## Summary

Closes the **last unclosed instance of the documented forward/reverse `attr()` invariant** in the RFDB Datalog engine — a silent wrong-answer bug for JSON `null`/object/array metadata values.

The forward read path `attr(id, K, V)` resolves a flat metadata value via `get_metadata_value` → `value_to_string` ([`datalog/utils.rs:86-93`](../blob/main/packages/rfdb-server/src/datalog/utils.rs#L86)), which returns `None` for `null`/object/array — only `String`/`Number`/`Bool` are exact-matchable primitives — so **forward yields no row** for these.

The reverse path `attr(X, K, "v")` for a flat key routes through the index-backed `find_by_attr` → `metadata_matches` ([`storage_v2/shard.rs:1015`](../blob/main/packages/rfdb-server/src/storage_v2/shard.rs#L1015)), whose exact-match arm stringified **any** value (`Null` → `"null"`, objects → order-dependent compact JSON via `other.to_string()`), so it **matched rows the forward direction rejects**.

This is the same class of forward/reverse asymmetry whose `semantic_id`/`version`/`id` and nested-dotted-path cases were already fixed (RFD-48 lineage — see the symmetry doc comments at `eval.rs:1420-1467`). The maintainer deliberately kept flat metadata keys on the fast `find_by_attr` index path on the assumption that `metadata_matches` agrees with `value_to_string`; that assumption holds for primitives but broke for `null`/object/array. This PR restores the assumption.

## Spec

- **Invariant restored:** forward `attr(id,K,V)` and reverse `attr(X,K,"v")` agree on which `(node, K, value)` triples match.
- **Given** a node with metadata `{"flag":null,"obj":{"a":1},"arr":[1,2],"label":"alpha"}`
  **When** I run `attr(X, "flag", "null")` (or the object/array equivalents)
  **Then** the result is empty — matching forward `attr(1, "flag", V)`, which binds nothing.
  **And** the primitive control `attr(X, "label", "alpha")` still returns node 1 (fast path unchanged).
- **Blast radius:** `metadata_matches` is shared by all `find_by_attr` callers — datalog `Evaluator` + `EvaluatorExplain` reverse lookups, and HTTP/MCP node queries. Fixing it here closes the class everywhere. Primitive (String/Number/Bool) matching is byte-for-byte unchanged; only the previously-broken `null`/object/array stringify-match is removed (no test relied on it; matching a JSON object by whitespace/key-order-dependent serialization was never sound).

## Fix

`packages/rfdb-server/src/storage_v2/shard.rs` — `metadata_matches` exact-match arm now mirrors `value_to_string`:

```rust
serde_json::Value::String(s) => s.clone(),
serde_json::Value::Bool(b) => b.to_string(),
serde_json::Value::Number(n) => n.to_string(),
// Null / Object / Array are not exact-matchable primitives … mirror value_to_string.
serde_json::Value::Null
| serde_json::Value::Object(_)
| serde_json::Value::Array(_) => return false,
```

(Side benefit: a metadata value that is the **string** `"null"` now round-trips unambiguously — previously a JSON `null` also matched `"null"`, conflating the two.)

## Before / After evidence

**RED (before fix)** — `cargo test --lib attr_reverse_nonprimitive_metadata_tests`:
```
test result: FAILED. 2 passed; 4 failed; 0 ignored
failures:
    test_reverse_attr_array_metadata_no_match
    test_reverse_attr_null_metadata_explain_parity
    test_reverse_attr_null_metadata_no_match
    test_reverse_attr_object_metadata_no_match
```
The 2 that passed (forward yields nothing + primitive control) precisely isolate the asymmetry.

**GREEN (after fix)**:
```
running 6 tests ... test result: ok. 6 passed; 0 failed
```

**Full gate:**
```
cargo test --lib        → ok. 1004 passed; 0 failed
cargo clippy --lib      → exit 0 (no hits on edited lines)
cargo build --bin rfdb-server → exit 0
```
(JS unit suite unaffected — Rust-only change — and was independently 697/697 green with `GRAFEMA_RFDB_SERVER` set.)

## Adversarial review

- **Round A (correctness):** The `:min`/`:max` range-filter arms run *before* the exact-match arm and `continue`, so they're untouched. Number matching is unchanged (explicit arm retained). The string `"null"` case is unaffected (only JSON `Null` changes). Nested-dotted reverse goes through `reverse_metadata_scan`/`get_metadata_value`, not this path.
- **Round B (fragility):** One match arm; no shared helper introduced to avoid coupling the storage crate to the datalog crate — the mirroring of `value_to_string` is documented inline as the drift guard.
- **Round C (class-not-instance):** Grepped for sibling `other => other.to_string()` stringify-match sites — this was the only one. The `EvaluatorExplain` reverse twin routes through the same `find_by_attr`/`metadata_matches` (verified by the passing explain-parity test), so it's covered by the same fix.

## Notes

No open GitHub issue / no Linear access this run; this defect was surfaced by auditing the documented `attr()` symmetry invariant (RFD-48 lineage). No source issue to link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015FX3Fgnyrp89ahGib5o9VC)_