### PR TITLE
fix(rust-analyzer): walk inline `const { }` block bodies

### DIFF
--- a/packages/grafema-orchestrator/src/rust_analyzer.rs
+++ b/packages/grafema-orchestrator/src/rust_analyzer.rs
@@ -1828,7 +1828,9 @@ fn walk_expr(expr: &syn::Expr, ctx: &mut Ctx) {
             });
         }
         syn::Expr::Macro(_) => {}
-        syn::Expr::Const(_) => {}
+        // Inline `const { ... }` block — walk its body like Unsafe/Async blocks
+        // so nested calls/references are not silently dropped from the graph.
+        syn::Expr::Const(e) => walk_block(&e.block, ctx),
         syn::Expr::Infer(_) => {}
         syn::Expr::Verbatim(_) => {}
 
@@ -2001,6 +2003,20 @@ mod tests {
         assert!(has_node(&fa, "CALL", "push"), "CALL push");
         let call = fa.nodes.iter().find(|n| n.node_type == "CALL" && n.name == "push").unwrap();
         assert_eq!(call.metadata.get("method"), Some(&serde_json::json!(true)));
+    }
+
+    #[test]
+    fn test_inline_const_block_walks_body() {
+        // syn::Expr::Const — inline `const { ... }` block expression (Rust 1.79+).
+        // Its body is a syn::Block and must be walked like Expr::Unsafe / Expr::Async,
+        // otherwise nested calls/references are silently dropped from the call graph.
+        let fa = parse_and_analyze(
+            "fn main() { let _x = const { helper() }; }  const fn helper() -> i32 { 0 }",
+        );
+        assert!(
+            has_node(&fa, "CALL", "helper"),
+            "CALL helper nested in inline const block must be emitted"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

In the in-process Rust analyzer, `syn::Expr::Const` — an inline `const { ... }` block expression (stabilized in Rust 1.79) — had an **empty no-op arm** in `walk_expr` ([`rust_analyzer.rs:1831`](../blob/main/packages/grafema-orchestrator/src/rust_analyzer.rs#L1831), `syn::Expr::Const(_) => {}`).

A const block carries a `syn::Block` exactly like its siblings `Expr::Unsafe` and `Expr::Async`, both of which walk their body via `walk_block`:

```rust
syn::Expr::Unsafe(e) => walk_block(&e.block, ctx),   // :1794
syn::Expr::Async(e)  => walk_block(&e.block, ctx),   // :1795
syn::Expr::Const(_)  => {}                            // :1831  ← odd one out
```

Because the const block's body was never walked, **every call, reference and literal nested inside `const { ... }` was silently dropped from the graph** — e.g. `compute()` in `let n = const { compute() };`. The call graph and backward dataflow had a hole everywhere an inline const block was used. This is the same class of defect as missing macro-argument walking (#376): a block-bearing expression whose body is not traversed.

No open GitHub issue and no Linear access this run; surfaced by auditing the analyzer's block-bearing `Expr` arms against the sibling `Unsafe`/`Async` handling (Enox-recorded audit pattern). Avoided overlap with open PRs #375 (impl/trait associated consts/types) and #376 (`Expr`/`Stmt::Macro`).

## Spec

- **Invariant restored:** every block-bearing expression has its body walked, so nested calls/references/literals are emitted into the graph. `Expr::Const` is brought in line with `Expr::Unsafe`/`Expr::Async`/`Expr::Block`.
- **Given** `fn main() { let _x = const { helper() }; }  const fn helper() -> i32 { 0 }`
  **When** `analyze_rust_file` runs
  **Then** there is a `CALL` node `helper` (the const block body was walked) — previously absent.
- **And** an empty const block (`const { }`) and nested const blocks (`const { const { f() } }`) are handled without panic (covered by `walk_block`'s ordinary stmt traversal).

## Fix

`packages/grafema-orchestrator/src/rust_analyzer.rs` — the `Expr::Const` arm now routes through the existing `walk_block`:

```rust
// Inline `const { ... }` block — walk its body like Unsafe/Async blocks
// so nested calls/references are not silently dropped from the graph.
syn::Expr::Const(e) => walk_block(&e.block, ctx),
```

Reuses the shared `walk_block` that `Unsafe`/`Async`/`Block` already use, so the four block-bearing arms cannot drift.

## Before / After (evidence)

New test `test_inline_const_block_walks_body` in `rust_analyzer.rs` `mod tests`, exercising the production `analyze_rust_file` and asserting graph shape.

**RED** (pre-fix):
```
test rust_analyzer::tests::test_inline_const_block_walks_body ... FAILED
  assertion failed: CALL helper nested in inline const block must be emitted
test result: FAILED. 0 passed; 1 failed
```

**GREEN** (post-fix):
```
test rust_analyzer::tests::test_inline_const_block_walks_body ... ok
test result: ok. 1 passed; 0 failed
```

**Full gate** (Linux x64, cargo 1.94):
```
cargo test --lib    → ok. 430 passed; 0 failed   (429 baseline + 1 new)
cargo clippy --lib  → 41 pre-existing warnings, none on the edited lines
cargo build         → Finished dev profile (1 pre-existing bin warning, unrelated)
```
JS suites unaffected — Rust-only change isolated to the `grafema-orchestrator` crate with no interface change; `test/unit` and snapshot suites exercise JS/TS analysis, not the in-process Rust analyzer (same framing as #376).

## Adversarial review

- **Round A — Correctness (Dijkstra).** Empty body `const {}` → `walk_block` iterates zero stmts → no nodes, no panic. Nested const blocks recurse through `walk_expr`. The const block as a *value source* still resolves to `None` in `expr_node_id` — unchanged, and consistent with `Unsafe`/`Async`, which are likewise absent there; this PR fixes only the silent body-drop, not value resolution. No duplication: the arm previously emitted **zero** nodes, so walking now emits exactly what the same statements would emit outside a const block.
- **Round B — Structural (Uncle Bob).** Routes through the existing shared `walk_block`; no new code path. `rust_analyzer.rs` is a pre-existing large dispatch file (2540 lines); this change adds one logic line + comment and does not introduce/worsen the god-file — a split is a separate refactor, out of scope.
- **Round C — Class-not-instance.** Audited every block/body-bearing `Expr` arm in `walk_expr`: `Block` (:1785), `Unsafe` (:1794), `Async` (:1795), `If` (:1668), `Match` (:1694), `Loop` (:1723), `While` (:1730), `ForLoop` (:1738), `Closure` (:1748) all walk their bodies. Among the no-op arms, `Continue`/`Infer`/`Verbatim` have no walkable body (correct), and `Macro` is PR #376's separate domain. `Expr::Const` was the **sole** remaining block-bearing silent no-op — class closed.

## Blast radius

The `Expr::Const` arm is reached only from `walk_expr`. Purely additive to graph output: previously zero nodes/edges, now the nested `CALL`/`REFERENCE`/`LITERAL` nodes and their edges. No existing node/edge changed or removed; no existing test changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_019QCqxoTGL3CBSE8JR4jqsi)_