### PR TITLE
docs: java/kotlin/go resolver migration specs (verified, with adversarial verdicts)

### DIFF
--- a/_ai/research/lang-spec-go.md
+++ b/_ai/research/lang-spec-go.md
@@ -1,0 +1,620 @@
+# Migration Spec: go-resolve → derive packs (Datalog v2)
+
+Follows the discipline of `_ai/research/resolve-datalog2-migration-specs.json` (js/rust precedent)
+and the synthesis ledger. All evidence from feat/datalog worktree HEAD `9ac0681c` (v0.4.0).
+Self-contained; sections are JSON-able in the precedent's `{spec: {target, purpose, sub_steps[],
+missing_capabilities[], differential_acceptance, expected_speedup_rationale, notes}}` shape.
+
+---
+
+## target
+
+`go-resolve` (binary `go-resolve --daemon`, packages/go-resolve/src/: Main.hs dispatching 5 modules
+via the single orchestrator command `go-all` — Main.hs:72-80 runs imports → calls → interfaces →
+types → context, feeding the CALLS EmitEdge output of step 2 into step 5 via extractCallEdges
+Main.hs:84-87). Driven by orchestrator main.rs:1673-1714 (analyze path) and main.rs:2573-2607
+(re-resolve path): streams ONLY `Language::Go` nodes (`&[config::Language::Go]` filter) to the
+daemon plus a `workspace_packages` wire carrying the go.mod module path
+(config::discover_go_module_path, config.rs:846-865; main.rs:1677-1686 wraps it as a single
+WorkspacePackageWire whose `name` IS the module path — Main.hs:61-63 extractModulePath takes
+`wpName` of the first entry).
+
+## purpose
+
+Go cross-file resolution: materializes
+- **IMPORTS_FROM** (IMPORT → MODULE, same-module only; GoImportResolution.hs)
+- **CALLS** (CALL → FUNCTION, 3 strategies; GoCallResolution.hs)
+- **IMPLEMENTS** (CLASS → INTERFACE, structural duck-typing by method-set subset; GoInterfaceSatisfaction.hs)
+- **TYPE_OF** (VARIABLE → CLASS/INTERFACE; GoTypeResolution.hs:73-88)
+- **RETURNS** (FUNCTION → CLASS/INTERFACE per comma-separated return type; GoTypeResolution.hs:95-111)
+- **PROPAGATES_CONTEXT** (FUNCTION → FUNCTION), **SPAWNS_WITH_CONTEXT** / **DEFERS_WITH_CONTEXT**
+  (CALL → FUNCTION) — context.Context flow; GoContextPropagation.hs.
+
+All legacy edges carry EMPTY metadata (every emitCallsEdge/EmitEdge site: ImportResolution:138-144,
+CallResolution:241-248, InterfaceSatisfaction:137-142, TypeResolution:75-79/97-101) — EXCEPT
+context edges for "possible" targets which carry `unresolved=true` (MetaBool, ContextPropagation:149-152).
+No `resolvedVia` stamps anywhere (unlike js/rust legacy).
+
+Inputs split — GRAPH data: MODULE/IMPORT/CALL/FUNCTION/CLASS/INTERFACE/VARIABLE nodes + their
+metadata. EXTERNAL data: the go.mod module path (wire-only today — never committed to the graph;
+precondition P1 below).
+
+## analyzer vocabulary (what go-analyzer emits that the resolver consumes — verified in source)
+
+Node types (packages/go-analyzer/src/):
+- `MODULE` — one per .go file; name = module-ish name, metadata `package` (Walker.hs:32-44).
+- `IMPORT` — name = import path; metadata `path` (=name), `blank`, `dot` (MetaBool),
+  optional `alias`, and `local_name` (the effective local identifier) (Imports.hs:63-80).
+- `CALL` — name = `recv.Sel` or bare ident (`exprToName`, Calls.hs:74-77); metadata `argCount`,
+  optional `receiver` (= exprToName of selector base — an EXPRESSION name, not a type),
+  `goroutine`/`deferred` (MetaBool, only when true) (Calls.hs:96-129).
+- `FUNCTION` — metadata `kind` ∈ {`function`, `method`, `interface_method`, `closure`},
+  `paramCount`, `returnCount`; functions/methods: optional `return_type` =
+  `T.intercalate "," (map goTypeToName results)` — **comma-joined, NO spaces**
+  (Declarations.hs:126-128 / :197-199; goTypeToName :639-650 never emits a comma);
+  methods additionally `receiver` = bare receiver TYPE name (`grTypeName`, :162,192 —
+  pointer-ness is the separate `pointer_receiver` bool), and
+  `accepts_context`/`possible_context` + `context_param_index`, `returns_error` (:95-109,:166-178).
+- `CLASS` (struct/named type, Declarations.hs:235-252,:318-339), `INTERFACE` (:266-283),
+  `VARIABLE` (metadata `type` = goTypeToName, walkVarSpec :491+).
+
+Edges:
+- `CONTAINS` everywhere (23 sites): MODULE→IMPORT (Imports.hs:83-88), scope→FUNCTION/CLASS/INTERFACE/
+  VARIABLE, **INTERFACE→FUNCTION(kind=interface_method)** (Declarations.hs:466-472), and
+  **scope→CALL** (Calls.hs:132-138). Critically: `Rules/ControlFlow.hs` creates NO scopes
+  (`grep -c withScope ControlFlow.hs` = 0) — only function/method/closure bodies push a scope
+  (Declarations.hs:145-152, Calls.hs FuncLitNode), so a CALL's CONTAINS source is exactly its
+  enclosing FUNCTION (or closure FUNCTION, or the MODULE for top-level initializers).
+  This is the structural substitute for every `[in:Parent]` semantic-id parse in the resolver
+  (same move as js_same_file_calls.dl DELTA 3: "class membership is structural truth").
+- Analyzer also emits CALLS/IMPORTS_FROM **DeferredRef**s (faUnresolvedRefs) — the orchestrator
+  turns unresolved ones into ISSUE diagnostics only (analyzer.rs:580-602), NEVER into CALLS edges.
+  So graph CALLS edges on .go files come exclusively from go-resolve → a pack consuming
+  materialized CALLS (step 9/10) sees exactly the go_calls pack output.
+
+## preconditions (orchestrator, not engine)
+
+- **P1 — GO module-path fact.** The go.mod module path must become a graph fact. Exact precedent
+  exists: WORKSPACE_PACKAGE facts committed at main.rs:2017-2032 for js packs
+  (js_module_imports.dl:157-158 joins `node(W,"WORKSPACE_PACKAGE"), attr(W,"name",N)`).
+  Commit the Go module path the same way (suggest type `WORKSPACE_PACKAGE` with
+  `node_attr(W,"language","go")`, name = module path) from the already-computed
+  `discover_go_module_path` value (main.rs:1677). Zero engine work.
+- **P2 — pack ordering (producer-before-consumer).** `go_calls` produces CALLS that `go_context`
+  consumes via `edge(C,T,"CALLS")` — declared pack order, same as rust_imports.dl's ORDERING
+  note (IMPORTS_FROM before js_cross_file_calls). Legacy did this in-process
+  (Main.hs:78-79 extractCallEdges).
+- **P3 — no-go.mod fallback selection.** Legacy branches globally on empty module path
+  (ImportResolution.hs:131-135 findBySuffix). A pack cannot test "the GO_MODULE fact does not
+  exist" without a zero-arity/global predicate (a `has_go_mod()` literal shares no variable with
+  the body — the §3 cross-join the planner refuses, cf. js_this_method_calls.dl:38-41).
+  Faithful translation: the ORCHESTRATOR (which knows whether go.mod resolved) loads either the
+  main pack or the suffix-fallback variant. Listed under missing capabilities as the engine
+  alternative.
+
+## sub_steps
+
+### 1. package-index kernel (shared; no edges)
+
+- **reads**: MODULE nodes (first-class `file`), GO module-path fact (P1).
+- **writes**: derived relations `mod_dir(M, D)` / `module_in_dir(D, M)` / `pkg_dir(ImportPath, D)`
+  consumed by steps 2-3. Legacy: buildPackageIndex (ImportResolution.hs:57-64 — dir → [moduleIds];
+  CallResolution.hs:118-128 — importPath → dir, with modPath-prefixed, root, and bare-dir keys).
+- **expressible**: yes (fully).
+- **idioms**:
+  - *dirname* (no dirname builtin): `basename` + `concat("/",B,SB)` + `strip_suffix(F,SB,D)`;
+    root-level files ("main.go") yield NO row from strip_suffix → complement clause via
+    derived-negation (`\+` on a derived has-subdir predicate), since there is no
+    `not_string_contains` builtin (only `not_starts_with`, builtin.rs:1268-1273).
+  - *file gate* (DELTA-5 of rust_imports.dl): `ends_with(F, ".go")` on every base relation —
+    MODULE/IMPORT/CALL/FUNCTION/CLASS/INTERFACE/VARIABLE are shared vocabulary across analyzers;
+    the legacy input gate was the orchestrator's Language::Go stream filter (config.rs:751,796).
+- **draft_rules**:
+```datalog
+go_mod(MP)        :- node(W, "WORKSPACE_PACKAGE"), node_attr(W, "language", "go"), attr(W, "name", MP).
+go_module(M, F)   :- node(M, "MODULE"), attr(M, "file", F), ends_with(F, ".go").
+mod_dir(M, D)     :- go_module(M, F), basename(F, B), concat("/", B, SB), strip_suffix(F, SB, D).
+mod_subdir(M)     :- mod_dir(M, _).
+module_in_dir(D, M)  :- mod_dir(M, D).
+module_in_dir("", M) :- go_module(M, _), \+ mod_subdir(M).
+% import-path -> package-dir map (all three legacy key families, CallResolution.hs:118-128)
+pkg_dir(P, D)     :- mod_dir(_, D), go_mod(MP), concat(MP, "/", MPS), concat(MPS, D, P).
+pkg_dir(MP, "")   :- go_mod(MP), module_in_dir("", _).
+pkg_dir(D, D)     :- mod_dir(_, D).
+```
+- **delta**: EXACT (a pure index reformulation).
+
+### 2. go-imports → IMPORTS_FROM (pack `go_imports.dl`)
+
+- **reads**: IMPORT nodes (`node_attr path`), kernel relations, go_mod fact.
+  Legacy: GoImportResolution.resolveOneImport (:116-145) — skip stdlib (isStdLib :87, "no dot in
+  first path segment"), strip module prefix + dropWhile '/' (:123-126), look up dir, emit edge to
+  **first** MODULE in dir (:129); empty-modPath fallback = first dir that is a suffix of the
+  import path, Map order (findBySuffix :152-163). Blank/dot imports resolve normally (:34-35).
+- **writes**: IMPORTS_FROM (IMPORT → MODULE), empty metadata. SHARED vocabulary (js/rust packs
+  also emit it) ⇒ `mode = "additive"`.
+- **expressible**: yes (main arms); fallback arm needs P3.
+- **draft_rules**:
+```datalog
+go_import(I, F, P) :- node(I, "IMPORT"), attr(I, "file", F), ends_with(F, ".go"),
+                      node_attr(I, "path", P).
+
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+go_import_from(I, M) :- go_import(I, _, P), go_mod(MP), concat(MP, "/", MPS),
+                        strip_prefix(P, MPS, Rel), module_in_dir(Rel, M).
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+go_import_from_root(I, M) :- go_import(I, _, P), go_mod(P), module_in_dir("", M).
+
+% fallback VARIANT pack (loaded by orchestrator only when go.mod is absent, P3):
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+go_import_suffix(I, M) :- go_import(I, _, P), string_contains(P, "."),
+                          module_in_dir(D, M), neq(D, ""), ends_with(P, D).
+```
+- **deltas**:
+  - DELTA G2-1 (REFINED — the isStdLib guard is dropped from the same-module arm): redundant
+    there — a stdlib path ("fmt", "net/http") cannot start with `<modPath>/`. Diverges only if
+    the module path itself collides with a stdlib name (pathological). The legacy
+    plain-stripPrefix boundary bug (modPath "…/p" string-prefix-matches "…/project2" then fails
+    the dir lookup, :123-126) is removed by requiring the "/" boundary; net effect on emitted
+    edges: none (legacy resolved those to a miss anyway).
+  - DELTA G2-2 (SUPERSET, bounded by files-per-package): legacy takes the FIRST MODULE id in the
+    target directory (`tid : _`, :129 — fold/insertion order, nondeterministic across runs);
+    set semantics derives one edge per MODULE node (= per .go file) in the package directory.
+    Arguably truer (a Go package IS the directory). Bound: #files in the imported package.
+  - DELTA G2-3 (fallback arm, MIXED): legacy fallback picks the alphabetically-first suffix-matching
+    dir (Map.toList order, :152-163) — the pack derives ALL suffix matches (SUPERSET, bound:
+    #dirs sharing the suffix). The `string_contains(P,".")` stdlib approximation replaces
+    "first segment has a dot": SUBSET for dotless module paths (`module myapp` imports
+    "myapp/util" — no dot anywhere → skipped where legacy's isStdLib ALSO skips it ("myapp" has
+    no dot) — actually EXACT for that case); residual divergence only for paths whose first
+    segment is dotless but a later segment has one ("foo/bar.v2" — legacy skips, pack keeps):
+    SUPERSET gated on a local dir literally suffix-matching such a path, ~0 in practice.
+    Exact fix = `first_segment` builtin (missing capability M1).
+
+### 3. go-calls strategy 1 — package-qualified CALLS (pack `go_calls.dl`)
+
+- **reads**: CALL nodes (`receiver` metadata, dotted `name`), IMPORT nodes in the SAME file
+  (`local_name`+`path`), kernel pkg_dir, FUNCTION nodes kind=function.
+  Legacy: resolveCall :157-174 dispatch (receiver matches an import alias in the caller's file →
+  strategy 1 ONLY, no fallback) + resolvePackageCall :188-210 (isStdLib skip; importPath → dir
+  via pkgIdx with modPath-strip fallback; (dir, callName) lookup; callName = after last ".",
+  extractCallName :54-57).
+- **writes**: CALLS (CALL → FUNCTION), empty metadata, additive (shared vocabulary).
+- **expressible**: yes.
+- **draft_rules**:
+```datalog
+go_call(C, F, N)   :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".go"), attr(C, "name", N).
+call_recv(C, R)    :- go_call(C, _, _), node_attr(C, "receiver", R).
+import_alias(F, L, P) :- node(I, "IMPORT"), attr(I, "file", F), ends_with(F, ".go"),
+                         node_attr(I, "local_name", L), node_attr(I, "path", P).
+fn_dir(T, D)       :- go_fn(T, TF), basename(TF, B), concat("/", B, SB), strip_suffix(TF, SB, D).
+go_fn(T, TF)       :- node(T, "FUNCTION"), attr(T, "file", TF), ends_with(TF, ".go"),
+                      node_attr(T, "kind", "function").
+fn_subdir(T)       :- fn_dir(T, _).
+func_in_dir(D, N, T)  :- go_fn(T, _), fn_dir(T, D), attr(T, "name", N).
+func_in_dir("", N, T) :- go_fn(T, _), \+ fn_subdir(T), attr(T, "name", N).
+% non-stdlib gate (approximation, see DELTA G3-2):
+ok_path(P) :- import_alias(_, _, P), string_contains(P, ".").
+ok_path(P) :- import_alias(_, _, P), go_mod(MP), concat(MP, "/", MPS), strip_prefix(P, MPS, _).
+
+@materialize(edge_type = "CALLS", mode = "additive")
+go_call_s1(C, T) :- call_recv(C, R), go_call(C, F, N), import_alias(F, R, P), ok_path(P),
+                    pkg_dir(P, D), method_suffix(N, MN), func_in_dir(D, MN, T).
+```
+- **deltas**:
+  - DELTA G3-1 (SUPERSET, bounded): FunctionIndex was `Map.fromList` = LAST-wins on duplicate
+    (dir, name) keys (CallResolution.hs:91-100) — duplicates arise from build-tag twins or
+    `_test.go` siblings defining the same name in one directory. Set semantics derives all
+    candidates. Bound: #same-name functions per directory (≈1-2; measure on fixture).
+  - DELTA G3-2 (the isStdLib approximation): exactly DELTA G2-3's classes; additionally the
+    bare-dir pkg_dir keys can let a stdlib-named LOCAL directory ("errors/", "log/") capture a
+    qualified call when no dot guard fires — the `ok_path` guard closes that (a dotless,
+    non-module-prefixed path never passes). Residual: same "foo/bar.v2"-shape SUPERSET as G2-3.
+
+### 4. go-calls strategy 2 — same-package function CALLS
+
+- **reads**: CALL nodes with NO `receiver` metadata; FUNCTION kind=function in the caller's dir.
+  Legacy: resolveSamePackageCall :213-222 — (callerDir, callName) lookup.
+- **expressible**: yes — "no receiver" via stratified negation over a derived predicate
+  (node_attr modes [B,B,F]/[B,B,B], builtin.rs:1176-1180, allow the free-value probe).
+- **draft_rules**:
+```datalog
+has_recv(C)   :- node(C, "CALL"), node_attr(C, "receiver", _).
+call_dir(C, D)   :- go_call(C, F, _), basename(F, B), concat("/", B, SB), strip_suffix(F, SB, D).
+call_subdir(C)   :- call_dir(C, _).
+
+@materialize(edge_type = "CALLS", mode = "additive")
+go_call_s2(C, T) :- go_call(C, F, N), \+ has_recv(C), call_dir(C, D), func_in_dir(D, N, T).
+@materialize(edge_type = "CALLS", mode = "additive")
+go_call_s2r(C, T) :- go_call(C, F, N), \+ has_recv(C), \+ call_subdir(C), func_in_dir("", N, T).
+```
+  (receiver-less names are never dotted — exprToName of a non-selector is the bare ident,
+  Calls.hs:74-77 — so N needs no extractCallName treatment; closures excluded from func_in_dir
+  by the kind="function" gate, matching Spec.hs:141-148.)
+- **deltas**: DELTA G3-1 (last-wins) applies identically. Otherwise EXACT.
+
+### 5. go-calls strategy 3 — same-package method CALLS
+
+- **reads**: CALL nodes whose `receiver` does NOT match any import alias in the same file;
+  FUNCTION kind=method nodes (`receiver` = bare TYPE name, Declarations.hs:162,192).
+  Legacy: resolveMethodCall :227-236 — global (receiverTYPE, method) MethodIndex; the call's
+  receiver is an EXPRESSION name, so this only hits when a variable shares the type's name
+  (the known weakness; fixture Spec.hs:120-127 encodes exactly that shape).
+- **expressible**: yes.
+- **draft_rules**:
+```datalog
+alias_recv(C) :- call_recv(C, R), go_call(C, F, _), import_alias(F, R, _).
+method_in(RT, MN, T) :- node(T, "FUNCTION"), attr(T, "file", TF), ends_with(TF, ".go"),
+                        node_attr(T, "kind", "method"), node_attr(T, "receiver", RT),
+                        attr(T, "name", MN).
+
+@materialize(edge_type = "CALLS", mode = "additive")
+go_call_s3(C, T) :- call_recv(C, R), \+ alias_recv(C), go_call(C, _, N),
+                    method_suffix(N, MN), method_in(R, MN, T).
+```
+- **deltas**:
+  - DELTA G5-1 (SUPERSET, bounded): MethodIndex is GLOBAL last-wins across packages
+    (CallResolution.hs:103-112) — same-named type with same-named method in two packages: legacy
+    picks one arbitrary winner, the pack derives all. A dir-scoped variant (join receiver-type's
+    dir to the call's dir) would REFINE instead — defer to the differential to choose
+    (rust_imports DELTA-1 governed-arm precedent).
+  - NOT attempted (parity): real receiver typing (variable name → VARIABLE → TYPE_OF → methods).
+    That is a Wave-2 REFINEMENT with the rust_receiver_typing.dl precedent, not a parity rule.
+
+### 6. go-interfaces → IMPLEMENTS (pack `go_interfaces.dl`)
+
+- **reads**: INTERFACE nodes + their method FUNCTIONs (kind=interface_method; parent interface
+  extracted by legacy from the `[in:Iface]` semantic-id suffix, GoInterfaceSatisfaction.hs:64-101 —
+  pack substitutes the structural INTERFACE -CONTAINS-> FUNCTION edge, Declarations.hs:466-472);
+  FUNCTION kind=method (`receiver` type name); CLASS nodes by name.
+  Legacy algorithm :132-148: non-empty interface method set ⊆ struct method set → IMPLEMENTS
+  (name-only matching; pointer/value both match — receiver metadata is the bare name).
+- **writes**: IMPLEMENTS (CLASS → INTERFACE), empty metadata. Go-only producer today, but keep
+  additive (vocabulary may be shared later).
+- **expressible**: yes — the ∀-subset via TWO strata of negation; the CLASS×INTERFACE candidate
+  cross-product is planner-illegal (§3 cross-join), so candidates are seeded through a shared
+  method NAME — sound because implementing a non-empty interface requires sharing ≥1 method name
+  (filter-before-generator).
+- **draft_rules**:
+```datalog
+iface_m(I, MN) :- node(I, "INTERFACE"), attr(I, "file", IF), ends_with(IF, ".go"),
+                  edge(I, MF, "CONTAINS"), node(MF, "FUNCTION"),
+                  node_attr(MF, "kind", "interface_method"), attr(MF, "name", MN).
+recv_m(SN, MN) :- node(MF, "FUNCTION"), attr(MF, "file", MFF), ends_with(MFF, ".go"),
+                  node_attr(MF, "kind", "method"), node_attr(MF, "receiver", SN),
+                  attr(MF, "name", MN).
+struct_m(S, MN) :- node(S, "CLASS"), attr(S, "file", SF), ends_with(SF, ".go"),
+                   attr(S, "name", SN), recv_m(SN, MN).
+cand(S, I)  :- struct_m(S, MN), iface_m(I, MN).
+lacks(S, I) :- cand(S, I), iface_m(I, MN2), \+ struct_m(S, MN2).
+
+@materialize(edge_type = "IMPLEMENTS", mode = "additive")
+go_implements(S, I) :- cand(S, I), \+ lacks(S, I).
+```
+- **deltas**:
+  - DELTA G6-1 (structural substitute, EXACT in practice): CONTAINS instead of `[in:Iface]`
+    parsing — the analyzer always emits both for the same construct (Declarations.hs:445-472),
+    so coverage is identical (js_same_file_calls DELTA-3 precedent).
+  - DELTA G6-2 (SUPERSET, bounded): legacy StructIndex AND StructMethodSet are global,
+    name-keyed (:108-126) — two same-named structs in different packages MERGE method sets
+    (a legacy false-positive generator) and only the last-wins CLASS id gets the edge. The pack
+    reproduces the name-keyed merge (parity) but emits the edge for EVERY same-named CLASS.
+    Bound: #duplicate struct names. A dir-scoped struct_m join (methods live in the type's
+    package — a Go language guarantee) is the REFINED variant; recommend measuring both in the
+    differential, expecting refined ⊆ parity with the difference = legacy's own false merges.
+  - Interface EXTENDS embedding stays un-expanded (legacy Phase-2 limitation :25-30) — parity.
+
+### 7. go-types → TYPE_OF (pack `go_types.dl`)
+
+- **reads**: VARIABLE nodes (`type` metadata = goTypeToName), CLASS+INTERFACE nodes by name.
+  Legacy: GoTypeResolution.hs:73-88 — recursive `*`/`[]` prefix strip (:47-51), 22-primitive skip
+  (:27-34), global name → id TypeIndex (last-wins, :60-66).
+- **expressible**: yes — the recursive strip is a recursive derived predicate over shrinking
+  strings (terminates); primitives are 22 ground facts (`ground facts parse`,
+  datalog/parser.rs:265-267 per the js spec's evidence note).
+- **draft_rules**:
+```datalog
+go_primitive("int"). go_primitive("int8"). go_primitive("int16"). go_primitive("int32").
+go_primitive("int64"). go_primitive("uint"). go_primitive("uint8"). go_primitive("uint16").
+go_primitive("uint32"). go_primitive("uint64"). go_primitive("uintptr"). go_primitive("float32").
+go_primitive("float64"). go_primitive("complex64"). go_primitive("complex128").
+go_primitive("string"). go_primitive("bool"). go_primitive("byte"). go_primitive("rune").
+go_primitive("error"). go_primitive("any").
+
+vt(V, T)  :- node(V, "VARIABLE"), attr(V, "file", F), ends_with(F, ".go"),
+             node_attr(V, "type", T).
+vt(V, T2) :- vt(V, T), strip_prefix(T, "*", T2).
+vt(V, T2) :- vt(V, T), strip_prefix(T, "[]", T2).
+vt_clean(V, T) :- vt(V, T), not_starts_with(T, "*"), not_starts_with(T, "["), neq(T, "").
+type_node(N, Ty) :- node(Ty, "CLASS"), attr(Ty, "file", TF), ends_with(TF, ".go"), attr(Ty, "name", N).
+type_node(N, Ty) :- node(Ty, "INTERFACE"), attr(Ty, "file", TF), ends_with(TF, ".go"), attr(Ty, "name", N).
+
+@materialize(edge_type = "TYPE_OF", mode = "additive")
+go_type_of(V, Ty) :- vt_clean(V, T), \+ go_primitive(T), type_node(T, Ty).
+```
+  (`not_starts_with(T,"[")` over-approximates `"[]"` only for map types "map[…" — those never
+  match type_node anyway; spelled `"["` because not_starts_with is FILTER2 and "[]"-exactness
+  needs two literals — use `not_starts_with(T, "[]")` directly; both are [B,B] legal.)
+- **deltas**: DELTA G7-1 (SUPERSET, bounded by duplicate type names): TypeIndex last-wins global —
+  same class as G5-1/G6-2. Qualified types ("pkg.User"), map/chan/func types never resolved in
+  legacy and never resolve here (no type_node key) — parity for free.
+
+### 8. go-types → RETURNS
+
+- **reads**: FUNCTION nodes' `return_type` metadata — comma-joined, NO spaces
+  (Declarations.hs:126-128; goTypeToName emits no commas, so the join is unambiguous).
+  Legacy: :95-111 — splitOn "," + T.strip + same strip/primitive/index pipeline.
+- **expressible**: yes — comma-SPLIT via right-peeling recursion with `last_segment`
+  (identity-when-no-separator semantics, builtin.rs:945-953) + `concat` + `strip_suffix`;
+  no `split` builtin needed:
+- **draft_rules**:
+```datalog
+rt(Fn, R)  :- node(Fn, "FUNCTION"), attr(Fn, "file", F), ends_with(F, ".go"),
+              node_attr(Fn, "return_type", R).
+rt(Fn, R2) :- rt(Fn, R), last_segment(R, ",", L), concat(",", L, CL), strip_suffix(R, CL, R2).
+ret0(Fn, T)  :- rt(Fn, R), last_segment(R, ",", T).
+ret0(Fn, T2) :- ret0(Fn, T), strip_prefix(T, "*", T2).
+ret0(Fn, T2) :- ret0(Fn, T), strip_prefix(T, "[]", T2).
+ret_clean(Fn, T) :- ret0(Fn, T), not_starts_with(T, "*"), not_starts_with(T, "[]"), neq(T, "").
+
+@materialize(edge_type = "RETURNS", mode = "additive")
+go_returns(Fn, Ty) :- ret_clean(Fn, T), \+ go_primitive(T), type_node(T, Ty).
+```
+- **deltas**: G7-1 applies. The legacy `T.strip` is a no-op on this metadata (no spaces emitted) —
+  EXACT. Legacy emits one edge PER comma part including duplicates of the same type
+  (e.g. "(*User, *User)") — list-comprehension duplicates collapse in the graph's edge-set
+  semantics for legacy too, so set semantics is EXACT.
+
+### 9. go-context → PROPAGATES_CONTEXT (pack `go_context.dl`, AFTER go_calls — P2)
+
+- **reads**: materialized CALLS edges (go files only — see analyzer-vocabulary note: Go CALLS come
+  exclusively from the go packs); FUNCTION `accepts_context`/`possible_context` (MetaBool —
+  surfaces as the string "true" via node_attr, the `__exported`/Wave-M contract documented in
+  rust_imports.dl:26-28); the CALL's enclosing FUNCTION.
+  Legacy: GoContextPropagation.hs — contextFns/possibleFns (:79-94), enclosing fn via
+  `[in:parent]` + (dir, bare-name) lookup EXCLUDING interface_method and closure kinds
+  (:101-112, :154-161); emit PROPAGATES_CONTEXT(encFn → target) when target accepts (certainly
+  or possibly) AND caller accepts; `unresolved=true` metadata iff the TARGET is only "possible"
+  (:141-176 — the caller's certainty does not affect metadata, fixture Spec.hs:288-301).
+- **expressible**: yes.
+- **draft_rules**:
+```datalog
+ctx_fn(T)  :- node(T, "FUNCTION"), node_attr(T, "accepts_context", "true").
+poss_fn(T) :- node(T, "FUNCTION"), node_attr(T, "possible_context", "true").
+go_calls_e(C, T) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".go"),
+                    edge(C, T, "CALLS"), node(T, "FUNCTION").
+closure_fn(EF) :- node(EF, "FUNCTION"), node_attr(EF, "kind", "closure").
+iface_fn(EF)   :- node(EF, "FUNCTION"), node_attr(EF, "kind", "interface_method").
+enc_fn(C, EF)  :- go_calls_e(C, _), edge(EF, C, "CONTAINS"), node(EF, "FUNCTION"),
+                  \+ closure_fn(EF), \+ iface_fn(EF).
+caller_ok(C)   :- enc_fn(C, EF), ctx_fn(EF).
+caller_ok(C)   :- enc_fn(C, EF), poss_fn(EF).
+
+@materialize(edge_type = "PROPAGATES_CONTEXT", mode = "additive")
+go_prop(EF, T) :- go_calls_e(C, T), ctx_fn(T), caller_ok(C), enc_fn(C, EF).
+@materialize(edge_type = "PROPAGATES_CONTEXT", mode = "additive", meta(unresolved))
+go_prop_u(EF, T, "true") :- go_calls_e(C, T), poss_fn(T), caller_ok(C), enc_fn(C, EF).
+```
+  (accepts/possible are mutually exclusive per function — the analyzer's contextMeta picks one,
+  Declarations.hs:99-105 — so no `\+ ctx_fn(T)` guard is needed on the possible arm.)
+- **deltas**:
+  - DELTA G9-1 (structural substitute, REFINED): enclosing fn = the literal CONTAINS parent
+    instead of the legacy (dir, parsed-bare-name) lookup, which could hit a DIFFERENT same-named
+    function/method in the directory (its Map is also last-wins, :104-112). Refinement removes
+    a legacy false-positive/false-negative class; bound = #same-bare-name functions per dir.
+    Calls inside closures: legacy finds no enclosing fn (closures excluded from the index AND the
+    `[in:]` name is "<closure>") → caller_ok false; the pack's CONTAINS parent IS the closure
+    node, excluded by `\+ closure_fn` → caller_ok false. EXACT match on that class.
+  - DELTA G9-2 (metadata representation): `unresolved` = string "true" (meta projection) vs
+    legacy MetaBool true — same class as the js packs' resolvedVia-projection delta; consumers
+    reading via node_attr/edge_attr string surface see the identical "true".
+
+### 10. go-context → SPAWNS_WITH_CONTEXT / DEFERS_WITH_CONTEXT
+
+- **reads**: as step 9 + CALL `goroutine`/`deferred` MetaBool flags (Calls.hs:127-128;
+  only stamped when true).
+  Legacy: :177-194 — CALL → target FUNCTION when target accepts (or possibly accepts) context,
+  independent of the caller's own context status.
+- **expressible**: yes.
+- **draft_rules**:
+```datalog
+@materialize(edge_type = "SPAWNS_WITH_CONTEXT", mode = "additive")
+go_spawn(C, T)  :- go_calls_e(C, T), ctx_fn(T), node_attr(C, "goroutine", "true").
+@materialize(edge_type = "SPAWNS_WITH_CONTEXT", mode = "additive", meta(unresolved))
+go_spawn_u(C, T, "true") :- go_calls_e(C, T), poss_fn(T), node_attr(C, "goroutine", "true").
+@materialize(edge_type = "DEFERS_WITH_CONTEXT", mode = "additive")
+go_defer(C, T)  :- go_calls_e(C, T), ctx_fn(T), node_attr(C, "deferred", "true").
+@materialize(edge_type = "DEFERS_WITH_CONTEXT", mode = "additive", meta(unresolved))
+go_defer_u(C, T, "true") :- go_calls_e(C, T), poss_fn(T), node_attr(C, "deferred", "true").
+```
+- **deltas**: G9-2 only. EXACT otherwise (the per-CALL edge has a unique (C,T) key; legacy
+  duplicates collapse identically under edge-set semantics).
+
+## missing_capabilities
+
+1. **`first_segment(S, Sep, Out)`** — the dual of `last_segment` (builtin.rs:945-967), identity
+   when no separator. The ONLY exact spelling of Go's isStdLib test ("first path segment
+   contains a dot", GoImportResolution.hs:87 / GoCallResolution.hs:47-50). Without it the
+   `string_contains(P,".")`-OR-module-prefix approximation leaves the bounded G2-3/G3-2 residue.
+   Low priority: residue ≈ 0 on real repos; becomes a real gap only for dot-less vanity import
+   paths colliding with local directory names.
+2. **Zero-arity (or global-constant) predicates** for "the EXTERNAL fact is absent" tests —
+   the no-go.mod fallback branch (P3). A `has_go_mod()` literal is currently a §3 cross-join
+   the planner refuses. Engine alternative to the recommended orchestrator-side pack selection.
+3. **`not_string_contains(S, Sub)`** — ergonomics only. The root-directory ("file has no '/'")
+   complement is expressible today via derived-negation (`\+ mod_subdir(M)`), which costs one
+   helper predicate per consumer; a negative filter twin of `string_contains` (like
+   `not_starts_with`, builtin.rs:1268-1273) collapses the idiom.
+4. *(precondition, not engine)* **P1 GO module-path fact** — orchestrator commit, precedent
+   main.rs:2017-2032 (WORKSPACE_PACKAGE). Today the module path is wire-only
+   (main.rs:1677-1686), invisible to any pack.
+
+NOT needed (verified against today's kit): `split/3` (the last_segment right-peel recursion covers
+comma-joined return_type exactly, step 8); `dirname` (basename+concat+strip_suffix idiom, step 1);
+`node_attr` (exists since Wave 2, modes builtin.rs:1176-1180 — every metadata read above is legal);
+semantic-id `[in:Parent]` parsing (structural CONTAINS substitutes everywhere — G6-1, G9-1).
+
+## differential_acceptance
+
+**The dogfood graph contains ZERO Go nodes** — probed on a /tmp copy of the 618MB
+`.grafema/graph.rfdb`: `grep -rc '\.go->'` across all segments = 0 matches (semantic ids embed the
+file path, and `.grafema/orchestrator.config.yaml` includes no `*.go` pattern). So the
+differential CANNOT run on dogfood; ground truth is fixture-based:
+
+1. **Unit stratum** — port the 23 Spec.hs cases (packages/go-resolve/test/Spec.hs:50-301) to
+   FixtureStorageView engine tests (the 0.04s discipline): per-strategy call shapes, stdlib/
+   third-party skips, first-MODULE multiplicity, empty-modPath fallback, subset-satisfaction
+   corner cases (missing method, empty interface, pointer receiver), context
+   certain/possible/goroutine/deferred matrix incl. the possible-caller/certain-target metadata
+   case (Spec.hs:288-301).
+2. **Repo stratum** — `packages/go-parser/` is a real 4-file Go module
+   (`module github.com/grafema/go-parser`, package main): analyze it into a /tmp DB twice —
+   legacy go-resolve ON / packs ON with the go resolution phase skipped (skip_resolver("go"),
+   main.rs:1674) — and diff `(src_semantic_id, dst_semantic_id, edge_type)` triples per edge
+   type. Note: single-package module → exercises strategies 2/3, types, context; NOT cross-package
+   imports.
+3. **Corpus stratum** — one small multi-package OSS Go repo (needs go.mod + internal packages +
+   interfaces; e.g. a CLI like spf13/cobra) for the cross-package arms (IMPORTS_FROM, S1 calls,
+   IMPLEMENTS at scale). Partition: edge type IS the sub-step partition for Go (the legacy stamps
+   no resolvedVia) — IMPORTS_FROM↔step2, CALLS↔steps3-5 (sub-partition by pack-rule `_source`
+   hash on the pack side; on the legacy side by receiver/alias shape recomputed offline),
+   IMPLEMENTS↔6, TYPE_OF↔7, RETURNS↔8, PROPAGATES/SPAWNS/DEFERS↔9-10.
+
+Acceptance: per-step EXACT except the enumerated bounded deltas (G2-2/G2-3/G3-1/G5-1/G6-2/G7-1
+SUPERSET classes must each be ≤ the stated bound and every extra edge must trace to a documented
+last-wins/first-match legacy tie-break; G9-1 differences must trace to same-name-in-dir
+ambiguity). Freshness gate before any diff (graph mtime vs HEAD).
+
+## expected_speedup_rationale
+
+Honest: NO measurable wall-clock claim — the dogfood graph has no Go nodes (probe above), and the
+go phase costs ~0 there today. The win is structural: retires the 4th `--daemon` Haskell resolver
+(its msgpack full-node-set streaming round-trip, plugin.rs:679-944) and 886 lines of Haskell
+(go-resolve/src = 5 modules + Main), moving Go to the same pack-runner as js/rust — one engine,
+one differential discipline, one less binary in scripts/build-native.sh and the Hello capability
+matrix. On Go-heavy target repos the js/rust precedent applies (in-engine joins over LSM segments
+vs per-phase IPC; the packs here are negation+node_attr ⇒ scratch floor, maintain-incremental
+refuses them — same accepted stance as every import pack, rust_imports.dl MAINTAIN ENVELOPE note).
+
+## honesty — what is NOT expressible / NOT attempted
+
+- **isStdLib exactly** (first-segment-dot): approximated; residue bounded and enumerated (M1).
+- **The no-go.mod global branch** as in-pack logic: needs orchestrator pack-selection or M2.
+- **Legacy tie-breaks** (first-MODULE-in-dir, Map last-wins in 4 indexes, alphabetical
+  findBySuffix winner): deliberately NOT reproduced — set semantics derives all candidates;
+  every such site is flagged SUPERSET with a bound. Reproducing them would need an ordering
+  primitive the engine doesn't have (and shouldn't — rust_imports DELTA-1 precedent refused it).
+- **MetaBool edge metadata**: `unresolved` rides the meta() projection as string "true" (G9-2).
+- **Module-path discovery, go.mod I/O, binary checks**: stays in the orchestrator (EXTERNAL).
+- **stderr edge-count diagnostics**: no pack analog (rust DELTA-4 class).
+- **Receiver typing for S3 / embedded-interface expansion / signature-aware satisfaction**:
+  legacy doesn't do them; the pack stays at parity. Each is a named Wave-2 refinement
+  (rust_receiver_typing.dl precedent; EXTENDS-closure over the analyzer's embedded-interface
+  edges; paramCount/returnCount as a cheap signature proxy already in metadata).
+- **The analyzer's EXTENDS-by-NAME bug**: walkEmbed emits EXTENDS with geTarget = the embedded
+  interface's NAME, not a node id (Declarations.hs:476-485) — an analyzer defect outside this
+  migration's scope; noted so the differential doesn't misattribute it to the packs.
+
+## notes — evidence base
+
+Resolver semantics: packages/go-resolve/src/{Main.hs:61-87, GoImportResolution.hs:57-163,
+GoCallResolution.hs:47-248, GoInterfaceSatisfaction.hs:64-148, GoTypeResolution.hs:27-122,
+GoContextPropagation.hs:79-194}; tests test/Spec.hs:50-301. Analyzer vocabulary:
+packages/go-analyzer/src/{Rules/Imports.hs:63-88, Rules/Calls.hs:74-138, Rules/Declarations.hs:
+95-199,235-283,318-339,445-485,491+,639-650, Analysis/Walker.hs:32-44, Analysis/Context.hs:81-82};
+ControlFlow.hs has zero withScope sites (no block scopes). Orchestrator: main.rs:1673-1714,
+2573-2607 (go-all dispatch + ws wire), config.rs:846-865 (go.mod discovery), 751/796 (language
+partition), main.rs:2017-2032 (WORKSPACE_PACKAGE commit precedent), analyzer.rs:580-602
+(unresolved→ISSUE only). Engine kit: derive/builtin.rs registry :1188-1374 — node/type/edge/
+incoming/attr/neq/gt/lt/gte/lte/starts_with/not_starts_with/string_contains/method_suffix/
+ends_with/concat/str_lower/basename/strip_quotes/strip_prefix/strip_suffix/last_segment/
+replace_all/path_resolve/edge_attr/node_attr; last_segment identity-no-separator :945-953;
+node_attr modes :1176-1180; attr first-class set {name,file,type,id} :546-554. Pack idioms:
+derive/stdlib/rust_imports.dl (DELTA discipline, bool→"true" surface, additive mode, ORDERING),
+js_module_imports.dl:157-158 (WORKSPACE_PACKAGE join), rust_calls.dl:86-89 (meta() projection),
+js_this_method_calls.dl:38-41 (§3 cross-join refusal). Dogfood probe: cp -R
+.grafema/graph.rfdb /tmp/go-spec-probe.rfdb; grep -rc '\.go->' = 0 (no Go nodes; config includes
+no *.go). Per the Evidence Rule, graph-shape claims here rest on analyzer source + Spec.hs
+fixtures because no live Go graph exists; the differential's repo stratum (packages/go-parser
+analyze) is the mandatory live confirmation before pack implementation.
+
+---
+
+# VERDICT (adversarial review, 2026-06-12, worktree HEAD 9ac0681c)
+
+**VERDICT: REVISE BEFORE IMPLEMENTATION — semantics inventory is accurate and complete, but the headline
+import/call draft rules are planner-illegal as written.** Re-verified in source: dispatch order (alias→S1
+only / receiver-no-alias→S3 / no-receiver→S2, GoCallResolution.hs:157-174), isStdLib first-segment-dot
+(:86-89), plain-stripPrefix + dropWhile '/' + first-MODULE pick + findBySuffix alphabetical-first
+(GoImportResolution.hs:116-163), interface subset algorithm with the non-empty gate
+(GoInterfaceSatisfaction.hs:130-148), context arms incl. SPAWNS/DEFERS sharing edgeMeta and the
+caller-independence of steps 10 (GoContextPropagation.hs:140-194 — `unresolved=true` iff target possible,
+on ALL three edge types, matching the drafted meta rules), return_type `T.intercalate ","`
+(Declarations.hs:126-128), accepts/possible mutual exclusivity (:98-105), goroutine/deferred only-when-true
+(Calls.hs:127-128), INTERFACE→FUNCTION(interface_method) CONTAINS (:466-472), EXTENDS-by-NAME analyzer
+defect (:476-485). Emit-site inventory complete (re-grepped: 3 call sites, 2 type sites, 1 import,
+1 interface, 3 context). The step-8 comma-peel and step-7 prefix-strip recursions are LEGAL — the same
+shipped idiom as js_module_imports.dl:172-179 `spec_pfx`. Corrections:
+
+**C1 (BLOCKING — E-PLAN-003 cross-joins in steps 1, 2, 3).** The §3 cross-join guard polices DERIVED legs
+too (plan.rs:308-318; introduces_tuples = anything that's not a filter/function, :714-717), and the
+ground-atom exemption requires ALL-constant args (plan.rs:1004-1007). Therefore, as drafted:
+- `pkg_dir(P,D) :- mod_dir(_,D), go_mod(MP), …` — go_mod(MP) shares no variable with {D} in any leg order → REJECTED;
+- `pkg_dir(MP,"") :- go_mod(MP), module_in_dir("",_)` — second leg disconnected → REJECTED;
+- `go_import_from(I,M) :- go_import(I,_,P), go_mod(MP), …` — go_mod(MP) disconnected from {I,P} → REJECTED;
+- `go_import_from_root(I,M) :- …, go_mod(P), module_in_dir("",M)` — module_in_dir("",M) has var M, shares
+  nothing → REJECTED (this arm is semantically a cross product: import × root modules);
+- `ok_path(P) :- import_alias(_,_,P), go_mod(MP), …` — same → REJECTED.
+The spec flagged this guard only for the zero-arity `has_go_mod()` (P3) while drafting the identical
+illegal shape in its main arms. LEGAL respelling exists and is the established one: derive the
+'/'-boundary PREFIXES of the import path by right-peel (the spec_pfx idiom), EQUALITY-join `go_mod` on
+the peeled prefix variable, then `strip_prefix(P, MP_slash, RelDir)` and join `module_in_dir(RelDir, M)`
+on the BOUND RelDir — which also covers the root case (RelDir="" is a bound value, not a constant leg).
+Consequence: the step-1 kernel's `pkg_dir` cannot exist as a standalone derived relation (the
+modPath×dirs product is inherently disconnected); consumers (S1 calls, imports) must inline the
+peel-join. This is a kernel redesign, not a tweak.
+
+**C2 (fallback arm harder-blocked than stated).** The no-go.mod fallback rule
+`go_import_suffix(I,M) :- go_import(I,_,P), …, module_in_dir(D,M), …, ends_with(P,D)` is the
+filter-connected spelling the guard exists to reject (the in-file "rust_imports f_anc lesson",
+js_module_imports.dl:168-170) — module_in_dir(D,M) is a disconnected positive leg regardless of which
+pack loads it, so P3's orchestrator-side variant selection does NOT rescue the rule body. An equality-join
+spelling needs the '/'-boundary SUFFIXES of P, which is a left-peel — it requires `first_segment`
+(missing capability M1). So M1 is the blocker for the fallback ARM itself, not merely for isStdLib
+exactness; either build M1 or declare the no-go.mod fallback dropped (bound: only projects without
+go.mod, where legacy's own behavior was the alphabetical-first heuristic).
+
+**C3 (missed delta class — interface-side name merge, step 6).** Legacy
+`collectIfaceMethods` UNIONS method sets across SAME-NAMED interfaces project-wide
+(GoInterfaceSatisfaction.hs:96-102, `Map.insertWith Set.union` keyed by interface NAME) and
+`Map.intersectionWith` pairs that union with ONE last-wins interface node id (:84-88). The pack's
+`iface_m(I, MN)` is per-NODE: for duplicate interface names the pack's requirement set is SMALLER
+(per-node, not the union) ⇒ structs can satisfy an interface the legacy merged-set rejected, AND the
+pack emits an edge per actual interface node vs legacy's single arbitrary winner. This is a separate
+SUPERSET class from G6-2's struct-side merge — declare it (bound = duplicate interface simple names,
+countable) or the differential will misclassify those rows.
+
+**C4 (missed seam — pack ordering beyond P2).** `go_imports` must be registered BEFORE `@stdlib/depends`:
+depends.dl consumes EVERY IMPORTS_FROM edge node-type-agnostically (derive/stdlib/depends.dl:1-6), and the
+go branch feeds `all_imports_from_edges` today (main.rs:1701). `go_calls` (CALLS producer) must precede the
+CALLS negators `method_calls`/`shape_verifier` (shape_verifier.dl:30 negates `edge(C,_,"CALLS")`, no file
+gate). The ordering const is orchestrator main.rs:59-104 STDLIB_RULE_PACKS + rfdb-server stdlib.rs
+STDLIB_PACKS — P2 covers only go_calls→go_context.
+
+**C5 (mechanism misattribution, conclusion stands).** "the orchestrator turns unresolved [DeferredRefs]
+into ISSUE diagnostics only (analyzer.rs:580-602)" — wrong mechanism: FileAnalysis has NO unresolvedRefs
+field (analyzer.rs:41-49; serde drops faUnresolvedRefs exactly as for java/kotlin). The ISSUE nodes are
+generated from POST-RESOLVE graph queries (main.rs:2060-2085: CALLs with no CALLS edge, IMPORT_BINDINGs
+with no IMPORTS_FROM) onto `__grafema_virtual/unresolved-diagnostics`. The load-bearing conclusion ("graph
+CALLS on .go files come exclusively from go-resolve") survives, but the differential must exclude the
+synthetic diagnostics file — pack-coverage deltas change the ISSUE population.
+
+**C6 (minor).** Step 7: rule text uses `not_starts_with(T,"[")` while the note recommends `"[]"` — pick
+one (both parity-safe: neither residue matches a type_node key). The dogfood probe (`grep -rc '\.go->'`
+over binary segments) is weaker evidence than the java/kotlin live-Datalog probes — rerun as a Datalog
+count on the /tmp copy before gating. Negated builtin filters are in fact legal (exec.rs:1912+ per-row
+anti-join; stratify adds no edge for builtins), so M3 `not_string_contains` is even less needed than
+stated — `\+ string_contains(F,"/")` works today (no stdlib precedent; fixture-test first).
+
+Ready for packs: NOT YET — C1/C2 require redrafting the import/call kernels (legal shapes exist and are
+specified above); steps 4-10 are implementable as drafted once the shared func_in_dir/pkg join is respelled.

--- a/_ai/research/lang-spec-java.md
+++ b/_ai/research/lang-spec-java.md
@@ -1,0 +1,566 @@
+# Migration spec: java-resolve → derive packs (Datalog v2)
+
+Date: 2026-06-12. Branch context: worktree at `9ac0681c` (v0.4.0, origin/main-era; `derive/` module layout).
+Discipline: the js/rust precedent in `_ai/research/resolve-datalog2-migration-specs.json` + synthesis-ledger §3/§5.
+All file:line references verified by Read/Grep in this worktree at HEAD.
+
+## 0. Target & purpose
+
+**Target:** `java-resolve` binary (`packages/java-resolve/src/`, 4 modules + Main, 869 LOC total), dispatched
+by the orchestrator as a one-shot full-graph daemon command `("java-all", &[])` over `Language::Java` nodes
+(`packages/grafema-orchestrator/src/main.rs:1566-1595` analyze path, `:2481-2501` reanalyze path; binary
+checked at `:838-839`). `java-all` runs all 4 phases in one pass (`java-resolve/src/Main.hs:64-70`).
+
+**Purpose:** Java cross-file resolution, materializing:
+- `IMPORTS_FROM` (IMPORT→class decl; IMPORT_BINDING→class decl) — `ImportResolution.hs`
+- `RETURNS`, `TYPE_OF`, `EXTENDS`, `IMPLEMENTS`, `THROWS_TYPE` — `TypeResolution.hs`
+- `CALLS`, `INSTANTIATES` — `CallResolution.hs`
+- `ANNOTATION_RESOLVES_TO` — `AnnotationResolution.hs`
+
+All emitted edges carry **EMPTY metadata** (every `mkEdge`/`EmitEdge` site: ImportResolution.hs:85-91,113-130;
+TypeResolution.hs:188-195; CallResolution.hs:132-139; AnnotationResolution.hs:46-53). No virtual nodes are
+minted anywhere in java-resolve — **no `@materialize_node`, no two-pack split needed** (unlike js builtins).
+No external data inputs (no effects-db, no workspace map): graph-in, edges-out. This is the *easiest*
+resolver family migrated so far.
+
+**Out of scope (adjacent):** `jvm-cross-resolve` (`packages/jvm-cross-resolve/src/`, 3 modules) — Java↔Kotlin
+cross-language `IMPORTS_FROM`/`CALLS`/type edges, emitted only when source and target file *languages differ*
+(CrossImportResolution.hs:5,17-18); run separately at main.rs:1793/2680. `kotlin-resolve` is a near-clone of
+java-resolve (own spec). Both deserve their own pack specs; the kernels below (qualified-class index,
+HAS_METHOD membership) are directly reusable.
+
+## 1. Analyzer vocabulary the resolver consumes (java-analyzer, verified)
+
+Node types emitted (`packages/java-analyzer/src/Rules/`):
+`MODULE` (Walker.hs:37-51, metadata `package` when the file has a package decl, else NO key),
+`IMPORT` (Imports.hs:65-81, name = full import path `com.example.Foo`, metadata `path`/`glob`(bool)/`static`(bool)),
+`IMPORT_BINDING` (Imports.hs:96-112, name = leaf `Foo`, metadata `imported_name`/`local_name`/`static` —
+**no `source` key**), `CLASS`/`INTERFACE`/`ENUM`/`RECORD`/`ANNOTATION_TYPE` (Declarations.hs; CLASS metadata
+`extends` single name :114, `implements` comma-joined :118; INTERFACE `extends` comma-joined :169; ENUM/RECORD
+`implements` comma-joined :219,:272), `FUNCTION` (methods :376-391 metadata `kind`="method"/`return_type`/
+`throws` comma-joined; constructors :459-467 `kind`="constructor"; compact ctors :529 `kind`="compact_constructor"),
+`VARIABLE` (fields :740-747 metadata `kind`="field"/`type`; locals/params/catch in Expressions.hs),
+`CALL` (Expressions.hs:103-123 method calls, metadata `method`/`argCount`/`receiver` only-when-nonempty;
+:777-795 `this()`/`super()` with `kind`="constructor_call"/`isThis`(bool); ctor calls named `"new " <> ClassName`
+:1086), `ATTRIBUTE` (Annotations.hs, annotation usages).
+
+Edge types emitted by the analyzer (counted): `CONTAINS` ×43 sites, `HAS_METHOD` (Declarations.hs:402-410
+methods, :477-483 constructors — **NOT compact constructors**: the :534-539 emission for compact ctors is
+CONTAINS-only), `HAS_PROPERTY`, `INNER_CLASS_OF`, plus expression-level edges (CALLS×2 analyzer-side,
+REFERENCES, ASSIGNED_FROM, THROWS, CATCHES, …).
+
+Semantic-id format (`grafema-common/src/Grafema/SemanticId.hs:2`): `file->TYPE->name[in:parent,h:xxx]`.
+- FUNCTION (method/ctor): `parent` = enclosing **class** name (`askNamedParent`, set by `withNamedParent name`
+  at the class walk, Declarations.hs:332-343).
+- CALL: `parent` = enclosing **method** name (`parent = encFn >>= extractName`, Expressions.hs:101,163,226,777;
+  `extractName` takes the *name segment* of the enclosing FUNCTION sid, :1098-1105).
+
+Scope mechanics: members get `CONTAINS` from `scopeId`; class scopes carry the class node id
+(Declarations.hs:332-338), method/ctor scopes carry the FUNCTION node id (:419-428, :542-548 ccScope), lambdas
+carry the lambda FUNCTION id (Expressions.hs:377,424). Blocks do NOT push scopes (no BlockScope construction
+in Rules/). So a CALL's `CONTAINS` source is the enclosing FUNCTION (or class for field initializers, or MODULE
+at top level) — the graph-native parent chain the packs use instead of sid parsing.
+
+**Streaming scope:** the daemon receives ONLY Java-language nodes (`run_resolve(..., &[config::Language::Java], ...)`,
+main.rs:1578). Every pack rule below therefore gates BOTH sides on `ends_with(F, ".java")` — this *is* legacy
+parity, and mandatory because the vocabulary is shared polyglot-wide (ATTRIBUTE also emitted by cpp/kotlin/
+python/swift analyzers; ANNOTATION_TYPE by kotlin; INSTANTIATES by cpp/kotlin/php resolvers — verified by grep).
+
+## 2. Production-dead legacy paths (load-bearing findings)
+
+These three findings change what "parity" means. Each is code-evidence (file:line both sides); the
+differential run must confirm them live (no java graph exists today to live-verify — §8).
+
+**(D1) `resolveBinding` is dead.** ImportResolution.hs:104-107 reads node metadata `source` and returns `[]`
+when absent. The analyzer stamps IMPORT_BINDING with `imported_name`/`local_name`/`static` only
+(Imports.hs:107-111); the intended `source` travels in `DeferredRef.drSource` (Imports.hs:122-135), but the
+orchestrator's `FileAnalysis` struct has **no `unresolvedRefs` field** (analyzer.rs:41-49) — serde drops it.
+⇒ Phase 3 (IMPORT_BINDING→decl) emits ZERO edges in production. The package unit test passes only because it
+fabricates the `source` key (test/Spec.hs:79-91).
+
+**(D2) `asterisk` vs `glob`.** ImportResolution.hs:78 reads metadata `asterisk`; the analyzer stamps `glob`
+(Imports.hs:78). `isAsterisk` is always False — benign: a glob IMPORT is named `com.example.*`, which can never
+match a qualified class name, so the net effect (no edge) is identical. The pack inherits this for free.
+
+**(D3) `resolveSameClassCalls` fires only inside constructors.** It keys the method index by
+`(className, methodName)` where className comes from the FUNCTION sid `[in:Class]` (CallResolution.hs:56-66),
+but looks it up with `extractParentClass(CALL sid)` (:191-194) — which is the enclosing **method** name (§1).
+The lookup matches only when enclosing-method-name == class-name, i.e. inside constructors. Calls in ordinary
+method bodies derive nothing. The unit test masks this by fabricating `[in:Service]` on the CALL sid
+(test/Spec.hs:214-221). Corollary: `resolveSuperThisCalls` (:232-257) **works correctly by the same accident** —
+`super()`/`this()` occur only inside constructors, where `[in:ctorName]` == class name.
+
+## 3. Per-step inventory + draft rules
+
+Builtin kit verified at `packages/rfdb-server/src/derive/builtin.rs` registry (:1188-1372): `node/type/edge/
+incoming/attr` (attr exposes ONLY name/file/type/id — :548-551; "id" is the u128 decimal, NOT the semantic id),
+`neq,gt,lt,gte,lte`, `starts_with,not_starts_with,string_contains,ends_with` [B,B], `method_suffix,str_lower,
+basename,strip_quotes` [B,F|B,B], `concat,strip_prefix,strip_suffix,last_segment,path_resolve` [B,B,F|B,B,B],
+`replace_all` [B,B,B,F|B,B,B,B], `edge_attr/5`, **`node_attr/3`** [B,B,F|B,B,B] point-probe (:1084-1115,
+:1176-1182; JSON string verbatim, number by JSON text, bool as "true"/"false"; missing key = tuple non-match).
+`node_attr` — the js-spec's #1 missing capability — EXISTS; it unblocks every metadata read below.
+Negated builtins are not a thing (`not_starts_with` exists precisely because `\+` applies to derived relations) —
+all "skip" filters below go through derived aux relations.
+
+```json
+[
+  {
+    "step": "S1 qualified-class kernel (buildModuleIndex+buildClassIndex, ImportResolution.hs:41-68)",
+    "reads": "MODULE.metadata.package (node_attr), CLASS/INTERFACE/ENUM/RECORD by (file,name), java gate",
+    "writes": "derived qual_class(QualifiedName, T) — consumed by S2/S3",
+    "expressible": "fully",
+    "deltas": ["last-write-wins Map on duplicate qualified names → set semantics derives ALL candidates (superset, same class as rust DELTA 4)"]
+  },
+  {
+    "step": "S2 IMPORT → class decl IMPORTS_FROM (resolveImport, ImportResolution.hs:75-92)",
+    "reads": "IMPORT.name = full path (first-class), glob exclusion (production-dead D2 — free parity)",
+    "writes": "IMPORTS_FROM IMPORT→{CLASS,INTERFACE,ENUM,RECORD}, empty meta",
+    "expressible": "fully",
+    "deltas": ["S1 superset inherits", "static imports `com.example.Foo.bar` resolve nothing on BOTH sides (full-path lookup fails) — exact parity; an opt-in improvement arm via last_segment exists but is NOT drafted (honesty: superset must be deliberate)"]
+  },
+  {
+    "step": "S3 IMPORT_BINDING → class decl IMPORTS_FROM (resolveBinding, ImportResolution.hs:99-131)",
+    "reads": "legacy: metadata source (NEVER present — D1). pack: IMPORT -CONTAINS-> IMPORT_BINDING + IMPORT.name (Imports.hs:114-120 emits exactly this edge)",
+    "writes": "IMPORTS_FROM IMPORT_BINDING→class decl",
+    "expressible": "fully (graph-native route)",
+    "deltas": ["DECLARED SUPERSET vs production (legacy derives 0); bound = count of java IMPORT_BINDING whose parent IMPORT name ∈ qual_class — measurable pre-flight. This restores the resolver's documented intent (module header :20, unit test :79). Ship decision: include (it is the feature), with the bound recorded"]
+  },
+  {
+    "step": "S4 simple-class kernel (TypeResolution.hs:41-50 / CallResolution.hs:44-52 buildClassIndex by simple name)",
+    "reads": "CLASS/INTERFACE/ENUM/RECORD (file,name), java gate",
+    "writes": "derived jclass_named(N, T) — consumed by S5-S9, S10, S12, S13",
+    "expressible": "fully",
+    "deltas": ["Map last-write-wins on duplicate simple names ACROSS THE PROJECT (e.g. two `Foo` in different packages) → set semantics derives an edge per candidate (superset; bound = names with >1 decl, measurable)"]
+  },
+  {
+    "step": "S5 RETURNS (resolveReturns, TypeResolution.hs:115-126; normalizeType :81-94)",
+    "reads": "FUNCTION.metadata.return_type (node_attr); normalize = strip-all-[] (replace_all), skip 10 primitives (ground facts), skip '?'-wildcards + '<unknown>' (derived-negation aux)",
+    "writes": "RETURNS FUNCTION→class decl",
+    "expressible": "fully",
+    "deltas": ["T.strip trim is not replicated (no trim builtin) — NO-OP: typeToName (Expressions.hs:1108-1114) never emits padded names", "S4 superset inherits"]
+  },
+  {
+    "step": "S6 TYPE_OF (resolveTypeOf, TypeResolution.hs:129-140)",
+    "reads": "VARIABLE.metadata.type (node_attr), same normalize",
+    "writes": "TYPE_OF VARIABLE→class decl",
+    "expressible": "fully",
+    "deltas": ["same as S5"]
+  },
+  {
+    "step": "S7 EXTENDS (resolveExtends, TypeResolution.hs:143-156)",
+    "reads": "CLASS/INTERFACE/ENUM/RECORD metadata.extends — NOTE legacy does NOT split: an interface with `extends A,B` (comma-joined, Declarations.hs:169) is looked up as the literal string 'A,B' and fails",
+    "writes": "EXTENDS decl→class decl",
+    "expressible": "fully (exact parity INCLUDING the no-split miss: a comma-bearing string matches no class name automatically)",
+    "deltas": ["S4 superset inherits", "interface multi-extends: 0 edges on both sides (exact); the FIX needs split/3 (missing capability #1)"]
+  },
+  {
+    "step": "S8 IMPLEMENTS (resolveImplements, TypeResolution.hs:159-171, splitTypes :97-98)",
+    "reads": "CLASS/ENUM metadata.implements, comma-SPLIT then per-element lookup",
+    "writes": "IMPLEMENTS decl→interface decl (one per resolved element)",
+    "expressible": "partially",
+    "deltas": ["single-element values: EXACT", "multi-element values: SUBSET — pack derives 0 of them (no split/3 builtin); bound = java CLASS/ENUM nodes whose implements metadata contains ',' (directly countable via string_contains)"]
+  },
+  {
+    "step": "S9 THROWS_TYPE (resolveThrows, TypeResolution.hs:174-186)",
+    "reads": "FUNCTION.metadata.throws, comma-split per element",
+    "writes": "THROWS_TYPE FUNCTION→class decl",
+    "expressible": "partially",
+    "deltas": ["same split SUBSET as S8 (multi-exception throws clauses); single-exception exact"]
+  },
+  {
+    "step": "S10 constructor calls (resolveConstructorCalls, CallResolution.hs:146-176)",
+    "reads": "CALL name 'new X' (strip_prefix), jclass_named, ctor membership: legacy ctorIdx = FUNCTION kind∈{constructor,compact_constructor} keyed by sid [in:Class] (:70-85) — pack: HAS_METHOD for ctors + RECORD-CONTAINS for compact ctors (HAS_METHOD gap, §1)",
+    "writes": "INSTANTIATES CALL→class decl + CALLS CALL→ctor FUNCTION",
+    "expressible": "fully",
+    "deltas": ["overload pick: legacy takes head of the ctor list (:174-175, arbitrary Map-fold order; the argCount comment is NOT implemented) → pack derives ALL ctors of the class (superset, bound = classes with >1 ctor)", "S4 superset inherits", "local-class ctors: legacy keyed them under the WRONG name when nested in a method (sid parent = method name); pack's edge-based membership is correct (superset/fix, rare)"]
+  },
+  {
+    "step": "S11 same-class method calls (resolveSameClassCalls, CallResolution.hs:182-205) — PRODUCTION-LATENT-BUGGED (D3)",
+    "reads": "CALL with receiver absent/''/'this' (node_attr + derived-negation), NOT ctor-call, NOT super/this; enclosing class: pack = CONTAINS-parent FUNCTION (+ nested-FUNCTION recursion for lambdas) + HAS_METHOD owner; method index = HAS_METHOD + name",
+    "writes": "CALLS CALL→FUNCTION (same class)",
+    "expressible": "fully",
+    "deltas": ["DECLARED SUPERSET: legacy derives only ctor-body calls (D3); pack derives all same-class no-receiver calls — the resolver's documented intent (:12-13) and its unit test (:214). Bound = plain calls in non-ctor methods with a same-class name match; semantically sound (no false-positive vector: the join requires an actual same-class method of that name)", "overload pick head → all-overloads superset", "field-initializer calls (CONTAINS from class node, no FUNCTION parent): legacy no-edge ([in:] absent → extractParentClass Nothing), pack no-edge through encl_fn (FUNCTION-typed parent leg) — parity"]
+  },
+  {
+    "step": "S12 static-style calls (resolveStaticCalls, CallResolution.hs:208-226)",
+    "reads": "CALL.metadata.receiver = a class simple name (node_attr), method via HAS_METHOD+name",
+    "writes": "CALLS CALL→FUNCTION",
+    "expressible": "fully",
+    "deltas": ["all-overloads superset; S4 dup-name superset; otherwise EXACT (receiver matching a non-class identifier derives nothing on both sides — unit test :243-249)"]
+  },
+  {
+    "step": "S13 super()/this() delegating ctor calls (resolveSuperThisCalls, CallResolution.hs:232-257)",
+    "reads": "CALL named 'super'/'this' or isThis=true (node_attr bool surface 'true'); this(): enclosing class ctor; super(): enclosing CLASS metadata.extends → superclass ctor",
+    "writes": "CALLS CALL→ctor FUNCTION",
+    "expressible": "fully",
+    "deltas": ["all-ctors superset vs head-pick; otherwise EXACT (legacy works here — D3 corollary)"]
+  },
+  {
+    "step": "S14 annotation resolution (AnnotationResolution.hs:26-44)",
+    "reads": "ATTRIBUTE.name ↔ ANNOTATION_TYPE.name (both first-class)",
+    "writes": "ANNOTATION_RESOLVES_TO ATTRIBUTE→ANNOTATION_TYPE",
+    "expressible": "fully",
+    "deltas": ["dup-name set-semantics superset; .java gate on BOTH legs is load-bearing (kotlin emits both node types — without the gate the pack would invent java→kotlin edges legacy never saw)"]
+  }
+]
+```
+
+## 4. Draft packs (4 files, canonical order: java_imports → java_types → java_calls → java_annotations)
+
+No inter-pack EDB dependencies (none consumes another's materialized edges), so the order is convention,
+not contract — record it in the STDLIB_PACKS comment anyway (stdlib.rs:303-358 discipline). All `mode =
+"additive"`: every edge type is shared vocabulary and the legacy resolver stays ON during hybrid rollout
+(the rust_trait_resolve.dl precedent). Legacy metadata is empty ⇒ no `meta(...)` columns anywhere; engine
+provenance `_source`/`_generation` is the standing metadata delta (rust DELTA 6).
+
+### 4.1 `java_imports.dl`
+
+```prolog
+% Self-contained name-keyed relations joined on strings (§3 connectivity discipline,
+% rust_trait_resolve.dl ENCODING NOTE — never inline node/attr legs next to a foreign leg).
+jmodule(M, F) :- node(M, "MODULE"), attr(M, "file", F), ends_with(F, ".java").
+jdecl(T, F, N) :- node(T, "CLASS"),     attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "INTERFACE"), attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "ENUM"),      attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "RECORD"),    attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+pkg_of(F, P)  :- jmodule(M, F), node_attr(M, "package", P), neq(P, "").
+has_pkg(F)    :- pkg_of(F, P).
+% qualified name = package "." simple name; default-package files contribute the bare name
+% (ImportResolution.hs:63-66 pkg-or-empty discipline).
+qual_class(Q, T) :- jdecl(T, F, N), pkg_of(F, P), concat(P, ".", P1), concat(P1, N, Q).
+qual_class(N, T) :- jdecl(T, F, N), \+ has_pkg(F).
+
+jimport(I, Q, F) :- node(I, "IMPORT"), attr(I, "file", F), ends_with(F, ".java"), attr(I, "name", Q).
+
+% S2 — IMPORT -> declaration (glob imports fall out naturally: '*'-suffixed names match nothing).
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+import_target(I, T) :- jimport(I, Q, F), qual_class(Q, T).
+
+% S3 — IMPORT_BINDING -> declaration via the parent IMPORT (graph-native source; DECLARED
+% SUPERSET vs the production-dead metadata-source path, §2 D1).
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+binding_target(B, T) :- node(B, "IMPORT_BINDING"), attr(B, "file", F), ends_with(F, ".java"),
+    edge(I, B, "CONTAINS"), jimport(I, Q, F), qual_class(Q, T).
+```
+
+### 4.2 `java_types.dl`
+
+```prolog
+prim("boolean"). prim("byte"). prim("char"). prim("short"). prim("int").
+prim("long"). prim("float"). prim("double"). prim("void"). prim("var").
+
+jdecl(T, F, N) :- node(T, "CLASS"),     attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "INTERFACE"), attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "ENUM"),      attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "RECORD"),    attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jclass_named(N, T) :- jdecl(T, F, N).
+
+% normalizeType (TypeResolution.hs:81-94): strip ALL "[]", reject primitives / '?' / '<unknown>' / "".
+% One raw value per (node,key) ⇒ the per-node bad-flag is a faithful negation surface.
+ret_strip(Fn, N) :- node(Fn, "FUNCTION"), attr(Fn, "file", F), ends_with(F, ".java"),
+    node_attr(Fn, "return_type", Raw), neq(Raw, ""), replace_all(Raw, "[]", "", N), neq(N, "").
+ret_bad(Fn) :- ret_strip(Fn, N), prim(N).
+ret_bad(Fn) :- ret_strip(Fn, N), string_contains(N, "?").
+ret_bad(Fn) :- ret_strip(Fn, "<unknown>").
+@materialize(edge_type = "RETURNS", mode = "additive")
+returns(Fn, T) :- ret_strip(Fn, N), \+ ret_bad(Fn), jclass_named(N, T).
+
+vty_strip(V, N) :- node(V, "VARIABLE"), attr(V, "file", F), ends_with(F, ".java"),
+    node_attr(V, "type", Raw), neq(Raw, ""), replace_all(Raw, "[]", "", N), neq(N, "").
+vty_bad(V) :- vty_strip(V, N), prim(N).
+vty_bad(V) :- vty_strip(V, N), string_contains(N, "?").
+vty_bad(V) :- vty_strip(V, "<unknown>").
+@materialize(edge_type = "TYPE_OF", mode = "additive")
+type_of(V, T) :- vty_strip(V, N), \+ vty_bad(V), jclass_named(N, T).
+
+% EXTENDS — all 4 decl types carry it (TypeResolution.hs:146); comma-joined interface
+% multi-extends matches no class name = the legacy no-split miss, reproduced exactly.
+ext_strip(C, N) :- jdecl(C, F, CN), node_attr(C, "extends", Raw), neq(Raw, ""),
+    replace_all(Raw, "[]", "", N), neq(N, "").
+ext_bad(C) :- ext_strip(C, N), prim(N).
+ext_bad(C) :- ext_strip(C, N), string_contains(N, "?").
+ext_bad(C) :- ext_strip(C, "<unknown>").
+@materialize(edge_type = "EXTENDS", mode = "additive")
+extends(C, T) :- ext_strip(C, N), \+ ext_bad(C), jclass_named(N, T), neq(C, T).
+
+% IMPLEMENTS (CLASS+ENUM only, :163) / THROWS_TYPE — SINGLE-element arm only (split/3 gap):
+% comma-bearing values are excluded explicitly so the subset is the DECLARED one, not an accident.
+impl_one(C, N) :- node(C, "CLASS"), attr(C, "file", F), ends_with(F, ".java"),
+    node_attr(C, "implements", N), neq(N, "").
+impl_one(C, N) :- node(C, "ENUM"),  attr(C, "file", F), ends_with(F, ".java"),
+    node_attr(C, "implements", N), neq(N, "").
+impl_multi(C) :- impl_one(C, N), string_contains(N, ",").
+@materialize(edge_type = "IMPLEMENTS", mode = "additive")
+implements(C, T) :- impl_one(C, N), \+ impl_multi(C), jclass_named(N, T).
+
+throws_one(Fn, N) :- node(Fn, "FUNCTION"), attr(Fn, "file", F), ends_with(F, ".java"),
+    node_attr(Fn, "throws", N), neq(N, "").
+throws_multi(Fn) :- throws_one(Fn, N), string_contains(N, ",").
+@materialize(edge_type = "THROWS_TYPE", mode = "additive")
+throws_type(Fn, T) :- throws_one(Fn, N), \+ throws_multi(Fn), jclass_named(N, T).
+```
+
+### 4.3 `java_calls.dl`
+
+```prolog
+jdecl(T, F, N) :- node(T, "CLASS"),     attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "INTERFACE"), attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "ENUM"),      attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "RECORD"),    attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jclass_named(N, T) :- jdecl(T, F, N).
+
+jcall(C, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".java"), attr(C, "name", N).
+
+% — classification (CallResolution.hs:260-270) —
+ctor_call(C, CN) :- jcall(C, N), strip_prefix(N, "new ", CN), neq(CN, "").
+is_ctor_call(C)  :- ctor_call(C, CN).
+is_ctor_call(C)  :- jcall(C, N), node_attr(C, "kind", "constructor_call").
+this_call(C)  :- jcall(C, "this").
+this_call(C)  :- jcall(C, N), node_attr(C, "isThis", "true").
+super_call(C) :- jcall(C, "super").
+super_this(C) :- this_call(C).
+super_this(C) :- super_call(C).
+has_recv(C) :- jcall(C, N), node_attr(C, "receiver", R), neq(R, ""), neq(R, "this").
+
+% — membership (graph-native replacement of the sid [in:Class] parse) —
+% ctor_of: HAS_METHOD covers methods+constructors (Declarations.hs:402,477); compact
+% constructors get only CONTAINS from the record scope (:534-539) — the second arm.
+ctor_of(Cls, Fn) :- edge(Cls, Fn, "HAS_METHOD"), node_attr(Fn, "kind", "constructor").
+ctor_of(Cls, Fn) :- node(Cls, "RECORD"), edge(Cls, Fn, "CONTAINS"),
+    node_attr(Fn, "kind", "compact_constructor").
+% enclosing class of a CALL: nearest FUNCTION ancestor via CONTAINS, then its HAS_METHOD
+% owner; the recursion lifts lambda/local-fn nesting (lambda FUNCTIONs have no HAS_METHOD).
+encl_fn(C, Fn) :- jcall(C, N), edge(Fn, C, "CONTAINS"), node(Fn, "FUNCTION").
+fn_owner(Fn, Cls) :- edge(Cls, Fn, "HAS_METHOD").
+fn_owner(Fn, Cls) :- edge(Outer, Fn, "CONTAINS"), node(Outer, "FUNCTION"), fn_owner(Outer, Cls).
+encl_class(C, Cls) :- encl_fn(C, Fn), fn_owner(Fn, Cls).
+
+% S10 — constructor calls.
+@materialize(edge_type = "INSTANTIATES", mode = "additive")
+instantiates(C, Cls) :- ctor_call(C, CN), jclass_named(CN, Cls).
+@materialize(edge_type = "CALLS", mode = "additive")
+ctor_calls(C, Fn) :- ctor_call(C, CN), jclass_named(CN, Cls), ctor_of(Cls, Fn).
+
+% S11 — same-class no-receiver calls (DECLARED SUPERSET — fixes §2 D3).
+plain_call(C, N) :- jcall(C, N), \+ is_ctor_call(C), \+ super_this(C), \+ has_recv(C).
+@materialize(edge_type = "CALLS", mode = "additive")
+same_class_calls(C, M) :- plain_call(C, N), encl_class(C, Cls),
+    edge(Cls, M, "HAS_METHOD"), attr(M, "name", N).
+
+% S12 — static-style calls (receiver names a class).
+recv_class(C, N, Cls) :- jcall(C, N), \+ is_ctor_call(C), \+ super_this(C),
+    node_attr(C, "receiver", R), neq(R, ""), neq(R, "this"), jclass_named(R, Cls).
+@materialize(edge_type = "CALLS", mode = "additive")
+static_calls(C, M) :- recv_class(C, N, Cls), edge(Cls, M, "HAS_METHOD"), attr(M, "name", N).
+
+% S13 — this()/super() delegation.
+@materialize(edge_type = "CALLS", mode = "additive")
+this_ctor_calls(C, Fn) :- this_call(C), encl_class(C, Cls), ctor_of(Cls, Fn).
+@materialize(edge_type = "CALLS", mode = "additive")
+super_ctor_calls(C, Fn) :- super_call(C), encl_class(C, Cls),
+    node_attr(Cls, "extends", SN), neq(SN, ""), jclass_named(SN, SCls), ctor_of(SCls, Fn).
+```
+
+### 4.4 `java_annotations.dl`
+
+```prolog
+% .java gates on BOTH legs are load-bearing: kotlin-analyzer emits ATTRIBUTE and
+% ANNOTATION_TYPE too (Rules/Annotations.hs); legacy only ever saw Java-streamed nodes.
+jattr(A, N) :- node(A, "ATTRIBUTE"), attr(A, "file", F), ends_with(F, ".java"),
+    attr(A, "name", N), neq(N, "").
+jann(N, T)  :- node(T, "ANNOTATION_TYPE"), attr(T, "file", F), ends_with(F, ".java"),
+    attr(T, "name", N), neq(N, "").
+@materialize(edge_type = "ANNOTATION_RESOLVES_TO", mode = "additive")
+ann_resolves(A, T) :- jattr(A, N), jann(N, T).
+```
+
+**Maintain envelope (all 4 packs):** `node_attr` legs + stratified negation ⇒ maintain-incremental refuses;
+the scratch floor applies (the standing Wave-2 expectation, rust_trait_resolve.dl MAINTAIN ENVELOPE note).
+`java_annotations` and `java_imports`' S2 arm are negation-light enough to shed it later.
+
+## 5. Predicted delta classes (declared BEFORE diffing, with bounds)
+
+EXACT-MATCH expected: S2 (modulo S1 dup-qual-name extras), S5/S6/S7 single-name types, S8/S9 single-element
+values, S12, S13, S14 (modulo dup-name extras everywhere — bound below).
+
+EXPECTED-SUPERSET (pack ⊇ legacy, each bounded & countable pre-flight):
+1. Set semantics vs Map last-write-wins — bound = decl names (simple or qualified) with >1 decl node;
+   count with `dup(N) :- jclass_named(N,T1), jclass_named(N,T2), neq(T1,T2)`.
+2. All-overloads vs head-pick (S10/S11/S12/S13 CALLS) — bound = (class, name) pairs with >1 FUNCTION.
+3. S3 binding edges — bound = java IMPORT_BINDING count whose parent IMPORT resolves (legacy = 0, §2 D1).
+4. S11 same-class calls outside ctor bodies (legacy = ctor-bodies only, §2 D3) — bound = plain_call rows
+   whose encl_fn is not kind=constructor.
+5. S10 local-class ctor membership fix (rare; classifiable by INNER_CLASS_OF/nesting).
+
+EXPECTED-SUBSET (pack ⊆ legacy, the split/3 debt — must go to zero when split lands):
+6. S8/S9 multi-element implements/throws — bound = nodes whose metadata value `string_contains ","`;
+   single Datalog count each.
+
+Any delta outside classes 1-6 = pack bug or new resolver knowledge → stop, witness (`explain_datalog_fact`
+on pack-extra; legacy stderr counters `java-resolve:`/`java-call-resolve:`… on pack-missing), classify,
+only then proceed.
+
+## 6. Missing capabilities (today's kit, ranked)
+
+1. **`split(S, Sep, Elem)` — multi-row string generator** [B,B,F]: binds Elem once per separator-delimited
+   element. THE only hard blocker in the whole java surface (S8 IMPLEMENTS / S9 THROWS_TYPE multi-element;
+   would also fix S7's interface multi-extends beyond parity). Same need will recur for kotlin-resolve
+   (same comma-joined metadata convention) — worth building once. A peel-from-the-right recursion using
+   `concat(",", Last, Suf), strip_suffix(S, Suf, Rest)` + `last_segment` is technically constructible
+   today but generates fresh string terms in a recursive rule (function-symbol territory the engine's
+   safety discipline does not sanction) — NOT proposed.
+2. (nice-to-have) negated string filters `not_contains`/`not_ends_with` — the derived-negation aux-relation
+   workaround (ret_bad/impl_multi above) is legal but verbose, and every aux relation deepens the negation
+   stratification that blocks maintain-incremental.
+3. (recorded, not needed here) semantic-id surface access from Datalog — `attr(X,"id",V)` yields the u128
+   decimal (builtin.rs:551), not the sid; the `[in:Class]` parses were replaced by HAS_METHOD/CONTAINS
+   edges instead, which is the better design anyway. Languages without membership edges would hit this.
+4. (not engine) **a Java differential corpus**: the dogfood graph has zero java nodes (§7) and
+   `.grafema/config.yaml` include has no `*.java` pattern. Options: (a) add
+   `packages/java-parser/src/main/**/*.java` (3 real files in-repo) to a worktree config — smoke-scale;
+   (b) an external OSS Java repo (e.g. a small Maven project) for real-scale. Either way the acceptance
+   run needs `grafema analyze` with the java analyzer+resolver toolchain built (cabal + the
+   `~/.grafema/bin` staleness trap from the skills list applies).
+
+## 7. Dogfood-graph probe (evidence)
+
+Probe: copied `/Users/vadimr/grafema/.grafema/graph.rfdb` (mtime Jun 11, 618MB) → `/tmp/java-spec-probe.rfdb`,
+own rfdb-server v0.4.0 on `/tmp/java-spec-probe.sock`; loaded 491,535 nodes / 1,037,299 edges. Datalog counts:
+
+```
+q(M,F) :- node(M,"MODULE"), attr(M,"file",F), ends_with(F,".java").   → 0 rows
+… same for IMPORT / CLASS / CALL / FUNCTION java-gated                 → 0 rows each
+string_contains(F,"java-parser")                                       → 0 rows
+ends_with(F,".kt")                                                     → 0 rows
+```
+
+**The dogfood graph contains NO java (or kotlin) nodes.** Root cause is config, not analyzers:
+`.grafema/config.yaml` includes only `*.ts/*.rs/*.hs/*.ex/*.erl`. The repo itself has 3 real .java files
+(`packages/java-parser/src/main/java/com/grafema/parser/{Main,DaemonProtocol,AstSerializer}.java`).
+Consequence: this spec's behavioral claims rest on (a) resolver+analyzer source (file:line cited throughout)
+and (b) the package unit fixtures (`java-resolve/test/Spec.hs`, 323 lines, 18 cases — caveat: two fixtures
+fabricate metadata/sids production never produces, §2 D1/D3). Graph-shape claims (HAS_METHOD coverage,
+CONTAINS chains, metadata keys as stored) MUST be re-verified by live query on the differential corpus DB
+before the acceptance diff is trusted (Evidence Rule: analyzer-source grepping is not graph evidence).
+
+## 8. Differential acceptance
+
+SETUP — two DBs from one checkout containing the chosen java corpus (§6.4): DB_legacy = `analyze` with
+java-resolve ON, java packs OFF; DB_pack = `analyze` with `--skip-resolver java` (the existing
+`skip_resolver("java")` gate, main.rs:1566/2481) + the 4 packs run via the prod pack-runner in §4 order.
+u128 ids are BLAKE3 of sids — comparable across DBs; export `(src_sid, dst_sid, edge_type)` triples regardless.
+
+PARTITION — cleaner than js: legacy stamps NO resolvedVia metadata, but **every edge type except CALLS has
+exactly one producer step**, so slicing is by edge type: IMPORTS_FROM (S2+S3, sub-split by source node type
+IMPORT vs IMPORT_BINDING — S3 expects legacy=∅), RETURNS(S5), TYPE_OF(S6), EXTENDS(S7), IMPLEMENTS(S8),
+THROWS_TYPE(S9), INSTANTIATES(S10), ANNOTATION_RESOLVES_TO(S14). CALLS partitions structurally by source
+CALL node: name starts "new "(S10) / name∈{super,this}∨isThis(S13) / has receiver∉{"",this}(S12) / rest(S11).
+NOTE: the java analyzer itself also emits 2 CALLS edge sites — exclude analyzer-generation edges from both
+sides by diffing only edges absent from a resolver-OFF/pack-OFF baseline DB (3-way diff), or by `_source`
+provenance on the pack side.
+
+PROCEDURE per slice: counts smoke-check → sorted set-diff → witness every diff row (pack-extra:
+`explain_datalog_fact`; pack-missing: legacy stderr totals ImportResolution.hs:148-150 /
+CallResolution.hs:290-293 / TypeResolution.hs:212-218 / AnnotationResolution.hs:63-64 + manual trace).
+Verify both sides before recording (the verify-before-recording lesson). ACCEPTANCE GATE per pack: zero
+deltas outside declared classes 1-6 (§5), each declared class counted against its pre-flight bound,
+a stdlib.rs fixture test per pack (FixtureStorageView units, 0.04s-class), wall-clock recorded.
+
+PREDICTIONS-FIRST headline checks: (P1) legacy IMPORT_BINDING IMPORTS_FROM slice = EXACTLY 0 rows (D1);
+(P2) legacy plain-call CALLS slice contains ONLY calls whose enclosing function is a constructor (D3);
+(P3) glob IMPORTs have no IMPORTS_FROM on either side (D2). If any prediction fails → my §2 reading is
+wrong → STOP and re-derive before shipping packs.
+
+## 9. Expected speedup & why migrate
+
+The java daemon path is the identical IPC shape the js migration killed (full node-set msgpack streaming
+into a Haskell daemon, one-shot `java-all`, per-command commit via `commit_resolve_output`,
+main.rs:1566-1595): the cost is serialization + process lifetime, not resolution math — all 14 steps are
+hash-map lookups. On java corpora of realistic size the packs are small-join workloads far below the
+proven 415k-node baselines (4-20s scratch for the method_calls class). The structural wins dominate:
+one fewer Haskell binary in the toolchain (java-resolve drops out of binaries_to_check :838-839),
+why()-able logic, and the two latent production bugs (D1, D3) become impossible-by-construction instead
+of silently shipping an unresolved java graph. Honesty: per-run wall win is minutes-of-build-and-spawn
+plus the streaming cost, not a 900s→56s headline — the corpus measurement in §8 records the real number.
+
+## 10. Honesty section — NOT expressible / NOT replicated
+
+1. **Multi-element implements/throws** (S8/S9): not expressible without `split/3`. Declared subset, counted.
+2. **Overload selection by argCount**: legacy doesn't implement it either (the CallResolution.hs:172 comment
+   lies; :174-175 takes head). The pack derives all overloads. NEITHER implements real Java overload
+   resolution; if exactly-one-edge semantics is ever required, the binding-table/semiring layer (Gate C §9.3)
+   is the mechanism, not a rule hack.
+3. **Static-import member resolution** (`import static com.example.Foo.bar`): unimplemented in legacy
+   (header comment ImportResolution.hs:17 vs code), unimplemented in the pack. Expressible today via
+   last_segment/strip_suffix if ever wanted — deliberate non-goal to keep parity honest.
+4. **JDK/third-party types**: silently skipped on both sides (no EXTERNAL_MODULE minting for Java).
+   A future java_builtins facts-pack (the js builtins two-pack pattern) is the natural follow-up; the JDK
+   surface is enormous — needs the lang-spec generated-facts route, not hand enumeration.
+5. **Wildcard-import bindings** (`import com.example.*` then bare `Foo` use): glob imports produce no
+   IMPORT_BINDING (Imports.hs:91-93) and no resolution on either side. A real gap in java *analysis*,
+   not a resolver-parity question.
+6. **Generic types**: `typeToName` flattens `List<Foo>` → `List` analyzer-side; type-argument edges don't
+   exist in either world.
+7. **encl_class via CONTAINS recursion** assumes member/expression CONTAINS chains are complete. Code-verified
+   (43 CONTAINS sites + scope discipline §1) but graph-unverified (no java graph) — P-check in §8 before trust.
+8. **kotlin-resolve / jvm-cross-resolve**: out of scope; java packs' .java gates keep them non-interfering.
+   jvm-cross's cross-language edges remain native until its own spec.
+
+---
+
+# VERDICT (adversarial review, 2026-06-12, worktree HEAD 9ac0681c)
+
+**VERDICT: APPROVE WITH CORRECTIONS.** Inventory is complete (all mkEdge/EmitEdge sites in the 4 modules
+covered: ImportResolution.hs:85/113/124, TypeResolution.hs:126/140/156/168/183, CallResolution.hs:157/174-175/
+196/224/246/255, AnnotationResolution.hs:44 — re-grepped). D1/D2/D3 all re-verified against both sides:
+D1 — `FileAnalysis` has no `unresolvedRefs` field (analyzer.rs:41-49 re-read: file/moduleId/nodes/edges/exports
+only) and `resolveBinding`'s ENTIRE body, including the inner bindingName fallback arm at ImportResolution.hs:124
+(which the spec didn't mention — it's inside the `T.null source` gate, so equally dead), emits nothing without
+`source`; analyzer stamps imported_name/local_name/static only (Imports.hs re-read). D2 — analyzer stamps `glob`
+(Imports.hs), resolver reads `asterisk` (ImportResolution.hs:78). D3 — methodIdx keyed by FUNCTION-sid [in:]
+(CallResolution.hs:56-66), probed with CALL-sid [in:] = enclosing-method name (java CALL sid parent =
+`encFn >>= extractName`, Expressions.hs:101-103 re-read). All draft rules re-checked against the registry and
+the planner: every leg's binding pattern has a registered mode (edge [F,B,B] exists for the `edge(I,B,"CONTAINS")`
+/ `edge(Fn,C,"CONTAINS")` spellings — builtin.rs EDGE_MODES), every positive leg is variable-connected
+(E-PLAN-003 clean), constants in derived legs are legal (exec.rs unify_atom handles Term::Const), head-pick
+:174-175 confirmed. Corrections:
+
+**C1 (load-bearing — kills missing-capability #1).** "split/3 is THE only hard blocker" is WRONG. The
+right-peel recursion over shrinking strings is a SANCTIONED, SHIPPED stdlib idiom: `spec_pfx` in
+js_module_imports.dl:172-179 uses exactly `last_segment` + `concat` + `strip_suffix` in a recursive rule, with
+an in-file comment that the fixpoint terminates at segment depth. Comma-split of `implements`/`throws` is the
+same shape (separator "," — analyzer joins with `T.intercalate ","`, Declarations.hs:118/169/219/272/391/467
+re-verified, no spaces; legacy splitTypes' T.strip is a no-op). Therefore **S8 IMPLEMENTS and S9 THROWS_TYPE
+multi-element are fully expressible TODAY**; delta class 6 (SUBSET) is closable in wave 1, and S7's interface
+multi-extends fix is available as a deliberate-superset arm. §6.1's "function-symbol territory the engine's
+safety discipline does not sanction" is contradicted by shipped stdlib. Demote split/3 to ergonomics.
+
+**C2 (engine claim wrong, minor).** "Negated builtins are not a thing" — false. The executor evaluates a
+negated builtin literal as a per-row anti-join (exec.rs:1912-1920 negated path; non-special-cased shapes
+"(attr, filters, …) keep the exact per-row fallback"), and the stratifier creates NO dependency edge for
+base/builtin literals (stratify.rs:215-217, :456 "base relation or builtin — no dependency edge"). So
+`\+ string_contains(N, ",")` / `\+ ends_with(...)` are legal AND stratification-free — the §6.2 rationale
+("every aux relation deepens the negation strata") is inverted: direct negated filters are LIGHTER than the
+ret_bad/impl_multi aux relations drafted. Caveat: zero stdlib packs use the form today (grep: only
+node/edge/derived are negated) — add one FixtureStorageView test before relying on it.
+
+**C3 (missed step — wire/seam).** The java resolve branch ALSO pushes IMPORTS_FROM into
+`all_imports_from_edges` (main.rs:1582-1586; at v0.4.0 consumed only as a count hint to
+run_stdlib_rule_packs :2853), and — the real seam — `@stdlib/depends` consumes EVERY IMPORTS_FROM edge,
+node-type-agnostically via file join (derive/stdlib/depends.dl:1-6). So java IMPORTS_FROM already feed
+MODULE→MODULE DEPENDS_ON today, and §4's "the order is convention, not contract" is wrong at the stdlib
+level: `java_imports` MUST be registered before `depends` in BOTH ordering consts (rfdb-server
+derive/stdlib.rs `STDLIB_PACKS` and orchestrator main.rs:59-104 `STDLIB_RULE_PACKS` — the latter is the
+ordering contract, not "stdlib.rs:303-358"); `java_calls` (a CALLS producer) must precede the CALLS
+negators `method_calls`/`shape_verifier` (shape_verifier.dl:30 negates `edge(C,_,"CALLS")` with NO file
+gate). Also: the unresolved-diagnostics ISSUE generation queries the graph post-resolve for CALLs without
+CALLS / IMPORT_BINDINGs without IMPORTS_FROM (main.rs:2060-2085) — pack-coverage changes (S3, S11) will
+change the ISSUE population on `__grafema_virtual/unresolved-diagnostics`; exclude it from the diff.
+
+**C4 (minor, differential hygiene).** The `<unknown>` skip is dead-letter on BOTH sides: java `typeToName`
+emits `"<type>"` for unhandled types (Expressions.hs:1114), never `"<unknown>"` (that's the resolver's own
+vocabulary, TypeResolution.hs:92). Parity unaffected ("<type>" matches no class name), but the differential
+should not expect the ret_bad("<unknown>") arm to ever fire.
+
+Ready for packs: YES once C1/C3 are folded in (S8/S9 upgraded to full split parity; pack registration order
+pinned). The drafted rules are planner-legal as written.

--- a/_ai/research/lang-spec-kotlin.md
+++ b/_ai/research/lang-spec-kotlin.md
@@ -1,0 +1,552 @@
+# Migration spec: kotlin-resolve → derive packs (.dl)
+
+Authored 2026-06-12 against worktree HEAD `9ac0681c` (chore: release v0.4.0), branch feat/datalog lineage.
+Discipline per `_ai/research/resolve-datalog2-migration-specs.json` (js/rust precedent) and the synthesis
+ledger `_ai/research/resolve-datalog2-migration-synthesis.md` §3 (differential harness) / §5 (per-resolver verdicts).
+All file:line references verified by Read/grep in this worktree at this HEAD.
+
+---
+
+## spec.target
+
+`kotlin-resolve` (binary `kotlin-resolve`, packages/kotlin-resolve/src/ — 4 resolver modules + Main.hs
+dispatch `kotlin-imports` / `kotlin-types` / `kotlin-calls` / `kotlin-annotations` / `kotlin-all`,
+Main.hs:60-70). Driven by the orchestrator at main.rs:1601-1633: single-worker daemon pool, one
+`kotlin-all` command via `plugin::stream_and_resolve_single_worker(&[Language::Kotlin], ...)`
+(plugin.rs:1226-1253) — streams ALL nodes of `RESOLVE_NODE_TYPES` (analyzer.rs:3145-3202) whose `file`
+detects as Kotlin (i.e. `.kt`/`.kts` files only; cross-language nodes are NOT visible to this resolver —
+Java↔Kotlin is the separate `jvm-cross-resolve` at main.rs:1792+, OUT OF SCOPE here and untouched by
+this migration). IMPORTS_FROM edges from the output are additionally collected into
+`all_imports_from_edges` (main.rs:1620-1627) for the orchestrator's MODULE-DEPENDS_ON derivation —
+a pack replacement must keep feeding that seam (the `depends.dl` pack consumes IMPORTS_FROM as EDB,
+so pack ordering kotlin-packs → depends.dl replaces the in-memory collection).
+
+## spec.purpose
+
+Kotlin same-language cross-file resolution, 4 phases (Main.hs:64-70 `kotlin-all` runs all in one pass):
+- **kotlin-imports** (ImportResolution.hs): IMPORTS_FROM edges, IMPORT→class and IMPORT_BINDING→class.
+- **kotlin-types** (TypeResolution.hs): RETURNS, TYPE_OF, EXTENDS, IMPLEMENTS, THROWS_TYPE edges from
+  node metadata type names against a project-wide simple-name class index.
+- **kotlin-calls** (CallResolution.hs): CALLS + INSTANTIATES edges, 5 arms (constructor / same-class /
+  static-companion / super-this / extension).
+- **kotlin-annotations** (AnnotationResolution.hs): ANNOTATION_RESOLVES_TO edges ATTRIBUTE→annotation type.
+
+All emitted edges carry EMPTY metadata (every `mkEdge`/EmitEdge in all 4 modules: geMetadata = Map.empty)
+— no resolvedVia stamps, so parity diffing is by (src_sid, dst_sid, type) triples only.
+
+---
+
+## ANALYZER VOCABULARY (the EDB the packs will see)
+
+What `kotlin-analyzer` (packages/kotlin-analyzer/src/) actually commits. This section is load-bearing:
+several resolver arms read metadata the analyzer NEVER stamps — those arms are dead in production and
+the spec's parity baseline is "zero edges", verified per-arm below.
+
+### Node types emitted (complete list, grep `gnType =` over Rules/ + Analysis/)
+MODULE (Walker.hs:35, metadata `package` when present :44), CLASS (Declarations.hs:95 classes incl.
+interfaces/enums/annotation-classes — `kind` ∈ class|interface|enum|data|sealed|value|annotation|inner;
+:154 object decls `kind=object, singleton=true`; :609 companion `kind=companion`), FUNCTION
+(:207 top-level fn `kind=function`, :366 method `kind=method`, :504 secondary ctor `kind=secondary_constructor`
+name=`<constructor>`, :565 init block `kind=init_block` name=`init`, :730 primary ctor
+`kind=primary_constructor` name=ClassName), VARIABLE (:272/:444 properties `kind=property` (+`type` when
+declared :290/:463), :684 enum entry `kind=enum_entry`, :776/:839 params `kind=parameter`, :804 ctor-val-param
+property, Expressions.hs:659-:766 locals/catch/destructured), TYPE_ALIAS (:319), IMPORT (Imports.hs:58,
+metadata `path`=full dotted name, `glob` Bool, `alias` opt :67-71), IMPORT_BINDING (Imports.hs:92, metadata
+`imported_name`=leaf, `local_name`, `alias` opt :100-104; NO `source` key — the dotted source lives in the
+sid hash bracket and on the containing IMPORT's name), CALL (Expressions.hs:84 `method=true, argCount`,
+`receiver` only when non-empty :96; :137 safe-call adds `safe_call=true`; :192 ObjectCreation
+`kind=constructor_call`, name=ClassName, NO receiver), PROPERTY_ACCESS (:243), REFERENCE (:278), CLOSURE
+(:328), LITERAL (:372), BRANCH, SCOPE, PARAMETER (:798), TYPE_PARAMETER (Types.hs:224), ATTRIBUTE
+(Annotations.hs:122/:177/:214, name=annotation simple name, `kind` classification).
+
+**NEVER emitted by kotlin-analyzer**: INTERFACE, ENUM, OBJECT, ANNOTATION_TYPE node types (everything is
+CLASS + `kind`). The resolver's index arms over those types (ImportResolution.hs:60, CallResolution.hs:55,
+TypeResolution.hs:60, AnnotationResolution.hs:33) are vacuous for the Kotlin-only node stream.
+
+### Edges emitted by the analyzer (already in EDB before resolve)
+CONTAINS (scope→node everywhere; **IMPORT→IMPORT_BINDING** Imports.hs:107-112 — the graph-reachable
+source-path seam, rust_imports.dl precedent), HAS_METHOD (CLASS→method FUNCTION Declarations.hs:401-409,
+CLASS→primary-ctor :752-757, CLASS→secondary-ctor :526-534), HAS_PROPERTY, HAS_ATTRIBUTE
+(decl→ATTRIBUTE Annotations.hs:142-147), COMPANION_OF (:636), DERIVES (enum entry :709), CATCHES,
+THROWS (ErrorFlow.hs:119 — emitted directly in analysis, NOT by the resolver), ITERATES_OVER.
+CALL CONTAINS-source = the enclosing FUNCTION node (method/fn body walks `withScope fnScope` with
+scopeId=fn nodeId, Declarations.hs:417-428; ctor :540-549; init :585-592) or CLOSURE (lambda re-scope,
+Expressions.hs:354 — the ONLY other re-scope; ControlFlow never re-scopes) or module scope (top level).
+
+### Semantic-id shape (SemanticId.hs:21-29)
+`file->TYPE->name[in:Parent,h:Hash]`. Methods: parent = enclosing CLASS name (Declarations.hs:356
+parent=askNamedParent). CALL: parent = enclosing FUNCTION **name** (Expressions.hs:75 `encFn >>= extractName`)
+— NOT the class. Primary ctor: parent=Nothing, h:primary_ctor (:723). This asymmetry kills two resolver
+arms (steps 5, 7 below).
+
+### THE DEFERRED-REF DROP (production-truth keystone)
+The analyzer routes every cross-file intention through `emitDeferred` DeferredRef (Context.hs:84-85):
+EXTENDS/IMPLEMENTS supertypes (Types.hs:166-180), RETURNS/TYPE_OF type refs (:183-201), CALLS
+(Expressions.hs:104-117), IMPORTS_FROM (Imports.hs:117-130), serialized as `unresolvedRefs` in
+FileAnalysis JSON (Types.hs:160-166). **The orchestrator's FileAnalysis struct has NO `unresolvedRefs`
+field (analyzer.rs:41-48) — serde silently drops them.** Consequence: supertype names exist NOWHERE in
+the committed graph (not as metadata, not as edges). Verified by the resolver-side greps below and live
+probe (kt EXTENDS edges = 0; though dogfood has 0 kt nodes at all — see HONESTY).
+
+---
+
+## spec.sub_steps
+
+Format per step: reads / writes / production-truth / expressible / blockers / delta classes / draft rules.
+File gate `kt(F) :- ends_with(F, ".kt"). kt(F) :- ends_with(F, ".kts").` is the cross-language leakage
+guard on every base relation (rust_imports.dl DELTA-5 precedent; CLASS/IMPORT/CALL are shared vocabulary).
+Shared prelude used by several steps:
+
+```prolog
+kt(F) :- ends_with(F, ".kt").
+kt(F) :- ends_with(F, ".kts").
+% class index, simple name (CallResolution.hs:50-58 / TypeResolution.hs:57-65 — CLASS only is live):
+kt_class(N, F, C) :- node(C, "CLASS"), attr(C, "file", F), kt(F), attr(C, "name", N).
+% qualified-name class index (ImportResolution.hs:53-71): package from the file's MODULE node
+kt_module(F, M) :- node(M, "MODULE"), attr(M, "file", F), kt(F).
+kt_pkg(F, P) :- kt_module(F, M), node_attr(M, "package", P).
+has_pkg(F) :- kt_pkg(F, _).
+kt_qclass(Q, F, C) :- kt_class(N, F, C), kt_pkg(F, P), concat(P, ".", PD), concat(PD, N, Q).
+kt_qclass(N, F, C) :- kt_class(N, F, C), \+ has_pkg(F).
+```
+
+### Step 1 — kotlin-imports: IMPORT → class (`resolveImport`, ImportResolution.hs:86-109)
+- **reads**: IMPORT nodes (name = full dotted path, first-class), metadata `asterisk` (Bool) — **analyzer
+  stamps `glob`, not `asterisk` (Imports.hs:69) → isAsterisk is ALWAYS False in production**; glob imports
+  fall through to the qualified lookup and miss (name "com.example.*" is no class key) — accidentally the
+  same skip, so behavior is unchanged. Qualified class index (package + "." + simple name).
+- **writes**: IMPORTS_FROM edge IMPORT→CLASS-node (NB: doc comment says "to MODULE nodes" :17 — the code
+  targets the class node :99-104), empty metadata.
+- **production-truth**: LIVE arm. External imports (stdlib/3rd-party) silently skipped (:109).
+- **expressible**: **fully, today** (node/attr/node_attr/concat/negation).
+- **blockers**: none.
+- **deltas**: D1 SUPERSET — duplicate qualified names across files: Haskell `Map.insert` last-wins
+  (ImportResolution.hs:70) keeps ONE arbitrary winner; set semantics derives all (bound = count of
+  duplicate (package,className) pairs, measurable). D2 EXACT — glob imports: no edge both sides.
+- **draft_rules**:
+```prolog
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+kt_import_class(I, C) :-
+    node(I, "IMPORT"), attr(I, "file", IF), kt(IF), attr(I, "name", Q),
+    kt_qclass(Q, _, C).
+```
+
+### Step 2 — kotlin-imports: IMPORT_BINDING → class (`resolveBinding`, ImportResolution.hs:111-167)
+- **reads**: IMPORT_BINDING (name=localName), metadata `source` — **analyzer never stamps `source`
+  (Imports.hs:100-104 stamps imported_name/local_name/alias only) → the source arm is dead; falls to
+  the importedName-only arm (:124-135)**: leaf name ("Foo") looked up against QUALIFIED keys
+  ("com.example.Foo") → matches only classes in package-less files.
+- **writes**: IMPORTS_FROM edge IMPORT_BINDING→CLASS, empty metadata.
+- **production-truth**: NEAR-DEAD — resolves only into files without a `package` declaration (rare in
+  real Kotlin). The dotted source IS graph-reachable: IMPORT -CONTAINS-> IMPORT_BINDING + IMPORT.name
+  (Imports.hs:107-112), the exact rust_imports.dl Phase-3 pattern.
+- **expressible**: **fully, today** — both the exact-parity arm and the corrected arm.
+- **blockers**: none.
+- **deltas**: D1 (exact-parity arm) EXACT vs legacy. D2 (corrected arm, RECOMMENDED) SUPERSET —
+  resolves every binding whose containing IMPORT's full path names a project class; bound = count of
+  IMPORT_BINDING with a CONTAINS-parent IMPORT resolving in step 1 minus legacy's package-less matches.
+  Aliased imports: localName=alias, but the join is via the IMPORT's path — alias-correct for free
+  (legacy's imported_name arm was alias-correct too, when it matched at all).
+- **draft_rules**:
+```prolog
+% exact-parity arm (replicates the importedName-vs-qualified-keys accident):
+kt_binding_parity(B, C) :-
+    node(B, "IMPORT_BINDING"), attr(B, "file", BF), kt(BF),
+    node_attr(B, "imported_name", N), kt_qclass(N, _, C).
+% corrected arm (the rust precedent — source via the CONTAINS seam; RECOMMENDED, declared superset):
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+kt_binding_import(B, C) :-
+    node(B, "IMPORT_BINDING"), attr(B, "file", BF), kt(BF),
+    incoming(B, I, "CONTAINS"), node(I, "IMPORT"), attr(I, "name", Q),
+    kt_qclass(Q, _, C).
+```
+  (Ship ONE of the two arms — both together double-derive the package-less case; additive mode dedups
+  identical (src,dst,type) but keep the program honest.)
+
+### Step 3 — kotlin-types: RETURNS (`resolveReturns`, TypeResolution.hs:130-141)
+- **reads**: FUNCTION metadata `return_type` — STAMPED (Declarations.hs:229 top-level, :394 methods);
+  normalize = strip `[]` (T.replace), strip trailing `?`, skip 30-entry builtin table (:38-55), skip
+  `<unknown>` and wildcard-containing; simple-name class index (CROSS-FILE, no package check :57-65).
+- **writes**: RETURNS edges FUNCTION→CLASS, empty metadata.
+- **production-truth**: LIVE arm. Generic args already dropped at stamp time (typeToName keeps base name,
+  Expressions.hs:860-862, nullable suffix `?` kept).
+- **expressible**: **fully, today** (node_attr + replace_all + strip_suffix + fact table + negation).
+- **blockers**: none.
+- **deltas**: D1 SUPERSET — duplicate simple class names across files (Map last-wins :64 vs all
+  candidates); bound = count of duplicate kt CLASS simple names. D2 EXACT — builtin/primitive skips
+  (the 30 names become ground facts, generated verbatim from TypeResolution.hs:38-55).
+- **draft_rules**:
+```prolog
+kt_builtin_type("Int"). kt_builtin_type("Long"). % ... ×30, generated from TypeResolution.hs:38-55
+% normalize: strip [] then trailing ? ; two-clause ladder (strip_suffix is a miss when absent)
+ty_norm0(T, R) :- bound_in_context, replace_all(T, "[]", "", R).   % see NOTE below
+ty_base(T, B) :- ty_norm0(T, S), strip_suffix(S, "?", B).
+ty_base(T, S) :- ty_norm0(T, S), \+ ends_with(S, "?").
+ty_ok(B) :- \+ kt_builtin_type(B), \+ string_contains(B, "?"), neq(B, "<unknown>").
+@materialize(edge_type = "RETURNS", mode = "additive")
+kt_returns(Fn, C) :-
+    node(Fn, "FUNCTION"), attr(Fn, "file", F), kt(F),
+    node_attr(Fn, "return_type", T), ty_base(T, B), ty_ok(B),
+    kt_class(B, _, C).
+```
+  NOTE: write `ty_base` inline in each consumer (the helper as shown is unsafe-headed); the inline
+  spelling is the established pack idiom — pseudo-helper shown for readability only.
+- **NOT carried over (recorded, deliberate)**: TypeResolution.hs builds a `_methodIdx` it never uses
+  (:139, leading underscore) — dead code, nothing to migrate.
+
+### Step 4 — kotlin-types: TYPE_OF (`resolveTypeOf`, TypeResolution.hs:143-154)
+- **reads**: VARIABLE metadata `type` — stamped ONLY on properties with declared types
+  (Declarations.hs:290 top-level, :463 member; NOT on parameters/locals/ctor-val-params).
+- **writes**: TYPE_OF edges VARIABLE→CLASS.
+- **production-truth**: LIVE, properties only.
+- **expressible**: **fully, today** — same shape as step 3 with `node_attr(V, "type", T)`.
+- **deltas**: same SUPERSET class as step 3 (duplicate simple names).
+- **draft_rules**: as step 3 with `node(V, "VARIABLE")` + `node_attr(V, "type", T)`,
+  `@materialize(edge_type = "TYPE_OF", mode = "additive")`.
+
+### Step 5 — kotlin-types: EXTENDS + IMPLEMENTS (`resolveExtends`/`resolveImplements`, TypeResolution.hs:156-183)
+- **reads**: CLASS/&c metadata `extends` (single) and `implements` (comma-separated, splitTypes :118).
+- **production-truth**: **DEAD — ZERO edges.** The analyzer NEVER stamps `extends`/`implements` metadata
+  (grep over Rules/*.hs: no such keys; supertypes go ONLY into deferred InheritanceResolve refs,
+  Types.hs:163-180, which the orchestrator drops — analyzer.rs:41-48). Kotlin classes have NO
+  inheritance edges in the production graph at all. This is the kotlin analog of the js superClass
+  story (js_class_inheritance.dl header), except the data is missing entirely rather than metadata-only.
+- **expressible**: rules trivially expressible TODAY (same shape as js_class_inheritance.dl A1), but
+  the EDB lacks the input — **blocked on analyzer-side data, not on the engine**.
+- **blockers**: ANALYZER CHANGE — stamp `extends` / `implements` (comma-joined) metadata on CLASS at
+  emission (Declarations.hs:89-118 has the supertype list in scope at walkDeclaration ClassDecl;
+  Types.hs:40-60 already classifies first-super-vs-interfaces). One-line-class change + version bump.
+- **deltas**: until the stamp lands: pack emits 0, legacy emits 0 — EXACT-zero parity, SHIP THE PACK
+  EMPTY-SAFE. After the stamp: declared SUPERSET vs legacy-zero (entirely new edges; bound = count of
+  kt classes with supertypes).
+- **draft_rules** (active the day the analyzer stamps):
+```prolog
+@materialize(edge_type = "EXTENDS", mode = "additive")
+kt_extends(C, T) :-
+    node(C, "CLASS"), attr(C, "file", F), kt(F),
+    node_attr(C, "extends", SN), ty_base(SN, B), ty_ok(B),
+    kt_class(B, _, T), neq(C, T).
+% implements: comma-split has no builtin — REQUIRES either analyzer stamping ONE name per key
+% (implements_0, implements_1, …) or a split-style builtin; see missing_capabilities #2.
+```
+
+### Step 6 — kotlin-types: THROWS_TYPE (`resolveThrows`, TypeResolution.hs:185-196)
+- **reads**: FUNCTION metadata `throws` (comma-separated).
+- **production-truth**: **DEAD — ZERO edges.** Analyzer never stamps `throws` (Kotlin has no checked
+  exceptions; only `error_exit_count` MetaInt is stamped, Declarations.hs:226). Throw-site edges are the
+  analyzer's own THROWS (ErrorFlow.hs:119), unrelated to this arm.
+- **expressible**: n/a — no input data, and none is coming (language semantics). **DROP, do not port.**
+- **deltas**: EXACT-zero by omission.
+
+### Step 7 — kotlin-calls: constructor calls (`resolveConstructorCalls`, CallResolution.hs:199-238)
+- **reads**: CALL with `kind=constructor_call` metadata (stamped, Expressions.hs:201) or name prefixed
+  `"new "` (never produced by the kotlin analyzer — Java-compat arm, vacuous on the .kt stream);
+  simple-name class index; constructor index.
+- **writes**: INSTANTIATES CALL→CLASS (live) + CALLS CALL→ctor-FUNCTION (see production-truth).
+- **production-truth**: INSTANTIATES arm LIVE. **The CALLS→constructor arm is provably DEAD: the
+  constructor index is ALWAYS EMPTY** (CallResolution.hs:75-95): primary ctors have kind
+  `primary_constructor` ✓ but sid `file->FUNCTION->Foo[h:primary_ctor]` with NO `[in:]` (parent=Nothing,
+  Declarations.hs:723) → extractParentClass=Nothing → skipped; secondary ctors have `[in:Foo]` ✓ but
+  kind `secondary_constructor` (:513) ∉ {"constructor","primary_constructor"} (:91-94) → skipped.
+- **expressible**: **fully, today.** INSTANTIATES = node_attr + name join. The ctor-CALLS arm has a
+  graph-native CORRECTED form (CLASS -HAS_METHOD-> primary-ctor FUNCTION, Declarations.hs:752-757) —
+  exact-parity (zero) needs nothing.
+- **deltas**: D1 SUPERSET — duplicate class simple names (set vs Map last-wins). D2 (only if the
+  corrected ctor arm ships) SUPERSET vs legacy-zero: CALLS to primary+secondary ctors; bound = count of
+  constructor_call CALLs whose class resolves. Recommendation: ship INSTANTIATES at parity in wave 1;
+  ship the ctor-CALLS correction behind the same pack with the delta declared.
+- **draft_rules**:
+```prolog
+ctor_call(C, N, F) :-
+    node(C, "CALL"), attr(C, "file", F), kt(F), attr(C, "name", N),
+    node_attr(C, "kind", "constructor_call").
+@materialize(edge_type = "INSTANTIATES", mode = "additive")
+kt_instantiates(C, Cls) :- ctor_call(C, N, _), kt_class(N, _, Cls).
+% corrected ctor-CALLS arm (declared superset vs legacy-zero):
+@materialize(edge_type = "CALLS", mode = "additive")
+kt_ctor_call(C, Ctor) :-
+    ctor_call(C, N, _), kt_class(N, _, Cls),
+    edge(Cls, Ctor, "HAS_METHOD"), node_attr(Ctor, "kind", "primary_constructor").
+```
+
+### Step 8 — kotlin-calls: same-class method calls (`resolveSameClassCalls`, CallResolution.hs:240-262)
+- **reads**: CALL with no receiver / receiver="this" (`receiver` metadata, stamped only when non-empty,
+  Expressions.hs:96); methodIdx keyed by the FUNCTION sid's `[in:Class]`; the CALL's own `[in:…]`.
+- **production-truth**: **EFFECTIVELY DEAD (coincidence-only).** The CALL sid's `[in:]` is the enclosing
+  FUNCTION's name (Expressions.hs:75), the methodIdx key is the enclosing CLASS name
+  (Declarations.hs:356) — the join `(extractParentClass call, callName)` vs `(className, methodName)`
+  matches only when a class happens to share the enclosing function's name. Cannot be replicated
+  byte-for-byte in a pack anyway: the semantic-id STRING is not on the attr row surface (attr "id"
+  returns the u128, builtin.rs:548-551) — and replicating a name-collision accident has negative value.
+- **expressible**: the CORRECTED semantics is **fully expressible today**, graph-natively: enclosing
+  function via incoming CONTAINS from FUNCTION (Declarations.hs:417-428 — scope source IS the fn node;
+  one recursive hop through CLOSURE for lambda bodies, Expressions.hs:354), enclosing class via
+  HAS_METHOD, member lookup via HAS_METHOD+name. Same substitution the js spec used for `[in:]` parsing.
+- **deltas**: declared SUPERSET vs legacy ~zero (bound: count of receiverless/this CALLs inside methods
+  whose class has a matching member; legacy baseline measurable as the count of (fn-name==class-name)
+  collisions — expected 0 on real code). Overloads: all candidates derived vs legacy head-of-list.
+- **draft_rules**:
+```prolog
+encl_fn(X, Fn) :- incoming(X, Fn, "CONTAINS"), node(Fn, "FUNCTION").
+encl_fn(X, Fn) :- incoming(X, L, "CONTAINS"), node(L, "CLOSURE"), encl_fn(L, Fn).
+encl_class(X, Cls) :- encl_fn(X, Fn), incoming(Fn, Cls, "HAS_METHOD").
+has_recv(C) :- node_attr(C, "receiver", _).
+self_recv(C) :- \+ has_recv(C).
+self_recv(C) :- node_attr(C, "receiver", "this").
+plain_call(C, N, F) :-
+    node(C, "CALL"), attr(C, "file", F), kt(F), attr(C, "name", N),
+    \+ node_attr(C, "kind", "constructor_call"), self_recv(C).
+@materialize(edge_type = "CALLS", mode = "additive")
+kt_same_class_call(C, M) :-
+    plain_call(C, N, _), encl_class(C, Cls),
+    edge(Cls, M, "HAS_METHOD"), attr(M, "name", N).
+```
+
+### Step 9 — kotlin-calls: static/companion calls (`resolveStaticCalls`, CallResolution.hs:264-285)
+- **reads**: CALL `receiver` metadata = a class simple name; classIdx membership gate; methodIdx
+  (receiver, callName).
+- **production-truth**: **LIVE** — the one CALLS arm that actually works: `Foo.create()` with `create`
+  a direct member of class/object/companion `Foo` (receiver name must equal the indexed class's gnName;
+  companion members resolve only under receiver `Companion`, the companion CLASS's own name,
+  Declarations.hs:600-609 — `Foo.create()` for a companion member does NOT match legacy either, since
+  methodIdx keys companion members under "Companion").
+- **expressible**: **fully, today** — methodIdx ≡ HAS_METHOD join (both derive from the same
+  NamedParent context; HAS_METHOD emitted for methods :401-409, primary :752, secondary :526).
+  Divergence: methodIdx also contains FUNCTIONs nested inside method bodies (withNamedParent=method
+  name, Declarations.hs:425) under the method-name key — those fire only if a CLASS shares the method's
+  name AND has no real member of that call name; HAS_METHOD doesn't contain them. SUBSET delta, bound =
+  count of (class-name==method-name) collisions, expected 0.
+- **deltas**: D1 SUBSET as above (≈0). D2 SUPERSET — overloads: all candidates vs head-of-list (:280).
+- **draft_rules**:
+```prolog
+@materialize(edge_type = "CALLS", mode = "additive")
+kt_static_call(C, M) :-
+    node(C, "CALL"), attr(C, "file", F), kt(F), attr(C, "name", N),
+    \+ node_attr(C, "kind", "constructor_call"),
+    node_attr(C, "receiver", R), neq(R, "this"), neq(R, "super"),
+    kt_class(R, _, Cls), edge(Cls, M, "HAS_METHOD"), attr(M, "name", N).
+```
+  (Legacy gate `isSuperOrThisCall` :268 excludes name super/this — see step 10: those nodes don't exist,
+  the receiver-neq guards are belt-and-braces.)
+
+### Step 10 — kotlin-calls: super()/this() delegation (`resolveSuperThisCalls`, CallResolution.hs:287-318)
+- **reads**: CALL named "super"/"this" or `isThis` metadata; ctorIdx; extendsIdx (CLASS `extends` metadata :97-104).
+- **production-truth**: **DEAD, three independent ways**: (a) the parser/analyzer IGNORES constructor
+  delegation (`SecondaryConstructor mods params _delegation _delegArgs`, Declarations.hs:490 — wildcards)
+  → no CALL nodes named super/this exist; (b) `isThis` is never stamped; (c) both ctorIdx (step 7 proof)
+  and extendsIdx (step 5 proof — no `extends` metadata) are always empty.
+- **expressible**: n/a today — no input data. **DROP from wave 1; revisit only after the analyzer emits
+  delegation CALLs + extends metadata** (then it's an easy HAS_METHOD/primary_constructor + extends join).
+- **deltas**: EXACT-zero by omission.
+
+### Step 11 — kotlin-calls: extension function calls (`resolveExtensionCalls`, CallResolution.hs:320-339)
+- **reads**: CALL with `extension=true` + `receiverType` metadata; extension index (FUNCTION
+  extension=true + receiverType, stamped ✓ Declarations.hs:224/228, :385+).
+- **production-truth**: **DEAD** — the analyzer stamps extension/receiverType on FUNCTIONs only, NEVER
+  on CALL nodes (Expressions.hs CALL metadata = method/argCount/receiver/safe_call/kind only). The
+  filter `getMetaBool "extension" node == Just True` on CALLs never passes.
+- **expressible**: rules expressible today, input data missing — **blocked on analyzer stamping CALL-side
+  receiver-type inference** (a static-typing judgment; substantial analyzer work, NOT a quick stamp).
+- **deltas**: EXACT-zero by omission. (The resolver's own unit test :267-295 feeds synthetic CALL
+  metadata the analyzer never produces — tests assert capability, not production behavior.)
+
+### Step 12 — kotlin-annotations (`resolveAnnotations`, AnnotationResolution.hs:28-55)
+- **reads**: ATTRIBUTE nodes (name = annotation simple name, Annotations.hs:112-133); index of
+  ANNOTATION_TYPE nodes (never emitted by kotlin-analyzer → vacuous on the .kt stream) ∪ CLASS with
+  `kind=annotation` (live — Kotlin `annotation class`, Declarations.hs kind taxonomy).
+- **writes**: ANNOTATION_RESOLVES_TO edges ATTRIBUTE→CLASS.
+- **production-truth**: LIVE for project-internal Kotlin annotation classes; external annotations skipped.
+- **expressible**: **fully, today**.
+- **deltas**: D1 SUPERSET — duplicate annotation-class simple names (set vs Map last-wins :36).
+- **draft_rules**:
+```prolog
+@materialize(edge_type = "ANNOTATION_RESOLVES_TO", mode = "additive")
+kt_annotation(A, T) :-
+    node(A, "ATTRIBUTE"), attr(A, "file", F), kt(F), attr(A, "name", N),
+    node(T, "CLASS"), attr(T, "name", N), attr(T, "file", TF), kt(TF),
+    node_attr(T, "kind", "annotation").
+```
+
+### Step 13 — wire/seam obligations (not a resolver step, but part of the migration surface)
+- The orchestrator currently collects kotlin IMPORTS_FROM into `all_imports_from_edges`
+  (main.rs:1620-1627). Pack ordering: kotlin import packs MUST be declared BEFORE `depends.dl` (its
+  IMPORTS_FROM-consuming clauses) — the shape_verifier.dl/rust_imports.dl ordering-contract pattern.
+- `jvm-cross-resolve` (main.rs:1792+) consumes the same node vocabulary natively and stays; the kt()
+  file gate guarantees the packs never collide with its Java-side outputs.
+- Removal of the kotlin resolve invocation = deleting main.rs:1601-1633 + the `kotlin-resolve` binary
+  from the binaries_to_check (main.rs:841-843) once packs are gated in.
+
+---
+
+## spec.missing_capabilities
+
+Ranked. THE HEADLINE: **the v0.4.0 builtin kit (builtin.rs:1188-1373 — node_attr, strip_prefix/suffix,
+path_resolve, replace_all, last_segment, concat, method_suffix, …) is SUFFICIENT for every arm of
+kotlin-resolve that is alive in production.** Every remaining blocker is DATA-side (analyzer emission)
+or a wire convention — none is an engine builtin gap, in sharp contrast to the js spec's era.
+
+1. **ANALYZER: stamp `extends`/`implements` on CLASS nodes** (Declarations.hs walkDeclaration ClassDecl —
+   the supertype list is in scope; Types.hs:40-60 already separates first-super from interfaces).
+   Unblocks step 5 (kotlin inheritance — currently ZERO edges in the entire production graph). The
+   root cause is structural: the orchestrator drops `unresolvedRefs` (analyzer.rs:41-48) and nobody
+   noticed because the resolver's metadata arms silently no-op. Highest value per line of change.
+2. **List-valued metadata convention** for `implements` (and any future comma-joined stamp): either
+   indexed keys (`implements_0…n`, ugly but works with node_attr today) or a `split(S, Sep, Elem)`
+   generator builtin (engine change, mode [B,B,F] multi-row — the only genuinely new engine capability
+   this spec would request, and only for the implements arm).
+3. **ANALYZER: emit delegation CALLs** (`this(...)`/`super(...)` — currently discarded wildcards,
+   Declarations.hs:490) — unblocks step 10.
+4. **ANALYZER: CALL-side receiver-type inference** (`extension`/`receiverType` on CALL) — unblocks
+   step 11 (extension calls). Substantial analysis work; lowest priority.
+5. (Hygiene, not a blocker) the resolver's `asterisk`/`source` reads vs the analyzer's `glob`/`path`
+   stamps — vocabulary drift that the packs simply do not inherit; record in the analyzer's vocabulary
+   doc so future arms don't re-diverge.
+6. NO new string/path builtins, NO node-minting, NO same-run-edge needs: kotlin packs emit edges between
+   existing nodes only, all modes "additive", no @materialize_node anywhere.
+
+## spec.differential_acceptance
+
+SETUP — **the dogfood graph CANNOT gate this migration**: live probe on a /tmp copy of
+`.grafema/graph.rfdb` (491,535 nodes / 1,037,299 edges loaded) returned **0 nodes and 0 edges for every
+kt-file-gated query** (MODULE/CLASS/CALL/IMPORT/IMPORT_BINDING/FUNCTION/ATTRIBUTE/VARIABLE; CALLS/
+IMPORTS_FROM/INSTANTIATES/EXTENDS/RETURNS/TYPE_OF/ANNOTATION_RESOLVES_TO) — the orchestrator config's
+include globs are ts/hs/rs only (`.grafema/orchestrator.config.yaml:2-14`), so the repo's 3 .kt files
+(packages/kotlin-parser/src/main/kotlin/com/grafema/parser/*.kt) were never analyzed.
+
+Gate instead on a FIXTURE PROJECT: (a) minimum viable = the repo's own kotlin-parser .kt sources +
+a synthetic package exercising each live arm (imports w/ and w/o package, aliased import, glob import,
+properties with declared types, constructor calls, companion-receiver calls, annotation classes,
+duplicate simple names for the superset bounds); (b) analyze twice from the same checkout — DB_legacy
+(kotlin resolve ON, packs OFF) vs DB_pack (skip_resolver("kotlin"), packs ON in declared order) — and
+diff per step by (src_sid, dst_sid, type) triples (legacy edges carry empty metadata, so no metadata
+column in the diff key; pack provenance _source/_generation excluded as always).
+
+DECLARED DELTA CLASSES (predictions-first; any delta outside these = stop, witness, classify):
+- EXACT: step 1 (modulo D1), step 2 parity-arm, glob-import skips, builtin-type skips,
+  steps 6/10/11 (zero-by-omission vs zero-by-deadness — assert BOTH sides are literally zero on the
+  fixture: `edge(_,_,"THROWS_TYPE")` count 0 in DB_legacy is itself a required check).
+- SUPERSET, bounded: duplicate-name set-semantics (steps 1/3/4/12 — bound = measured duplicate-key
+  counts on the fixture), overload all-candidates (step 9), corrected arms IF shipped (step 2 corrected,
+  step 7 ctor-CALLS, step 8 same-class — bound each by the candidate-join count, and verify every extra
+  edge with a why()/explain_datalog_fact witness + manual source read).
+- SUBSET, bounded ≈0: step 9 nested-fn methodIdx accident (bound = class-name==method-name collisions).
+ACCEPTANCE per pack: zero unexpected deltas + per-class counted bounds + a stdlib.rs fixture test per
+pack (established pattern) + the step-5/6/10/11 zero-assertions on DB_legacy (they document the dead
+arms as executable evidence).
+
+## spec.expected_speedup_rationale
+
+Honest framing: kotlin volume in known target graphs is currently ZERO (dogfood) to small — this
+migration's value is NOT wall-clock, it is (a) retiring a whole Haskell daemon binary + process pool +
+full-node-set msgpack stream from the per-run path (plugin.rs:1226-1253 collects and ships every
+RESOLVE_NODE_TYPES node of the language per command), (b) making 6 of 12 resolver arms' production
+deadness EXPLICIT and inspectable (why()-able) instead of silently vacuous, and (c) the step-5 analyzer
+stamp turning kotlin inheritance from non-existent to derived. The packs are small pure joins over
+name/file/node_attr probes (the build-once hash-join class — method_calls.dl precedent: 4-20s on a 415k
+graph, and the kt-gated base relations will be orders smaller). Maintain envelope: every pack uses
+node_attr and/or negation ⇒ scratch floor on maintain (same accepted stance as every import pack —
+rust_imports.dl MAINTAIN ENVELOPE note).
+
+## spec.honesty — what is NOT expressible / not known
+
+1. **Byte-exact replication of the `[in:]` sid-parse arms is NOT expressible** (steps 5/7/8: the
+   semantic-id string is not on the attr surface — attr "id" yields the u128, builtin.rs:548-551).
+   Irrelevant for parity (those arms are dead or coincidence-only) but it means the packs CANNOT
+   reproduce the legacy name-collision false positives — pack-vs-legacy diffs on a fixture engineered
+   with such collisions will show legacy-only edges that are BUGS, not coverage.
+2. **`implements` comma-split** is inexpressible today (no split builtin; fact-enumeration impossible
+   for open-ended names) — moot until the analyzer stamps the key at all; the indexed-keys convention
+   (missing_capabilities #2) avoids the engine change entirely.
+3. **Wildcard (glob) import binding-level resolution** ("handled at binding level" per the comment,
+   ImportResolution.hs:14) is handled NOWHERE — glob imports produce an IMPORT node and nothing else
+   in both legacy and pack. Not a regression; recorded as a (pre-existing) coverage gap.
+4. **Ground truth for production behavior is code-derived, not graph-derived**: zero kotlin nodes exist
+   in the dogfood graph (live-probe evidence above), so every dead-arm claim rests on cross-module
+   source analysis (analyzer stamp inventory vs resolver read inventory, file:line cited per step) plus
+   the package's unit suites (kotlin-resolve/test/Spec.hs:59-378 — NB its fixtures hand-feed metadata
+   the analyzer never emits: `source` on bindings :76-89, `extends`/`implements` :134-170, `kind=
+   "constructor"` ctors :232-244, CALL-side `extension`/`receiverType` :267-295 — the tests assert the
+   resolver's CAPABILITY, and are exactly how the vocabulary drift went unnoticed). A fixture-project
+   analyze run (differential SETUP above) is REQUIRED before gating; if it contradicts any dead-arm
+   claim here, the spec must be corrected first (verify-before-recording).
+5. **kotlin-parser is a JVM binary** (packages/kotlin-parser, Kotlin sources) — the analyze phase
+   itself stays untouched by this migration; only the resolve daemon is replaced.
+6. `.kts` script files: detect_language mapping for Kotlin includes them or not — NOT verified in this
+   pass (config.rs detect_language test :1252 checks .kt only). The kt() gate above includes .kts
+   defensively; align it with detect_language before shipping (one-line check).
+
+## appendix: per-arm production-liveness verdict table
+
+| # | arm | legacy production output | pack wave |
+|---|-----|--------------------------|-----------|
+| 1 | IMPORT→class | LIVE | wave 1, EXACT+D1 |
+| 2 | IMPORT_BINDING→class | near-dead (package-less only) | wave 1, corrected (declared superset) |
+| 3 | RETURNS | LIVE | wave 1, EXACT+superset(dup names) |
+| 4 | TYPE_OF | LIVE (properties only) | wave 1, EXACT+superset(dup names) |
+| 5 | EXTENDS/IMPLEMENTS | DEAD (no metadata; deferred refs dropped) | pack ready; blocked on analyzer stamp |
+| 6 | THROWS_TYPE | DEAD (no such Kotlin data) | drop forever |
+| 7 | INSTANTIATES / ctor-CALLS | LIVE / DEAD (ctorIdx provably empty) | wave 1 / corrected optional |
+| 8 | same-class CALLS | dead-coincidence ([in:] fn-vs-class mismatch) | wave 1 corrected (declared superset) |
+| 9 | static/companion CALLS | LIVE | wave 1, EXACT+overload superset |
+| 10 | super()/this() | DEAD (delegation discarded by analyzer) | drop until analyzer emits |
+| 11 | extension CALLS | DEAD (no CALL-side metadata) | drop until analyzer infers |
+| 12 | ANNOTATION_RESOLVES_TO | LIVE (kotlin annotation classes) | wave 1, EXACT+superset(dup names) |
+
+---
+
+# VERDICT (adversarial review, 2026-06-12, worktree HEAD 9ac0681c)
+
+**VERDICT: APPROVE WITH CORRECTIONS (draft-rule respellings required).** Every dead-arm finding re-verified
+in source: ctorIdx provably empty (CallResolution.hs:74-95 re-read — isConstructor accepts only
+"constructor"/"primary_constructor", secondary ctors are kind=secondary_constructor Declarations.hs:513,
+primary ctors have parent=Nothing in the sid Declarations.hs:723 → extractParentClass=Nothing); analyzer
+stamps NO extends/implements metadata (grep over kotlin-analyzer Rules/: zero hits outside a Types.hs:50
+comment); FileAnalysis drops unresolvedRefs (analyzer.rs:41-49 re-read); constructor delegation discarded
+(`_delegation _delegArgs` wildcards, Declarations.hs:490); CALL metadata = method/argCount/receiver/
+safe_call/kind only (Expressions.hs:93-203 re-read — no extension/receiverType); IMPORT→IMPORT_BINDING
+CONTAINS seam exists (Imports.hs re-read); resolveBinding's importedName fallback confirmed (the
+"package-less only" near-dead reading is correct); annotation index = ANNOTATION_TYPE ∪ CLASS kind=annotation
+(AnnotationResolution.hs:25-36). Emit-site inventory complete (re-grepped all mkEdge/EmitEdge: 4 import
+sites, 5 type sites, 7 call sites incl. extension :283, 1 annotation site — all mapped to steps).
+Orchestrator/seam cites verified (main.rs:1602-1633, skip_resolver, plugin streaming). Corrections:
+
+**C1 (draft-rule BUG — the shared prelude is planner-illegal).** `kt(F) :- ends_with(F, ".kt").` is an
+unsafe rule: `ends_with` is a FILTER with the single mode [B,B] (builtin.rs FILTER2_MODES) — it cannot
+generate F, so the rule fails E-PLAN-001/002 and the whole program is rejected. No stdlib pack defines a
+filter-helper relation; the established spelling inlines the gate (`attr(C,"file",F), ends_with(F,".kt")`)
+per base relation — exactly what the java/go sibling specs draft. Every rule using `kt(F)` must be
+respelled (mechanical; the kt()/kts() disjunction becomes two clauses per base relation or one derived
+base relation per node type carrying the file gate inside).
+
+**C2 (draft-rule BUG — step 8).** `has_recv(C) :- node_attr(C, "receiver", _).` is illegal: node_attr has
+NO generator mode — the node id must be bound (builtin.rs NODE_ATTR_MODES [B,B,F]/[B,B,B] only,
+"deliberately NO generator mode"). And `self_recv(C) :- \+ has_recv(C).` is unsafe-headed (C unbound).
+Respell as `has_recv(C) :- node(C,"CALL"), node_attr(C,"receiver",R), neq(R,"this").` and use
+`\+ has_recv(C)` inline in plain_call (the java spec's S11 shape). Same class of fix: step 3's `ty_ok(B)`
+is unsafe-headed too — the NOTE flags only ty_base; flag both, inline all filters in consumers.
+
+**C3 (engine claim wrong — missing_capabilities #2 and honesty #2).** "implements comma-split is
+inexpressible today (no split builtin)" is FALSE as an engine claim: the recursive right-peel over a
+shrinking string (`last_segment` + `concat` + `strip_suffix`) is a shipped stdlib idiom —
+js_module_imports.dl:172-179 `spec_pfx`, with the termination argument in-file. When the analyzer stamps
+comma-joined `implements`, the pack can split it with TODAY'S kit; the indexed-keys convention and the
+split/3 builtin are both unnecessary. (Bonus: negated builtin filters are legal too — exec.rs:1912+ per-row
+anti-join fallback; stratify.rs adds no edge for builtins — so the builtin-table skip can be spelled
+`\+ kt_builtin_type(B), \+ string_contains(B,"?")` without extra strata. No stdlib precedent for the
+negated-filter form yet; add a fixture test first.)
+
+**C4 (honesty #6 resolved).** `.kts` IS mapped to Kotlin: config.rs:749 `"kt" | "kts" => Some(Language::Kotlin)`.
+The kt()+kts() gate is confirmed correct, not "defensive".
+
+**C5 (step 13 mechanism stale, conclusion right).** At v0.4.0 `all_imports_from_edges` is consumed ONLY as
+a count hint to run_stdlib_rule_packs (main.rs:2853 → :573-577 `imports_from_hint`); MODULE→MODULE
+DEPENDS_ON is derived by `@stdlib/depends`, which consumes EVERY IMPORTS_FROM edge node-type-agnostically
+(derive/stdlib/depends.dl:1-6). The ordering obligation is therefore exactly as stated (kotlin import pack
+before `depends` in STDLIB_PACKS/STDLIB_RULE_PACKS), plus one the spec missed: kotlin_calls is a CALLS
+producer and must precede the CALLS negators `method_calls`/`shape_verifier` (shape_verifier.dl:30 negates
+CALLS with no file gate). Also exclude `__grafema_virtual/unresolved-diagnostics` from the differential —
+ISSUE nodes are generated from post-resolve graph queries (main.rs:2060-2085), so corrected-arm coverage
+changes that population.
+
+Ready for packs: YES after the C1/C2 mechanical respellings — the semantics, liveness table, and delta
+classes all survived adversarial re-reading unchanged.


### PR DESCRIPTION
Spec round for the next language wave. Key discovery: 6/12 kotlin resolver arms and java's IMPORT_BINDING resolution are provably dead in production (analyzer↔resolver vocabulary drift + dropped deferred refs) — the packs will be parity-or-better by construction. Details in the three specs' VERDICT sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)