### PR TITLE
fix(mcp): parse disambiguated semantic-ID URIs in humanReadableId

### DIFF
--- a/packages/mcp/src/handlers/query-handlers.ts
+++ b/packages/mcp/src/handlers/query-handlers.ts
@@ -524,21 +524,34 @@ async function enrichNodes(
 
 /** Convert a semantic ID to human-readable "name in file.ts" format.
  * Handles: grafema://host/path/file.ts#TYPE->name[scope], path/file.ts#TYPE->name,
- * TYPE-%3Ename (URL-encoded, no file prefix), or raw node IDs. */
-function humanReadableId(semanticId: string): string {
+ * TYPE-%3Ename (URL-encoded, no file prefix), or raw node IDs.
+ *
+ * Exported for unit testing.
+ * @internal */
+export function humanReadableId(semanticId: string): string {
   if (!semanticId) return '?';
-  // Decode URI components first
-  let id = semanticId;
-  try { id = decodeURIComponent(id); } catch { /* keep as-is */ }
 
-  // Find the # separator between file path and node descriptor
-  const hashIdx = id.lastIndexOf('#');
-  let filePart = '';
-  let nodePart = id;
+  // Split file path from node descriptor on the FIRST literal '#' of the RAW
+  // (still percent-encoded) id, BEFORE decoding. The grafema:// URI form encodes
+  // the disambiguation counter ('#N', appended by computeSemanticIdV2 for hash
+  // collisions) as '%23N' inside the fragment. Decoding first and then splitting
+  // on the LAST '#' would mistake that counter for the path/fragment boundary and
+  // corrupt the label. A file path never contains a literal '#'. This mirrors the
+  // canonical parseSemanticIdV2 (packages/util/src/core/SemanticId.ts).
+  const hashIdx = semanticId.indexOf('#');
+  let rawFile = '';
+  let rawNode = semanticId;
   if (hashIdx !== -1) {
-    filePart = id.slice(0, hashIdx);
-    nodePart = id.slice(hashIdx + 1);
+    rawFile = semanticId.slice(0, hashIdx);
+    rawNode = semanticId.slice(hashIdx + 1);
   }
+
+  const decode = (s: string): string => {
+    try { return decodeURIComponent(s); } catch { return s; }
+  };
+  const filePart = decode(rawFile);
+  // Strip the trailing disambiguation counter ('#N') from the decoded descriptor.
+  const nodePart = decode(rawNode).replace(/#\d+$/, '');
 
   const fileName = filePart ? (filePart.split('/').pop() || '') : '';
 

--- a/packages/mcp/test/human-readable-id.test.ts
+++ b/packages/mcp/test/human-readable-id.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for humanReadableId (packages/mcp/src/handlers/query-handlers.ts).
+ *
+ * humanReadableId builds the agent-facing `callers` / `parent` / `members`
+ * labels in MCP query results. It must correctly parse the grafema:// semantic
+ * ID URI form — including the disambiguation counter that computeSemanticIdV2
+ * appends for hash collisions (`#N`, encoded as `%23N` in the URI fragment).
+ *
+ * Regression: the original implementation percent-decoded the WHOLE id first and
+ * then split on the LAST '#'. For a disambiguated id the decoded counter ('#N')
+ * became the chosen path/fragment boundary, so the label degraded to garbage like
+ * `app.js#FN->a[in:x,h:ff00]` instead of `a (in x) in app.js`. The canonical
+ * parser (packages/util/src/core/SemanticId.ts parseSemanticIdV2) splits on the
+ * first '#' BEFORE decoding; humanReadableId must agree.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { humanReadableId } from '../src/handlers/query-handlers.js';
+
+describe('humanReadableId — grafema:// URI semantic IDs', () => {
+  it('control: a non-disambiguated FUNCTION id resolves to "name in file"', () => {
+    assert.equal(
+      humanReadableId('grafema://localhost/grafema/src/app.js#FUNCTION-%3Efoo'),
+      'foo in app.js'
+    );
+  });
+
+  it('disambiguation counter (%23N) does not corrupt a bracketed id', () => {
+    // Fragment decodes to: FN->a[in:x,h:ff00]#1
+    assert.equal(
+      humanReadableId('grafema://localhost/grafema/src/app.js#FN-%3Ea%5Bin:x,h:ff00%5D%231'),
+      'a (in x) in app.js'
+    );
+  });
+
+  it('disambiguation counter (%23N) is stripped from a bare id', () => {
+    // Fragment decodes to: FUNCTION->foo#1
+    assert.equal(
+      humanReadableId('grafema://localhost/grafema/src/app.js#FUNCTION-%3Efoo%231'),
+      'foo in app.js'
+    );
+  });
+
+  it('MODULE id (no node descriptor) resolves to the file name', () => {
+    assert.equal(
+      humanReadableId('grafema://localhost/grafema/src/app.js#MODULE'),
+      'app.js'
+    );
+  });
+
+  it('bracketed scope without a counter is unchanged', () => {
+    assert.equal(
+      humanReadableId('grafema://localhost/grafema/src/app.js#CALL-%3Elog%5Bin:handler,h:a3f2%5D'),
+      'log (in handler) in app.js'
+    );
+  });
+
+  it('empty input yields the "?" sentinel', () => {
+    assert.equal(humanReadableId(''), '?');
+  });
+});


### PR DESCRIPTION
## Summary

`humanReadableId()` ([`packages/mcp/src/handlers/query-handlers.ts:528`](../blob/main/packages/mcp/src/handlers/query-handlers.ts#L528)) builds the **agent-facing** `callers` / `parent` / `members` labels in MCP query results (`enrichNodes`, lines 489/493/505). It percent‑decoded the **whole** `grafema://` semantic ID first, then split on the **last** `#`.

The `grafema://` URI fragment encodes the **disambiguation counter** — `#N`, appended by `computeSemanticIdV2` ([`SemanticId.ts:269-271`](../blob/main/packages/util/src/core/SemanticId.ts#L269)) for hash collisions — as `%23N`. Decoding first turned that into a literal `#`, so `lastIndexOf('#')` picked the **counter** as the path/fragment boundary and the label degraded to garbage:

```
grafema://localhost/grafema/src/app.js#FN-%3Ea%5Bin:x,h:ff00%5D%231
  → "app.js#FN->a[in:x,h:ff00]"        (should be "a (in x) in app.js")
```

This is a direct hit on the core thesis — these labels are how an agent reads call/containment relationships from the graph; any duplicate‑named (collision‑disambiguated) node rendered as noise.

No open GitHub issue / no Linear access this run. Surfaced by auditing the `grafema://` URI parsing class (the repo's own `grafema-uri-semantic-id-parsing` guidance) against `query-handlers.ts`, the only MCP handler that hand‑rolls `#` splitting instead of delegating to `@grafema/util`.

## Spec

- **Invariant restored:** `humanReadableId` agrees with the canonical `parseSemanticIdV2` on where the path/fragment boundary is — the **first literal `#`**, located on the raw (still percent‑encoded) id **before** decoding. A disambiguation counter never corrupts the label.
- **Given** a caller/parent/member node ID `grafema://…/app.js#FN-%3Ea%5Bin:x,h:ff00%5D%231` (decodes to `FN->a[in:x,h:ff00]#1`)
  **When** `humanReadableId` renders it
  **Then** the label is `a (in x) in app.js` — identical to the same ID without the `#1` counter.
  **And** every previously‑correct form (non‑disambiguated FUNCTION, MODULE, bracketed scope, encoded‑no‑file, empty input) is byte‑for‑byte unchanged.

## Fix

`packages/mcp/src/handlers/query-handlers.ts` — split on the **first** literal `#` of the **raw** id before decoding, decode the file/descriptor parts **separately**, and strip a trailing `#N` counter. File paths never contain a literal `#`, so the boundary is unambiguous. The comment cites `parseSemanticIdV2` as the source of truth (drift guard). The helper is exported `@internal` for unit testing.

## Before / After (evidence — built `dist`)

```
BEFORE (main)                                          AFTER (this PR)
#FUNCTION-%3Efoo        → "foo in app.js"              "foo in app.js"            (control, unchanged)
#FN-%3Ea%5B…%5D%231     → "app.js#FN->a[in:x,h:ff00]"  "a (in x) in app.js"       FIXED
#FUNCTION-%3Efoo%231    → "app.js#FUNCTION->foo"       "foo in app.js"            FIXED
#MODULE                 → "app.js"                     "app.js"                   (control, unchanged)
```

**RED → GREEN** — new `packages/mcp/test/human-readable-id.test.ts` (6 cases) against pre‑fix code:
```
# pass 4  # fail 2     ← the two disambiguation cases fail for the right reason
```
After the fix:
```
# tests 6  # pass 6  # fail 0
```

**Full gate** (Linux x64, Node 22):
```
pnpm --filter @grafema/mcp build   → ok
pnpm --filter @grafema/mcp test    → 107 tests, 106 pass, 1 skipped, 0 fail   (101 baseline + 6 new)
pnpm typecheck                     → clean (platform-only WARNs)
pnpm lint                          → clean
```

## Adversarial review

- **Round A — Correctness (Dijkstra).** No `#` (virtual node `…/_/EXTERNAL_MODULE-%3Elodash`) → `lodash`, unchanged. Compact `src/app.js#FUNCTION->foo` (literal `->`) and encoded‑no‑file `FUNCTION-%3Efoo` → unchanged. `decodeURIComponent` is now applied **per part** in a guarded helper, so a malformed `%` in the path no longer leaves the whole id encoded (strictly more robust). Counter strip is anchored `#\d+$`, so a `#` inside an unexpected position can't be misread. Bracketed‑scope case (`CALL-%3Elog%5Bin:handler,h:a3f2%5D`) verified unchanged.
- **Round B — Structural (Uncle Bob).** `query-handlers.ts` is a pre‑existing 634‑line file (>500 guideline); this change is +13 net lines to one cohesive helper and does not introduce/worsen the god‑file — splitting it is a separate refactor, out of scope. The fix mirrors and cites `parseSemanticIdV2` rather than re‑deriving the format blind.
- **Round C — Class‑not‑instance.** Grepped MCP for sibling parsers: `humanReadableId` is used **only** in `query-handlers.ts` (3 call sites), and it is the **only** handler that hand‑rolls `#` splitting. The siblings (`graph-handlers`, `context-handlers`, `guard-handlers`) already delegate to canonical `@grafema/util` helpers (`isGrafemaUri`, `toCompactSemanticId`, `getNodeDisplayName`) — not latent. Class contained; no other instance.

## Blast radius

`humanReadableId` feeds only the `_context.callers` / `_context.parent` / `_context.members` display fields of MCP `find_nodes`‑style results. Purely a display‑label correction: previously‑correct labels are unchanged; previously‑garbled disambiguated labels now render correctly. No graph node/edge, query routing, or tool contract changes.

## Follow-up (recorded, not in this PR)

- [ ] Consider replacing the bespoke `humanReadableId` with the canonical `getNodeDisplayName` from `@grafema/util` (same direction the sibling handlers already took) to remove the second hand‑rolled formatter entirely. Left out to keep this slice minimal and avoid changing the MCP‑specific `"(in scope)"` output shape.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gr1JxX3NM18QTce8estG44)_