### PR TITLE
fix(util): strip authority from grafema:// URI in extractFilePath (FederatedRouter)

### DIFF
--- a/packages/util/src/federation/FederatedRouter.ts
+++ b/packages/util/src/federation/FederatedRouter.ts
@@ -430,20 +430,32 @@ export function extractSymbolFromId(semanticId: string): string | null {
 }
 
 /**
- * Extract absolute file path from a semantic ID or grafema URI.
- * Handles both formats:
- * - Arrow format: "path/to/file.ts->FUNCTION->name"
- * - URI format: "grafema://path/to/file.ts#FUNCTION%3Aname"
+ * Extract the file path from a semantic ID, in either wire format.
+ *
+ * - Arrow format: "path/to/file.ts->FUNCTION->name" → "path/to/file.ts"
+ * - URI format:   "grafema://localhost/proj/path/to/file.ts#FUNCTION-%3Ename" → "path/to/file.ts"
+ *
+ * The grafema:// URI form (produced by the analysis pipeline's to_uri_format())
+ * is grafema://{authority}/{file}#{fragment} where {authority} is the host+project
+ * — "localhost/proj" (2 segments) or "github.com/owner/repo" (3 segments). Slicing
+ * off only the "grafema://" scheme left the authority prepended to the path
+ * ("localhost/proj/path/to/file.ts"), so groupByShard's ShardDiscovery.resolve()
+ * — which longest-prefix-matches against ABSOLUTE shard roots — never matched and
+ * mis-routed every URI-format edge to the "__unresolved__" group. URI ids are
+ * delegated to the canonical parseSemanticIdV2 (which strips the authority); the
+ * arrow fast-path is preserved verbatim. Mirrors the sibling extractSymbolFromId.
+ *
+ * Exported for unit testing.
+ * @internal
  */
-function extractFilePath(semanticId: string): string | null {
+export function extractFilePath(semanticId: string): string | null {
   if (!semanticId) return null;
 
-  // URI format: grafema://path/to/file.ts#fragment
+  // URI-format ids embed the authority before the file path; delegate to the
+  // canonical parser, which strips it. parsed.file is '' for virtual nodes.
   if (semanticId.startsWith('grafema://')) {
-    const hashIdx = semanticId.indexOf('#');
-    return hashIdx > 0
-      ? semanticId.slice('grafema://'.length, hashIdx)
-      : semanticId.slice('grafema://'.length);
+    const parsed = parseSemanticIdV2(semanticId);
+    return parsed && parsed.file ? parsed.file : null;
   }
 
   // Arrow format: path/to/file.ts->FUNCTION->name

--- a/packages/util/src/federation/index.ts
+++ b/packages/util/src/federation/index.ts
@@ -25,7 +25,7 @@
 export { ShardDiscovery } from './ShardDiscovery.js';
 export type { ShardRegistration } from './ShardDiscovery.js';
 
-export { FederatedRouter, extractSymbolFromId } from './FederatedRouter.js';
+export { FederatedRouter, extractSymbolFromId, extractFilePath } from './FederatedRouter.js';
 export type {
   FederatedTraceResult,
   FederatedTraceHop,

--- a/test/unit/FederatedRouterFilePath.test.js
+++ b/test/unit/FederatedRouterFilePath.test.js
@@ -1,0 +1,54 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { toGrafemaUri } from '@grafema/util';
+// extractFilePath is an @internal helper — imported via the federation
+// subpath so it stays off the top-level public barrel (mirrors extractSymbolFromId).
+import { extractFilePath } from '@grafema/util/federation/index';
+
+/**
+ * Regression: extractFilePath must recover the SAME file path from BOTH wire
+ * formats of a semantic ID — it must be wire-format-agnostic.
+ *
+ * FederatedRouter.groupByShard uses extractFilePath(edge.dst) and feeds the
+ * result to ShardDiscovery.resolve(), which does longest-prefix matching of the
+ * file path against absolute shard roots. Its sibling extractSymbolFromId was
+ * upgraded to parse the grafema:// URI form; extractFilePath kept a naive URI
+ * branch that sliced off only the "grafema://" scheme, leaving the URI AUTHORITY
+ * (e.g. "localhost/proj" or "github.com/owner/repo") prepended to the path.
+ *
+ * The analysis pipeline's to_uri_format() emits ids as grafema:// URIs of the
+ * form grafema://{authority}/{file}#{fragment} (GrafemaUri.toGrafemaUri). The old
+ * branch therefore returned "localhost/proj/src/app.ts" instead of "src/app.ts",
+ * so every URI-format edge mis-routed to the "__unresolved__" group: the
+ * authority-prefixed string never startsWith() an absolute shard root.
+ */
+describe('FederatedRouter.extractFilePath', () => {
+  it('extracts the file path from the arrow format (unchanged)', () => {
+    assert.equal(extractFilePath('src/app.ts->FUNCTION->myFunc'), 'src/app.ts');
+  });
+
+  it('strips the authority from the grafema:// URI format (regression)', () => {
+    const compact = 'src/app.ts->FUNCTION->myFunc';
+    const uri = toGrafemaUri(compact, 'localhost/proj');
+    // uri === 'grafema://localhost/proj/src/app.ts#FUNCTION-%3EmyFunc'
+    assert.ok(uri.startsWith('grafema://') && !uri.includes('->'),
+      `URI form must carry no literal '->': ${uri}`);
+    // Format-agnostic: URI and arrow forms of the SAME node yield the SAME path.
+    assert.equal(extractFilePath(uri), 'src/app.ts');
+  });
+
+  it('strips a 3-segment host/owner/repo authority', () => {
+    const uri = toGrafemaUri('packages/api/src/x.ts->CLASS->Foo', 'github.com/owner/repo');
+    assert.equal(extractFilePath(uri), 'packages/api/src/x.ts');
+  });
+
+  it('handles the MODULE URI form', () => {
+    const uri = toGrafemaUri('MODULE#src/app.ts', 'localhost/proj');
+    // uri === 'grafema://localhost/proj/src/app.ts#MODULE'
+    assert.equal(extractFilePath(uri), 'src/app.ts');
+  });
+
+  it('returns null for empty input', () => {
+    assert.equal(extractFilePath(''), null);
+  });
+});


### PR DESCRIPTION
## Summary

`FederatedRouter.extractFilePath` mishandled the **grafema:// URI** wire format: it sliced off only the `grafema://` scheme, leaving the URI **authority** (host+project) prepended to the file path. This is the file-path sibling of the symbol-name fix in **#384** (`70cecb2`), which already upgraded `extractSymbolFromId` to parse URI ids — `extractFilePath` was missed.

### Spec
- **Invariant restored:** `extractFilePath` is **wire-format-agnostic** — the same logical node yields the same file path whether its id is arrow form (`src/app.ts->FUNCTION->myFunc`) or grafema:// URI form (`grafema://localhost/proj/src/app.ts#FUNCTION-%3EmyFunc`).
- **Given** a URI-format id from the analysis pipeline's `to_uri_format()` — always `grafema://{authority}/{file}#{fragment}`, authority = `localhost/proj` (2 seg) or `github.com/owner/repo` (3 seg) — **When** `extractFilePath` runs, **Then** it returns the project-relative path with the authority stripped, matching the arrow form and canonical `parseGrafemaUri`/`parseSemanticIdV2`.
- **Blast radius:** sole caller `groupByShard` (`FederatedRouter.ts:379`) → `ShardDiscovery.resolve(filePath)`, which longest-prefix-matches against **absolute** shard roots. An authority-prefixed string never `startsWith()` an absolute root, so **every URI-format edge mis-routed to the `__unresolved__` group** in cross-shard federation.

## Before / After (reproduced against built dist)

```
compact: src/app.ts->FUNCTION->myFunc
uri:     grafema://localhost/proj/src/app.ts#FUNCTION-%3EmyFunc

extractFilePath — BEFORE
  arrow -> src/app.ts
  uri   -> localhost/proj/src/app.ts      <-- authority contamination
extractFilePath — AFTER
  arrow -> src/app.ts
  uri   -> src/app.ts                      <-- matches arrow + canonical
```

Red run (before fix): `# tests 5  # pass 2  # fail 3`
```
expected: 'src/app.ts'                    actual: 'localhost/proj/src/app.ts'
expected: 'packages/api/src/x.ts'         actual: 'github.com/owner/repo/packages/api/src/x.ts'
```
Green run (after fix): `# tests 5  # pass 5  # fail 0`

## Fix

Delegate the URI branch to the canonical `parseSemanticIdV2(id).file` (already imported and used by the sibling `extractSymbolFromId`). It strips the authority across 2-/3-segment authorities and the MODULE form; the arrow fast-path is preserved verbatim. Net change: one function body + docstring; `extractFilePath` exported via the `@grafema/util/federation/index` subpath for unit testing (mirrors `extractSymbolFromId`).

## Adversarial review

- **A — Correctness:** empty → `null`; arrow form unchanged; malformed/virtual URI (`/_/`, no `.file`) → `null` (previously a garbage authority-prefixed string that also never resolved — no regression, strictly tighter); non-URI path-like fallback unchanged.
- **B — Structural:** reuses the already-imported canonical parser (no new coupling, no duplication, consistent with sibling). `FederatedRouter.ts` = 473 lines (< 500).
- **C — Class-not-instance:** grepped all `grafema://`-scheme slices repo-wide; the only other site is `parseGrafemaUri` itself (the canonical parser, which strips authority correctly). **Bug class fully closed** — no remaining siblings.

## Verification (actual outputs)

| Gate | Result |
|------|--------|
| `pnpm build` | exit 0 |
| `pnpm typecheck` | exit 0 |
| `pnpm lint` | exit 0 |
| `pnpm test:coverage` (root unit) | **720 / 720** pass, 0 fail (+5 new) |
| `pnpm --filter @grafema/mcp test` | **106 / 106** pass, 0 fail |

Sibling/prior art: PR #384 (`70cecb2`) — symbol-name half of this same bug class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzMQSfr7rBUF1xzNfjkA4Z)_