### PR TITLE
fix(cli/doctor): don't delete a live server's socket on ping timeout

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "clean": "rm -rf dist",
     "start": "node dist/cli.js",
     "test": "node --import tsx --test test/*.test.ts",
-    "test:unit": "node --import tsx --test --test-concurrency=1 test/analyze-utils.test.ts test/formatNode.test.ts test/pathutils-resolveprojectroot.test.ts test/progressRenderer.test.ts test/query-raw-predicate-warning.test.ts test/extension-mts-cts-coverage.test.ts"
+    "test:unit": "node --import tsx --test --test-concurrency=1 test/analyze-utils.test.ts test/formatNode.test.ts test/pathutils-resolveprojectroot.test.ts test/progressRenderer.test.ts test/query-raw-predicate-warning.test.ts test/extension-mts-cts-coverage.test.ts test/doctor-server-status.test.ts"
   },
   "keywords": [
     "grafema",

--- a/packages/cli/src/commands/doctor/checks.ts
+++ b/packages/cli/src/commands/doctor/checks.ts
@@ -249,8 +249,16 @@ export async function checkServerStatus(
   const client = new RFDBClient(socketPath, 'cli');
   client.on('error', () => {}); // Suppress error events
 
+  // Tracks whether the server accepted our connection. If `connect()` resolves,
+  // a live listener is bound to the socket — so the socket is NOT stale and must
+  // not be removed even if a later operation (e.g. `ping`) fails. We capture this
+  // in a local rather than reading `client.connected`, because a server that
+  // drops the connection flips `client.connected` back to false.
+  let serverAccepted = false;
+
   try {
     await client.connect();
+    serverAccepted = true;
     const version = await client.ping();
     await client.close();
 
@@ -261,6 +269,25 @@ export async function checkServerStatus(
       details: { version, socketPath },
     };
   } catch {
+    try { await client.close(); } catch { /* best-effort */ }
+
+    if (serverAccepted) {
+      // The server accepted the connection but did not respond to `ping`
+      // (e.g. it is busy/starting up, or stalled under RFDB write-lock
+      // contention where reads can time out at 60s). The listener is alive, so
+      // removing the socket file here would break a healthy server. Report it
+      // as unresponsive instead of deleting its socket.
+      return {
+        name: 'server',
+        status: 'warn',
+        message: 'RFDB server is running but did not respond to ping (may be busy or starting up).',
+        recommendation: 'Wait a moment and retry; if it persists, restart: grafema stop && grafema analyze',
+        details: { socketPath },
+      };
+    }
+
+    // `connect()` failed: nothing is listening on the socket path, so the
+    // socket file is a stale leftover from a crashed/stopped server. Remove it.
     try { unlinkSync(socketPath); } catch { /* already gone */ }
     return {
       name: 'server',

--- a/packages/cli/test/doctor-server-status.test.ts
+++ b/packages/cli/test/doctor-server-status.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for `checkServerStatus` socket-staleness discrimination.
+ *
+ * Regression guard for the destructive false-positive in the diagnostic check:
+ * `grafema doctor` must only delete `.grafema/rfdb.sock` when the socket is
+ * genuinely STALE (no listener bound). A live server that accepted the
+ * connection but is slow/unresponsive to `ping` (e.g. under RFDB write-lock
+ * contention, where reads can time out at 60s) must NOT have its socket file
+ * removed — doing so breaks new connections to a healthy server.
+ *
+ * Discriminator: if `client.connect()` resolves, a listener is bound to the
+ * socket, so the socket is NOT stale regardless of a later ping failure.
+ *
+ * Backend-free: drives `checkServerStatus` directly with an in-process
+ * `net` server. No CLI spawn, no native binary.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { createServer, type Server } from 'node:net';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { checkServerStatus } from '../src/commands/doctor/checks.ts';
+
+describe('checkServerStatus — socket staleness discrimination', () => {
+  let projectPath: string;
+  let socketPath: string;
+  let server: Server | undefined;
+
+  beforeEach(() => {
+    projectPath = mkdtempSync(join(tmpdir(), 'grafema-doctor-'));
+    mkdirSync(join(projectPath, '.grafema'), { recursive: true });
+    socketPath = join(projectPath, '.grafema', 'rfdb.sock');
+    server = undefined;
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()));
+      server = undefined;
+    }
+    rmSync(projectPath, { recursive: true, force: true });
+  });
+
+  it('warns (does not crash) when no socket file exists', async () => {
+    const result = await checkServerStatus(projectPath);
+    assert.strictEqual(result.status, 'warn');
+    assert.match(result.message, /not running/i);
+  });
+
+  it('removes a genuinely stale socket (no listener bound)', async () => {
+    // A leftover file at the socket path with nothing listening: connect() must
+    // fail, so the file is stale and should be removed.
+    writeFileSync(socketPath, '');
+    assert.ok(existsSync(socketPath));
+
+    const result = await checkServerStatus(projectPath);
+
+    assert.strictEqual(result.status, 'warn');
+    assert.match(result.message, /stale socket removed/i);
+    assert.ok(!existsSync(socketPath), 'stale socket file should be removed');
+  });
+
+  it('does NOT remove the socket of a live server that is unresponsive to ping', async () => {
+    // A server that accepts the connection but drops it (stand-in for a live
+    // but unresponsive server whose ping would time out). connect() resolves,
+    // so the listener is alive — the socket must be preserved.
+    server = createServer((sock) => {
+      setTimeout(() => sock.destroy(), 50);
+    });
+    await new Promise<void>((resolve, reject) => {
+      server!.once('error', reject);
+      server!.listen(socketPath, () => resolve());
+    });
+    assert.ok(existsSync(socketPath));
+
+    const result = await checkServerStatus(projectPath);
+
+    assert.ok(
+      existsSync(socketPath),
+      'socket of a live (connection-accepting) server must not be deleted'
+    );
+    assert.strictEqual(result.status, 'warn');
+    assert.doesNotMatch(
+      result.message,
+      /stale socket removed/i,
+      'a live server must not be reported as a removed stale socket'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`grafema doctor`'s `checkServerStatus` is a **read-only diagnostic**, but it called `unlinkSync(.grafema/rfdb.sock)` on **any** connect/ping failure. A *live-but-slow* RFDB server — e.g. `ping` timing out at 60s under write-lock contention — would have its socket file deleted, breaking new connections to a **healthy** server, with no recovery path. A diagnostic must not destroy state on a false positive.

No GitHub/Linear issue — surfaced from the repo's own Enox memory + `KNOWN_LIMITATIONS.md` "Known Bugs" triage (the stale-socket entry), then narrowed to this specific destructive false-positive by reading the code paths.

## Spec

- **Invariant restored:** a diagnostic check never deletes the socket of a server that is bound and listening.
- **Discriminator:** if `client.connect()` *resolves*, a listener is bound to the socket ⇒ the socket is **not** stale, regardless of a later `ping` failure. Only `connect()` failing (no listener) means the socket is a stale leftover and is removed.
  - Error `code` can't be used: `RFDBSocketClient._enhanceConnectionError` (`packages/rfdb/ts/client.ts:127,135`) rewraps `ENOENT`/`ECONNREFUSED` into a plain `Error`, dropping `err.code`. Call-sequencing is the robust signal.
  - We capture a local `serverAccepted` flag rather than reading `client.connected`, because a server that drops the connection flips `client.connected` back to `false`.

**Acceptance (BDD)**
- *Given* a leftover socket file with no listener, *When* `checkServerStatus` runs, *Then* the file is removed and reported as stale.
- *Given* a live server that accepts the connection but is unresponsive to `ping`, *When* `checkServerStatus` runs, *Then* the socket file is **preserved** and the server is reported as running-but-unresponsive.
- *Given* no socket file, *Then* it warns "not running" (unchanged).

## Before / After (evidence)

New test `packages/cli/test/doctor-server-status.test.ts`, against current `main` code:

```
not ok 3 - does NOT remove the socket of a live server that is unresponsive to ping
  error: 'socket of a live (connection-accepting) server must not be deleted'
  expected: true   actual: false
# pass 2  # fail 1
```

After the fix:

```
# tests 3  # pass 3  # fail 0
```

Full gate (Linux x64, Node v22.22.2):
- `pnpm -r build` ✓
- `./scripts/test.sh` (root `test/unit/*.test.js`) → **697 pass, 0 fail**
- `pnpm --filter @grafema/cli test:unit` (CI-gated; now includes the new file) → **87 pass, 0 fail**
- `pnpm typecheck` ✓ (no TS errors)
- `pnpm lint` ✓ (clean)

## Adversarial review

**Round A — Correctness (Dijkstra).** `connect` ok + `ping` ok → `pass` (unchanged). `connect` ok + `ping` throws (timeout / connection-closed / server error) → preserve socket, warn unresponsive. `connect` fails (`ECONNREFUSED`/`ENOENT`/`ENOTSOCK`) → remove stale socket, warn. If `close()` throws on the success path it now falls to the unresponsive-warn branch *without* deleting — strictly safer than the previous behavior (which would have deleted). `'error'` events are suppressed, so no unhandled-error crash.

**Round B — Structural (Uncle Bob).** `checks.ts` is a pre-existing 759-line file (>500-line guideline); this change adds ~26 lines and does not introduce the god-file. Extracting `checks.ts` is a separate refactor, intentionally out of scope. The function stays cohesive and is documented for agents.

**Round C — Class-not-instance.** Audited every `unlinkSync(socket)` site:
- `startRfdbServer.ts:149`, `server.ts:186/210`, `start.ts:*` — **intentional lifecycle** (reclaim socket before bind / clean up on child close), guarded by PID liveness checks. Correct, not the bug.
- `packages/vscode/src/grafemaClient.ts:431-442` — **true sibling** (probe `connect`+`ping`, `unlinkSync` on catch), but inside a deliberate kill+restart flow, so a false positive causes an *unnecessary restart* rather than silent breakage with no recovery. Different severity/semantics → **follow-up**, not folded in here to avoid scope-creep and changing VS Code restart behavior.

## Blast radius

`checkServerStatus` is called only by the `grafema doctor` flow (`packages/cli/src/commands/doctor/`). No other callers. Behavior change is limited to the failure branch: a previously-deleted live socket is now preserved.

## Follow-ups
- [ ] `vscode/src/grafemaClient.ts startServer()` shares the latent "delete on ping failure" pattern (softer severity). Decide whether to skip the restart when the server accepted the connection but is slow to `ping`.
- [ ] `KNOWN_LIMITATIONS.md` "RFDB stale socket" entry is stale — the socket is auto-cleaned (now correctly, only when stale).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015NgyHXC9cMur4geVykhWRi)_