### PR TITLE
fix(rust-analyzer): degrade gracefully on unhandled `syn` variants instead of dropping the whole file

### DIFF
--- a/packages/grafema-orchestrator/src/rust_analyzer.rs
+++ b/packages/grafema-orchestrator/src/rust_analyzer.rs
@@ -255,6 +255,39 @@ impl Ctx {
     fn meta_int(key: &str, val: i64) -> (String, serde_json::Value) {
         (key.to_string(), serde_json::json!(val))
     }
+
+    /// Record an unrecognised AST construct without aborting analysis of the file.
+    ///
+    /// `syn`'s `Item`/`Expr`/`Pat`/etc. enums are `#[non_exhaustive]`, and new
+    /// stable variants land with most Rust releases. Historically every walker's
+    /// catch-all arm `panic!`ed on a variant it didn't recognise. Because per-file
+    /// analysis runs inside `spawn_blocking`, that panic was caught upstream
+    /// (`analyze_rust_files_native`) and the ENTIRE file was discarded
+    /// (`analysis: None`) and mislabelled a `parse_error` — so a single
+    /// unrecognised construct (e.g. the `&raw const` operator, stable since Rust
+    /// 1.82) made every node and edge in an otherwise-parseable file vanish from
+    /// the graph. That directly violates the core thesis that the graph must be
+    /// trustworthy enough to query instead of reading the source.
+    ///
+    /// Instead we degrade gracefully: the unknown construct is skipped (its
+    /// children are not walked, so the graph for this file is partial) but the
+    /// rest of the file is still analysed, and the gap is surfaced as a
+    /// `tracing::warn!` so it is visible ("here be dragons") rather than silent.
+    /// `kind` is the enum name (e.g. `"Expr"`); `detail` is a concrete variant
+    /// name when known, or `""` when not.
+    fn warn_unhandled(&self, kind: &str, detail: &str) {
+        if detail.is_empty() {
+            tracing::warn!(
+                "rust_analyzer: unhandled {kind} variant in {} — skipping (graph for this file will be partial)",
+                self.file
+            );
+        } else {
+            tracing::warn!(
+                "rust_analyzer: unhandled {kind} variant `{detail}` in {} — skipping (graph for this file will be partial)",
+                self.file
+            );
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -492,7 +525,7 @@ fn walk_item(item: &syn::Item, ctx: &mut Ctx) {
         syn::Item::Union(u) => walk_union(u, ctx),
         syn::Item::TraitAlias(_) => {}
         syn::Item::Verbatim(_) => {}
-        _ => panic!("rust_analyzer: unhandled Item variant: {}", item_variant_name(item)),
+        _ => ctx.warn_unhandled("Item", item_variant_name(item)),
     }
 }
 
@@ -945,7 +978,7 @@ fn walk_impl_item(item: &syn::ImplItem, ctx: &mut Ctx) {
         syn::ImplItem::Type(_) => {}
         syn::ImplItem::Macro(_) => {}
         syn::ImplItem::Verbatim(_) => {}
-        _ => panic!("rust_analyzer: unhandled ImplItem variant"),
+        _ => ctx.warn_unhandled("ImplItem", ""),
     }
 }
 
@@ -1141,7 +1174,7 @@ fn walk_foreign_mod(fm: &syn::ItemForeignMod, ctx: &mut Ctx) {
             // unparsed tokens — neither introduces a resolvable symbol here.
             syn::ForeignItem::Macro(_) => {}
             syn::ForeignItem::Verbatim(_) => {}
-            _ => panic!("rust_analyzer: unhandled ForeignItem variant"),
+            _ => ctx.warn_unhandled("ForeignItem", ""),
         }
     }
 }
@@ -1490,7 +1523,7 @@ fn walk_pat_bindings(pat: &syn::Pat, kind: &str, ctx: &mut Ctx) {
         syn::Pat::Const(_) => {
             // const block pattern — no variable bindings
         }
-        _ => panic!("rust_analyzer: unhandled Pat variant in walk_pat_bindings"),
+        _ => ctx.warn_unhandled("Pat", ""),
     }
 }
 
@@ -1832,7 +1865,7 @@ fn walk_expr(expr: &syn::Expr, ctx: &mut Ctx) {
         syn::Expr::Infer(_) => {}
         syn::Expr::Verbatim(_) => {}
 
-        _ => panic!("rust_analyzer: unhandled Expr variant"),
+        _ => ctx.warn_unhandled("Expr", ""),
     }
 }
 
@@ -2302,16 +2335,30 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "unhandled")]
-    fn test_fail_early_on_unknown() {
-        // This test verifies the fail-early policy.
-        // syn::Expr::Verbatim won't panic (it's handled), but we can verify
-        // the mechanism works by checking that unknown items would panic.
-        // For now, verify that the module compiles with the panic branches.
-        let _ = parse_and_analyze("fn main() {}");
-        // If we get here, the basic case works. The panic branches are tested
-        // by the compiler — they exist in the match arms.
-        panic!("unhandled — test sentinel");
+    fn test_unhandled_expr_variant_degrades_gracefully() {
+        // `&raw const`/`&raw mut` (the raw-reference operator, stable since Rust
+        // 1.82) parses as `syn::Expr::RawAddr`, a variant this walker does not
+        // recognise, so it falls to the catch-all arm in `walk_expr`. That arm
+        // used to `panic!`; because per-file analysis runs inside
+        // `spawn_blocking`, the panic was caught upstream and the ENTIRE file was
+        // discarded (`analysis: None`, mislabelled `parse_error`).
+        //
+        // Invariant under test: one unrecognised construct must NOT erase the
+        // rest of an otherwise-parseable file. The file is still analysed; the
+        // unknown construct is simply skipped.
+        let fa = parse_and_analyze(
+            "fn make() { let x = 0u8; let p = &raw const x; helper(); } fn helper() {}",
+        );
+        assert!(has_node(&fa, "MODULE", "test"), "MODULE node survives");
+        assert!(has_node(&fa, "FUNCTION", "make"), "FUNCTION make survives");
+        assert!(
+            has_node(&fa, "FUNCTION", "helper"),
+            "sibling FUNCTION helper survives the unhandled RawAddr expr"
+        );
+        assert!(
+            has_node(&fa, "CALL", "helper"),
+            "CALL helper after the unhandled expr is still emitted"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The native in-process Rust analyzer (`packages/grafema-orchestrator/src/rust_analyzer.rs`) had **five** catch-all match arms that `panic!`ed on any `syn` variant they didn't recognise:

| fn | line (HEAD) | enum |
|----|------|------|
| `walk_item` | 495 | `Item` |
| `walk_impl_item` | 948 | `ImplItem` |
| `walk_foreign_mod` | 1144 | `ForeignItem` |
| `walk_pat_bindings` | 1493 | `Pat` |
| `walk_expr` | 1835 | `Expr` |

Because per-file analysis runs inside `tokio::task::spawn_blocking`, that panic is caught upstream in `analyze_rust_files_native` ([`rust_analyzer.rs:395`](../blob/main/packages/grafema-orchestrator/src/rust_analyzer.rs#L395)) and the **entire file is discarded** — `analysis: None`, mislabelled a `parse_error` (`:399`). One unrecognised-but-parseable construct erases every node and edge of an otherwise-valid file from the graph.

The clearest live trigger on `main`: the raw-reference operator `&raw const` / `&raw mut` (`syn::Expr::RawAddr`, **stable since Rust 1.82**, idiomatic in `unsafe`/FFI/systems code — Grafema's stated target domain). `walk_expr` on `main` has no arm for it, so any file using it falls to `_ => panic!(...)` and vanishes whole. That is a direct hit to the core thesis: *the graph must be trustworthy enough to query instead of reading the source.*

No open GitHub issue / no Linear access this run. Surfaced by the recorded follow-up of the per-variant arm work (#375/#376/#379/#381/#382): *"decide panic-vs-graceful-skip policy for the 5 unhandled-variant arms so a future syn upgrade degrades to a partial graph instead of dropping files."* This PR is the **policy** change (the catch-all arms), disjoint from those PRs which add **specific** arms before the catch-all.

## Spec

- **Invariant restored:** a parseable Rust file is never wholly dropped from the graph because of one construct the walker doesn't model yet. Entities: `FileAnalysis` (nodes/edges of every other construct in the file).
- **Given** a Rust file containing an unhandled `syn` construct (e.g. `&raw const x`) alongside ordinary items, **When** it is analysed, **Then** the unknown construct is skipped (its children aren't walked → partial graph) and every other node/edge in the file is still emitted, with a `tracing::warn!` surfacing the gap ("here be dragons") instead of a silent or total loss.

## Change

A single `Ctx::warn_unhandled(kind, detail)` helper (documented for agents) replaces all five `panic!`s: it logs a `tracing::warn!` and returns, skipping the construct. Centralizing the policy makes it one place to evolve (e.g. structured diagnostics later).

Also replaces the placeholder `test_fail_early_on_unknown` — which only `panic!`ed on a literal sentinel and asserted nothing about the walker ("The panic branches are tested by the compiler") — with a real regression test.

## Before / After

**Before** (`main`, red): `&raw const` panics in `walk_expr`, dropping the file:
```
thread '...' panicked at src/rust_analyzer.rs:1835 ... unhandled Expr variant
   walk_expr → walk_stmt → walk_block → walk_fn → walk_item → analyze_rust_file
test result: FAILED. 0 passed; 1 failed
```

**After** (green):
```
$ cargo test --lib
test result: ok. 429 passed; 0 failed; 0 ignored
```
New test `test_unhandled_expr_variant_degrades_gracefully` feeds
`fn make() { let x = 0u8; let p = &raw const x; helper(); } fn helper() {}`
and asserts MODULE + both FUNCTIONs + the `helper` CALL survive.

Gate: `cargo test --lib` 429 pass · `cargo clippy --lib` — no warnings on touched lines (pre-existing warnings elsewhere unchanged) · `cargo build -p grafema-orchestrator` ok.

## Adversarial review

- **A — Correctness:** nested unhandled variants warn+skip locally while the parent node is already emitted; multiple occurrences → multiple warns, file preserved; the `Item` catch-all is unreachable for current `syn` (all stable variants matched) but now safe for future ones; `&self` helper call on `&mut Ctx` borrow-checks in all five sites.
- **B — Structure:** one DRY helper, no duplication, policy centralized. File is already >500 lines (pre-existing); extraction is out of scope.
- **C — Class, not instance:** sibling instance found — the native **Ruby** analyzer (`ruby_analyzer.rs:3233`) has the same `panic!`-on-unhandled-Prism-variant arm under the same `spawn_blocking` harness. **Not** changed here: it carries an explicit `//! FAIL-EARLY POLICY` module doc and, unlike rust_analyzer, has no recorded reconsideration — left for a maintainer decision rather than flipped unilaterally.

## Blast radius

- The upstream panic-catch branch (`Err(JoinError)`, `:395`) stays live for genuine task panics (e.g. the scope-stack `.expect` invariants); it just no longer fires for unhandled variants.
- No code depended on the panic except the removed placeholder test; no `should_panic` tests or docs reference a rust fail-early policy.
- Interaction with open arm-PRs: if #382 (`Expr::RawAddr`/`TryBlock`) merges, the test's trigger becomes *handled* — the test still passes (it asserts file-survival, not skip-specifically) and the diffs don't overlap (they add arms above the catch-all; this changes the catch-all line).

## Follow-ups
- [ ] `ruby_analyzer.rs:3233` — same class; decide whether the graceful-degradation policy should apply to the documented FAIL-EARLY Ruby analyzer too.
- [ ] Optionally surface unhandled-variant warnings as structured `AnalysisIssue`s (severity `warning`) so the gap is queryable in the graph, not only in logs.

https://claude.ai/code/session_01WLMdUTbN5NTy1FBnmH9M3J

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLMdUTbN5NTy1FBnmH9M3J)_