### PR TITLE
fix(util): resolve extensionless & directory imports to .mts/.cts files

### DIFF
--- a/packages/util/src/utils/moduleResolution.ts
+++ b/packages/util/src/utils/moduleResolution.ts
@@ -16,8 +16,15 @@ import { dirname, extname, resolve, join } from 'path';
 /**
  * Default file extensions to try when resolving modules.
  * Order: exact match first, then JS variants, then TS variants.
+ *
+ * MUST stay aligned with the set of JS/TS extensions the orchestrator indexes —
+ * `is_js_ts_file` in packages/grafema-orchestrator/src/analyzer.rs
+ * (`js | jsx | ts | tsx | mjs | cjs | mts | cts`) — otherwise an indexed
+ * definition file becomes unreachable to extensionless/directory imports.
+ * `.mts`/`.cts` are appended last so the resolution order of every
+ * previously-resolving specifier is unchanged.
  */
-export const DEFAULT_EXTENSIONS = ['', '.js', '.mjs', '.cjs', '.jsx', '.ts', '.tsx'];
+export const DEFAULT_EXTENSIONS = ['', '.js', '.mjs', '.cjs', '.jsx', '.ts', '.tsx', '.mts', '.cts'];
 
 /**
  * TypeScript extension redirects (REG-426).
@@ -35,6 +42,10 @@ const TS_EXTENSION_REDIRECTS: Record<string, string[]> = {
 /**
  * Default index files to try when resolving directory imports.
  * Order: JS variants first (most common), then TS variants.
+ *
+ * Covers the same JS/TS extension set the orchestrator indexes (see
+ * `DEFAULT_EXTENSIONS`). `index.mts`/`index.cts` are appended last so the
+ * resolution order of every previously-resolving directory import is unchanged.
  */
 export const DEFAULT_INDEX_FILES = [
   'index.js',
@@ -42,7 +53,9 @@ export const DEFAULT_INDEX_FILES = [
   'index.mjs',
   'index.cjs',
   'index.jsx',
-  'index.tsx'
+  'index.tsx',
+  'index.mts',
+  'index.cts'
 ];
 
 /**
@@ -87,7 +100,7 @@ export interface ModuleResolutionOptions {
 
   /**
    * Extensions to try (in order).
-   * Default: ['', '.js', '.mjs', '.cjs', '.jsx', '.ts', '.tsx']
+   * Default: ['', '.js', '.mjs', '.cjs', '.jsx', '.ts', '.tsx', '.mts', '.cts']
    *
    * Empty string '' means try exact path first.
    */
@@ -95,7 +108,7 @@ export interface ModuleResolutionOptions {
 
   /**
    * Index files to try (in order).
-   * Default: ['index.js', 'index.ts', 'index.mjs', 'index.cjs', 'index.jsx', 'index.tsx']
+   * Default: ['index.js', 'index.ts', 'index.mjs', 'index.cjs', 'index.jsx', 'index.tsx', 'index.mts', 'index.cts']
    */
   indexFiles?: string[];
 }

--- a/test/unit/moduleResolutionMtsCts.test.js
+++ b/test/unit/moduleResolutionMtsCts.test.js
@@ -1,0 +1,102 @@
+/**
+ * Module resolution — `.mts` / `.cts` extension coverage.
+ *
+ * The shared `resolveModulePath` utility (packages/util/src/utils/moduleResolution.ts)
+ * is consumed by MountPointResolver, JSModuleIndexer, FunctionCallResolver and
+ * IncrementalModuleIndexer. Its candidate-extension set MUST equal the set of
+ * JS/TS extensions the orchestrator actually indexes — `is_js_ts_file` in
+ * packages/grafema-orchestrator/src/analyzer.rs:326:
+ *
+ *   matches!(ext, "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" | "mts" | "cts")
+ *
+ * `DEFAULT_EXTENSIONS` / `DEFAULT_INDEX_FILES` historically omitted `.mts` and
+ * `.cts` (the `TS_EXTENSION_REDIRECTS` map only rescued *explicit* `.mjs`/`.cjs`
+ * specifiers). As a result an extensionless relative import — `import './foo'` —
+ * whose definition lives in `foo.mts` / `foo.cts`, and a directory import whose
+ * entry point is `index.mts` / `index.cts`, resolved to `null` even though the
+ * orchestrator had indexed those files. This left a real, graph-present
+ * definition unreachable to the resolver.
+ *
+ * Acceptance (BDD):
+ *   Given a definition that exists ONLY in a `.mts` (resp. `.cts`) file,
+ *   When `resolveModulePath` is asked for the extensionless base path,
+ *   Then it resolves to that `.mts` (resp. `.cts`) file.
+ *   And the same holds for directory imports resolving to `index.mts`/`index.cts`.
+ *   And every previously-resolving case (`.ts`/`.js`/...) is byte-for-byte unchanged.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { resolveModulePath, DEFAULT_EXTENSIONS, DEFAULT_INDEX_FILES } from '@grafema/util';
+
+let dir;
+
+before(() => {
+  dir = mkdtempSync(join(tmpdir(), 'grafema-mr-mtscts-'));
+
+  // Definitions that exist ONLY in .mts / .cts (no JS/TS sibling).
+  writeFileSync(join(dir, 'alpha.mts'), 'export const a = 1;\n');
+  writeFileSync(join(dir, 'beta.cts'), 'export const b = 1;\n');
+
+  // Directory entry points in .mts / .cts.
+  mkdirSync(join(dir, 'pkgm'));
+  writeFileSync(join(dir, 'pkgm', 'index.mts'), 'export const m = 1;\n');
+  mkdirSync(join(dir, 'pkgc'));
+  writeFileSync(join(dir, 'pkgc', 'index.cts'), 'export const c = 1;\n');
+
+  // Controls — must keep resolving exactly as before.
+  writeFileSync(join(dir, 'gamma.ts'), 'export const g = 1;\n');
+  mkdirSync(join(dir, 'pkgts'));
+  writeFileSync(join(dir, 'pkgts', 'index.ts'), 'export const t = 1;\n');
+
+  // Preference control: when both .ts and .mts exist, .ts still wins (no regression).
+  writeFileSync(join(dir, 'both.ts'), 'export const x = 1;\n');
+  writeFileSync(join(dir, 'both.mts'), 'export const x = 2;\n');
+});
+
+after(() => {
+  if (dir) {
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+});
+
+describe('resolveModulePath — .mts / .cts coverage', () => {
+  it('resolves an extensionless import to a .mts definition', () => {
+    assert.equal(resolveModulePath(join(dir, 'alpha')), join(dir, 'alpha.mts'));
+  });
+
+  it('resolves an extensionless import to a .cts definition', () => {
+    assert.equal(resolveModulePath(join(dir, 'beta')), join(dir, 'beta.cts'));
+  });
+
+  it('resolves a directory import to index.mts', () => {
+    assert.equal(resolveModulePath(join(dir, 'pkgm')), join(dir, 'pkgm', 'index.mts'));
+  });
+
+  it('resolves a directory import to index.cts', () => {
+    assert.equal(resolveModulePath(join(dir, 'pkgc')), join(dir, 'pkgc', 'index.cts'));
+  });
+
+  it('still resolves extensionless .ts (control, unchanged)', () => {
+    assert.equal(resolveModulePath(join(dir, 'gamma')), join(dir, 'gamma.ts'));
+  });
+
+  it('still resolves directory index.ts (control, unchanged)', () => {
+    assert.equal(resolveModulePath(join(dir, 'pkgts')), join(dir, 'pkgts', 'index.ts'));
+  });
+
+  it('prefers .ts over .mts when both exist (determinism, no regression)', () => {
+    assert.equal(resolveModulePath(join(dir, 'both')), join(dir, 'both.ts'));
+  });
+
+  it('exposes .mts/.cts in the canonical extension/index lists', () => {
+    assert.ok(DEFAULT_EXTENSIONS.includes('.mts'), 'DEFAULT_EXTENSIONS must include .mts');
+    assert.ok(DEFAULT_EXTENSIONS.includes('.cts'), 'DEFAULT_EXTENSIONS must include .cts');
+    assert.ok(DEFAULT_INDEX_FILES.includes('index.mts'), 'DEFAULT_INDEX_FILES must include index.mts');
+    assert.ok(DEFAULT_INDEX_FILES.includes('index.cts'), 'DEFAULT_INDEX_FILES must include index.cts');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the last unfixed instance of the **resolver-extension-set invariant** that PR #372 established and recorded as a follow-up: the shared module resolver still omitted `.mts`/`.cts`.

`resolveModulePath` ([`packages/util/src/utils/moduleResolution.ts`](../blob/main/packages/util/src/utils/moduleResolution.ts)) is the **single** resolver consumed by `MountPointResolver`, `JSModuleIndexer`, `FunctionCallResolver` and `IncrementalModuleIndexer` (file header, lines 4-8). Its candidate set must equal the JS/TS extensions the orchestrator indexes — `is_js_ts_file` in [`packages/grafema-orchestrator/src/analyzer.rs:326`](../blob/main/packages/grafema-orchestrator/src/analyzer.rs#L326):

```rust
matches!(ext, "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" | "mts" | "cts")
```

`DEFAULT_EXTENSIONS` was `['', '.js', '.mjs', '.cjs', '.jsx', '.ts', '.tsx']` and `DEFAULT_INDEX_FILES` lacked `index.mts`/`index.cts`. `TS_EXTENSION_REDIRECTS` only rescued **explicit** `.mjs`/`.cjs` specifiers. So an **extensionless** import `import './foo'` whose definition lives in `foo.mts`/`foo.cts`, and a **directory** import whose entry point is `index.mts`/`index.cts`, resolved to `null` — even though the orchestrator had already indexed those files into the graph. A graph-present definition was unreachable to the resolver.

## Spec

- **Invariant restored:** the candidate-extension/index set used by `resolveModulePath` equals the set of JS/TS extensions the orchestrator indexes. No indexed definition is unreachable to an extensionless/directory import.
- **Given** a definition that exists ONLY in `foo.mts` (resp. `.cts`, resp. `pkg/index.mts`, `pkg/index.cts`)
  **When** `resolveModulePath` is asked for the extensionless base path / directory
  **Then** it resolves to that `.mts`/`.cts` file.
  **And** every previously-resolving case (`.ts`/`.js`/`index.ts`/…) is byte-for-byte unchanged, incl. `.ts`-over-`.mts` preference when both exist.
- **Blast radius:** `DEFAULT_EXTENSIONS`/`DEFAULT_INDEX_FILES` are consumed only by `resolveModulePath`/`resolveRelativeSpecifier` in this file. The change is **append-only** — `.mts`/`.cts` are added **last**, so every specifier that already matched one of the first 7 candidates returns the identical first match; only the three previously-missed forms newly resolve. Fixing the shared utility closes the class across all four consuming resolvers.

## Fix

`packages/util/src/utils/moduleResolution.ts`:
- `DEFAULT_EXTENSIONS` → `['', '.js', '.mjs', '.cjs', '.jsx', '.ts', '.tsx', '.mts', '.cts']`
- `DEFAULT_INDEX_FILES` → append `'index.mts'`, `'index.cts'`
- Both lists' doc comments now cite `analyzer.rs` as the authoritative drift-guard source of truth, and the `ModuleResolutionOptions` JSDoc defaults updated to match.

## Before / After (evidence)

**Repro on current `main` build** (direct call, no test harness):
```
extensionless -> .mts            => null
extensionless -> .cts            => null
dir index -> index.mts           => null
dir index -> index.cts           => null
control extensionless -> .ts     => /tmp/mr-.../gamma.ts
```

**RED** — new `test/unit/moduleResolutionMtsCts.test.js` against pre-fix code:
```
# tests 8  # pass 3  # fail 5
not ok 1 - resolves an extensionless import to a .mts definition
  expected: '.../alpha.mts'   actual: ~      (null)
```
(The 3 that pass are the controls — `.ts`/`index.ts`/`.ts`-over-`.mts` — precisely isolating the gap.)

**GREEN** — after fix: `# tests 8  # pass 8  # fail 0`

**Full gate** (Linux x64, Node 22, `GRAFEMA_RFDB_SERVER` = prebuilt linux-x64):
```
pnpm -r build (JS pkgs)  → exit 0
./scripts/test.sh        → # tests 705  # pass 705  # fail 0   (697 baseline + 8 new)
pnpm typecheck           → clean (platform-only WARNs)
pnpm lint                → clean
```
The test lives at top-level `test/unit/*.test.js` so it is picked up by CI's `test:coverage` glob (the existing `test/unit/utils/moduleResolution.test.js` is in a subdir the glob excludes — orphaned from CI).

## Adversarial review

- **Round A (correctness):** Append-only ordering ⇒ every previously-resolving specifier keeps its first match (proven by 3 control tests incl. `.ts`-over-`.mts` determinism). Explicit `.mts`/`.cts` imports already matched via the `''` exact-path arm — unchanged. `.mjs→.mts`/`.cjs→.cts` redirects untouched. No false positive: `./foo.mjs` + `.mts` candidate is `./foo.mjs.mts`, which never exists.
- **Round B (fragility):** File is ~290 lines (<500). Two explicit lists kept (their intentional orderings — exact/JS/TS vs JS-common-first — make derivation lossy); drift hardened by documenting `analyzer.rs` as the single source of truth.
- **Round C (class-not-instance):** This *is* the shared resolver, so the fix lands across all four consumers at once. Other **independent** hardcoded JS/TS extension lists still omit `.mts`/`.cts` on `main` and live in separate subsystems with their own surfaces — recorded as follow-ups below, not folded in (scope discipline).

## Sibling latent sites (follow-ups, NOT in this PR — verified still missing `.mts`/`.cts` on `main`)

- [ ] `packages/util/src/core/CoverageAnalyzer.ts:22` — `JS_SUPPORTED = ['.js','.mjs','.cjs','.jsx','.ts','.tsx']`
- [ ] `packages/cli/src/commands/query.ts:398` — file-path routing extension list
- [ ] `packages/cli/src/utils/quickstart.ts` — discovery list (per #372)
- [ ] `packages/vscode/src/initRunner.ts` — init discovery list (per #372)

Recommend the single consolidation #372 proposed: export one canonical JS/TS extension set from a TS module (mirroring `analyzer.rs`) and point all sites at it.

## Notes

No open GitHub issue and no Linear access this run. This defect is the explicit follow-up #372 recorded (`moduleResolution.ts DEFAULT_EXTENSIONS`), confirmed live on current `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHb1YpZ8jfAKkZPHdmCQ8z)_