### PR TITLE
fix(js-analyzer): export every declarator of a multi-declarator export (#394)

### DIFF
--- a/packages/js-analyzer/src/Rules/Declarations.hs
+++ b/packages/js-analyzer/src/Rules/Declarations.hs
@@ -33,10 +33,18 @@ import Data.Maybe (fromMaybe)
 
 -- ── Variable Declaration ────────────────────────────────────────────────
 
--- | VariableDeclaration: walk each declarator, passing down the kind (var/let/const).
--- Uses a fold so each declarator is declared in scope for subsequent declarators.
-ruleVariableDeclaration :: ASTNode -> Analyzer (Maybe Text)
-ruleVariableDeclaration node = do
+-- | Walk a VariableDeclaration, returning @(bindingName, nodeId)@ for every
+-- top-level simple-identifier declarator, in source order. Each binding is
+-- declared in scope for the declarators that follow it (so later initializers
+-- resolve earlier bindings). Destructuring declarators are still emitted as
+-- nodes but reported with an empty @bindingName@ — they have no single binding id.
+--
+-- This is the single source of truth for "which bindings does this var-decl
+-- introduce". Both 'ruleVariableDeclaration' (plain-walk path) and
+-- 'ruleExportNamedDeclaration' (export path) consume it, so a multi-declarator
+-- declaration (@const a = 1, b = 2@) yields every binding exactly once.
+ruleVariableDeclarationBindings :: ASTNode -> Analyzer [(Text, Text)]
+ruleVariableDeclarationBindings node = do
   let decls = getChildren "declarations" node
       kind  = getTextFieldOr "kind" "let" node
       dk = case kind of
@@ -44,24 +52,32 @@ ruleVariableDeclaration node = do
         "let"   -> DeclLet
         "const" -> DeclConst
         _       -> DeclLet
-  goDeclarators dk Nothing decls
+  goDeclarators dk decls
   where
-    goDeclarators :: DeclKind -> Maybe Text -> [ASTNode] -> Analyzer (Maybe Text)
-    goDeclarators _ firstId [] = return firstId
-    goDeclarators dk firstId (d:ds) = do
+    goDeclarators :: DeclKind -> [ASTNode] -> Analyzer [(Text, Text)]
+    goDeclarators _ [] = return []
+    goDeclarators dk (d:ds) = do
       mNodeId <- withAncestor node (ruleVariableDeclarator d node)
       case mNodeId of
         Just nodeId -> do
           let name = case getChildrenMaybe "id" d of
                        Just idNode -> getTextFieldOr "name" "" idNode
                        Nothing     -> ""
-              firstId' = case firstId of
-                Nothing -> Just nodeId
-                _       -> firstId
-          if T.null name
-            then goDeclarators dk firstId' ds
-            else declareInScope (Declaration nodeId dk name) (goDeclarators dk firstId' ds)
-        Nothing -> goDeclarators dk firstId ds
+          rest <- if T.null name
+                    then goDeclarators dk ds
+                    else declareInScope (Declaration nodeId dk name) (goDeclarators dk ds)
+          return ((name, nodeId) : rest)
+        Nothing -> goDeclarators dk ds
+
+-- | VariableDeclaration: walk every declarator (emitting nodes + scope edges)
+-- and return the first declarator's node id, preserving 'walkNode's
+-- @Maybe Text@ contract (a declaration as a whole resolves to its first binding).
+ruleVariableDeclaration :: ASTNode -> Analyzer (Maybe Text)
+ruleVariableDeclaration node = do
+  binds <- ruleVariableDeclarationBindings node
+  return $ case binds of
+    ((_, firstId) : _) -> Just firstId
+    []                 -> Nothing
 
 -- | VariableDeclarator: emit VARIABLE or CONSTANT node + DECLARES edge + ASSIGNED_FROM
 ruleVariableDeclarator :: ASTNode -> ASTNode -> Analyzer (Maybe Text)
@@ -623,8 +639,24 @@ ruleExportNamedDeclaration node = do
     , gnExported = True, gnMetadata = Map.empty
     }
 
-  -- Walk the declaration if present (withExported so child nodes get exported=True)
+  -- Walk the declaration if present (withExported so child nodes get exported=True).
+  -- A VariableDeclaration may bind several names (export const a = 1, b = 2); every
+  -- binding must get its own EXPORTS edge + export-index entry, not just the first.
   case getChildrenMaybe "declaration" node of
+    Just decl@(VariableDeclarationNode _ _) -> do
+      binds <- withExported $ withAncestor node (ruleVariableDeclarationBindings decl)
+      forM_ binds $ \(bindName, childId) -> do
+        emitEdge GraphEdge
+          { geSource = nodeId, geTarget = childId
+          , geType = "EXPORTS", geMetadata = Map.empty
+          }
+        -- Destructuring declarators (export const { a, b } = x) have no single
+        -- binding name today; that is a pre-existing gap, left unchanged here.
+        if T.null bindName
+          then return ()
+          else emitExport ExportInfo
+                 { eiName = bindName, eiNodeId = childId
+                 , eiKind = NamedExport, eiSource = Nothing }
     Just decl -> do
       mChildId <- withExported $ withAncestor node (walkNode decl)
       forM_ mChildId $ \childId -> do

--- a/packages/js-analyzer/test/Spec.hs
+++ b/packages/js-analyzer/test/Spec.hs
@@ -219,6 +219,29 @@ exportTests = do
           ]
     hasExport "*" ReExport fa `shouldBe` True
 
+  -- Test 8b: export const a = 1, b = 2 -- every declarator must be exported
+  it "exports every declarator of a multi-declarator export" $ do
+    let fa = analyzeAST $ BL.concat
+          [ "{\"type\":\"Program\",\"start\":0,\"end\":26,\"body\":["
+          , "{\"type\":\"ExportNamedDeclaration\",\"start\":0,\"end\":26,"
+          , "\"declaration\":{\"type\":\"VariableDeclaration\",\"start\":7,\"end\":25,\"kind\":\"const\",\"declarations\":["
+          , "{\"type\":\"VariableDeclarator\",\"start\":13,\"end\":18,"
+          , "\"id\":{\"type\":\"Identifier\",\"start\":13,\"end\":14,\"name\":\"a\"},"
+          , "\"init\":{\"type\":\"Literal\",\"start\":17,\"end\":18,\"value\":1,\"raw\":\"1\"}},"
+          , "{\"type\":\"VariableDeclarator\",\"start\":20,\"end\":25,"
+          , "\"id\":{\"type\":\"Identifier\",\"start\":20,\"end\":21,\"name\":\"b\"},"
+          , "\"init\":{\"type\":\"Literal\",\"start\":24,\"end\":25,\"value\":2,\"raw\":\"2\"}}"
+          , "]},\"specifiers\":[]}"
+          , "]}"
+          ]
+    hasExport "a" NamedExport fa `shouldBe` True
+    hasExport "b" NamedExport fa `shouldBe` True
+    exportNode <- requireNode "EXPORT" "named" fa
+    aNode <- requireNode "CONSTANT" "a" fa
+    bNode <- requireNode "CONSTANT" "b" fa
+    hasEdge "EXPORTS" (gnId exportNode) (gnId aNode) fa `shouldBe` True
+    hasEdge "EXPORTS" (gnId exportNode) (gnId bNode) fa `shouldBe` True
+
 
 edgeCaseTests :: Spec
 edgeCaseTests = do


### PR DESCRIPTION
Closes #394.

## Spec

**Invariant restored:** an `ExportNamedDeclaration` whose declaration is a multi-declarator `VariableDeclaration` exports *every* binding, not just the first.

**Given** a module `export const a = 1, b = 2;`
**When** the file is analyzed
**Then** the `EXPORT` node has `EXPORTS` edges to **both** the `a` and `b` `CONSTANT` nodes, and the file export index contains both `a` and `b` as `NamedExport` (so `import { b } from './x'` resolves).

**Entities:** `EXPORT` node, `CONSTANT`/`VARIABLE` nodes, `EXPORTS` edges, export-index (`emitExport`).

## Root cause (HEAD `9ac0681`)

`ruleVariableDeclaration` collapsed all declarators to a single `firstId`, and `ruleExportNamedDeclaration`'s declaration branch used that one id + first-declarator `getDeclName` to emit exactly one `EXPORTS` edge + one `emitExport`. Subsequent bindings were created as nodes (correctly `exported=true`) but orphaned from the export surface — invisible to cross-module import resolution. (Originally surfaced by live probing, recorded in `_ai/gaps.md`.)

## Fix (minimal, single source of truth)

- Factor the declarator fold into `ruleVariableDeclarationBindings :: ASTNode -> Analyzer [(Text, Text)]`, returning `(bindingName, nodeId)` for every top-level simple-identifier declarator, in source order, with scope threading preserved (later initializers still resolve earlier bindings).
- `ruleVariableDeclaration` becomes a thin wrapper returning the first binding's id — `walkNode`'s `Maybe Text` contract is unchanged.
- `ruleExportNamedDeclaration` special-cases a `VariableDeclaration` declaration and emits an `EXPORTS` edge + export-index entry **per binding**.

This removes the duplicated declarator-iteration that *was* the bug class.

## Before / after (evidence)

Env: GHC 9.4.7 + cabal 3.8.1.0 (apt), in-process Hspec harness (`analyzeAST` inspects graph shape directly — no orchestrator/RFDB).

**Before** (new test on HEAD — red for the right reason; `a` passes, `b` fails):
```
Exports
  exports every declarator of a multi-declarator export [x]
test/Spec.hs:238: 1) ... expected: True but got: False   -- hasExport "b" NamedExport
```

**After** (`cabal test spec`):
```
Exports
  exports every declarator of a multi-declarator export [v]
26 examples, 1 failure
```
The single remaining failure is **pre-existing and unrelated** — `TypeScript Interfaces / creates METHOD_SIGNATURE with HAS_PROPERTY edge from interface` (fails identically on clean HEAD, 25→26 examples after my added case). Not touched by this PR.

`cabal build grafema-analyzer` (the executable target, `-Wall -Werror -O2`) links clean with the shared source change.

## Adversarial review

- **A — Correctness:** empty declarations → `Nothing` (unchanged); single declarator → identical edge + export; scope/shadowing tests (`const a=1, b=a`) still pass; destructuring (`export const { a, b } = x`) — `EXPORTS` edge still emitted, the prior meaningless `name=""` index entry is now skipped (strict improvement; destructuring binding-name remains a pre-existing gap, unchanged).
- **B — Fragility:** `ruleVariableDeclarationBindings` is now the single source of truth for "which bindings does this var-decl introduce", consumed by both the plain-walk and export paths. `Declarations.hs` is 890 lines — a **pre-existing** god-file (858 before); splitting is out of scope for this fix.
- **C — Class-not-instance:** `export default` cannot be multi-declarator (verified — `ruleExportDefaultDeclaration` unaffected). No other "collapse-to-first" call-site. No fixture/snapshot in the repo uses the multi-declarator export pattern (grep confirmed only the new test).

## Blast radius

`ruleVariableDeclaration` / `ruleVariableDeclarator` are used only within `Declarations.hs` + `Analysis/Walker.hs:52`. The change only *adds* `EXPORTS` edges + export entries for the previously-dropped bindings; it removes nothing observable.

## Follow-ups (not in this PR)

- EXPORT semantic-id collision: every `ExportNamedDeclaration` in a file shares sid `…->EXPORT->named` (`Declarations.hs:617`) — distinct bug, recorded in `_ai/gaps.md`.
- Destructuring export binding names (`export const { a, b } = x`) — pre-existing gap.

🤖 https://claude.ai/code/session_01MTJthNnW3WWpyxzXm1VY8K

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTJthNnW3WWpyxzXm1VY8K)_