### PR TITLE
fix(util): resolve .jsx/.mts/.cts re-export sources in packageApiEnricher

### DIFF
--- a/packages/util/src/enrichers/packageApiEnricher.ts
+++ b/packages/util/src/enrichers/packageApiEnricher.ts
@@ -302,11 +302,41 @@ function resolveRelative(fromFile: string, source: string): string {
   return (resolved.startsWith('/') ? '/' : '') + stack.join('/');
 }
 
-/** Source-file extensions a re-export specifier may resolve to, TS-first. */
-const REEXPORT_EXTENSIONS: readonly string[] = ['.ts', '.tsx', '.js', '.mjs', '.cjs'];
-/** Directory index file names, TS-first. */
+/**
+ * Source-file extensions a re-export specifier may resolve to.
+ *
+ * This MUST mirror the JS/TS extension set the orchestrator actually analyzes
+ * and indexes — `is_js_ts_file` in
+ * `packages/grafema-orchestrator/src/analyzer.rs` (`js | jsx | ts | tsx | mjs |
+ * cjs | mts | cts`). Any extension the orchestrator indexes but this list omits
+ * is a definition file that an extensionless/directory re-export can never
+ * resolve to, silently inflating `exportsWithoutHandler`.
+ *
+ * Ordered TS-family first (`.ts/.tsx/.mts/.cts`) then JS-family
+ * (`.js/.jsx/.mjs/.cjs`) so a re-export resolves to the TypeScript definition
+ * before a compiled JS sibling when both happen to be in the graph — keeping
+ * `resolveReExportTarget`'s first-match deterministic.
+ */
+const REEXPORT_EXTENSIONS: readonly string[] = [
+  '.ts',
+  '.tsx',
+  '.mts',
+  '.cts',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+];
+/** Directory index file names, same TS-first order as {@link REEXPORT_EXTENSIONS}. */
 const REEXPORT_INDEX_FILES: readonly string[] = REEXPORT_EXTENSIONS.map(e => `index${e}`);
-const KNOWN_EXT_RE = /\.(?:ts|tsx|js|mjs|cjs|jsx)$/;
+/**
+ * Matches a trailing known JS/TS extension. Derived from {@link
+ * REEXPORT_EXTENSIONS} so the two can never drift apart — a specifier whose
+ * extension is in the candidate set is treated as carrying a known extension.
+ */
+const KNOWN_EXT_RE = new RegExp(
+  `\\.(?:${REEXPORT_EXTENSIONS.map(e => e.slice(1)).join('|')})$`,
+);
 
 /**
  * Expand a normalized re-export base path into the candidate graph file paths

--- a/test/unit/packageApiEnricher.test.js
+++ b/test/unit/packageApiEnricher.test.js
@@ -323,6 +323,57 @@ describe('packageApiEnricher', () => {
     assert.equal(target.name, 'bar');
   });
 
+  // The orchestrator analyzes & indexes eight JS/TS extensions
+  // (analyzer.rs `is_js_ts_file`): js, jsx, ts, tsx, mjs, cjs, mts, cts. An
+  // extensionless re-export specifier must expand to ALL of them — otherwise a
+  // definition living in a `.jsx`/`.mts`/`.cts` file is silently unresolved and
+  // over-counts `exportsWithoutHandler`. This is the same class as the
+  // `.ts`/dir-index cases above, just for the three extensions the candidate
+  // list previously omitted.
+  for (const ext of ['jsx', 'mts', 'cts']) {
+    it(`extensionless re-export source resolves to the .${ext} definition`, async () => {
+      const barrel = 'packages/pkg-a/src/index.ts';
+      const defFile = `packages/pkg-a/src/widget.${ext}`;
+      await seedBarrelModule(backend, barrel);
+      await seedBarrelModule(backend, defFile);
+
+      await backend.addNode({
+        id: 'test::eb-widget',
+        type: 'EXPORT_BINDING',
+        name: 'widget',
+        file: barrel,
+        exported: true,
+        exportedName: 'widget',
+        source: './widget', // extensionless
+      });
+      await backend.addNode({
+        id: 'test::fn-widget',
+        type: 'FUNCTION',
+        name: 'widget',
+        file: defFile,
+      });
+
+      const result = await enrichPackageApis(client);
+
+      assert.equal(result.apiNodesCreated, 1);
+      assert.equal(
+        result.handlesEdgesCreated,
+        1,
+        `extensionless source must resolve to a .${ext} HANDLES target`,
+      );
+      assert.equal(result.exportsWithoutHandler, 0);
+
+      const apiNodes = [];
+      for await (const wn of client.queryNodes({ type: 'package:export' })) apiNodes.push(wn);
+      const has = await getEdges(client, apiNodes[0].id, 'HANDLES');
+      assert.equal(has.length, 1, 'one HANDLES edge expected');
+      const target = await client.getNode(String(has[0].dst));
+      assert.equal(target.nodeType, 'FUNCTION');
+      assert.equal(target.name, 'widget');
+      assert.equal(target.file, defFile);
+    });
+  }
+
   it('extensionless source pointing nowhere still increments exportsWithoutHandler (no false resolve)', async () => {
     // Adversarial: a same-named definition exists in an UNRELATED file. The
     // resolver must NOT resolve to it — candidate expansion stays scoped to the


### PR DESCRIPTION
## Summary

Completes the re-export source resolution that #370 began. `packageApiEnricher` expands an extensionless or directory re-export specifier into candidate graph files via `REEXPORT_EXTENSIONS`, but that list covered only **five** of the **eight** JS/TS extensions the orchestrator actually analyzes and indexes.

**Authoritative source of truth** — `is_js_ts_file` in [`packages/grafema-orchestrator/src/analyzer.rs:326`](../blob/main/packages/grafema-orchestrator/src/analyzer.rs#L326):

```rust
.map(|ext| matches!(ext, "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" | "mts" | "cts"))
```

`REEXPORT_EXTENSIONS` was `['.ts', '.tsx', '.js', '.mjs', '.cjs']` — it **omitted `.jsx`, `.mts`, `.cts`**. So a re-export

```ts
export { widget } from './widget'   // extensionless
```

whose definition lives in `widget.jsx` / `widget.mts` / `widget.cts` fell through to no `HANDLES` edge and over-counted `exportsWithoutHandler`. `KNOWN_EXT_RE` was independently inconsistent (had `jsx`, lacked `mts`/`cts`). This is the exact class #370 fixed for the `.ts` and directory-index forms — left incomplete for three extensions.

## Spec

- **Invariant restored:** the candidate-extension set used to resolve a re-export's `HANDLES` target equals the set of JS/TS extensions the orchestrator indexes. No indexed definition file is unreachable to an extensionless/directory re-export.
- **Given** a barrel `export { widget } from './widget'` and a `FUNCTION widget` defined in `widget.jsx` (resp. `.mts`, `.cts`)
  **When** `enrichPackageApis` runs
  **Then** one `HANDLES` edge is emitted to that definition and `exportsWithoutHandler == 0` — matching the existing `.ts`/dir-index behaviour.
- **Blast radius:** `REEXPORT_EXTENSIONS` / `KNOWN_EXT_RE` are private to `packageApiEnricher.ts`; only `candidateFiles` / `resolveReExportTarget` consume them. The change is **purely additive** for the original five extensions and **preserves their relative order** (`.ts < .tsx < .js < .mjs < .cjs`), so `resolveReExportTarget`'s first-match is byte-for-byte unchanged for any case that already resolved; only the three previously-missed extensions newly resolve.

## Fix

`packages/util/src/enrichers/packageApiEnricher.ts`:
- `REEXPORT_EXTENSIONS` now covers all eight extensions, ordered **TS-family first** (`.ts/.tsx/.mts/.cts`) then **JS-family** (`.js/.jsx/.mjs/.cjs`) so a re-export resolves to the TypeScript definition before a compiled JS sibling when both are in the graph — keeping first-match deterministic.
- `KNOWN_EXT_RE` is now **derived from** `REEXPORT_EXTENSIONS` (`new RegExp(...)`) so the two lists can never drift apart again — the root cause of this bug being that two hand-maintained lists disagreed.
- The doc comment cites `analyzer.rs` as the source of truth to keep future edits in sync.

## Before / After evidence

**RED** (before fix) — `node --test test/unit/packageApiEnricher.test.js`:
```
not ok 7 - extensionless re-export source resolves to the .jsx definition
not ok 8 - extensionless re-export source resolves to the .mts definition
not ok 9 - extensionless re-export source resolves to the .cts definition
# tests 11 / pass 8 / fail 3
```
Failed for the right reason: `extensionless source must resolve to a .<ext> HANDLES target` (handlesEdgesCreated was 0).

**GREEN** (after fix):
```
# tests 11 / pass 11 / fail 0
```

**Full gate** (`GRAFEMA_RFDB_SERVER` set to the prebuilt linux-x64 binary):
```
./scripts/test.sh   → # tests 700 / pass 700 / fail 0   (was 697 + 3 new)
pnpm typecheck      → clean (platform-only WARNs)
pnpm lint           → clean
pnpm -r build       → ok
```

## Adversarial review

- **Round A (correctness):** Determinism — new list keeps the original five extensions' relative order, with `.mts/.cts` inserted after `.tsx` and `.jsx` after `.js`; every previously-resolving case returns the identical first match (no regression). Verbatim `./foo.mts`/`.cts` specifiers now match `KNOWN_EXT_RE` and route through the sibling-expansion branch instead of producing the wasteful `foo.mts.ts` candidates the old `else` branch generated (verbatim still resolved before via `push(resolved)`, so behaviour is at worst unchanged, now cleaner). The adversarial "no false resolve" test (same-named symbol in an unrelated file) still passes — candidate expansion stays scoped to the source path and `fuzzyNameFallback` stays disabled.
- **Round B (fragility):** Root cause was two hand-maintained extension lists drifting. Hardened by deriving `KNOWN_EXT_RE` from `REEXPORT_EXTENSIONS` (single source) and documenting `analyzer.rs` as the upstream source of truth. No god-file (file is 419 lines).
- **Round C (class-not-instance):** Grepped the TS side for sibling hardcoded JS/TS extension lists. Several exist and **also lack `.mts`/`.cts`** (the orchestrator added them to its indexed set but these never caught up) — see checklist below. They live in *different* subsystems with their own repro/test surfaces; folding them in would balloon this PR past one focused slice, so they're recorded as follow-ups rather than fixed here.

## Sibling latent sites found (follow-ups, NOT in this PR)

Each omits `.mts`/`.cts` (some also `.jsx`) relative to `analyzer.rs`'s indexed set:
- [ ] `packages/util/src/utils/moduleResolution.ts:20` — `DEFAULT_EXTENSIONS`
- [ ] `packages/util/src/core/CoverageAnalyzer.ts:22` — `JS_SUPPORTED`
- [ ] `packages/cli/src/utils/quickstart.ts:15` — discovery extension list
- [ ] `packages/cli/src/commands/query.ts:412` — file-path routing regex
- [ ] `packages/vscode/src/initRunner.ts:15` — init discovery list

Recommend a single follow-up that exports the canonical JS/TS extension set from one TS module (mirroring `analyzer.rs`) and points all sites at it.

## Notes

No open GitHub issue and no Linear access this run; this defect was surfaced by auditing the #370 re-export fix against the orchestrator's authoritative `is_js_ts_file` set. No source issue to link.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4phNaYYyjWbyqDaYxouwR)_