### PR TITLE
fix(rust-analyzer): emit FFI declarations from `extern` blocks

### DIFF
--- a/packages/grafema-orchestrator/src/rust_analyzer.rs
+++ b/packages/grafema-orchestrator/src/rust_analyzer.rs
@@ -483,9 +483,11 @@ fn walk_item(item: &syn::Item, ctx: &mut Ctx) {
         syn::Item::Use(u) => walk_use(u, ctx),
         syn::Item::Mod(m) => walk_mod(m, ctx),
         syn::Item::Type(t) => walk_type_alias(t, ctx),
+        // `extern "ABI" { ... }` declares real FFI symbols (fns/statics) that
+        // other code calls/reads — not transparent.
+        syn::Item::ForeignMod(fm) => walk_foreign_mod(fm, ctx),
         // Transparent items — no graph nodes needed
         syn::Item::ExternCrate(_) => {}
-        syn::Item::ForeignMod(_) => {}
         syn::Item::Macro(_) => {}
         syn::Item::Union(u) => walk_union(u, ctx),
         syn::Item::TraitAlias(_) => {}
@@ -1103,6 +1105,150 @@ fn walk_type_alias(t: &syn::ItemType, ctx: &mut Ctx) {
         end_line: ctx.span_end_line_col(t.ident.span()).0, end_column: ctx.span_end_line_col(t.ident.span()).1,
         exported: is_pub(&t.vis),
         metadata: HashMap::new(),
+        extra: HashMap::new(),
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Foreign (FFI) declarations — `extern "ABI" { ... }`
+// ---------------------------------------------------------------------------
+
+/// Walk an `extern "ABI" { ... }` foreign module.
+///
+/// Foreign items are *declarations without bodies*: the functions and statics
+/// they introduce are real symbols that other code calls / reads, so they must
+/// appear in the graph — otherwise every call into FFI is a dangling,
+/// unresolvable edge. Each item is modelled like its in-Rust counterpart
+/// (foreign `fn` → FUNCTION, foreign `static` → VARIABLE kind=static, foreign
+/// opaque `type` → TYPE_ALIAS) and tagged `metadata["foreign"] = true` plus the
+/// block's `abi`, so queries can distinguish FFI symbols. There is no body to
+/// walk; parameter nodes (and their type annotations) are still emitted so the
+/// signature is queryable.
+fn walk_foreign_mod(fm: &syn::ItemForeignMod, ctx: &mut Ctx) {
+    // `extern { ... }` with no explicit ABI string defaults to "C".
+    let abi = fm
+        .abi
+        .name
+        .as_ref()
+        .map(|s| s.value())
+        .unwrap_or_else(|| "C".to_string());
+    for item in &fm.items {
+        match item {
+            syn::ForeignItem::Fn(f) => walk_foreign_fn(f, &abi, ctx),
+            syn::ForeignItem::Static(s) => walk_foreign_static(s, &abi, ctx),
+            syn::ForeignItem::Type(t) => walk_foreign_type(t, ctx),
+            // A foreign macro expands at a different stage and a verbatim item is
+            // unparsed tokens — neither introduces a resolvable symbol here.
+            syn::ForeignItem::Macro(_) => {}
+            syn::ForeignItem::Verbatim(_) => {}
+            _ => panic!("rust_analyzer: unhandled ForeignItem variant"),
+        }
+    }
+}
+
+/// Foreign function declaration (`extern` block `fn`). Mirrors `walk_fn` but has
+/// no body: emits a FUNCTION node tagged `foreign`/`abi` and walks the signature
+/// parameters. Registered in the enclosing (module) scope so same-file calls
+/// resolve to it via the deferred-CALLS scope walk.
+fn walk_foreign_fn(f: &syn::ForeignItemFn, abi: &str, ctx: &mut Ctx) {
+    let ident = f.sig.ident.to_string();
+    let (line, col) = ctx.span_line_col(f.sig.ident.span());
+    let (end_line, end_col) = ctx.span_end_line_col(f.sig.ident.span());
+    let is_exported = is_pub(&f.vis);
+    let node_id = semantic_id(&ctx.file, "FUNCTION", &ident, None, None);
+
+    let mut fn_meta = HashMap::from([
+        Ctx::meta_text("visibility", vis_to_text(&f.vis)),
+        Ctx::meta_bool("async", f.sig.asyncness.is_some()),
+        Ctx::meta_bool("unsafe", f.sig.unsafety.is_some()),
+        Ctx::meta_bool("const", f.sig.constness.is_some()),
+        Ctx::meta_bool("foreign", true),
+        Ctx::meta_text("abi", abi),
+    ]);
+    if let syn::ReturnType::Type(_, ty) = &f.sig.output {
+        let return_type = type_to_name(ty);
+        if return_type != "<type>" {
+            let (k, v) = Ctx::meta_text("returnType", &return_type);
+            fn_meta.insert(k, v);
+        }
+    }
+    ctx.emit_declaration(GraphNode {
+        id: node_id.clone(),
+        node_type: "FUNCTION".to_string(),
+        name: ident.clone(),
+        file: ctx.file.clone(),
+        line, column: col,
+        end_line, end_column: end_col,
+        exported: is_exported,
+        metadata: fn_meta,
+        extra: HashMap::new(),
+    });
+
+    if is_exported {
+        ctx.exports.push(ExportInfo {
+            name: ident.clone(),
+            node_id: node_id.clone(),
+            kind: "function".to_string(),
+            source: None,
+        });
+    }
+
+    // No body — walk only the signature parameters.
+    for param in &f.sig.inputs {
+        walk_fn_param(param, &node_id, ctx);
+    }
+}
+
+/// Foreign static declaration (`extern` block `static`). Mirrors `walk_static`
+/// but has no initializer: emits a VARIABLE node (kind=static) tagged `foreign`.
+fn walk_foreign_static(s: &syn::ForeignItemStatic, abi: &str, ctx: &mut Ctx) {
+    let ident = s.ident.to_string();
+    let (line, col) = ctx.span_line_col(s.ident.span());
+    let (end_line, end_col) = ctx.span_end_line_col(s.ident.span());
+    let is_exported = is_pub(&s.vis);
+    let is_mut = matches!(s.mutability, syn::StaticMutability::Mut(_));
+    let node_id = semantic_id(&ctx.file, "VARIABLE", &ident, None, None);
+
+    ctx.emit_declaration(GraphNode {
+        id: node_id.clone(),
+        node_type: "VARIABLE".to_string(),
+        name: ident.clone(),
+        file: ctx.file.clone(),
+        line, column: col,
+        end_line, end_column: end_col,
+        exported: is_exported,
+        metadata: HashMap::from([
+            Ctx::meta_text("kind", "static"),
+            Ctx::meta_bool("mutable", is_mut),
+            Ctx::meta_text("visibility", vis_to_text(&s.vis)),
+            Ctx::meta_bool("foreign", true),
+            Ctx::meta_text("abi", abi),
+        ]),
+        extra: HashMap::new(),
+    });
+
+    if is_exported {
+        ctx.exports.push(ExportInfo {
+            name: ident, node_id, kind: "variable".to_string(), source: None,
+        });
+    }
+}
+
+/// Foreign opaque type declaration (`extern` block `type Foo;`). Mirrors
+/// `walk_type_alias` but the type has no aliased target; tagged `foreign`.
+fn walk_foreign_type(t: &syn::ForeignItemType, ctx: &mut Ctx) {
+    let ident = t.ident.to_string();
+    let (line, col) = ctx.span_line_col(t.ident.span());
+    let (end_line, end_col) = ctx.span_end_line_col(t.ident.span());
+    ctx.emit_declaration(GraphNode {
+        id: semantic_id(&ctx.file, "TYPE_ALIAS", &ident, None, None),
+        node_type: "TYPE_ALIAS".to_string(),
+        name: ident,
+        file: ctx.file.clone(),
+        line, column: col,
+        end_line, end_column: end_col,
+        exported: is_pub(&t.vis),
+        metadata: HashMap::from([Ctx::meta_bool("foreign", true)]),
         extra: HashMap::new(),
     });
 }
@@ -2285,5 +2431,98 @@ mod tests {
             .filter(|e| e.edge_type == "READS_FROM" && e.src.contains("PROPERTY_ACCESS"))
             .collect();
         assert!(!reads.is_empty(), "PROPERTY_ACCESS should have READS_FROM");
+    }
+
+    // -----------------------------------------------------------------------
+    // Foreign (FFI) declarations — `extern "C" { ... }` blocks
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_foreign_fn_emits_function_node() {
+        let fa = parse_and_analyze(r#"extern "C" { fn malloc(size: usize) -> *mut u8; }"#);
+        assert!(has_node(&fa, "FUNCTION", "malloc"), "foreign fn -> FUNCTION node");
+        let f = fa.nodes.iter()
+            .find(|n| n.node_type == "FUNCTION" && n.name == "malloc")
+            .unwrap();
+        assert_eq!(f.metadata.get("foreign"), Some(&serde_json::json!(true)), "tagged foreign=true");
+        assert_eq!(f.metadata.get("abi"), Some(&serde_json::json!("C")), "abi recorded");
+        // Declared in module scope so it is a resolution target.
+        assert!(has_edge(&fa, "CONTAINS", "MODULE", "FUNCTION->malloc"), "CONTAINS from module");
+        assert!(has_edge(&fa, "DECLARES", "MODULE", "FUNCTION->malloc"), "DECLARES from module");
+    }
+
+    #[test]
+    fn test_foreign_fn_params_walked() {
+        let fa = parse_and_analyze(
+            r#"extern "C" { fn write(fd: i32, buf: *const u8, n: usize) -> isize; }"#
+        );
+        assert!(has_node(&fa, "PARAMETER", "fd"), "param fd");
+        assert!(has_node(&fa, "PARAMETER", "buf"), "param buf");
+        assert!(has_node(&fa, "PARAMETER", "n"), "param n");
+        let fd = fa.nodes.iter()
+            .find(|n| n.node_type == "PARAMETER" && n.name == "fd")
+            .unwrap();
+        assert_eq!(fd.metadata.get("typeAnnotation"), Some(&serde_json::json!("i32")));
+    }
+
+    #[test]
+    fn test_foreign_static_emits_variable() {
+        let fa = parse_and_analyze(r#"extern "C" { static mut errno: i32; }"#);
+        assert!(has_node(&fa, "VARIABLE", "errno"), "foreign static -> VARIABLE node");
+        let v = fa.nodes.iter()
+            .find(|n| n.node_type == "VARIABLE" && n.name == "errno")
+            .unwrap();
+        assert_eq!(v.metadata.get("kind"), Some(&serde_json::json!("static")));
+        assert_eq!(v.metadata.get("mutable"), Some(&serde_json::json!(true)));
+        assert_eq!(v.metadata.get("foreign"), Some(&serde_json::json!(true)));
+    }
+
+    #[test]
+    fn test_foreign_opaque_type_emits_type_alias() {
+        let fa = parse_and_analyze(r#"extern "C" { type Opaque; }"#);
+        assert!(has_node(&fa, "TYPE_ALIAS", "Opaque"), "foreign type -> TYPE_ALIAS node");
+        let t = fa.nodes.iter()
+            .find(|n| n.node_type == "TYPE_ALIAS" && n.name == "Opaque")
+            .unwrap();
+        assert_eq!(t.metadata.get("foreign"), Some(&serde_json::json!(true)));
+    }
+
+    #[test]
+    fn test_call_to_foreign_fn_resolves() {
+        // A same-file call to a foreign fn must resolve to the foreign FUNCTION
+        // declaration via the deferred-CALLS scope-chain walk.
+        let fa = parse_and_analyze(
+            r#"extern "C" { fn abs(x: i32) -> i32; } fn main() { let _ = abs(-3); }"#
+        );
+        assert!(has_node(&fa, "FUNCTION", "abs"), "foreign FUNCTION abs");
+        assert!(has_node(&fa, "CALL", "abs"), "CALL abs");
+        let calls: Vec<_> = fa.edges.iter()
+            .filter(|e| e.edge_type == "CALLS" && e.dst.contains("FUNCTION->abs"))
+            .collect();
+        assert!(!calls.is_empty(), "CALLS edge resolves to foreign fn abs");
+    }
+
+    #[test]
+    fn test_foreign_variadic_fn_no_panic() {
+        // C variadics (`...`) live in sig.variadic, not sig.inputs — must not panic.
+        let fa = parse_and_analyze(r#"extern "C" { fn printf(fmt: *const u8, ...) -> i32; }"#);
+        assert!(has_node(&fa, "FUNCTION", "printf"), "variadic foreign fn -> FUNCTION");
+        assert!(has_node(&fa, "PARAMETER", "fmt"), "fixed param fmt emitted");
+    }
+
+    #[test]
+    fn test_empty_extern_block_no_panic() {
+        let fa = parse_and_analyze(r#"extern "C" {}"#);
+        assert_eq!(count_nodes(&fa, "FUNCTION"), 0, "empty extern block emits no fns");
+    }
+
+    #[test]
+    fn test_bare_extern_block_defaults_abi_c() {
+        // `extern { ... }` with no explicit ABI string defaults to "C".
+        let fa = parse_and_analyze(r#"extern { fn puts(s: *const u8) -> i32; }"#);
+        let f = fa.nodes.iter()
+            .find(|n| n.node_type == "FUNCTION" && n.name == "puts")
+            .expect("FUNCTION puts");
+        assert_eq!(f.metadata.get("abi"), Some(&serde_json::json!("C")));
     }
 }


### PR DESCRIPTION
## Summary

The in-process Rust analyzer treated `extern "ABI" { ... }` blocks as a **transparent no-op** — `walk_item`'s arm was literally `syn::Item::ForeignMod(_) => {}` ([`rust_analyzer.rs:488`](../blob/main/packages/grafema-orchestrator/src/rust_analyzer.rs#L488)), grouped under a `// Transparent items — no graph nodes needed` comment. But an `extern` block is **not** transparent: it *declares* functions, statics and opaque types. As a result:

- A foreign function (`extern "C" { fn malloc(...); }`) produced **ZERO graph nodes**, so every same-file call into FFI — `abs()`, `malloc()`, `write()`, … — had **no resolvable `CALLS` target** (a silent hole in the call graph).
- Foreign `static`s and opaque `type`s were likewise invisible to the graph.

This is the same class the recent analyzer fixes addressed (associated consts/types #375, macro CALLs #376): a documented-supported construct silently dropped by an empty match arm — a direct hit to the core thesis that the graph must be trustworthy enough to query instead of reading code.

No open GitHub issue / no Linear access this run; surfaced by auditing the analyzer's no-op AST arms. Deliberately avoided the macro arms (`Item/ImplItem/Stmt/Expr::Macro`, open PR #376) and `ImplItem::Const/Type` (open PR #375).

## Spec

- **Invariant restored:** a declaration inside an `extern` block produces a graph node of the same shape as its in-Rust counterpart, so FFI symbols are visible and callable in the graph.
- **Given** `extern "C" { fn malloc(size: usize) -> *mut u8; }`
  **When** `analyze_rust_file` runs
  **Then** there is a `FUNCTION` node `malloc` (metadata `foreign=true`, `abi="C"`) with `CONTAINS` + `DECLARES` edges from the module scope, and its `PARAMETER` nodes (with type annotations) are emitted.
- **And** a same-file call `abs(-3)` to `extern "C" { fn abs(x: i32) -> i32; }` resolves a `CALLS` edge to the foreign `FUNCTION` (it is registered in module scope, so the deferred-CALLS scope walk finds it).
- **And** `static mut errno: i32;` → `VARIABLE` (kind=static, mutable, foreign); `type Opaque;` → `TYPE_ALIAS` (foreign).
- **And** a bare `extern { ... }` (no ABI string) defaults `abi` to `"C"`; C variadics (`printf(fmt, ...)`) and empty blocks never panic.

## Fix

`packages/grafema-orchestrator/src/rust_analyzer.rs` — route `Item::ForeignMod` through a new documented `walk_foreign_mod` that dispatches each `ForeignItem` to a focused helper mirroring the existing free-item walkers:

| Foreign item | Helper | Node | mirrors |
|---|---|---|---|
| `fn`     | `walk_foreign_fn`     | `FUNCTION` (params/return walked, **no body**) | `walk_fn` |
| `static` | `walk_foreign_static` | `VARIABLE` (kind=static) | `walk_static` |
| `type`   | `walk_foreign_type`   | `TYPE_ALIAS` | `walk_type_alias` |

All tagged `metadata["foreign"]=true` + the block's `abi`. `ForeignItem::Macro`/`Verbatim` stay documented no-ops (no resolvable symbol); unknown future variants `panic!` per the file's stated fail-early policy.

## Before / After (evidence)

New tests in `rust_analyzer.rs` `mod tests`, asserting the graph shape emitted by the production `analyze_rust_file`.

**RED** (against pre-fix code, `cargo test --lib foreign`):
```
test result: FAILED. 0 passed; 5 failed; 0 ignored; 422 filtered out
failures:
    test_call_to_foreign_fn_resolves
    test_foreign_fn_emits_function_node
    test_foreign_fn_params_walked
    test_foreign_opaque_type_emits_type_alias
    test_foreign_static_emits_variable
```
(failed for the right reason: `foreign fn -> FUNCTION node` — no node existed)

**GREEN** (after fix, full lib suite):
```
cargo test --lib   → test result: ok. 429 passed; 0 failed   (421 baseline + 8 new)
cargo clippy --lib → 0 warnings on rust_analyzer.rs (grep count = 0; the 41 pre-existing
                     warnings are all in other analyzers — ruby/scala/etc.)
cargo build --lib  → Finished (1 pre-existing warning, unrelated)
```
JS/snapshot suites unaffected — this is a Rust-only change isolated to the `grafema-orchestrator` crate with no interface change; those suites exercise JS/TS analysis, not the Rust analyzer.

## Adversarial review

- **Round A — Correctness (Dijkstra).** Empty `extern "C" {}` → no items → nothing emitted (test). Bare `extern { … }` → `abi.name` is `None` → defaults `"C"` (test). C variadic `printf(fmt, ...)` → `...` lives in `sig.variadic`, not `sig.inputs`, so it's simply not a param and never panics (test). No body to walk, so no scope is pushed (unlike `walk_fn`) — params are emitted in the enclosing/module scope exactly as `walk_fn` does. `pub` foreign items push `ExportInfo` like their free counterparts. Unknown `ForeignItem` variant panics (fail-early), consistent with `walk_item`.
- **Round B — Structural (Uncle Bob).** Logic is one dispatcher + three small cohesive helpers that reuse the same node shapes as `walk_fn`/`walk_static`/`walk_type_alias`, so foreign and free items cannot drift in node type/metadata. `rust_analyzer.rs` is a pre-existing large dispatch file (was 2289 lines); this adds ~150 focused lines and does **not** introduce/materially worsen the god-file — splitting this analyzer is a separate refactor, intentionally out of scope (same posture as #375/#376).
- **Round C — Class-not-instance.** The class is "empty `walk_item`/`walk_*` arm drops a real declaration." This PR closes the **FFI** instance fully (fn/static/type). Remaining siblings are left as scoped follow-ups (different constructs / under other open PRs), not folded in:
  - `Item::TraitAlias` (`trait Foo = Bar;`) — drops a trait-alias declaration; unstable feature, rare.
  - `Item::ExternCrate` (`extern crate foo;`) — legacy 2015-edition import; arguably transparent in 2018+.
  - `Expr::Const` (`const { … }` block) — nested calls in the block body dropped (same family as #376's macro-arg walking).

## Blast radius

`walk_foreign_mod` is reached only from the `Item::ForeignMod` arm. It is **purely additive** to graph output: these blocks previously produced **zero** nodes/edges, so no existing node/edge is changed or removed — only new `FUNCTION`/`VARIABLE`/`TYPE_ALIAS` nodes (`foreign=true`), their params, and the now-resolvable `CALLS` edges. No existing test changed.

## Follow-ups (recorded, NOT in this PR)
- [ ] `Item::TraitAlias` (`rust_analyzer.rs`) — emit a node for trait aliases.
- [ ] `Item::ExternCrate` — decide whether to model an import-like edge or keep transparent.
- [ ] `Expr::Const` block — walk body so nested calls/refs aren't dropped.
- [ ] Haskell `grafema-resolve` extension drift (`ClassInheritance.hs:77`, `JsThisMethodCalls.hs:45` missing `.mts`/`.cts`; `ImportResolution.hs:242` candidate list missing `.mjs/.cjs/.mts/.cts`) vs `analyzer.rs::is_js_ts_file` — verified live this run but **not fixable here** (no GHC/cabal in this environment, despite expectation).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QsmN81uFMFkZ2YnLSp8Ut5)_