### PR TITLE
fix(rust-analyzer): walk `&raw const`/`&raw mut` and `try {}` bodies (stop dropping whole file)

### DIFF
--- a/packages/grafema-orchestrator/src/rust_analyzer.rs
+++ b/packages/grafema-orchestrator/src/rust_analyzer.rs
@@ -2008,6 +2008,15 @@ fn walk_expr(expr: &syn::Expr, ctx: &mut Ctx) {
         syn::Expr::Infer(_) => {}
         syn::Expr::Verbatim(_) => {}
 
+        // Raw reference operator `&raw const expr` / `&raw mut expr`
+        // (stable since Rust 1.82). The operand is a place expression that may
+        // contain nested calls/references; walk it like `Reference`/`Unary` so
+        // they reach the graph.
+        syn::Expr::RawAddr(e) => walk_expr(&e.expr, ctx),
+        // `try { ... }` block (unstable): carries a `syn::Block` like
+        // `Unsafe`/`Async`; walk its body so nested calls/references survive.
+        syn::Expr::TryBlock(e) => walk_block(&e.block, ctx),
+
         _ => ctx.warn_unhandled("Expr", ""),
     }
 }
@@ -2215,6 +2224,43 @@ mod tests {
         let fa = parse_and_analyze("fn main() { let x: u64 = 42; }");
         let x = fa.nodes.iter().find(|n| n.node_type == "VARIABLE" && n.name == "x").unwrap();
         assert_eq!(x.metadata.get("typeAnnotation"), Some(&serde_json::json!("u64")));
+    }
+
+    #[test]
+    fn test_raw_ref_operand_is_walked() {
+        // `&raw const expr` / `&raw mut expr` is the raw-reference operator,
+        // STABLE since Rust 1.82. Its operand is a place expression that can
+        // contain nested calls/references. Before the fix this variant fell
+        // through `walk_expr`'s unhandled-variant `panic!`, so the entire file
+        // was dropped from the graph (analysis: None) — not just the operand.
+        // The operand must be walked like `Reference`/`Unary`/`Cast`.
+        let fa = parse_and_analyze(
+            "fn main() { let _p = &raw mut buf()[idx()]; }  \
+             fn buf() -> [u8; 4] { [0; 4] }  fn idx() -> usize { 0 }",
+        );
+        assert!(
+            has_node(&fa, "CALL", "buf"),
+            "CALL buf nested in &raw mut operand must be emitted (file not dropped)"
+        );
+        assert!(
+            has_node(&fa, "CALL", "idx"),
+            "CALL idx nested in the raw-ref index must be emitted"
+        );
+    }
+
+    #[test]
+    fn test_try_block_body_is_walked() {
+        // `try { ... }` block (unstable): like `&raw`, it previously fell
+        // through to the unhandled-variant `panic!`. It carries a `syn::Block`
+        // and must be walked like `Unsafe`/`Async` so nested calls survive.
+        let fa = parse_and_analyze(
+            "fn main() { let _r: Result<(), ()> = try { helper()?; }; }  \
+             fn helper() -> Result<(), ()> { Ok(()) }",
+        );
+        assert!(
+            has_node(&fa, "CALL", "helper"),
+            "CALL helper nested in try-block body must be emitted (file not dropped)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

In the in-process Rust analyzer, `walk_expr` ([`rust_analyzer.rs`](../blob/main/packages/grafema-orchestrator/src/rust_analyzer.rs)) ended in a hard `_ => panic!("rust_analyzer: unhandled Expr variant")` arm (`:1835` on `main`). Diffing the full `syn` 2.0.117 `Expr` enum against the handled arms, **exactly two** stable/parseable variants fell through to it:

- **`Expr::RawAddr`** — the raw-reference operator `&raw const expr` / `&raw mut expr`, **stabilized in Rust 1.82** and the recommended way to form a raw pointer without an intermediate reference (common in `unsafe`/FFI/systems code — Grafema's stated target domain).
- **`Expr::TryBlock`** — the `try { ... }` block (unstable, but `syn` parses it).

Per-file analysis runs inside `tokio::task::spawn_blocking`, so the panic is **caught** at [`rust_analyzer.rs:395`](../blob/main/packages/grafema-orchestrator/src/rust_analyzer.rs#L395) and turned into an `AnalysisResult { analysis: None, … }` tagged `parse_error`. Net effect: **any Rust file containing a `&raw const`/`&raw mut` expression is dropped from the graph in its entirety** — every node, every edge — and mislabeled as a parse error, even though the file parses fine. That is a direct hit to the core thesis (the graph must be trustworthy enough to query instead of reading code): a whole file silently disappears.

No open GitHub issue / no Linear access this run; surfaced by auditing `walk_expr`'s variant coverage against the `syn` `Expr` enum. Deliberately disjoint from the two open Rust-analyzer PRs that touch `walk_expr`: **#376** (`Expr::Macro`) and **#381** (`Expr::Const`) — this PR touches neither arm.

## Spec

- **Invariant restored:** every `syn` `Expr` variant reachable from real source is handled by `walk_expr`; an expression form never escalates to the unhandled-variant `panic!` and drops the whole file. A block/operand-bearing expression has its children walked so nested calls/references reach the graph.
- **Given** `fn main() { let _p = &raw mut buf()[idx()]; }` (+ `buf`, `idx` defined)
  **When** `analyze_rust_file` runs
  **Then** the file is analyzed (not dropped) and there are `CALL` nodes `buf` and `idx` — the operand of the raw-ref (and the nested index) is walked. Previously: panic → `analysis: None`.
- **And** `try { helper()?; }` is analyzed without panic and emits the nested `CALL helper`.
- **And** after the change, **every** `syn` 2.0.117 `Expr` variant is handled (verified by diffing the enum against the analyzer — empty difference).

## Fix

`packages/grafema-orchestrator/src/rust_analyzer.rs` — two arms added before the `_ => panic!`, reusing the existing shared walkers so the four block/operand-bearing arms cannot drift:

```rust
// Raw reference operator `&raw const expr` / `&raw mut expr`
// (stable since Rust 1.82). Walk the operand like Reference/Unary.
syn::Expr::RawAddr(e) => walk_expr(&e.expr, ctx),
// `try { ... }` block: carries a syn::Block like Unsafe/Async.
syn::Expr::TryBlock(e) => walk_block(&e.block, ctx),
```

## Before / After (evidence)

New tests in `rust_analyzer.rs` `mod tests`, exercising the production `analyze_rust_file` path.

**RED** (pre-fix) — the panic propagates through `parse_and_analyze`:
```
rust_analyzer: unhandled Expr variant
  ...
  2: grafema_orchestrator::rust_analyzer::walk_expr   at ./src/rust_analyzer.rs:1835:14
  8: ...::analyze_rust_file                            at ./src/rust_analyzer.rs:286:9
failures:
    rust_analyzer::tests::test_raw_ref_operand_is_walked
    rust_analyzer::tests::test_try_block_body_is_walked
test result: FAILED. 0 passed; 2 failed; 429 filtered out
```

**GREEN** (post-fix):
```
test rust_analyzer::tests::test_try_block_body_is_walked ... ok
test rust_analyzer::tests::test_raw_ref_operand_is_walked ... ok
test result: ok. 2 passed; 0 failed
```

**Full gate** (Linux x64, cargo / rustc stable):
```
cargo test --lib    → ok. 431 passed; 0 failed   (429 baseline + 2 new)
cargo clippy --lib  → 41 pre-existing warnings, NONE on the edited lines
cargo build --lib   → Finished dev profile (1 pre-existing warning, unrelated)
```
JS suites unaffected — Rust-only change isolated to the `grafema-orchestrator` crate with no interface change (same framing as #376/#381).

## Adversarial review

- **Round A — Correctness (Dijkstra).** `RawAddr` routes to `walk_expr(&e.expr)`, identical in shape to `Reference`/`Unary`/`Cast`; an operand with no nested calls (`&raw const GLOBAL`) emits nothing and cannot panic. `TryBlock` routes to `walk_block`, identical to `Unsafe`/`Async`; an empty `try {}` walks zero stmts. Nested forms (`&raw const (&raw mut x)`, `try { try { f() } }`) recurse through `walk_expr`/`walk_block`. Purely additive: these arms previously emitted **zero** nodes (they panicked), so walking now emits exactly what the same sub-expression would emit elsewhere.
- **Round B — Structural (Uncle Bob).** Reuses the existing shared `walk_expr`/`walk_block`; no new code path. `rust_analyzer.rs` is a pre-existing large dispatch file; this adds two logic lines + comments and does not introduce/worsen the god-file (a split is a separate refactor, out of scope). **Fragility called out:** the deeper landmine is the `_ => panic!` *policy* itself — there are five such arms (Item `:495`, ImplItem `:948`, ForeignItem `:1144`, Pat `:1493`, Expr `:1835`), and any future `syn` upgrade that adds a variant will reintroduce whole-file drops. Converting these to a graceful "skip + record an analysis issue" (degrade to a partial graph instead of dropping the file) is a behavior change for the maintainer to decide — filed as a follow-up, not folded in here.
- **Round C — Class-not-instance.** Audited all four sibling panic arms for variants reachable by **stable** syntax from their actual call sites:
  - **Expr** — `RawAddr` (stable) + `TryBlock` were the only two unhandled; **fixed**. Post-fix the enum diff is empty.
  - **Pat** (`walk_pat_bindings`) — the only unhandled stable variant is `Pat::Path` (e.g. `Ordering::Less`), but its callers are **irrefutable** contexts only — fn/closure params (`:607`) and `let` bindings (`:1283`); match-arm patterns are **not** routed here (the `Match` arm at `:1711` walks only guard/body, and `Expr::Let` at `:1796` walks only the scrutinee). So `Pat::Path` cannot appear in valid code reaching this function — not a live bug.
  - **Item / ImplItem / ForeignItem** — their handled sets cover the stable variants reachable from item position; `_` is reached only by genuinely exotic/future `syn` additions. Recorded under the Round-B follow-up rather than fixed speculatively.

## Blast radius

The `RawAddr`/`TryBlock` arms are reached only from `walk_expr`. Purely additive to graph output: previously these produced **zero** nodes (panic → whole file dropped), now the file is analyzed normally and the nested `CALL`/`REFERENCE`/`LITERAL` nodes inside the operand/body are emitted. No existing node/edge changed or removed; no existing test changed (429 → 431).

## Follow-ups (recorded, NOT in this PR)
- [ ] Decide the `_ => panic!` policy for the five unhandled-variant arms (Item/ImplItem/ForeignItem/Pat/Expr): keep loud-panic (caught → whole file dropped) vs. graceful skip + recorded analysis issue (partial graph). The latter would make a future `syn` upgrade degrade gracefully instead of silently dropping files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNBYx47JX4hpkU5kXX3tXe)_