### PR TITLE
fix(util): count .mts/.cts files in CoverageAnalyzer (un-inflate coverage)

### DIFF
--- a/packages/util/src/core/CoverageAnalyzer.ts
+++ b/packages/util/src/core/CoverageAnalyzer.ts
@@ -17,9 +17,17 @@ import { join, relative, extname } from 'path';
 import type { GraphBackend } from '@grafema/types';
 
 /**
- * Supported file extensions by language
+ * Supported file extensions by language.
+ *
+ * The JS/TS set MUST match the orchestrator's authoritative `is_js_ts_file`
+ * (`packages/grafema-orchestrator/src/analyzer.rs`: `js | jsx | ts | tsx |
+ * mjs | cjs | mts | cts`) — that function decides which files are indexed into
+ * the graph as MODULE nodes. If this list omits an extension the orchestrator
+ * indexes, an on-disk file of that extension that is NOT in the graph is never
+ * scanned (see {@link CODE_EXTENSIONS} / `walkDirectory`), so it silently drops
+ * out of `total` and the `unreachable` breakdown — inflating coverage %.
  */
-const JS_SUPPORTED = ['.js', '.mjs', '.cjs', '.jsx', '.ts', '.tsx'];
+const JS_SUPPORTED = ['.js', '.mjs', '.cjs', '.jsx', '.ts', '.tsx', '.mts', '.cts'];
 const RUST_SUPPORTED = ['.rs'];
 const SUPPORTED_EXTENSIONS = new Set([...JS_SUPPORTED, ...RUST_SUPPORTED]);
 

--- a/test/unit/coverageAnalyzerMtsCts.test.js
+++ b/test/unit/coverageAnalyzerMtsCts.test.js
@@ -1,0 +1,118 @@
+/**
+ * Regression: CoverageAnalyzer must treat `.mts`/`.cts` as supported JS/TS files.
+ *
+ * The orchestrator's authoritative `is_js_ts_file`
+ * (`packages/grafema-orchestrator/src/analyzer.rs:325`) indexes EIGHT JS/TS
+ * extensions:
+ *
+ *   js | jsx | ts | tsx | mjs | cjs | mts | cts
+ *
+ * but CoverageAnalyzer's `JS_SUPPORTED` listed only six, omitting `.mts`/`.cts`.
+ * Because `CODE_EXTENSIONS` (the disk-scan filter) derives from `JS_SUPPORTED`,
+ * a `.mts`/`.cts` file present on disk but NOT in the graph — the `unreachable`
+ * category — was never scanned, so it vanished from `total` entirely. That
+ * silently INFLATES the reported coverage percentage: the very files Grafema
+ * failed to analyze are the ones it should be surfacing as a coverage gap.
+ *
+ * This test is hermetic — no analyzer binary, no `grafema analyze`, no rfdb
+ * server. It feeds a fake graph (mirroring how the symlink-root regression test
+ * does) and real on-disk fixture files.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  realpathSync,
+  rmSync,
+  existsSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { CoverageAnalyzer } from '@grafema/util';
+
+/**
+ * Minimal GraphBackend stand-in yielding MODULE/ISSUE nodes the analyzer queries
+ * via `queryNodes({ type })`. MODULE file paths are canonical ABSOLUTE paths,
+ * matching what the real analyzer emits.
+ */
+class FakeGraph {
+  constructor(moduleAbsoluteFiles = []) {
+    this.moduleFiles = moduleAbsoluteFiles;
+  }
+
+  async *queryNodes(filter) {
+    if (filter && filter.type === 'MODULE') {
+      for (const file of this.moduleFiles) {
+        yield {
+          id: `module:${file}`,
+          type: 'MODULE',
+          nodeType: 'MODULE',
+          name: file.split('/').pop() || file,
+          file,
+          line: 1,
+          column: 0,
+          metadata: '{}',
+        };
+      }
+    }
+    // No ISSUE nodes in these fixtures.
+  }
+}
+
+describe('CoverageAnalyzer — .mts/.cts are supported JS/TS extensions', () => {
+  let root;
+
+  beforeEach(() => {
+    root = realpathSync(mkdtempSync(join(tmpdir(), 'cov-mts-')));
+    mkdirSync(join(root, 'src'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (root && existsSync(root)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it('reports on-disk .mts/.cts files not in the graph as unreachable', async () => {
+    // Three supported source files on disk, none in the graph.
+    writeFileSync(join(root, 'src', 'index.ts'), 'export const x = 1;'); // control
+    writeFileSync(join(root, 'src', 'esm.mts'), 'export const y = 2;');
+    writeFileSync(join(root, 'src', 'cjs.cts'), 'export const z = 3;');
+
+    const analyzer = new CoverageAnalyzer(new FakeGraph(), root);
+    const result = await analyzer.analyze();
+
+    assert.strictEqual(result.total, 3, 'all three supported files must be counted');
+    assert.strictEqual(result.unreachable.count, 3, 'all three are supported-but-not-in-graph');
+    assert.strictEqual(result.unsupported.count, 0, '.mts/.cts must not be reported as unsupported');
+    assert.ok(
+      result.unreachable.byExtension['.mts'],
+      '.mts must appear in the unreachable extension breakdown',
+    );
+    assert.ok(
+      result.unreachable.byExtension['.cts'],
+      '.cts must appear in the unreachable extension breakdown',
+    );
+  });
+
+  it('does not inflate coverage % by dropping an unreachable .mts file', async () => {
+    // One analyzed .ts (MODULE node) + one .mts on disk that was NOT analyzed.
+    writeFileSync(join(root, 'src', 'index.ts'), 'export const x = 1;');
+    writeFileSync(join(root, 'src', 'esm.mts'), 'export const y = 2;');
+
+    const graph = new FakeGraph([join(root, 'src', 'index.ts')]);
+    const analyzer = new CoverageAnalyzer(graph, root);
+    const result = await analyzer.analyze();
+
+    assert.strictEqual(result.analyzed.count, 1, 'the .ts file is analyzed');
+    assert.strictEqual(result.unreachable.count, 1, 'the unreachable .mts must be counted');
+    assert.strictEqual(result.total, 2, 'both files contribute to total');
+    assert.strictEqual(
+      result.percentages.analyzed,
+      50,
+      'coverage must be 50%, not inflated to 100% by dropping the .mts file',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`CoverageAnalyzer` under-reports the file population for projects that use modern ESM/CJS TypeScript (`.mts`/`.cts`), **silently inflating the headline coverage percentage**.

The orchestrator's authoritative `is_js_ts_file` ([`packages/grafema-orchestrator/src/analyzer.rs:325`](../blob/main/packages/grafema-orchestrator/src/analyzer.rs#L325)) indexes **eight** JS/TS extensions into the graph as MODULE nodes:

```rust
matches!(ext, "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" | "mts" | "cts")
```

But `CoverageAnalyzer`'s `JS_SUPPORTED` ([`packages/util/src/core/CoverageAnalyzer.ts:22`](../blob/main/packages/util/src/core/CoverageAnalyzer.ts#L22)) listed only six — it omitted `.mts`/`.cts`. Since `CODE_EXTENSIONS` (the disk-scan filter used by `walkDirectory`, line 337) derives from `JS_SUPPORTED`, a `.mts`/`.cts` file present on disk but **not** in the graph — the `unreachable` category — is never scanned, so it drops out of `total` and the `unreachable` breakdown entirely. The very files Grafema failed to analyze (the coverage gap it exists to surface) become invisible, and `analyzed / total` rounds up.

No open GitHub issue, no Linear access this run. This defect is the explicit `CoverageAnalyzer.ts:22 JS_SUPPORTED` follow-up recorded by PRs #372 and #374, confirmed live on current `main`. It is fully isolated from those in-flight PRs (which touch `moduleResolution.ts` / `packageApiEnricher.ts`).

## Spec

- **Invariant restored:** the JS/TS extension set CoverageAnalyzer treats as supported equals the set the orchestrator indexes (`analyzer.rs` `is_js_ts_file`). No indexed-or-indexable file extension is invisible to coverage.
- **Given** a project containing on-disk `esm.mts` and `cjs.cts` files that are NOT in the graph
  **When** `analyze()` runs
  **Then** both are counted in `total` and reported under `unreachable.byExtension['.mts']` / `['.cts']` (not dropped, not mislabelled `unsupported`).
- **And** a project with one analyzed `.ts` plus one unreachable `.mts` reports `analyzed = 50%`, not an inflated `100%`.
- **Blast radius:** `JS_SUPPORTED` is the single source for `SUPPORTED_EXTENSIONS` and `CODE_EXTENSIONS`, both consumed only inside `CoverageAnalyzer`. `.mts`/`.cts` are appended to a membership `Set`, so every previously-counted extension behaves identically; only the two previously-missed extensions are newly counted.

## Fix

`packages/util/src/core/CoverageAnalyzer.ts`:
- `JS_SUPPORTED` → append `'.mts'`, `'.cts'`.
- Doc comment now cites `analyzer.rs` `is_js_ts_file` as the source of truth and explains the inflation failure mode, to harden against future drift.

## Before / After (evidence)

New hermetic test `test/unit/coverageAnalyzerMtsCts.test.js` (no analyzer binary, no `grafema analyze`, no rfdb server — `FakeGraph` + real fixture files), against pre-fix code:

```
RED:
  not ok 1 - reports on-disk .mts/.cts files not in the graph as unreachable
             all three supported files must be counted   (total: actual 1, expected 3)
  not ok 2 - does not inflate coverage % by dropping an unreachable .mts file
             the unreachable .mts must be counted        (unreachable.count: actual 0, expected 1)
  # tests 2  # pass 0  # fail 2
```

After the fix:

```
GREEN:
  ok 1 - reports on-disk .mts/.cts files not in the graph as unreachable
  ok 2 - does not inflate coverage % by dropping an unreachable .mts file
  # tests 2  # pass 2  # fail 0
```

Full gate (Linux x64, Node v22.22.2, `GRAFEMA_RFDB_SERVER` = prebuilt linux-x64):

```
pnpm install --no-frozen-lockfile  → ok
pnpm build                         → ok
./scripts/test.sh                  → # tests 699  # pass 699  # fail 0   (697 baseline + 2 new)
pnpm typecheck                     → clean (platform-only WARNs)
pnpm lint                          → clean
```

The test lives at top-level `test/unit/*.test.js`, so CI's `test:coverage` glob picks it up (mirroring the existing `coverageAnalyzerSymlinkedRoot.test.js` regression).

## Adversarial review

- **Round A — Correctness (Dijkstra).** `SUPPORTED_EXTENSIONS` / `CODE_EXTENSIONS` are `Set`s, so append order is irrelevant to membership. `extname('foo.mts').toLowerCase()` → `'.mts'` matches; `.MTS` is lowercased; `foo.d.mts` → `'.mts'`. An analyzed `.mts` (its MODULE node comes from the unfiltered `getAnalyzedFiles`) stays in `analyzedSet` and is skipped in the categorize loop → never double-counted as both analyzed and unreachable. No false positives.
- **Round B — Structural (Uncle Bob).** File is 349 lines (< 500). One source list (`JS_SUPPORTED`) feeds both derived `Set`s, so they cannot drift from each other; drift against the orchestrator is hardened by the new doc comment pointing at `analyzer.rs`.
- **Round C — Class-not-instance.** Within this file there is no other JS/TS extension list. The same `.mts`/`.cts` omission exists in sibling subsystems (see follow-ups); they have their own repro/test surfaces and folding them in would balloon this slice, so they are filed as follow-ups (scope discipline). `moduleResolution.ts` / `packageApiEnricher.ts` are deliberately untouched — they are in-flight in #374 / #372.

## Sibling latent sites (follow-ups, NOT in this PR — each still omits `.mts`/`.cts` on `main`)

- [ ] `packages/cli/src/utils/quickstart.ts` — `SUPPORTED_EXTENSIONS` discovery list (`js, jsx, mjs, cjs, ts, tsx` only)
- [ ] `packages/vscode/src/initRunner.ts` — init discovery list (same omission)
- [ ] `packages/cli/src/commands/query.ts:412` — `isFileScope` regex `/\.(ts|js|tsx|jsx|mjs|cjs)$/i` (mis-scopes a bare `app.mts` filename)
- [ ] In-flight elsewhere: `moduleResolution.ts` (#374), `packageApiEnricher.ts` (#372)

Recommend the single consolidation #372/#374 proposed: export one canonical JS/TS extension set from a TS module (mirroring `analyzer.rs`) and point all sites at it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Muz1oEPqx6YyQngawTocAR)_