### PR TITLE
fix(rust-analyzer): emit CALL nodes for macro invocations and walk their args

### DIFF
--- a/packages/grafema-orchestrator/src/rust_analyzer.rs
+++ b/packages/grafema-orchestrator/src/rust_analyzer.rs
@@ -1382,7 +1382,7 @@ fn walk_stmt(stmt: &syn::Stmt, ctx: &mut Ctx) {
         syn::Stmt::Local(local) => walk_let(local, ctx),
         syn::Stmt::Item(item) => walk_item(item, ctx),
         syn::Stmt::Expr(expr, _semi) => walk_expr(expr, ctx),
-        syn::Stmt::Macro(_) => {}
+        syn::Stmt::Macro(m) => walk_macro(&m.mac, ctx),
     }
 }
 
@@ -1408,6 +1408,66 @@ fn walk_let(local: &syn::Local, ctx: &mut Ctx) {
                     dst: init_node_id.clone(),
                     edge_type: "ASSIGNED_FROM".to_string(),
                     metadata: HashMap::new(),
+                });
+            }
+        }
+    }
+}
+
+/// Walk a Rust macro invocation: `name!(...)`, `name![...]`, or `name!{...}`.
+///
+/// `syn` does not expand macros, so the body is an opaque `TokenStream` rather
+/// than a parsed AST. We model the invocation itself as a CALL node tagged
+/// `macro=true` — honouring the KNOWN_LIMITATIONS contract that "macro
+/// invocations appear as CALL nodes" and letting downstream passes tell a
+/// macro call apart from a real function call. We do NOT defer a CALLS
+/// reference for the macro name: `foo!` is not the function `foo`.
+///
+/// Best-effort, we then parse the body as a comma-separated expression list and
+/// walk each argument, so calls/references nested inside common function-like
+/// macros (`vec![a(), b]`, `println!("{}", compute())`, `assert_eq!(x, y())`)
+/// are still recorded in the graph — otherwise they would be silently lost.
+/// Macros whose body is not an expression list (e.g. `matches!`, `quote!`)
+/// simply contribute no argument edges; the parse failure is swallowed, never
+/// a panic.
+fn walk_macro(mac: &syn::Macro, ctx: &mut Ctx) {
+    let name = path_to_string(&mac.path);
+    let span = mac.path.segments.last()
+        .map(|s| s.ident.span())
+        .unwrap_or_else(Span::call_site);
+    let (line, col) = ctx.span_line_col(span);
+    let parent = ctx.enclosing_fn.as_deref();
+    let hash = ctx.pos_hash(line, col);
+    let node_id = semantic_id(&ctx.file, "CALL", &name, parent, Some(&hash));
+    let (end_line, end_col) = ctx.span_end_line_col(span);
+
+    ctx.emit_node(GraphNode {
+        id: node_id.clone(),
+        node_type: "CALL".to_string(),
+        name: name.clone(),
+        file: ctx.file.clone(),
+        line, column: col,
+        end_line, end_column: end_col,
+        exported: false,
+        metadata: HashMap::from([
+            Ctx::meta_bool("method", false),
+            Ctx::meta_bool("macro", true),
+        ]),
+        extra: HashMap::new(),
+    });
+
+    // Best-effort argument walking; non-expression bodies are skipped safely.
+    if let Ok(args) = mac.parse_body_with(
+        syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated,
+    ) {
+        for (i, arg) in args.iter().enumerate() {
+            walk_expr(arg, ctx);
+            if let Some(arg_id) = expr_node_id(arg, ctx) {
+                ctx.emit_edge(GraphEdge {
+                    src: node_id.clone(),
+                    dst: arg_id,
+                    edge_type: "PASSES_ARGUMENT".to_string(),
+                    metadata: HashMap::from([Ctx::meta_int("index", i as i64)]),
                 });
             }
         }
@@ -1941,7 +2001,7 @@ fn walk_expr(expr: &syn::Expr, ctx: &mut Ctx) {
                 extra: HashMap::new(),
             });
         }
-        syn::Expr::Macro(_) => {}
+        syn::Expr::Macro(e) => walk_macro(&e.mac, ctx),
         // Inline `const { ... }` block — walk its body like Unsafe/Async blocks
         // so nested calls/references are not silently dropped from the graph.
         syn::Expr::Const(e) => walk_block(&e.block, ctx),
@@ -2715,5 +2775,65 @@ mod tests {
         assert!(has_edge(&fa, "CONTAINS", "TRAIT", "TYPE_ALIAS"), "TRAIT CONTAINS type");
         // The function signature is still emitted alongside the associated type.
         assert_eq!(count_nodes(&fa, "TYPE_SIGNATURE"), 1);
+    // ── Macro invocations ───────────────────────────────────────────────
+    // `syn` does not expand macros, so before this fix `Expr::Macro` and
+    // `Stmt::Macro` were dropped entirely. That violated KNOWN_LIMITATIONS'
+    // contract ("macro invocations appear as CALL nodes") and, worse, lost
+    // every call/reference nested inside macro arguments from the graph.
+
+    #[test]
+    fn test_macro_invocation_emits_call_node() {
+        let fa = parse_and_analyze("fn main() { println!(\"hello\"); }");
+        let call = fa.nodes.iter()
+            .find(|n| n.node_type == "CALL" && n.name == "println")
+            .expect("macro invocation should emit a CALL node");
+        assert_eq!(call.metadata.get("macro"), Some(&serde_json::json!(true)),
+            "macro CALL node tagged macro=true to distinguish from real fn calls");
+        assert_eq!(call.metadata.get("method"), Some(&serde_json::json!(false)),
+            "macro CALL is not a method call");
+    }
+
+    #[test]
+    fn test_nested_call_inside_macro_is_walked() {
+        // The real cost of dropping Expr::Macro: calls nested in macro args
+        // vanish from the graph. compute() inside println! must be captured.
+        let fa = parse_and_analyze(
+            "fn main() { println!(\"{}\", compute()); } fn compute() -> i32 { 0 }"
+        );
+        assert!(has_node(&fa, "CALL", "compute"),
+            "call nested inside a macro argument must be walked into the graph");
+        // The macro CALL passes the nested call as an argument.
+        assert!(has_edge(&fa, "PASSES_ARGUMENT", "CALL", "CALL"),
+            "macro should emit PASSES_ARGUMENT to its walked expression args");
+    }
+
+    #[test]
+    fn test_macro_expr_and_stmt_positions_walk_args() {
+        // `vec![...]` as a let initializer is Expr::Macro; `assert_eq!(...)` as a
+        // bare statement is Stmt::Macro. Both must emit CALL nodes and walk their
+        // comma-separated expression arguments.
+        let fa = parse_and_analyze(
+            "fn main() {
+                let v = vec![first(), second()];
+                assert_eq!(left(), right());
+            }
+            fn first() {} fn second() {} fn left() {} fn right() {}"
+        );
+        assert!(has_node(&fa, "CALL", "vec"), "vec! emits CALL (Expr::Macro)");
+        assert!(has_node(&fa, "CALL", "assert_eq"), "assert_eq! emits CALL (Stmt::Macro)");
+        for callee in ["first", "second", "left", "right"] {
+            assert!(has_node(&fa, "CALL", callee),
+                "nested call {callee} inside a macro must be walked");
+        }
+    }
+
+    #[test]
+    fn test_non_expression_macro_body_no_panic() {
+        // A macro whose body is not a comma-separated expression list (here a
+        // match-style pattern arm) must not panic and must still emit the macro
+        // CALL node — argument walking is strictly best-effort.
+        let fa = parse_and_analyze("fn main() { let _ = matches!(x, Some(_)); }");
+        assert!(has_node(&fa, "CALL", "matches"),
+            "matches! emits a CALL node even though its body isn't an expr list");
     }
 }


### PR DESCRIPTION
## Summary

The in-process Rust analyzer dropped **macro invocations entirely**: in `walk_expr`/`walk_stmt` the `syn::Expr::Macro` ([`rust_analyzer.rs:1684`](../blob/main/packages/grafema-orchestrator/src/rust_analyzer.rs#L1684)) and `syn::Stmt::Macro` ([`:1125`](../blob/main/packages/grafema-orchestrator/src/rust_analyzer.rs#L1125)) arms were empty no-ops (`=> {}`).

This violated the analyzer's own documented contract — `KNOWN_LIMITATIONS.md` (Cross-Language): *"Macro expansion (Rust) — macro invocations **appear as CALL nodes**, no expansion"* — they did **not** appear at all. Worse, because the macro body was never walked, **every call/reference nested inside a macro's arguments was lost from the graph**: `compute()` in `println!("{}", compute())`, `build()` in `vec[build()]`, nested calls in `assert_eq!`, `tokio::spawn`-style macros, etc. The call graph and backward dataflow had silent holes everywhere macros were used — a direct hit to the core thesis (the graph must be trustworthy enough to query instead of reading code).

No open GitHub issue / no Linear access this run; surfaced by auditing the analyzer's no-op AST arms against the documented `KNOWN_LIMITATIONS` contract. Avoided the `walk_impl_item` / `walk_trait` area (open PR #375).

## Spec

- **Invariant restored:** a Rust macro invocation in expression or statement position produces a CALL node (per the documented contract), and expression arguments inside common function-like macros are walked so nested calls/references are not silently dropped.
- **Given** `fn main() { println!("{}", compute()); }`
  **When** `analyze_rust_file` runs
  **Then** there is a CALL node `println` (metadata `macro=true`, `method=false`) **and** a CALL node `compute` (the nested arg was walked), with a `PASSES_ARGUMENT` edge from the macro CALL to the walked arg.
- **And** both positions are covered: `let v = vec[first(), second()]` (`Expr::Macro`) and `assert_eq!(left(), right());` (`Stmt::Macro`) each emit a CALL node and walk their args.
- **And** a non-expression macro body (`matches!(x, Some(_))`) still emits the macro CALL node and never panics — argument walking is strictly best-effort.

## Fix

Both arms now route through a new documented `walk_macro` helper (`rust_analyzer.rs`):
- Emits a `CALL` node for the invocation, tagged `macro=true` so downstream passes can distinguish it from a real function call. It intentionally does **not** `defer_ref` a `CALLS` reference for the macro name — `foo!` is not the function `foo`.
- Best-effort parses the body as `Punctuated<Expr, Comma>` (`parse_body_with`) and walks each argument, recording nested calls/refs and `PASSES_ARGUMENT` edges. Bodies that aren't expression lists (`matches!`, `quote!`, `vec[0; N]` repeat syntax) fail this parse and are skipped safely — no panic.

## Before / After (evidence)

New tests in `rust_analyzer.rs` `mod tests`, against pre-fix code:

```
RED:
  test_macro_invocation_emits_call_node ........ FAILED  (no CALL node "println")
  test_nested_call_inside_macro_is_walked ...... FAILED  (no CALL node "compute")
  test_macro_expr_and_stmt_positions_walk_args . FAILED  (vec! emits no CALL)
  test_non_expression_macro_body_no_panic ...... FAILED  (no CALL node "matches")
  test result: FAILED. 0 passed; ... failed
```

After the fix:

```
GREEN:
  cargo test --lib macro
  test rust_analyzer::tests::test_macro_invocation_emits_call_node ... ok
  test rust_analyzer::tests::test_non_expression_macro_body_no_panic ... ok
  test rust_analyzer::tests::test_nested_call_inside_macro_is_walked ... ok
  test rust_analyzer::tests::test_macro_expr_and_stmt_positions_walk_args ... ok
  test result: ok. 4 passed; 0 failed
```

Full gate (Linux x64, cargo 1.94):
```
cargo test --lib            → ok. 425 passed; 0 failed  (421 baseline + 4 new)
cargo clippy --lib          → exit 0 (no warnings on rust_analyzer.rs / walk_macro)
cargo build                 → Finished dev profile (compiles; 1 pre-existing bin warning)
```
JS suites unaffected — this is a Rust-only change isolated to the `grafema-orchestrator` crate with no interface change; the `test/unit` and snapshot suites exercise JS/TS analysis, not the Rust analyzer.

## Adversarial review

- **Round A — Correctness (Dijkstra).** Empty body `foo!()` → `parse_terminated` yields an empty list → CALL emitted, no args (correct). Repeat syntax `vec[0; 100]` and pattern bodies `matches!(x, Some(_))` → parse fails → CALL emitted, args skipped (no panic — covered by a test). Path macros `std::println!(...)` → name `"std::println"`, no defer (correct). Nested macros recurse through `walk_expr` → inner macro also handled. The macro CALL is tagged `macro=true` and carries **no** deferred `CALLS` reference, so it cannot be falsely resolved to a same-named function by the deferred resolver.
- **Round B — Structural (Uncle Bob).** Logic is extracted into one cohesive `walk_macro` helper shared by both call sites, so `Expr::Macro` and `Stmt::Macro` cannot drift. `rust_analyzer.rs` is a pre-existing large dispatch file (was 2289 lines); this change adds a focused ~60-line helper and does not introduce or materially worsen the god-file — a split of this file is a separate refactor, intentionally out of scope.
- **Round C — Class-not-instance.** Audited the other no-op macro arms. `Item::Macro` (`:489`, e.g. `lazy_static!{}`, `thread_local!{}`, `macro_rules!` defs) and `ImplItem::Macro` (`:944`) are **declaration-position** macros whose bodies generate *items*, not expression lists — a genuinely different sub-case that the expr-list parse would not handle. Left as follow-ups rather than folded in (scope discipline). `Pat::Macro`/`Type` macros are rarer still. This PR fixes the common, high-value **call-position** class (expr + stmt).

## Blast radius

`walk_macro` is reached only from the `Expr::Macro` / `Stmt::Macro` arms. It is purely additive to graph output: previously these produced **zero** nodes/edges, so no existing node/edge is changed or removed — only new `CALL` nodes (`macro=true`), their walked argument nodes, and `PASSES_ARGUMENT` edges are added. No existing test changed.

## Follow-ups (filed as recorded notes, NOT in this PR)
- [ ] `Item::Macro` (`rust_analyzer.rs:489`) and `ImplItem::Macro` (`:944`) — declaration-position macros still no-op; need item-generating handling.
- [ ] Unrelated but recorded this run: the Haskell resolve layer has the same `.mts`/`.cts` extension drift (`grafema-resolve/src/ClassInheritance.hs:77`, `JsThisMethodCalls.hs:45`) dropping EXTENDS/INSTANCE_OF/`this.method()` edges for `.mts`/`.cts` files — not fixable here (no Haskell toolchain in this environment).

---
_Generated by [Claude Code](https://claude.ai/code/session_01719v9SJt29huQuEu91F4iS)_