### PR TITLE
fix(rust-analyzer): walk let-else diverge block so nested calls aren't dropped

### DIFF
--- a/packages/grafema-orchestrator/src/rust_analyzer.rs
+++ b/packages/grafema-orchestrator/src/rust_analyzer.rs
@@ -1399,6 +1399,13 @@ fn walk_let(local: &syn::Local, ctx: &mut Ctx) {
     if let Some(init) = &local.init {
         walk_expr(&init.expr, ctx);
 
+        // `let PAT = INIT else { DIVERGE };` — the diverge block is a separate
+        // sub-expression (`LocalInit::diverge`). Walk it so calls/references
+        // nested in the `else { ... }` are not dropped from the graph.
+        if let Some((_else, diverge)) = &init.diverge {
+            walk_expr(diverge, ctx);
+        }
+
         // ASSIGNED_FROM edges: each binding ← init expression
         // For simple expressions (path, lit), emit direct edge
         if let Some(init_node_id) = expr_node_id(&init.expr, ctx) {
@@ -2506,6 +2513,27 @@ mod tests {
     fn test_reference_pattern_let() {
         let fa = parse_and_analyze("fn main() { let &x = &42; }");
         assert!(has_node(&fa, "VARIABLE", "x"), "VARIABLE x from ref pattern");
+    }
+
+    #[test]
+    fn test_let_else_diverge_block_walks_calls() {
+        // `let PAT = INIT else { DIVERGE };` (Rust 1.65+). The init expression
+        // is walked, but the `else` diverge block is a separate sub-expression
+        // (`syn::LocalInit::diverge`). Calls nested in it must not be dropped —
+        // same class as Expr::Macro args (#376) and Expr::TryBlock (#382).
+        let fa = parse_and_analyze(
+            "fn main() { let Some(x) = get() else { log_error(reason()); return; }; use_it(x); }",
+        );
+        assert!(has_node(&fa, "CALL", "get"), "CALL get from init expr");
+        assert!(
+            has_node(&fa, "CALL", "log_error"),
+            "CALL log_error nested in let-else diverge block"
+        );
+        assert!(
+            has_node(&fa, "CALL", "reason"),
+            "CALL reason nested in let-else diverge block args"
+        );
+        assert!(has_node(&fa, "CALL", "use_it"), "CALL use_it after let-else");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`walk_let` in the native Rust analyzer (`packages/grafema-orchestrator/src/rust_analyzer.rs:1389`) walked the **init** expression of a `let` binding but never touched `LocalInit::diverge` — the `else { ... }` block of a `let-else` statement (`let PAT = INIT else { ... };`, Rust 1.65+).

Result: **every `CALL`/reference nested in a `let-else` diverge block was silently dropped from the graph.** `let-else` with a non-trivial `else` arm (`else { log_error(...); return; }`, `else { bail!(...) }`, etc.) is idiomatic modern Rust, so this lost real call edges.

This is the same latent class as the merged fixes #376 (`Expr::Macro` args) and #382 (`Expr::TryBlock` / `&raw const`): a sub-expression position the walker failed to descend into.

## Spec

- **Invariant restored:** every executable sub-expression of a `let` statement is walked. The diverge block of a `let-else` is walked identically to any other block, so nested calls/references appear in the graph.
- **Given** `let Some(x) = get() else { log_error(reason()); return; };`
  **When** the file is analyzed,
  **Then** `CALL` nodes exist for `get` (init), **and** `log_error` + `reason` (diverge block) — previously only `get` survived.
- **Root cause:** `walk_let` called `walk_expr(&init.expr)` but ignored `init.diverge`.

## Fix

```rust
if let Some((_else, diverge)) = &init.diverge {
    walk_expr(diverge, ctx);
}
```

after the existing `walk_expr(&init.expr, ctx)`. `ASSIGNED_FROM` edge derivation is unchanged (it keys off `init.expr` only); the diverge walk is purely additive (emits the previously-dropped CALL nodes).

## Before / After (live `cargo test`)

```
# BEFORE (red, for the right reason)
test rust_analyzer::tests::test_let_else_diverge_block_walks_calls ... FAILED
panicked at src/rust_analyzer.rs:2521: CALL log_error nested in let-else diverge block
# (CALL `get` from init expr passed; CALL `log_error`/`reason` in the else block were dropped)

# AFTER
test rust_analyzer::tests::test_let_else_diverge_block_walks_calls ... ok
```

## Verify — full gate (actual outputs)

- `cargo test --lib rust_analyzer` → **65 passed; 0 failed**
- `cargo test -p grafema-orchestrator --lib` → **441 passed; 0 failed; 0 ignored**
- `cargo build -p grafema-orchestrator` → only 2 **pre-existing** warnings in unrelated code (`request_id/ok/chunk_index` fields, `total_files_committed`); **zero** from this change.

## Adversarial review

- **A — Correctness:** Plain `let x = y;` has `init.diverge == None` → no behavior change. The diverge expr is always an `Expr::Block` per Rust grammar, handled by `walk_expr` → `walk_block`. The unused `Else` token is bound as `_else` (no warning). `ASSIGNED_FROM` is computed from `init.expr` and is untouched.
- **B — Structural fragility:** The fix mirrors the existing handled sub-expression positions exactly. Note: `rust_analyzer.rs` is already a large file (>500 lines) — a pre-existing condition this 7-line additive change neither causes nor worsens; an extract/split is a separate task, out of scope here.
- **C — Class / siblings:** Swept every other nested sub-expression position for the same "dropped sub-expression" class — all already walked: `if`/`else` branches (`:1870`), `match` arm **guards + bodies** (`:1896`–`:1899`), `while`/`for` conditions (`:1914`/`:1922`), `walk_expr` covers all 40 `syn::Expr` variants, `walk_stmt` all 4. The `let-else` diverge was the only remaining gap. No follow-ups needed.

## Blast radius

Native Rust analysis path only (`analyze_rust_file`). Behavior change is strictly additive — new CALL nodes for previously-dropped diverge-block expressions; no previously-emitted node/edge changes.

---
_Generated by Claude Code (autonomous bug-fix run)._

---
_Generated by [Claude Code](https://claude.ai/code/session_01WF8aX7N8hDKcdahomZrCfK)_