### PR TITLE
fix(util): canonicalize namespaced endpoint types in VersionManager stable-ID + comparison keys

### DIFF
--- a/packages/util/src/core/VersionManager.ts
+++ b/packages/util/src/core/VersionManager.ts
@@ -13,6 +13,7 @@
  */
 
 import { createHash } from 'crypto';
+import { canonicalEndpointType } from './nodes/NodeKind.js';
 
 /**
  * Version constants
@@ -186,12 +187,18 @@ export class VersionManager {
       return `${type}:${file}:${line || 0}:${column || 0}`;
     }
 
-    // Для EXTERNAL нод (DATABASE_QUERY, HTTP_REQUEST) - используем содержимое
-    if (['DATABASE_QUERY', 'HTTP_REQUEST', 'FILESYSTEM', 'NETWORK'].includes(type)) {
+    // Для EXTERNAL нод (DATABASE_QUERY, HTTP_REQUEST, ...) - используем содержимое.
+    // canonicalEndpointType сводит namespaced написания (db:query, http:request,
+    // fs:operation, net:request, net:stdio) к их legacy-эквивалентам, чтобы
+    // namespaced ноды хешировались по содержимому так же, как legacy, и не
+    // падали в default-ветку (где две db:query с одинаковым name коллизировали).
+    const canonicalType = canonicalEndpointType(type);
+    if (['DATABASE_QUERY', 'HTTP_REQUEST', 'FILESYSTEM', 'NETWORK'].includes(canonicalType)) {
       // Используем хеш содержимого для уникальности
       const content = node.query || node.url || node.path || node.endpoint || '';
       const hash = createHash('sha256').update(content).digest('hex').substring(0, 16);
-      return `${type}:${hash}`;
+      // Канонический префикс => db:query ≡ DATABASE_QUERY дают одинаковый stable ID
+      return `${canonicalType}:${hash}`;
     }
 
     // По умолчанию - используем все доступные поля
@@ -260,7 +267,10 @@ export class VersionManager {
       ENDPOINT: ['path', 'method', 'handler']
     };
 
-    return [...commonKeys, ...(typeSpecificKeys[nodeType] || [])];
+    // canonicalEndpointType сводит namespaced endpoint-типы к legacy-ключам
+    // таблицы, чтобы изменения query/operation/url/method/endpoint у db:query /
+    // http:request детектировались так же, как у DATABASE_QUERY / HTTP_REQUEST.
+    return [...commonKeys, ...(typeSpecificKeys[canonicalEndpointType(nodeType)] || [])];
   }
 
   /**

--- a/packages/util/src/core/nodes/NodeKind.ts
+++ b/packages/util/src/core/nodes/NodeKind.ts
@@ -176,6 +176,53 @@ export function matchesTypePattern(nodeType: string, pattern: string): boolean {
 }
 
 /**
+ * Endpoint-type aliases — single source of truth.
+ *
+ * The analyzers emit *namespaced* endpoint types (`db:query`, `http:request`,
+ * `fs:operation`, `net:request`, `net:stdio`), but legacy code and older
+ * graphs use the un-namespaced names (`DATABASE_QUERY`, `HTTP_REQUEST`,
+ * `FILESYSTEM`, `NETWORK`). Any code that keys node identity or diff semantics
+ * off these types MUST treat the two spellings as equivalent — otherwise a
+ * namespaced node silently falls through to a generic path (e.g. a name-based
+ * stable ID that collides two distinct `db:query` nodes sharing a name).
+ *
+ * This map collapses every known spelling to one canonical legacy name. It is
+ * deliberately the only place this taxonomy lives; consumers call
+ * {@link canonicalEndpointType} rather than re-listing the pairs locally.
+ *
+ * Mapping (any spelling → canonical):
+ * - `db:query`      → `DATABASE_QUERY`
+ * - `http:request`  → `HTTP_REQUEST`
+ * - `fs:operation`  → `FILESYSTEM`
+ * - `net:request`, `net:stdio`, `EXTERNAL_NETWORK`, `EXTERNAL_STDIO` → `NETWORK`
+ */
+export const ENDPOINT_TYPE_ALIASES: Readonly<Record<string, string>> = Object.freeze({
+  'db:query': 'DATABASE_QUERY',
+  'http:request': 'HTTP_REQUEST',
+  'fs:operation': 'FILESYSTEM',
+  'net:request': 'NETWORK',
+  'net:stdio': 'NETWORK',
+  EXTERNAL_NETWORK: 'NETWORK',
+  EXTERNAL_STDIO: 'NETWORK',
+});
+
+/**
+ * Canonicalize an endpoint type to its legacy name.
+ *
+ * Returns the canonical legacy spelling for any aliased endpoint type
+ * (see {@link ENDPOINT_TYPE_ALIASES}); for every other type the input is
+ * returned unchanged. Use this anywhere endpoint identity or diff semantics
+ * must be spelling-agnostic, so `db:query` ≡ `DATABASE_QUERY` etc.
+ *
+ * @param nodeType - node.type to canonicalize
+ * @returns canonical legacy endpoint type, or the input unchanged
+ */
+export function canonicalEndpointType(nodeType: string): string {
+  if (!nodeType) return nodeType;
+  return ENDPOINT_TYPE_ALIASES[nodeType] ?? nodeType;
+}
+
+/**
  * Check if type is a guarantee type (guarantee:queue, guarantee:api, etc.)
  */
 export function isGuaranteeType(nodeType: string): boolean {

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -169,7 +169,7 @@ export { GuaranteeAPI } from './api/GuaranteeAPI.js';
 export type { GuaranteeGraphBackend } from './api/GuaranteeAPI.js';
 
 // Node kinds
-export { isGuaranteeType, isGrafemaType } from './core/nodes/NodeKind.js';
+export { isGuaranteeType, isGrafemaType, canonicalEndpointType, ENDPOINT_TYPE_ALIASES } from './core/nodes/NodeKind.js';
 
 // Issue nodes (detected problems)
 export { IssueNode, type IssueNodeRecord, type IssueSeverity, type IssueType } from './core/nodes/IssueNode.js';

--- a/test/unit/VersionManagerEndpointAliases.test.js
+++ b/test/unit/VersionManagerEndpointAliases.test.js
@@ -1,0 +1,68 @@
+/**
+ * VersionManager endpoint-type alias TDD tests (issue #389)
+ *
+ * ЦЕЛЬ: stable-ID и comparison-key generation должны трактовать namespaced
+ * endpoint-типы (db:query, http:request, fs:operation, net:request, net:stdio)
+ * идентично их legacy-эквивалентам (DATABASE_QUERY, HTTP_REQUEST, FILESYSTEM,
+ * NETWORK) — одинаковая identity/diff семантика независимо от написания.
+ *
+ * REGRESSION (issue #389): namespaced endpoint nodes падали в default-ветку
+ * generateStableId (ключ по name:file:line), поэтому две db:query ноды с
+ * одинаковым name, но разным query, коллизировали на один stable ID. И
+ * _getComparisonKeys возвращал только common keys, теряя изменения query/url.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { VersionManager } from '@grafema/util';
+
+describe('VersionManager endpoint-type aliases (issue #389)', () => {
+  const vm = new VersionManager();
+
+  it('content-hashes namespaced db:query nodes (same name, different query => distinct stable IDs)', () => {
+    const a = { type: 'db:query', name: 'query', file: 'a.js', line: 1, column: 0, query: 'SELECT * FROM orders WHERE id = ?' };
+    const b = { type: 'db:query', name: 'query', file: 'a.js', line: 1, column: 0, query: 'SELECT * FROM users WHERE id = ?' };
+
+    const idA = vm.generateStableId(a);
+    const idB = vm.generateStableId(b);
+
+    assert.notStrictEqual(idA, idB, 'two db:query nodes with the same name but different query must get distinct stable IDs');
+  });
+
+  it('treats db:query ≡ DATABASE_QUERY (same query content => identical stable ID)', () => {
+    const query = 'SELECT * FROM orders WHERE id = ?';
+    const namespaced = { type: 'db:query', name: 'q', file: 'a.js', line: 1, column: 0, query };
+    const legacy = { type: 'DATABASE_QUERY', name: 'q', file: 'a.js', line: 1, column: 0, query };
+
+    assert.strictEqual(
+      vm.generateStableId(namespaced),
+      vm.generateStableId(legacy),
+      'db:query and DATABASE_QUERY with identical content must produce identical stable IDs'
+    );
+  });
+
+  it('content-hashes namespaced http:request nodes by url (different url => distinct stable IDs)', () => {
+    const a = { type: 'http:request', name: 'fetch', file: 'a.js', line: 2, column: 0, url: 'https://api.example.com/v1/orders' };
+    const b = { type: 'http:request', name: 'fetch', file: 'a.js', line: 2, column: 0, url: 'https://api.example.com/v1/users' };
+
+    assert.notStrictEqual(vm.generateStableId(a), vm.generateStableId(b));
+  });
+
+  it('detects structural change in query for namespaced db:query via comparison keys', () => {
+    const oldNode = { type: 'db:query', name: 'query', line: 1, column: 0, query: 'SELECT 1', operation: 'select', collection: 'orders' };
+    const newNode = { type: 'db:query', name: 'query', line: 1, column: 0, query: 'SELECT 2', operation: 'select', collection: 'orders' };
+
+    assert.strictEqual(
+      vm.hasStructuralChanges(oldNode, newNode),
+      true,
+      'changing query of a db:query node must be detected as a structural change'
+    );
+  });
+
+  it('detects structural change in url/method for namespaced http:request via comparison keys', () => {
+    const oldNode = { type: 'http:request', name: 'req', line: 1, column: 0, method: 'GET', url: '/a', endpoint: '/a' };
+    const newNode = { type: 'http:request', name: 'req', line: 1, column: 0, method: 'POST', url: '/a', endpoint: '/a' };
+
+    assert.strictEqual(vm.hasStructuralChanges(oldNode, newNode), true);
+  });
+});


### PR DESCRIPTION
Closes #389. Sibling-of-#388 (the open PR fixes the same latent class in `PathValidator`; this PR fixes it in `VersionManager`, the higher-blast-radius node-identity site).

## The bug

`VersionManager.generateStableId` (`VersionManager.ts:190`) and `_getComparisonKeys` (`VersionManager.ts:258`) matched only the **legacy** endpoint type names (`DATABASE_QUERY`/`HTTP_REQUEST`/`FILESYSTEM`/`NETWORK`). The analyzers emit the **namespaced** spellings (`db:query`, `http:request`, `fs:operation`, `net:request`, `net:stdio`), which therefore fell through:

- `generateStableId` → default branch keyed by `[type, name, file, line, column]`. Two `db:query` nodes with the **same `name` but different `query`** collide on one stable ID instead of being distinguished by content hash → wrong version-diff (the two queries merge into one node identity).
- `_getComparisonKeys` → only the common keys (`name`/`line`/`column`), so a changed `query`/`operation`/`url`/`method`/`endpoint` on a namespaced endpoint node is **not** detected as a structural change.

## Spec

- **Invariant restored:** stable-ID and comparison-key generation are spelling-agnostic — `db:query ≡ DATABASE_QUERY`, `http:request ≡ HTTP_REQUEST`, `fs:operation ≡ FILESYSTEM`, `net:request`/`net:stdio ≡ NETWORK`. Same identity/diff semantics regardless of spelling.
- **Given** two `db:query` nodes with the same `name` but different `query`, **When** stable IDs are generated, **Then** they are distinct (content-hashed), not collided on the name-based default.
- **Given** a `db:query` and a `DATABASE_QUERY` node with identical `query`, **When** stable IDs are generated, **Then** they are identical.
- **Given** a `db:query` node whose `query` changes, **When** `hasStructuralChanges` runs, **Then** it returns `true`.
- **Single source of truth:** the namespaced↔legacy alias taxonomy lives in exactly one place (`NodeKind.ts`), not duplicated per file.

## Fix

`packages/util/src/core/nodes/NodeKind.ts` — add `ENDPOINT_TYPE_ALIASES` (frozen map, the one place the taxonomy lives) + `canonicalEndpointType(type)` helper, exported from `@grafema/util`. `VersionManager` routes both sites through `canonicalEndpointType`:

- `generateStableId` content-hashes when the **canonical** type is in the content-addressed set, and returns `` `${canonicalType}:${hash}` `` so `db:query` and `DATABASE_QUERY` produce identical IDs.
- `_getComparisonKeys` looks up `typeSpecificKeys[canonicalEndpointType(nodeType)]`.

Legacy types are not in the alias map, so `canonicalEndpointType` returns them unchanged → **legacy stable IDs are byte-for-byte unchanged** (no breaking ID churn for existing legacy graphs).

## Before / After (live `node --test`)

```
# BEFORE (red, for the right reason) — 5/5 fail
not ok 1 - content-hashes namespaced db:query nodes (same name, different query => distinct stable IDs)
          operator: 'notStrictEqual'  (both collided on db:query:query:a.js:1:0)
not ok 2 - treats db:query ≡ DATABASE_QUERY (same query content => identical stable ID)
not ok 4 - detects structural change in query for namespaced db:query via comparison keys

# AFTER — 5/5 pass
ok 1 - VersionManager endpoint-type aliases (issue #389)
# tests 5 # pass 5 # fail 0
```

## Verify — full gate (actual outputs)

- `pnpm build` ✅
- `./scripts/test.sh` → **`# tests 725 # pass 725 # fail 0 # skipped 0`** (was 720 before +5 new) — `ALL TESTS PASSED`
- `pnpm typecheck` ✅ (only `platform-cpu` install warnings, no TS errors)
- `eslint` on the 4 changed files → exit 0

## Adversarial review

- **A — Correctness:** Empty/undefined `type` is guarded in `canonicalEndpointType` and falls through exactly as before. Legacy `DATABASE_QUERY`/`HTTP_REQUEST`/… are not aliased → unchanged IDs (proven by test 2: `db:query` ID == `DATABASE_QUERY` ID). `net:request`/`net:stdio` collapse to one `NETWORK` content-addressed ID — verified correct, **not** a new collision: those are **SINGLETON** nodes (`SemanticId.ts:145` `parseSemanticId` returns `type: 'SINGLETON'`; stats show the single `net:stdio:__stdio__`).
- **B — Structural:** `NodeKind.ts` ~243 lines, `VersionManager.ts` ~415 lines (both < 500). The alias taxonomy is now centralized + frozen, removing the per-file duplication the issue called out. Documented coupling: the canonical content-addressed set (`DATABASE_QUERY/HTTP_REQUEST/FILESYSTEM/NETWORK`) stays local to `VersionManager`; new aliases must map to one of those canonicals.
- **C — Class / siblings:** the same legacy-only-matching class exists in exactly two families: (1) `PathValidator` reason methods (`_getMissingReason:301`, `_getAddedReason:320`) — **already in-flight in open PR #388**, intentionally not touched here to avoid conflict; (2) the two `VersionManager` sites — fixed by this PR. Swept the rest: `typeValidation.ts` is a validation allowlist already carrying both spellings (no identity logic); `SemanticId.ts` handles net singletons correctly. No other sites.

## Blast radius

`VersionManager`/`versionManager` are exported from `@grafema/util` (`index.ts:137`) with no internal `mcp`/`cli`/`packages` callers (grep) — consumed via the public incremental-analysis API. Behavior changes **only** for namespaced endpoint nodes (now content-hashed like their legacy equivalents); legacy-node output is unchanged. Stable IDs are re-derived per analysis run for both `main` and `__local`, so the new format is internally consistent within a run.

## Sibling latent issues

- [x] `VersionManager` stable-ID + comparison keys — **this PR**.
- [ ] `PathValidator` reason methods (`DATABASE_QUERY` only) — open **PR #388** (could later adopt the new shared `canonicalEndpointType`).

---
_Generated by Claude Code (autonomous bug-fix run)._

---
_Generated by [Claude Code](https://claude.ai/code/session_0111B8spBFaAywX4dGoFadbV)_