### PR TITLE
fix(util): extract symbol name from grafema:// URI ids in FederatedRouter

### DIFF
--- a/packages/util/src/federation/FederatedRouter.ts
+++ b/packages/util/src/federation/FederatedRouter.ts
@@ -20,6 +20,7 @@ import type { WireNode, WireEdge } from '@grafema/types';
 import type { ShardDiscovery, ShardRegistration } from './ShardDiscovery.js';
 import type { ManifestResolver } from '../manifest/index.js';
 import type { ResolveResult } from '../manifest/resolver.js';
+import { parseSemanticIdV2 } from '../core/SemanticId.js';
 
 // ── Types ──────────────────────────────────────────────────────
 
@@ -400,10 +401,30 @@ function parseEdgeMetadata(metadata?: string): Record<string, string> {
   }
 }
 
-/** Extract symbol name from the last segment of a semantic ID. */
-function extractSymbolFromId(semanticId: string): string | null {
+/**
+ * Extract symbol name from a semantic ID, in either wire format.
+ *
+ * - Arrow format: "file.ts->FUNCTION->myFunc" → "myFunc"
+ * - URI format:   "grafema://localhost/proj/file.ts#FUNCTION-%3EmyFunc" → "myFunc"
+ *
+ * The grafema:// URI form (produced by the analysis pipeline's to_uri_format())
+ * percent-encodes the '>' of every '->' as '%3E', so a URI-format id contains no
+ * literal '->'. The old `split('->')` path therefore yielded a single part and
+ * returned null for every URI-format id — silently degrading symbol-level
+ * manifest resolution in tryManifestFallback to a wildcard. URI ids are delegated
+ * to the canonical parseSemanticIdV2; the arrow fast-path is preserved verbatim.
+ *
+ * Exported for unit testing.
+ * @internal
+ */
+export function extractSymbolFromId(semanticId: string): string | null {
   if (!semanticId) return null;
-  // "file.ts->FUNCTION->myFunc" → "myFunc"
+  // URI-format ids carry no literal '->'; delegate to the canonical parser.
+  if (semanticId.startsWith('grafema://')) {
+    const parsed = parseSemanticIdV2(semanticId);
+    return parsed ? parsed.name : null;
+  }
+  // Arrow format: "file.ts->FUNCTION->myFunc" → "myFunc"
   const parts = semanticId.split('->');
   return parts.length >= 3 ? parts[parts.length - 1] : null;
 }

--- a/packages/util/src/federation/index.ts
+++ b/packages/util/src/federation/index.ts
@@ -25,7 +25,7 @@
 export { ShardDiscovery } from './ShardDiscovery.js';
 export type { ShardRegistration } from './ShardDiscovery.js';
 
-export { FederatedRouter } from './FederatedRouter.js';
+export { FederatedRouter, extractSymbolFromId } from './FederatedRouter.js';
 export type {
   FederatedTraceResult,
   FederatedTraceHop,

--- a/test/unit/FederatedRouterSymbolId.test.js
+++ b/test/unit/FederatedRouterSymbolId.test.js
@@ -1,0 +1,52 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { toGrafemaUri } from '@grafema/util';
+// extractSymbolFromId is an @internal helper — imported via the federation
+// subpath so it stays off the top-level public barrel.
+import { extractSymbolFromId } from '@grafema/util/federation/index';
+
+/**
+ * Regression: extractSymbolFromId must recover the symbol name from BOTH wire
+ * formats of a semantic ID.
+ *
+ * FederatedRouter.tryManifestFallback uses extractSymbolFromId(edge.src) as the
+ * last-resort symbol name when an IMPORTS_FROM edge carries no specifier/localName
+ * in its metadata, then looks that name up in a package manifest. Its sibling
+ * extractFilePath was upgraded to parse the grafema:// URI form, but
+ * extractSymbolFromId kept an arrow-only `split('->')` path.
+ *
+ * The analysis pipeline's to_uri_format() emits ids as grafema:// URIs whose
+ * fragment percent-encodes every '->' as '-%3E' (GrafemaUri.encodeFragment turns
+ * '>' into '%3E'). So a URI-format id contains no literal '->', split('->')
+ * yields a single part, and the old code returned null — silently degrading a
+ * precise symbol-level manifest resolution to a wildcard '*'.
+ */
+describe('FederatedRouter.extractSymbolFromId', () => {
+  const compact = 'src/app.ts->FUNCTION->myFunc';
+  const uri = toGrafemaUri(compact, 'localhost/proj');
+
+  it('extracts the symbol from the arrow format (unchanged)', () => {
+    assert.equal(extractSymbolFromId(compact), 'myFunc');
+  });
+
+  it('extracts the symbol from the grafema:// URI format (regression)', () => {
+    // uri === 'grafema://localhost/proj/src/app.ts#FUNCTION-%3EmyFunc'
+    assert.ok(uri.startsWith('grafema://') && !uri.includes('->'),
+      `URI form must carry no literal '->': ${uri}`);
+    assert.equal(extractSymbolFromId(uri), 'myFunc');
+  });
+
+  it('strips bracket scope + disambiguation counter from URI-format ids', () => {
+    const compactScoped = 'src/app.ts->FUNCTION->myFunc[in:src/app.ts->CLASS->Foo,h:ab12]#2';
+    const uriScoped = toGrafemaUri(compactScoped, 'localhost/proj');
+    assert.equal(extractSymbolFromId(uriScoped), 'myFunc');
+  });
+
+  it('returns null for empty input', () => {
+    assert.equal(extractSymbolFromId(''), null);
+  });
+
+  it('returns null for an arrow id with fewer than three segments', () => {
+    assert.equal(extractSymbolFromId('EXTERNAL_MODULE->lodash'), null);
+  });
+});


### PR DESCRIPTION
## Summary

`FederatedRouter.tryManifestFallback` ([`FederatedRouter.ts:340`](../blob/main/packages/util/src/federation/FederatedRouter.ts#L340)) uses `extractSymbolFromId(edge.src)` as the **last-resort symbol name** for an `IMPORTS_FROM` edge that carries no `specifier`/`localName` in its metadata, then looks that name up in a package manifest to resolve cross-package effects.

`extractSymbolFromId` only handled the **arrow** wire format (`file.ts->FUNCTION->name`) via `split('->')`:

```ts
const parts = semanticId.split('->');
return parts.length >= 3 ? parts[parts.length - 1] : null;
```

But the analysis pipeline's `to_uri_format()` emits node ids as `grafema://` URIs whose fragment percent-encodes every `->` as `-%3E` (`GrafemaUri.encodeFragment` turns `>` into `%3E`). A URI-format id therefore contains **no literal `->`**, so `split('->')` yields a single part and the helper returned `null` for every URI-format id — silently degrading a precise **symbol-level** manifest resolution to the wildcard `*` branch (or a miss). Same URI-drift bug class as #380; the sibling `extractFilePath` ([`:417`](../blob/main/packages/util/src/federation/FederatedRouter.ts#L417)) was already taught both formats — `extractSymbolFromId` was the missed sibling.

No open GitHub issue / no Linear access this run; surfaced by auditing manual `->`-splitting semantic-ID parsers against the `grafema://` URI format. Disjoint from the open Rust-analyzer PRs (#375/#376/#381/#382/#383).

## Spec

- **Invariant restored:** `extractSymbolFromId` recovers the symbol name from **both** wire formats of a node id, so manifest fallback keeps symbol-level precision after `to_uri_format()`.
- **Given** an `IMPORTS_FROM` frontier edge whose `src` is a `grafema://` URI id and whose metadata lacks `specifier`/`localName`, **When** `tryManifestFallback` extracts the symbol from `src`, **Then** it gets the clean symbol name (not `null`) and performs a symbol-level manifest lookup instead of falling through to wildcard `*`.
- **Blast radius:** only callers of `extractSymbolFromId` — exactly one (`tryManifestFallback:340`). Arrow inputs are byte-for-byte unchanged (fast-path preserved verbatim).

## Fix

Delegate URI-format ids to the canonical `parseSemanticIdV2` (which already handles `grafema://` and additionally strips bracket scope + `#N` disambiguation counter, yielding a clean manifest lookup key). Arrow fast-path untouched → zero regression risk for existing arrow callers.

```ts
export function extractSymbolFromId(semanticId: string): string | null {
  if (!semanticId) return null;
  // URI-format ids carry no literal '->'; delegate to the canonical parser.
  if (semanticId.startsWith('grafema://')) {
    const parsed = parseSemanticIdV2(semanticId);
    return parsed ? parsed.name : null;
  }
  // Arrow format: "file.ts->FUNCTION->myFunc" → "myFunc"
  const parts = semanticId.split('->');
  return parts.length >= 3 ? parts[parts.length - 1] : null;
}
```

The `@internal` helper is exported from the `federation` subpath only (not the top-level `@grafema/util` barrel) so the test can reach it without widening the public API.

## Before / After (reproduction)

Production encode path (`GrafemaUri.toGrafemaUri`) + the **old** arrow-only helper, run verbatim:

```
compact id : src/app.ts->FUNCTION->myFunc
uri id     : grafema://localhost/proj/src/app.ts#FUNCTION-%3EmyFunc
symbol(compact): "myFunc"
symbol(uri)    : null   <-- BUG: should be "myFunc"
```

After the fix, the URI form yields `"myFunc"`.

## TDD evidence

New `test/unit/FederatedRouterSymbolId.test.js`. **RED** (URI branch disabled), arrow/control cases still pass:

```
expected: 'myFunc'   actual: ~   (x2 URI cases)
# tests 5  # pass 3  # fail 2
```

**GREEN** (fix in place):

```
# tests 5  # pass 5  # fail 0
```

## Adversarial review

- **Round A — Correctness.** Empty → `null` ✓. Arrow unchanged ✓. URI standard node → name ✓. URI id with bracket scope whose `in:` parent itself contains `->` + a trailing `#N` counter → clean `myFunc` ✓ (parseSemanticIdV2 nested-parent handling, cf. `SemanticIdV2NestedParent.test.js`). Malformed URI → `parseSemanticIdV2` returns `null` → `null` ✓. No `decodeURIComponent` throw risk (canonical parser uses explicit `replaceAll`).
- **Round B — Structural fragility.** `FederatedRouter.ts` stays at 442 lines (< 500). The fix *removes* divergence: both `extractFilePath` (URI-aware) and `extractSymbolFromId` now agree that URI ids exist. New coupling is to the canonical `parseSemanticIdV2` — the single source of truth — which is the right layer.
- **Round C — Class, not instance.** Scanned all non-test prod sites that split on `->`: `extractFilePath` (already URI-aware), `GrafemaUri.toGrafemaUri:68` (encoder, compact input by contract), `SemanticId.ts` (canonical, both formats), `context.ts`/`context-handlers.ts` (edge-direction display arrow, not id parsing), `mcp humanReadableId:559` (operates on already-decoded fragment post-#380). `extractSymbolFromId` was the one genuine unguarded sibling — no others remain.

## Full gate (all green)

```
pnpm install --no-frozen-lockfile   ok
pnpm build (incl. cargo rfdb-server) exit 0
./scripts/test.sh                    # tests 704  # pass 704  # fail 0
pnpm typecheck                       exit 0
pnpm lint                            exit 0
```

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMEm9RyXMxnHevmjH3zABm)_