### PR TITLE
fix(cli): recognize .mts/.cts in init discovery and query file-scope routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - perf(plugins): Datalog-based reimplementations of `shape-tracker`, `type-inference`, `method-call-resolver`, and `shape-verifier`, opt-in behind the `GRAFEMA_DATALOG_PLUGINS` env flag (comma-separated plugin names); the default path is byte-for-byte the existing legacy logic, relocated into `*Legacy` functions (REG-1128 Phase 3b+3c, #265)
 
 ### Bug Fixes
+- fix(cli): `grafema init` / `analyze --quickstart` discovery and `grafema query "X in foo.mts"` file-scope routing now recognize `.mts`/`.cts` TypeScript files — both CLI extension lists had drifted from the orchestrator's authoritative `is_js_ts_file` set, so ESM/CJS TypeScript files were silently excluded from the generated analysis glob and misrouted as symbol scopes (#378)
 - fix(rfdb): edge-lifting attributes hidden nodes to their actual containing function/class by walking `CONTAINS` ancestry, instead of collapsing them onto whichever visible node happens to be first in the file (REG-1132, #265)
 - fix(doctor): `checkServerStatus` removes a stale RFDB socket file so a leftover socket from a crashed server no longer blocks a clean restart (REG-1129, #265)
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "clean": "rm -rf dist",
     "start": "node dist/cli.js",
     "test": "node --import tsx --test test/*.test.ts",
-    "test:unit": "node --import tsx --test --test-concurrency=1 test/analyze-utils.test.ts test/formatNode.test.ts test/pathutils-resolveprojectroot.test.ts test/progressRenderer.test.ts test/query-raw-predicate-warning.test.ts"
+    "test:unit": "node --import tsx --test --test-concurrency=1 test/analyze-utils.test.ts test/formatNode.test.ts test/pathutils-resolveprojectroot.test.ts test/progressRenderer.test.ts test/query-raw-predicate-warning.test.ts test/extension-mts-cts-coverage.test.ts"
   },
   "keywords": [
     "grafema",

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -395,7 +395,8 @@ export function parseQuery(pattern: string): ParsedQuery {
  *
  * Heuristics:
  * - Contains "/" -> file path
- * - Ends with .ts, .js, .tsx, .jsx, .mjs, .cjs -> file path
+ * - Ends with a JS/TS extension (.ts/.js/.tsx/.jsx/.mjs/.cjs/.mts/.cts) -> file path
+ *   (mirrors the orchestrator's authoritative `is_js_ts_file` in analyzer.rs)
  *
  * Examples:
  *   "src/app.ts" -> true
@@ -408,8 +409,8 @@ export function isFileScope(scope: string): boolean {
   // Contains path separator
   if (scope.includes('/')) return true;
 
-  // Ends with common JS/TS extensions
-  const fileExtensions = /\.(ts|js|tsx|jsx|mjs|cjs)$/i;
+  // Ends with common JS/TS extensions (kept in sync with analyzer.rs is_js_ts_file)
+  const fileExtensions = /\.(ts|js|tsx|jsx|mjs|cjs|mts|cts)$/i;
   if (fileExtensions.test(scope)) return true;
 
   return false;

--- a/packages/cli/src/utils/quickstart.ts
+++ b/packages/cli/src/utils/quickstart.ts
@@ -9,10 +9,20 @@ import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from 
 import { stringify as stringifyYAML } from 'yaml';
 import { GRAFEMA_VERSION, getSchemaVersion } from '@grafema/util';
 
-/** All file extensions supported by Grafema's analyzers. */
+/**
+ * All file extensions supported by Grafema's analyzers.
+ *
+ * The JS/TS subset MUST mirror the orchestrator's authoritative
+ * `is_js_ts_file` (packages/grafema-orchestrator/src/analyzer.rs:
+ * `js | jsx | ts | tsx | mjs | cjs | mts | cts`). Keeping `.mts`/`.cts`
+ * here is what makes ESM/CJS TypeScript files discoverable by
+ * `grafema init` / `analyze --quickstart` and included in the generated
+ * analysis glob — without them such files are indexed by the orchestrator
+ * but never reach the analysis include set.
+ */
 export const SUPPORTED_EXTENSIONS = [
   // JavaScript / TypeScript
-  'js', 'jsx', 'mjs', 'cjs', 'ts', 'tsx',
+  'js', 'jsx', 'mjs', 'cjs', 'ts', 'tsx', 'mts', 'cts',
   // Rust
   'rs',
   // Java / Kotlin

--- a/packages/cli/test/extension-mts-cts-coverage.test.ts
+++ b/packages/cli/test/extension-mts-cts-coverage.test.ts
@@ -1,0 +1,82 @@
+/**
+ * JS/TS extension-set coverage for `.mts` / `.cts` (ESM/CJS TypeScript).
+ *
+ * The orchestrator's authoritative `is_js_ts_file`
+ * (packages/grafema-orchestrator/src/analyzer.rs) indexes
+ * `js | jsx | ts | tsx | mjs | cjs | mts | cts`. Any CLI-side extension
+ * list that is supposed to mirror that set MUST include `.mts`/`.cts`,
+ * otherwise files the orchestrator happily indexes become invisible to
+ * the CLI surface.
+ *
+ * This test pins the two `@grafema/cli` sites that drifted from that set:
+ *   1. `quickstart.ts` SUPPORTED_EXTENSIONS — drives `grafema init` /
+ *      `analyze --quickstart` discovery + the generated analysis glob.
+ *      Missing `.mts`/`.cts` ⇒ such files are never discovered/analyzed.
+ *   2. `query.ts` isFileScope — routes `grafema query "X in foo.mts"`.
+ *      Missing `.mts`/`.cts` ⇒ the file scope is misread as a symbol scope.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { isFileScope } from '../src/commands/query.js';
+import {
+  SUPPORTED_EXTENSIONS,
+  scanExtensions,
+  generateSmartConfig,
+} from '../src/utils/quickstart.js';
+
+describe('isFileScope (query.ts) — .mts/.cts file-scope routing', () => {
+  it('recognizes a .mts file as a file scope', () => {
+    assert.equal(isFileScope('app.mts'), true);
+  });
+
+  it('recognizes a .cts file as a file scope', () => {
+    assert.equal(isFileScope('config.cts'), true);
+  });
+
+  // Controls: the previously-working cases must stay unchanged.
+  it('still recognizes a .ts file as a file scope', () => {
+    assert.equal(isFileScope('app.ts'), true);
+  });
+
+  it('does not treat a bare identifier as a file scope', () => {
+    assert.equal(isFileScope('UserService'), false);
+  });
+});
+
+describe('SUPPORTED_EXTENSIONS / discovery (quickstart.ts) — .mts/.cts', () => {
+  it('SUPPORTED_EXTENSIONS includes mts and cts', () => {
+    assert.ok(SUPPORTED_EXTENSIONS.includes('mts'), 'expected "mts" in SUPPORTED_EXTENSIONS');
+    assert.ok(SUPPORTED_EXTENSIONS.includes('cts'), 'expected "cts" in SUPPORTED_EXTENSIONS');
+  });
+
+  it('scanExtensions counts .mts/.cts source files', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'grafema-mtscts-'));
+    try {
+      writeFileSync(join(dir, 'esm.mts'), 'export const x = 1;\n');
+      writeFileSync(join(dir, 'cjs.cts'), 'module.exports = {};\n');
+      writeFileSync(join(dir, 'plain.ts'), 'export const y = 2;\n'); // control
+
+      const counts = scanExtensions(dir);
+      assert.equal(counts.get('mts'), 1, '.mts file must be discovered');
+      assert.equal(counts.get('cts'), 1, '.cts file must be discovered');
+      assert.equal(counts.get('ts'), 1, '.ts control must still be discovered');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('generateSmartConfig include glob covers detected .mts/.cts', () => {
+    const counts = new Map<string, number>([
+      ['mts', 1],
+      ['cts', 1],
+    ]);
+    const cfg = generateSmartConfig(counts);
+    assert.match(cfg, /mts/, 'generated include glob must contain mts');
+    assert.match(cfg, /cts/, 'generated include glob must contain cts');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the two recorded `@grafema/cli` follow-ups from the `.mts`/`.cts` extension-drift class (PRs #372 / #374 checklists). Both CLI extension lists had drifted from the orchestrator's **authoritative** `is_js_ts_file` ([`packages/grafema-orchestrator/src/analyzer.rs:325`](../blob/main/packages/grafema-orchestrator/src/analyzer.rs#L325)):

```rust
matches!(ext, "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" | "mts" | "cts")
```

1. **`quickstart.ts` `SUPPORTED_EXTENSIONS`** ([line 15](../blob/main/packages/cli/src/utils/quickstart.ts#L15)) — JS/TS group was `js, jsx, mjs, cjs, ts, tsx`, omitting `mts`/`cts`. Used by `grafema init` and `analyze --quickstart`: `scanExtensions` counts files via `SUPPORTED_SET`, and `generateSmartConfig` builds the analysis `include` glob from the detected set. So an `.mts`/`.cts` file was **never discovered** and **excluded from the generated analysis glob** — even though the orchestrator indexes those extensions. A graph-present file class was unreachable to the entry-point that decides what gets analyzed.
2. **`query.ts` `isFileScope`** ([line 413](../blob/main/packages/cli/src/commands/query.ts#L413)) — regex `/\.(ts|js|tsx|jsx|mjs|cjs)$/i` omitted `mts`/`cts`, so `grafema query "X in foo.mts"` misread the file scope as a **symbol scope**, silently returning wrong/no results.

No open GitHub issue and no Linear access this run; these are the explicit `quickstart.ts:15` and `query.ts` follow-ups recorded in #372/#374, confirmed live on current `main`.

## Spec

- **Invariant restored:** the JS/TS extension set used by CLI discovery and file-scope routing equals the orchestrator's indexed JS/TS set. No file the orchestrator indexes is invisible to `init`/`quickstart` discovery or misrouted by `query`.
- **Given** a project whose only TS files are `a.mts` / `b.cts`
  **When** `scanExtensions` runs **Then** they are counted, and `generateSmartConfig`'s `include` glob covers `mts`/`cts`.
- **And Given** `grafema query "X in foo.mts"` **When** `isFileScope("foo.mts")` is evaluated **Then** it returns `true` (file scope), like `.ts`.
- **And** every previously-recognized case is unchanged (`.ts` file scope still `true`; a bare identifier still `false`; `.d.ts` already matched via the `ts` suffix).
- **Blast radius:** `SUPPORTED_EXTENSIONS` is consumed only by `scanExtensions`/`generateSmartConfig` (Set/Map-keyed — order-independent, deduped); the change is append-only. `isFileScope` adds two regex alternatives. No existing behavior changes; only the three previously-missed forms newly resolve.

## Before / After (evidence)

New backend-free test `packages/cli/test/extension-mts-cts-coverage.test.ts`, against pre-fix `main`:

```
RED:
  not ok - recognizes a .mts file as a file scope          (isFileScope → false)
  not ok - recognizes a .cts file as a file scope          (isFileScope → false)
  not ok - SUPPORTED_EXTENSIONS includes mts and cts
  not ok - scanExtensions counts .mts/.cts source files     (mts → undefined !== 1)
  # pass 3  # fail 4
```
(The 3 passing are the controls — `.ts` file scope, bare-identifier non-scope, and the glob-builder path with a directly-supplied Map — precisely isolating the gap.)

After the fix:
```
GREEN:
  # tests 7  # pass 7  # fail 0
```

Full gate (Linux x64, Node v22.22.2, `GRAFEMA_RFDB_SERVER` = prebuilt linux-x64):
```
pnpm install --no-frozen-lockfile        → ok
pnpm build                               → ok (exit 0)
./scripts/test.sh                        → # tests 699  # pass 699  # fail 0
pnpm --filter @grafema/cli test:unit     → # tests 91   # pass 91   # fail 0  (now includes the new file)
pnpm typecheck                           → clean (platform-only WARNs)
pnpm lint                                → clean
```

## Adversarial review

- **Round A — Correctness (Dijkstra).** Append-only: existing `SUPPORTED_EXTENSIONS` entries keep their slots; `scanExtensions` uses a `Set` and `generateSmartConfig` a `Map` so order/dedup are unaffected. `isFileScope` adds `mts|cts` as `$`-anchored, case-insensitive alternatives — controls (`.ts` → true, `UserService` → false) still pass; no false positive (`foo.mtsx` is not matched). `.d.ts` already matched via the `ts` suffix, unchanged.
- **Round B — Structural (Uncle Bob).** `quickstart.ts` ~130 lines, `query.ts` is a pre-existing large dispatch file not materially worsened (a 2-char regex change + comment). The recurring root cause — multiple hand-maintained extension lists drifting — is hardened by documenting `analyzer.rs is_js_ts_file` inline as the single source of truth in both sites (matching #372/#374 convention).
- **Round C — Class-not-instance.** Grepped for the literal drifted pattern `'js', 'jsx', 'mjs', 'cjs', 'ts', 'tsx',`. Both `@grafema/cli` instances are fixed here. The only remaining sibling is `packages/vscode/src/initRunner.ts:15` — a **different package with no `@grafema/util` dependency** (folding it in would add a cross-package dependency = scope creep), and it additionally lacks `lean`. Recorded as a follow-up. `CoverageAnalyzer.ts` was fixed in #377 (merged); `moduleResolution.ts` (#374) and `packageApiEnricher.ts` (#372) are in-flight.

## Follow-ups (NOT in this PR)
- [ ] `packages/vscode/src/initRunner.ts:15` `SUPPORTED_EXTENSIONS` — same drift (missing `.mts`/`.cts`, and `lean`); separate package, no shared util dependency.
- [ ] Consolidation: export one canonical JS/TS extension set (mirroring `analyzer.rs`) and point all sites at it — the root-cause fix repeatedly recommended across #372/#374; spans packages with no shared dependency, so a deliberate cross-package change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWEGekagYExRbDUvJFeNJk)_