### PR TITLE
fix(util): anchor grafema:// virtual marker to authority boundary

### DIFF
--- a/packages/util/src/core/GrafemaUri.ts
+++ b/packages/util/src/core/GrafemaUri.ts
@@ -113,20 +113,28 @@ export function parseGrafemaUri(uri: string): ParsedGrafemaUri | null {
 
   const rest = uri.slice(GRAFEMA_SCHEME.length); // "authority/file#fragment"
 
-  // Find the authority: everything up to the first '/' after the host
-  // Authority format: "host/project" (e.g., "github.com/owner/repo" or "localhost/project")
-  // We need to find where authority ends and file path begins.
-  // Convention: authority is "host/path" where host has no '/', so we split on first '/' after host.
-  // Actually, authority can be multi-segment (github.com/owner/repo = 3 segments).
-  // Strategy: find '#' first (fragment delimiter), then split the path part.
+  // Determine the authority boundary first. The authority is "host/project"
+  // (2 segments, e.g. "localhost/grafema") or "host/owner/repo" (3 segments)
+  // for known forge hosts. Everything after the authority is either the
+  // reserved virtual marker "_/..." or a "file/path#fragment".
+  const segments = rest.split('/');
+  const host = segments[0];
+  const authoritySegments =
+    host === 'github.com' || host === 'gitlab.com' || host === 'bitbucket.org'
+      ? 3 // host/owner/repo
+      : 2; // host/project (localhost/grafema)
 
-  const hashPos = rest.indexOf('#');
-  const slashUnderscoreSlash = rest.indexOf('/_/');
+  if (segments.length < authoritySegments) return null;
 
-  if (slashUnderscoreSlash !== -1 && (hashPos === -1 || slashUnderscoreSlash < hashPos)) {
-    // Virtual node: authority/_/encoded_id
-    const authority = rest.slice(0, slashUnderscoreSlash);
-    const encodedId = rest.slice(slashUnderscoreSlash + 3); // after "/_/"
+  const authority = segments.slice(0, authoritySegments).join('/');
+  const afterAuthority = rest.slice(authority.length + 1); // skip the '/' after authority
+
+  // Virtual node: the segment immediately after the authority is exactly "_".
+  // This MUST be anchored to the authority boundary — a "_" path segment deeper
+  // in a real file path (e.g. src/_/util.ts) is NOT a virtual marker, so we
+  // cannot scan the whole string for the substring "/_/".
+  if (afterAuthority === '_' || afterAuthority.startsWith('_/')) {
+    const encodedId = afterAuthority.slice(2); // after "_/"
     const decodedId = decodeFragment(encodedId);
 
     // Reconstruct compact ID -- it's just the decoded full ID
@@ -139,41 +147,13 @@ export function parseGrafemaUri(uri: string): ParsedGrafemaUri | null {
     };
   }
 
+  // Standard node: afterAuthority = "file/path#fragment"
+  const hashPos = afterAuthority.indexOf('#');
   if (hashPos === -1) return null; // No fragment = invalid
 
-  const pathPart = rest.slice(0, hashPos); // "authority/file/path"
-  const fragment = rest.slice(hashPos + 1); // "TYPE-%3Ename..."
+  const filePath = afterAuthority.slice(0, hashPos);
+  const fragment = afterAuthority.slice(hashPos + 1); // "TYPE-%3Ename..."
   const decodedFragment = decodeFragment(fragment);
-
-  // Split pathPart into authority and filePath.
-  // The authority is the first N segments that represent the host+project.
-  // Problem: we don't know where authority ends and file begins.
-  // Convention from the plan: authority = "host/project" (e.g., "localhost/grafema")
-  //   or "github.com/owner/repo" (3 segments).
-  // The file path typically starts with src/, lib/, etc.
-  //
-  // Better approach: find the file path by working backward from the fragment.
-  // The fragment's decoded form tells us the type. The module_id for MODULE# format
-  // means filePath = pathPart minus authority.
-  //
-  // Simplest reliable approach: the authority is stored separately or we use a heuristic.
-  // For now: authority = first 2 segments for "host/project" format,
-  // first 3 segments for known hosts (github.com, gitlab.com, bitbucket.org).
-
-  const segments = pathPart.split('/');
-  let authoritySegments: number;
-
-  const host = segments[0];
-  if (host === 'github.com' || host === 'gitlab.com' || host === 'bitbucket.org') {
-    authoritySegments = 3; // host/owner/repo
-  } else {
-    authoritySegments = 2; // host/project (localhost/grafema)
-  }
-
-  if (segments.length < authoritySegments) return null;
-
-  const authority = segments.slice(0, authoritySegments).join('/');
-  const filePath = segments.slice(authoritySegments).join('/');
 
   // Reconstruct compact semantic ID
   let semanticId: string;

--- a/packages/util/src/core/SemanticId.ts
+++ b/packages/util/src/core/SemanticId.ts
@@ -16,6 +16,8 @@
  *   External modules: EXTERNAL_MODULE->lodash
  */
 
+import { parseGrafemaUri } from './GrafemaUri.js';
+
 /**
  * Location in source file
  */
@@ -281,52 +283,22 @@ export function computeSemanticIdV2(
  * @returns Parsed components or null if not a valid v2 ID
  */
 export function parseSemanticIdV2(id: string): ParsedSemanticIdV2 | null {
-  // Handle grafema:// URI input — convert to compact first
+  // Handle grafema:// URI input — convert to compact first. Delegate the URI
+  // structure parsing to the canonical parseGrafemaUri (single source of truth
+  // for authority detection and the reserved "_" virtual marker) instead of
+  // re-implementing it here, which previously diverged and mis-handled file
+  // paths containing a "_" segment.
   if (id.startsWith('grafema://')) {
-    const scheme = 'grafema://';
-    const rest = id.slice(scheme.length);
+    const parsedUri = parseGrafemaUri(id);
+    if (!parsedUri) return null;
 
-    const slashUnderscore = rest.indexOf('/_/');
-    const hashPos = rest.indexOf('#');
-
-    if (slashUnderscore !== -1 && (hashPos === -1 || slashUnderscore < hashPos)) {
-      // Virtual node: decode and re-parse
-      const encodedId = rest.slice(slashUnderscore + 3);
-      const decoded = encodedId
-        .replaceAll('%3E', '>').replaceAll('%3e', '>')
-        .replaceAll('%5B', '[').replaceAll('%5b', '[')
-        .replaceAll('%5D', ']').replaceAll('%5d', ']')
-        .replaceAll('%23', '#');
-      return parseSemanticIdV2(decoded);
+    // MODULE nodes carry no FUNCTION/TYPE fragment to re-parse.
+    if (parsedUri.symbolPart === 'MODULE') {
+      return { file: parsedUri.filePath, type: 'MODULE', name: parsedUri.filePath };
     }
 
-    if (hashPos !== -1) {
-      const pathPart = rest.slice(0, hashPos);
-      const fragment = rest.slice(hashPos + 1);
-      const decoded = fragment
-        .replaceAll('%3E', '>').replaceAll('%3e', '>')
-        .replaceAll('%5B', '[').replaceAll('%5b', '[')
-        .replaceAll('%5D', ']').replaceAll('%5d', ']')
-        .replaceAll('%23', '#');
-
-      if (decoded === 'MODULE') {
-        const segments = pathPart.split('/');
-        const host = segments[0];
-        const skip = (host === 'github.com' || host === 'gitlab.com' || host === 'bitbucket.org') ? 3 : 2;
-        const filePath = segments.slice(skip).join('/');
-        return { file: filePath, type: 'MODULE', name: filePath };
-      }
-
-      // Standard node: extract file and reconstruct compact ID
-      const segments = pathPart.split('/');
-      const host = segments[0];
-      const skip = (host === 'github.com' || host === 'gitlab.com' || host === 'bitbucket.org') ? 3 : 2;
-      const filePath = segments.slice(skip).join('/');
-      const compactId = `${filePath}->${decoded}`;
-      return parseSemanticIdV2(compactId);
-    }
-
-    return null;
+    // Everything else (standard + virtual) round-trips through the compact form.
+    return parseSemanticIdV2(parsedUri.semanticId);
   }
 
   // Handle singletons

--- a/test/unit/GrafemaUriUnderscorePath.test.js
+++ b/test/unit/GrafemaUriUnderscorePath.test.js
@@ -1,0 +1,98 @@
+/**
+ * Regression: grafema:// URIs whose file path contains a "_" path segment.
+ *
+ * The virtual-node marker "_" is a reserved path segment that appears
+ * immediately after the authority (grafema://{authority}/_/{encoded_id}). It
+ * MUST be detected at the authority boundary, NOT by scanning the whole string
+ * for the substring "/_/". A real file path that contains a bare "_" segment
+ * (e.g. src/_/util.ts) was previously misparsed as a virtual node, silently
+ * corrupting the reconstructed semantic ID (round-tripped to "util.ts#..." and
+ * parseSemanticIdV2 returned undefined file/type/name).
+ *
+ * Lives at the top level of test/unit/ so the CI `test:coverage` glob
+ * (`test/unit/*.test.js`, non-recursive) actually gates it.
+ */
+
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import {
+  toGrafemaUri,
+  parseGrafemaUri,
+  toCompactSemanticId,
+  parseSemanticIdV2,
+} from '@grafema/util';
+
+describe('grafema:// URI with "_" file-path segment (regression)', () => {
+  it('parseGrafemaUri keeps a "_" directory in the file path', () => {
+    const parsed = parseGrafemaUri('grafema://localhost/grafema/src/_/util.ts#FUNCTION-%3Efoo');
+    assert.ok(parsed);
+    assert.equal(parsed.isVirtual, false);
+    assert.equal(parsed.filePath, 'src/_/util.ts');
+    assert.equal(parsed.semanticId, 'src/_/util.ts->FUNCTION->foo');
+  });
+
+  it('parseGrafemaUri handles multiple "_" segments', () => {
+    const parsed = parseGrafemaUri('grafema://localhost/grafema/a/_/b/_/c.ts#FN-%3Ez');
+    assert.ok(parsed);
+    assert.equal(parsed.isVirtual, false);
+    assert.equal(parsed.filePath, 'a/_/b/_/c.ts');
+    assert.equal(parsed.semanticId, 'a/_/b/_/c.ts->FN->z');
+  });
+
+  it('parseGrafemaUri handles a "_" segment under github.com authority', () => {
+    const parsed = parseGrafemaUri('grafema://github.com/owner/repo/src/_/util.ts#FUNCTION-%3Efoo');
+    assert.ok(parsed);
+    assert.equal(parsed.authority, 'github.com/owner/repo');
+    assert.equal(parsed.filePath, 'src/_/util.ts');
+    assert.equal(parsed.semanticId, 'src/_/util.ts->FUNCTION->foo');
+  });
+
+  it('parseGrafemaUri keeps a "_" directory for a MODULE node', () => {
+    const parsed = parseGrafemaUri('grafema://localhost/grafema/src/_/a.ts#MODULE');
+    assert.ok(parsed);
+    assert.equal(parsed.isVirtual, false);
+    assert.equal(parsed.filePath, 'src/_/a.ts');
+    assert.equal(parsed.semanticId, 'MODULE#src/_/a.ts');
+  });
+
+  it('parseSemanticIdV2 parses a node whose file has a "_" segment', () => {
+    const parsed = parseSemanticIdV2('grafema://localhost/grafema/src/_/util.ts#FUNCTION-%3Efoo');
+    assert.ok(parsed);
+    assert.equal(parsed.file, 'src/_/util.ts');
+    assert.equal(parsed.type, 'FUNCTION');
+    assert.equal(parsed.name, 'foo');
+  });
+
+  it('parseSemanticIdV2 parses a MODULE node whose file has a "_" segment', () => {
+    const parsed = parseSemanticIdV2('grafema://localhost/grafema/src/_/a.ts#MODULE');
+    assert.ok(parsed);
+    assert.equal(parsed.file, 'src/_/a.ts');
+    assert.equal(parsed.type, 'MODULE');
+  });
+
+  it('still parses genuine virtual nodes (marker right after authority)', () => {
+    const parsed = parseGrafemaUri('grafema://localhost/grafema/_/EXTERNAL_MODULE-%3Elodash');
+    assert.ok(parsed);
+    assert.equal(parsed.isVirtual, true);
+    assert.equal(parsed.semanticId, 'EXTERNAL_MODULE->lodash');
+  });
+
+  it('parseSemanticIdV2 still parses genuine virtual singleton nodes', () => {
+    const parsed = parseSemanticIdV2('grafema://localhost/grafema/_/net:stdio-%3E__stdio__');
+    assert.ok(parsed);
+    assert.equal(parsed.type, 'SINGLETON');
+    assert.equal(parsed.name, '__stdio__');
+  });
+
+  for (const compact of [
+    'src/_/util.ts->FUNCTION->foo',
+    'a/_/b/_/c.ts->FN->z',
+    'src/_/helpers/x.ts->CLASS->C[in:p]',
+    'MODULE#src/_/a.ts',
+  ]) {
+    it(`roundtrips through URI: ${compact}`, () => {
+      const uri = toGrafemaUri(compact, 'localhost/grafema');
+      assert.equal(toCompactSemanticId(uri), compact);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

`parseGrafemaUri` detected the reserved virtual-node marker `_` by scanning the **whole** string for the substring `/_/`. A real file path containing a bare `_` path segment (e.g. `src/_/util.ts`) was therefore misparsed as a *virtual* node, **silently corrupting** the reconstructed semantic ID. `parseSemanticIdV2` carried a second, divergent copy of the same URI-parsing logic with the identical bug.

This is the same latent class as #386 (semantic-ID parsing silently failing on the `grafema://` URI format).

## Spec

- **Invariant restored:** `toCompactSemanticId(toGrafemaUri(id)) === id` for every semantic ID whose file path contains a `_` segment; `parseSemanticIdV2` returns correct `file`/`type`/`name` for such URIs.
- **Given** a node URI `grafema://localhost/grafema/src/_/util.ts#FUNCTION-%3Efoo`
  **When** parsed, **Then** `filePath = src/_/util.ts`, `semanticId = src/_/util.ts->FUNCTION->foo`, `isVirtual = false` (previously: `isVirtual = true`, `semanticId = util.ts#FUNCTION->foo`).
- **Root cause:** the `_` virtual marker is reserved *only* immediately after the authority (`grafema://{authority}/_/...`). Locating it anywhere in the string aliases with legitimate `_` directories.

## Fix

`packages/util/src/core/GrafemaUri.ts` — split off the authority first (2 segments, or 3 for `github.com`/`gitlab.com`/`bitbucket.org`), then treat the remainder as virtual only when it is exactly `_` or starts with `_/`. Standard nodes parse `file#fragment` from the post-authority remainder.

`packages/util/src/core/SemanticId.ts` — `parseSemanticIdV2` now delegates its `grafema://` handling to the canonical `parseGrafemaUri` (single source of truth for authority detection + the `_` marker), removing the divergent buggy copy. MODULE/virtual/singleton/standard shapes are preserved via the existing compact-form recursion.

## Before / After (live `tsx` run against source)

```
# BEFORE
BUG compact="src/_/util.ts->FUNCTION->foo"
      uri=grafema://localhost/grafema/src/_/util.ts#FUNCTION-%3Efoo
      back="util.ts#FUNCTION->foo"  | v2: file=undefined type=undefined name=undefined

# AFTER
OK  rt  "src/_/util.ts->FUNCTION->foo" -> grafema://localhost/grafema/src/_/util.ts#FUNCTION-%3Efoo -> "src/_/util.ts->FUNCTION->foo"
OK  v2  grafema://localhost/grafema/src/_/util.ts#FUNCTION-%3Efoo => src/_/util.ts|FUNCTION|foo
OK  rt  "MODULE#src/_/a.ts" -> grafema://localhost/grafema/src/_/a.ts#MODULE -> "MODULE#src/_/a.ts"
OK  rt  "src/file.ts->CLASS->C" (github.com/owner/repo authority) -> ... -> roundtrips
```

## Tests

New `test/unit/GrafemaUriUnderscorePath.test.js` (12 cases) — placed top-level because the CI `test:coverage` glob `test/unit/*.test.js` is **non-recursive** and does not pick up `test/unit/core/`.

- Red before fix: 7/8 new structural cases failed for the right reason (the genuine-virtual case already passed).
- After fix:
  - New file: **12/12 pass**.
  - `test/unit/core/GrafemaUri.test.js`: 37/37 pass (existing, unchanged).
  - `FederatedRouterFilePath` / `FederatedRouterSymbolId` / `SemanticAddressResolver` / `SemanticIdV2NestedParent`: all pass.
  - Full CI-gated root glob: baseline **489 pass / 107 fail** → with this change **501 pass / 107 fail** (+12 new passing, **0 new failures**). The 107 pre-existing failures are environmental (native `rfdb-server` binary not built; `mcp`/`cli` `dist` not built) and are identical with the change stashed.
- `eslint` on changed files: clean (exit 0).

## Adversarial review

- **A — Correctness:** multiple `_` segments, `_` under `github.com` 3-segment authority, MODULE nodes whose file has a `_` segment, bracket/counter suffixes, singletons, external-module virtual nodes — all round-trip (live harness above).
- **B — Structural:** removed a duplicated URI parser; `GrafemaUri.ts` now the single source of truth. Import direction is one-way (`SemanticId → GrafemaUri`, no cycle — `GrafemaUri` imports nothing). Both files < 500 lines.
- **C — Class/invariant:** grep confirms exactly two `indexOf('/_/')` sites (`GrafemaUri.ts`, `SemanticId.ts`); both now go through the one corrected implementation.

## Known limitation (pre-existing, by design — not a regression)

A directory literally named `_` at the **repository root** (`_/util.ts`) remains inherently ambiguous with the `authority/_/` virtual marker. Disambiguating it would require changing the URI wire format shared with the Rust orchestrator's `to_uri_format`, which is out of scope. The realistic case (a `_` segment anywhere below the top level, e.g. `src/_/`) is fully fixed.

## Blast radius

Callers of `parseGrafemaUri` / `parseSemanticIdV2` / `toCompactSemanticId` (FederatedRouter cross-repo routing, CLI `query`/`trace`, MCP handlers). Behavior changes **only** for inputs containing a `_` path segment, which previously produced corrupted output — no previously-correct result changes (verified by the unchanged 107/501 split and passing federation/semantic test suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FugWRbm5EfGy8FuARYa2G3)_