### PR TITLE
fix(util): PathValidator reports DB-specific reason for namespaced db:query endpoints

### DIFF
--- a/packages/util/src/validation/PathValidator.ts
+++ b/packages/util/src/validation/PathValidator.ts
@@ -269,13 +269,30 @@ export class PathValidator {
   }
 
   /**
+   * Является ли endpoint запросом к БД.
+   *
+   * Single source of truth for the database-query type aliases: the
+   * namespaced `db:query` (current emitter output) and the legacy
+   * `DATABASE_QUERY` (kept for backward compatibility). Key generation and
+   * both reason generators MUST agree on this set — otherwise a db:query
+   * endpoint is keyed as a database query but reported with the generic
+   * "no longer reachable" message, silently dropping the SQL text.
+   *
+   * @param type - node.type of the endpoint
+   * @returns true if the type denotes a database query
+   */
+  private _isDatabaseQuery(type: string): boolean {
+    return type === 'db:query' || type === 'DATABASE_QUERY';
+  }
+
+  /**
    * Получить уникальный ключ для endpoint
    *
    * @param endpoint - Endpoint нода
    * @returns Уникальный ключ
    */
   private _getEndpointKey(endpoint: EndpointNode): string {
-    if (endpoint.type === 'DATABASE_QUERY' || endpoint.type === 'db:query') {
+    if (this._isDatabaseQuery(endpoint.type)) {
       // Для DB query используем query text
       return `db:query:${endpoint.query || endpoint.name}`;
     }
@@ -298,8 +315,8 @@ export class PathValidator {
    * Получить reason для missing endpoint
    */
   private _getMissingReason(endpoint: EndpointNode): string {
-    if (endpoint.type === 'DATABASE_QUERY') {
-      return `Database query no longer executed: ${endpoint.query}`;
+    if (this._isDatabaseQuery(endpoint.type)) {
+      return `Database query no longer executed: ${endpoint.query || endpoint.name}`;
     }
 
     if (endpoint.type === 'FUNCTION' && endpoint.exported) {
@@ -317,8 +334,8 @@ export class PathValidator {
    * Получить reason для added endpoint
    */
   private _getAddedReason(endpoint: EndpointNode): string {
-    if (endpoint.type === 'DATABASE_QUERY') {
-      return `New database query added: ${endpoint.query}`;
+    if (this._isDatabaseQuery(endpoint.type)) {
+      return `New database query added: ${endpoint.query || endpoint.name}`;
     }
 
     if (endpoint.type === 'FUNCTION' && endpoint.exported) {

--- a/test/unit/PathValidator.test.js
+++ b/test/unit/PathValidator.test.js
@@ -177,8 +177,11 @@ describe('PathValidator', () => {
       assert.strictEqual(result.missing.length, 1);
       // DATABASE_QUERY is now mapped to 'db:query'
       assert.strictEqual(result.missing[0].type, 'db:query');
-      // The reason message is "Endpoint no longer reachable: <name>"
-      assert.match(result.missing[0].reason, /no longer reachable/i);
+      // The namespaced db:query endpoint must report the database-specific
+      // reason carrying the actual SQL text (regression: db:query previously
+      // fell through to the generic "no longer reachable" message).
+      assert.match(result.missing[0].reason, /database query no longer executed/i);
+      assert.match(result.missing[0].reason, /SELECT \* FROM orders WHERE id = \?/);
     });
   });
 
@@ -242,8 +245,10 @@ describe('PathValidator', () => {
       assert.match(result.message, /new behavior/i);
       assert.ok(result.added);
       assert.strictEqual(result.added.length, 1);
-      // The reason message is "New <type> added: <name>"
-      assert.match(result.added[0].reason, /new.*(query|endpoint)/i);
+      // The namespaced db:query endpoint must report the database-specific
+      // "New database query added" reason carrying the actual SQL text.
+      assert.match(result.added[0].reason, /new database query added/i);
+      assert.match(result.added[0].reason, /INSERT INTO audit_log \(action\) VALUES \(\?\)/);
     });
   });
 


### PR DESCRIPTION
## Summary

`PathValidator` (the path-equivalence refactoring-safety check) carries a **partial-migration bug**. The endpoint type for database queries was migrated from the legacy `DATABASE_QUERY` to the namespaced `db:query`, and two of the three call-sites were updated to accept **both** spellings — but the reason generators were not:

| Site | Accepts `db:query`? |
|------|---------------------|
| `_getReachableEndpoints` (membership) `PathValidator.ts:191` | ✅ both |
| `_getEndpointKey` (identity) `PathValidator.ts:278` | ✅ both |
| `_getMissingReason` `PathValidator.ts:301` | ❌ legacy only |
| `_getAddedReason` `PathValidator.ts:320` | ❌ legacy only |

Result: a `db:query` endpoint that appears/disappears in a refactoring is correctly detected and keyed, but reported with the generic `Endpoint no longer reachable: <name>` / `New endpoint reachable: <name>` message — **silently dropping the actual SQL text** from the breaking-change report. The existing tests even codified this degraded behavior (`PathValidator.test.js:178-181`, `245-246`).

## Spec

- **Invariant restored:** the set of types treated as a database query is identical across membership, key generation, and reason generation. A `db:query` endpoint reports the same database-specific, SQL-bearing reason as the legacy `DATABASE_QUERY`.
- **Given** a `main` function reaching a `db:query` endpoint `{ query: 'SELECT * FROM orders WHERE id = ?' }`, **When** the `__local` version no longer reaches it, **Then** `result.missing[0].reason` = `Database query no longer executed: SELECT * FROM orders WHERE id = ?` (previously: `Endpoint no longer reachable: SELECT * FROM orders`).
- **Given** a `__local` function reaching a new `db:query` endpoint, **When** validated, **Then** `result.added[0].reason` = `New database query added: <sql>` (previously: `New endpoint reachable: <name>`).
- **Root cause:** the `db:query` alias was added to `_getReachableEndpoints` + `_getEndpointKey` but not to the two reason methods.

## Fix

`packages/util/src/validation/PathValidator.ts` — introduce a single private `_isDatabaseQuery(type)` (the **one** source of truth for the `db:query` / `DATABASE_QUERY` alias set) and route all three sites through it, so they cannot diverge again. The reason now falls back to `name` when `query` is absent (matching the key generator), avoiding a literal `undefined` in the message.

## Before / After (live `node --test`)

```
# BEFORE (red, for the right reason)
Scenario 2 missing reason: 'Endpoint no longer reachable: SELECT * FROM orders'
Scenario 3 added   reason: 'New endpoint reachable: INSERT INTO audit'

# AFTER
Scenario 2 missing reason: 'Database query no longer executed: SELECT * FROM orders WHERE id = ?'
Scenario 3 added   reason: 'New database query added: INSERT INTO audit_log (action) VALUES (?)'
```

## Tests

`test/unit/PathValidator.test.js` — Scenario 2 (breaking change / missing) and Scenario 3 (new behavior / added) now assert the database-specific reason **and** that the SQL text is present. Confirmed red→green:

- Red (pre-fix): both new assertions failed against the generic message above.
- Green (post-fix): `PathValidator.test.js` 8/8 pass.
- **Full gate:** `pnpm build` ✅, full unit suite **720/720 pass / 0 fail / 0 skipped**, `pnpm typecheck` ✅ (only platform-cpu warnings), `eslint` on changed file ✅.

## Adversarial review

- **A — Correctness:** `_isDatabaseQuery` matches exactly the two strings, nothing else. `query || name` fallback handles empty/undefined `query` (strictly more robust than the previous `${endpoint.query}` which could emit `undefined`). `safe`/`severity`/`endpointsChecked`/`missing[].type`/`name` are computed independently and are unchanged — only the `reason` text changes for `db:query`.
- **B — Structural:** removed a duplicated/divergent alias check; the three sites now share one predicate. File 351 lines (< 500). No new imports, no layer change.
- **C — Class / siblings:** grep for other legacy-only `DATABASE_QUERY` checks → `packages/util/src/core/VersionManager.ts:190` (`generateStableId`) and `:258` (`_getComparisonKeys`) are the **same latent class** (legacy-only type names, no namespaced aliases). They were **deliberately left out of this PR** because they govern node-identity / stable-ID generation (higher blast radius: version diffing, node identity) and would require the full namespaced↔legacy taxonomy (`http:request`/`HTTP_REQUEST`, `fs:operation`/`FILESYSTEM`, `net:request`/`NETWORK`) verified plus its own reproduction. Filed as a follow-up (see checklist).

## Blast radius

`PathValidator` is exported from `@grafema/util` (`index.ts:133`) with no internal `mcp`/`cli` callers; consumed via the public API. Behavior changes **only** the `reason` string for `db:query` endpoints (from generic → database-specific). No previously-correct output changes.

## Sibling latent issues found

- [ ] `VersionManager.generateStableId` / `_getComparisonKeys` use legacy-only endpoint type names (`DATABASE_QUERY`, `HTTP_REQUEST`, `FILESYSTEM`, `NETWORK`) — a `db:query` node falls to the default name-based stable-ID branch instead of the content-hash branch. Needs its own reproduction + the full type-alias taxonomy. **Follow-up filed.**

---
_Generated by Claude Code (autonomous bug-fix run)._

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJeufFZCroM5a4CEyVibN7)_