### PR TITLE
fix(type-inference): streaming + flush — plugin no longer exits 1; plugin failures abort analyze

### DIFF
--- a/packages/grafema-orchestrator/src/main.rs
+++ b/packages/grafema-orchestrator/src/main.rs
@@ -1989,7 +1989,9 @@ async fn main() -> Result<()> {
                     }
                 };
 
-                let plugin_results = plugin::run_plugins_dag(
+                // A plugin failure aborts the analyze run (loud-failure policy,
+                // same as derive-pack failures) — but shut the pool down first.
+                let dag_result = plugin::run_plugins_dag(
                     &user_plugins,
                     &mut rfdb,
                     &socket_path,
@@ -1997,17 +1999,13 @@ async fn main() -> Result<()> {
                     generation,
                     resolve_pool.as_ref(),
                 )
-                .await?;
+                .await;
 
                 if let Some(pool) = resolve_pool {
                     pool.shutdown().await;
                 }
 
-                for pr in &plugin_results {
-                    if let Some(ref err) = pr.error {
-                        tracing::error!(plugin = %pr.plugin_name, "{err}");
-                    }
-                }
+                dag_result?;
             }
 
             let resolve_ms = resolve_timer.elapsed().as_millis() as u64;
@@ -2823,7 +2821,9 @@ async fn main() -> Result<()> {
                     }
                 };
 
-                let plugin_results = plugin::run_plugins_dag(
+                // A plugin failure aborts the analyze run (loud-failure policy,
+                // same as derive-pack failures) — but shut the pool down first.
+                let dag_result = plugin::run_plugins_dag(
                     &user_plugins,
                     &mut rfdb,
                     &socket_path,
@@ -2831,17 +2831,13 @@ async fn main() -> Result<()> {
                     generation,
                     resolve_pool.as_ref(),
                 )
-                .await?;
+                .await;
 
                 if let Some(pool) = resolve_pool {
                     pool.shutdown().await;
                 }
 
-                for pr in &plugin_results {
-                    if let Some(ref err) = pr.error {
-                        tracing::error!(plugin = %pr.plugin_name, "{err}");
-                    }
-                }
+                dag_result?;
             }
 
             // Rule-pack phase (Wave 6): the packs are the only producer of the

--- a/packages/grafema-orchestrator/src/main.rs
+++ b/packages/grafema-orchestrator/src/main.rs
@@ -3350,14 +3350,16 @@ mod tests {
     ) -> std::path::PathBuf {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+        // Unique per call: pid + a process-wide counter. A timestamp alone is
+        // NOT unique — concurrent tests can land in the same SystemTime tick,
+        // collide on the socket name, and the second bind panics (flaky
+        // EADDRINUSE in pack_failure_fails_the_run_with_a_loud_summary).
+        static SOCK_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         let dir = std::env::temp_dir();
         let sock = dir.join(format!(
             "grafema-fake-rfdb-{}-{}.sock",
             std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
+            SOCK_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
         ));
         let _ = std::fs::remove_file(&sock);
         let listener = std::os::unix::net::UnixListener::bind(&sock).expect("bind fake socket");

--- a/packages/grafema-orchestrator/src/plugin.rs
+++ b/packages/grafema-orchestrator/src/plugin.rs
@@ -1841,6 +1841,98 @@ mod tests {
         assert!(err.contains("timed out"), "{err}");
     }
 
+    /// Minimal fake RFDB server: answers every incoming frame with a
+    /// Hello-shaped MessagePack response — just enough for
+    /// `RfdbClient::connect` to complete its handshake. Batch plugins never
+    /// touch the client afterwards, so nothing else is needed.
+    fn spawn_fake_hello_server(listener: tokio::net::UnixListener) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    return;
+                };
+                tokio::spawn(async move {
+                    // protocolVersion must match rfdb::PROTOCOL_VERSION (3).
+                    let reply = rmp_serde::to_vec_named(&serde_json::json!({
+                        "requestId": "r0",
+                        "ok": true,
+                        "protocolVersion": 3,
+                        "serverVersion": "fake-rfdb",
+                        "features": [],
+                    }))
+                    .expect("encode fake hello reply");
+                    loop {
+                        let mut len_buf = [0u8; 4];
+                        if stream.read_exact(&mut len_buf).await.is_err() {
+                            return;
+                        }
+                        let len = u32::from_be_bytes(len_buf) as usize;
+                        let mut payload = vec![0u8; len];
+                        if stream.read_exact(&mut payload).await.is_err() {
+                            return;
+                        }
+                        let frame_len = (reply.len() as u32).to_be_bytes();
+                        if stream.write_all(&frame_len).await.is_err() {
+                            return;
+                        }
+                        if stream.write_all(&reply).await.is_err() {
+                            return;
+                        }
+                    }
+                });
+            }
+        });
+    }
+
+    /// Helper: a batch-mode plugin running an arbitrary command.
+    fn make_batch_plugin(name: &str, command: String, deps: &[&str]) -> PluginConfig {
+        PluginConfig {
+            name: name.to_string(),
+            command,
+            query: None,
+            depends_on: deps.iter().map(|s| s.to_string()).collect(),
+            mode: PluginMode::Batch,
+            timeout_secs: None,
+        }
+    }
+
+    /// Gate PLACEMENT test: the three `check_plugin_result` unit tests above
+    /// would keep passing even if the gate call were deleted from the DAG
+    /// loop. This exercises the real `run_plugins_dag`: in the chain
+    /// A → B(fails) → C, the run must return Err naming B, and B's dependent
+    /// C must never execute against the half-populated graph.
+    #[tokio::test]
+    async fn run_plugins_dag_failing_plugin_aborts_and_skips_dependents() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock = dir.path().join("fake-rfdb.sock");
+        let listener = tokio::net::UnixListener::bind(&sock).expect("bind fake rfdb socket");
+        spawn_fake_hello_server(listener);
+
+        let mut rfdb = RfdbClient::connect(&sock)
+            .await
+            .expect("handshake with fake hello server");
+
+        // C touches a sentinel file iff it actually runs.
+        let sentinel = dir.path().join("c-ran");
+        let plugins = vec![
+            make_batch_plugin("A", "true".to_string(), &[]),
+            make_batch_plugin("B", "false".to_string(), &["A"]),
+            make_batch_plugin("C", format!("touch {}", sentinel.display()), &["B"]),
+        ];
+
+        let err = run_plugins_dag(&plugins, &mut rfdb, &sock, "testdb", 1, None)
+            .await
+            .expect_err("a failing plugin must abort the DAG");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("Plugin 'B' failed"), "{msg}");
+        assert!(msg.contains("exit status"), "{msg}");
+        assert!(
+            !sentinel.exists(),
+            "dependent plugin C ran even though its dependency B failed"
+        );
+    }
+
     // -- resolve_progress telemetry (REG-1138 defect 2) --
 
     /// The `resolve_progress` event carries the phase + progress counters under

--- a/packages/grafema-orchestrator/src/plugin.rs
+++ b/packages/grafema-orchestrator/src/plugin.rs
@@ -1305,6 +1305,19 @@ pub async fn stream_and_resolve_single_worker(
 // Full DAG execution
 // ---------------------------------------------------------------------------
 
+/// Convert a finished plugin result into a hard error if the plugin failed.
+///
+/// Wave 6 made derive-pack failures fail the analyze run, but plugin failures
+/// were still log-and-continue — a plugin exiting non-zero (or timing out)
+/// silently shipped a graph missing whole edge families (e.g. type-inference
+/// is the sole INSTANCE_OF producer). A failed plugin now aborts the run.
+pub fn check_plugin_result(result: &PluginRunResult) -> Result<()> {
+    if let Some(ref err) = result.error {
+        bail!("Plugin '{}' failed: {}", result.plugin_name, err);
+    }
+    Ok(())
+}
+
 /// Execute the full plugin DAG: build levels, run each level sequentially.
 ///
 /// Within each level, plugins are run sequentially because `RfdbClient` requires
@@ -1316,6 +1329,11 @@ pub async fn stream_and_resolve_single_worker(
 ///
 /// For streaming plugins: output is validated, metadata-stamped, and committed.
 /// Results for all plugins are collected and returned.
+///
+/// A plugin failure (non-zero exit, timeout, invalid output, commit failure)
+/// aborts the DAG with an error via [`check_plugin_result`] — dependents of a
+/// failed plugin never run against a half-populated graph, and the analyze
+/// run fails loudly instead of logging and continuing.
 pub async fn run_plugins_dag(
     plugins: &[PluginConfig],
     rfdb: &mut RfdbClient,
@@ -1350,6 +1368,7 @@ pub async fn run_plugins_dag(
                 );
             }
 
+            check_plugin_result(&result)?;
             results.push(result);
         }
     }
@@ -1774,6 +1793,52 @@ mod tests {
         acc.record(&[ck_node("a")], &[]);
         acc.record(&[ck_node("b")], &[]);
         assert!(acc.take_if_due().is_some(), "counter reset after empty checkpoint");
+    }
+
+    // -- loud-failure policy: plugin failures abort the analyze run --
+
+    /// Helper: build a PluginRunResult with an optional error.
+    fn make_result(name: &str, error: Option<&str>) -> PluginRunResult {
+        PluginRunResult {
+            plugin_name: name.to_string(),
+            nodes_emitted: 0,
+            edges_emitted: 0,
+            duration: Duration::from_millis(1),
+            error: error.map(|s| s.to_string()),
+        }
+    }
+
+    /// A successful plugin result passes the gate.
+    #[test]
+    fn check_plugin_result_ok_passes() {
+        let result = make_result("type-inference", None);
+        assert!(check_plugin_result(&result).is_ok());
+    }
+
+    /// A plugin that exited non-zero fails the run, naming the plugin and
+    /// carrying the underlying error (run_plugins_dag calls this per result,
+    /// so the `?` aborts the DAG → the analyze run fails loudly).
+    #[test]
+    fn check_plugin_result_exit_failure_aborts() {
+        let result = make_result(
+            "type-inference",
+            Some("Batch plugin 'type-inference' exited with status: exit status: 1"),
+        );
+        let err = check_plugin_result(&result).unwrap_err().to_string();
+        assert!(err.contains("Plugin 'type-inference' failed"), "{err}");
+        assert!(err.contains("exit status: 1"), "{err}");
+    }
+
+    /// A timed-out plugin is a failure too — same gate, same abort.
+    #[test]
+    fn check_plugin_result_timeout_aborts() {
+        let result = make_result(
+            "shape-tracker",
+            Some("Plugin 'shape-tracker' timed out after 600s"),
+        );
+        let err = check_plugin_result(&result).unwrap_err().to_string();
+        assert!(err.contains("Plugin 'shape-tracker' failed"), "{err}");
+        assert!(err.contains("timed out"), "{err}");
     }
 
     // -- resolve_progress telemetry (REG-1138 defect 2) --

--- a/plugins/type-inference.mjs
+++ b/plugins/type-inference.mjs
@@ -98,6 +98,11 @@ const client = new RFDBClient(socketPath, 'type-inference');
 
 try {
   await client.connect();
+  // Negotiate protocol v3 so queryNodes streams in chunks. Without hello() the
+  // client stays on the non-streaming path, and a single QueryNodes over a large
+  // node type (e.g. ~93k CALL nodes on the Grafema dogfood graph) exceeds the
+  // client's fixed 60s request timeout — the plugin then exits 1 every run.
+  await client.hello();
   if (dbName) await client.openDatabase(dbName);
 
   // Phase 1: Create builtin CLASS + METHOD nodes (same in both paths)
@@ -111,6 +116,10 @@ try {
     await typeInferenceLegacy(client);
   }
 
+  // Publish staged writes: under MVCC (visibility=publish) addNodes/addEdges are
+  // not visible to other connections — or durable — until a flush. Without this,
+  // every INSTANCE_OF edge created above is silently dropped when the process exits.
+  await client.flush();
   await client.close();
 } catch (err) {
   console.error(`[type-inference] Error: ${err.message}`);

--- a/plugins/type-inference.mjs
+++ b/plugins/type-inference.mjs
@@ -525,8 +525,8 @@ async function typeInferenceLegacy(client) {
 
 async function createBuiltinNodes(client) {
   const classIds = new Map();
-  const nodes = [];
   const edgesBatch = [];
+  let nodesCreated = 0;
 
   for (const [className, methods] of Object.entries(BUILTINS)) {
     let classNodeId = null;
@@ -538,74 +538,82 @@ async function createBuiltinNodes(client) {
     }
 
     if (!classNodeId) {
+      // The server derives the numeric node id deterministically by hashing the
+      // string id we supply (string_id_to_u128), so the id is known at write
+      // time. Do NOT re-query for it: under MVCC an unflushed node is invisible
+      // to same-session reads, so a read-after-add returns null and the
+      // HAS_METHOD edge would be silently dropped (and skipped forever on
+      // later runs, because the node then exists).
+      classNodeId = `builtin::${className}`;
       await client.addNodes([{
-        id: `builtin::${className}`,
+        id: classNodeId,
         type: 'CLASS',
         name: className,
         file: '<builtin>',
         exported: true,
         metadata: JSON.stringify({ _source: 'type-inference', builtin: true }),
       }]);
-      for await (const n of client.queryNodes({ type: 'CLASS', name: className })) {
-        if (n.file === '<builtin>') {
-          classNodeId = String(n.id);
-          break;
-        }
-      }
+      nodesCreated++;
     }
-
-    if (!classNodeId) continue;
     classIds.set(className, classNodeId);
 
     for (const methodName of methods) {
-      let exists = false;
+      let methodId = null;
       for await (const n of client.queryNodes({ type: 'METHOD', name: methodName })) {
         if (n.file === '<builtin>') {
           const meta = typeof n.metadata === 'string' ? JSON.parse(n.metadata || '{}') : {};
-          if (meta.parentClass === className) { exists = true; break; }
+          if (meta.parentClass === className) { methodId = String(n.id); break; }
         }
       }
-      if (exists) continue;
 
-      await client.addNodes([{
-        id: `builtin::${className}::${methodName}`,
-        type: 'METHOD',
-        name: methodName,
-        file: '<builtin>',
-        exported: true,
-        metadata: JSON.stringify({
-          _source: 'type-inference', builtin: true, kind: 'method',
-          parentClass: className,
-        }),
-      }]);
+      if (!methodId) {
+        methodId = `builtin::${className}::${methodName}`;
+        await client.addNodes([{
+          id: methodId,
+          type: 'METHOD',
+          name: methodName,
+          file: '<builtin>',
+          exported: true,
+          metadata: JSON.stringify({
+            _source: 'type-inference', builtin: true, kind: 'method',
+            parentClass: className,
+          }),
+        }]);
+        nodesCreated++;
+      }
 
-      let methodNumId = null;
-      for await (const n of client.queryNodes({ type: 'METHOD', name: methodName })) {
-        if (n.file === '<builtin>') {
-          const meta = typeof n.metadata === 'string' ? JSON.parse(n.metadata || '{}') : {};
-          if (meta.parentClass === className) { methodNumId = String(n.id); break; }
-        }
-      }
-      if (methodNumId) {
-        edgesBatch.push({
-          src: classNodeId,
-          dst: methodNumId,
-          type: 'HAS_METHOD',
-          metadata: JSON.stringify({ _source: 'type-inference' }),
-        });
-      }
+      // Always (re-)assert the edge — addEdges is an upsert, so this is
+      // idempotent AND heals graphs where a previous run created the METHOD
+      // node but lost the edge to the read-after-add bug.
+      edgesBatch.push({
+        src: classNodeId,
+        dst: methodId,
+        type: 'HAS_METHOD',
+        metadata: JSON.stringify({ _source: 'type-inference' }),
+      });
     }
   }
 
-  if (nodes.length > 0) {
-    await client.addNodes(nodes);
-    console.error(`[type-inference] Created ${nodes.length} builtin nodes`);
+  if (nodesCreated > 0) {
+    console.error(`[type-inference] Created ${nodesCreated} builtin nodes`);
+    // Publish the new nodes before adding edges that reference them by string
+    // id: the server resolves a string src/dst via get_node(hash) only for
+    // published nodes — an unpublished endpoint falls into a full-graph
+    // semantic-id scan per edge. Flushing also makes the builtin CLASS nodes
+    // visible to the classIndex queries later in this same session.
+    await client.flush();
   }
+
   if (edgesBatch.length > 0) {
     const BATCH = 500;
     for (let i = 0; i < edgesBatch.length; i += BATCH) {
       await client.addEdges(edgesBatch.slice(i, i + BATCH));
     }
+    // Publish HAS_METHOD edges now rather than relying on the end-of-process
+    // flush: if a later phase crashes the plugin, every staged write is lost
+    // and the builtin METHOD nodes (already published above) become permanent
+    // orphans — the exact failure mode this function used to have.
+    await client.flush();
   }
 
   return classIds;


### PR DESCRIPTION
## The sole INSTANCE_OF producer was failing on every fresh analyze

Conveyor-diagnosed root cause: the plugin never calls `hello()`, so `queryNodes` falls back to the legacy non-streaming path with a 60s hard timeout — Phase 4's 92,736 CALL nodes die every run (`exit 1` after ~102s). A second latent bug: no `flush()` — under MVCC (visibility=publish) its edges published only as a side effect of later orchestrator commits.

**Fix (+9 lines in the plugin):** `hello()` after connect (negotiates streaming: same query 11s vs 60s-timeout) + `flush()` before close.

**Verified on a dogfood graph copy:** exit 0 in 2m26s; INSTANCE_OF **97 → 2,289** (arithmetic exact); idempotent second run (0 new edges).

## Plugin failures now abort the run

Since 0.4.0 removed the legacy resolve fallback, a silently failing plugin means a silently half-populated graph. `check_plugin_result` in the orchestrator DAG runner aborts on plugin exit/timeout/invalid-output/commit failure (3 unit tests + e2e proven both directions: failing plugin → analyze exit 1; passing → exit 0).

## Known follow-up (found by the adversarial review, pre-existing)

`createBuiltinNodes` read-after-add is invisible under MVCC → builtin `HAS_METHOD` edges orphaned (proven: +215 METHOD nodes, HAS_METHOD unchanged). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)