### PR TITLE
feat(derive): HTTP routes as derive packs — effects-db facts + js_http_routes pair (REG-1115)

### DIFF
--- a/packages/grafema-orchestrator/src/main.rs
+++ b/packages/grafema-orchestrator/src/main.rs
@@ -48,7 +48,8 @@ use std::path::PathBuf;
 /// js_import_bindings → js_class_inheritance → js_cross_file_calls →
 /// js_property_access_ns → js_property_access_full → js_builtins_nodes →
 /// js_builtins_edges → js_runtime_globals_nodes → js_runtime_globals_edges →
-/// depends → method_calls → shape_verifier → axum_routes.
+/// depends → method_calls → shape_verifier → axum_routes →
+/// js_http_routes_nodes → js_http_routes_edges.
 /// Wave 3c moved depends INTO this list, after every IMPORTS_FROM producer:
 /// with legacy import-resolution gated, the IMPORT-level edges depends
 /// consumes are produced by the packs above it (it ran separately FIRST while
@@ -105,6 +106,12 @@ const STDLIB_RULE_PACKS: &[&str] = &[
     "@stdlib/method_calls",
     "@stdlib/shape_verifier",
     "@stdlib/axum_routes",
+    // Wave 14 feature-detection vertical: the nodes pack MINTS the
+    // anchorCall-pinned http:route endpoints the edges pack joins as
+    // committed EDB (strict nodes→edges order — the js_builtins two-pack
+    // split); both consume analyzer EDB only.
+    "@stdlib/js_http_routes_nodes",
+    "@stdlib/js_http_routes_edges",
 ];
 
 
@@ -539,6 +546,8 @@ fn pack_owned_slice(pack: &str) -> &'static str {
         "@stdlib/method_calls" => "fuzzy method-call CALLS fallback",
         "@stdlib/shape_verifier" => "shape-violation ISSUE diagnostics",
         "@stdlib/axum_routes" => "axum ROUTES_TO",
+        "@stdlib/js_http_routes_nodes" => "js http:route nodes + ROUTES_TO (express/fastify/koa/hono)",
+        "@stdlib/js_http_routes_edges" => "js http:route EXPOSES + HANDLES",
         _ => "(unregistered pack)",
     }
 }

--- a/packages/rfdb-server/src/datalog/parser.rs
+++ b/packages/rfdb-server/src/datalog/parser.rs
@@ -106,18 +106,37 @@ impl<'a> Parser<'a> {
         Ok(self.input[start..self.pos].to_string())
     }
 
+    /// Parse a double-quoted string literal.
+    ///
+    /// Escape handling is LENIENT (Wave 14): a backslash followed by `"` or
+    /// `\` is an escape sequence producing that character (so a literal
+    /// double-quote CAN appear inside a string — required by quote-stripping
+    /// rules over JS string literals, whose graph `name` keeps the raw source
+    /// quoting). A backslash followed by anything else stays a literal
+    /// backslash — pre-escape strings like `"C:\Users"` keep their meaning
+    /// (only `\"` / `\\` sequences, previously impossible to express in the
+    /// first case and degenerate in the second, change interpretation).
     fn parse_string(&mut self) -> Result<String, ParseError> {
         self.skip_whitespace();
         self.expect("\"")?;
 
         let start = self.pos;
+        let mut value = String::new();
         while self.pos < self.input.len() {
             let c = self.input[self.pos..].chars().next().unwrap();
             if c == '"' {
-                let value = self.input[start..self.pos].to_string();
                 self.pos += 1; // consume closing quote
                 return Ok(value);
             }
+            if c == '\\' {
+                let next = self.input[self.pos + 1..].chars().next();
+                if matches!(next, Some('"') | Some('\\')) {
+                    value.push(next.unwrap());
+                    self.pos += 1 + next.unwrap().len_utf8();
+                    continue;
+                }
+            }
+            value.push(c);
             self.pos += c.len_utf8();
         }
 
@@ -359,4 +378,39 @@ pub fn parse_query(input: &str) -> Result<Vec<Literal>, ParseError> {
         ));
     }
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn const_of(t: &Term) -> &str {
+        match t {
+            Term::Const(s) => s,
+            other => panic!("expected Const, got {other:?}"),
+        }
+    }
+
+    /// Wave 14 — lenient escape sequences in string literals: `\"` and `\\`
+    /// decode to the bare character; any other backslash stays literal
+    /// (pre-escape behavior for strings like "C:\Users" is preserved).
+    #[test]
+    fn string_literal_escapes_are_lenient() {
+        let a = parse_atom(r#"p("a\"b")"#).expect("escaped quote parses");
+        assert_eq!(const_of(&a.args()[0]), "a\"b");
+
+        let a = parse_atom(r#"p("a\\b")"#).expect("escaped backslash parses");
+        assert_eq!(const_of(&a.args()[0]), "a\\b");
+
+        // Lone backslash before a non-escapable char stays literal.
+        let a = parse_atom(r#"p("C:\Users")"#).expect("non-escape backslash parses");
+        assert_eq!(const_of(&a.args()[0]), "C:\\Users");
+
+        // A bare double-quote literal — the quote-strip use case.
+        let a = parse_atom(r#"sw(X, "\"")"#).expect("single dquote literal parses");
+        assert_eq!(const_of(&a.args()[1]), "\"");
+
+        // Unterminated string (escape eats the closer) still errors.
+        assert!(parse_atom(r#"p("abc\")"#).is_err());
+    }
 }

--- a/packages/rfdb-server/src/derive/parser_ext.rs
+++ b/packages/rfdb-server/src/derive/parser_ext.rs
@@ -430,6 +430,16 @@ impl<'a> Framer<'a> {
         while self.pos < self.bytes.len() {
             let c = self.bytes[self.pos];
             if in_string {
+                // Lenient escapes (Wave 14, mirrors datalog::parser::parse_string):
+                // a backslash followed by `"` or `\` is consumed as one unit so an
+                // escaped quote never terminates the string scan.
+                if c == b'\\'
+                    && self.pos + 1 < self.bytes.len()
+                    && matches!(self.bytes[self.pos + 1], b'"' | b'\\')
+                {
+                    self.pos += 2;
+                    continue;
+                }
                 if c == b'"' {
                     in_string = false;
                 }
@@ -946,6 +956,19 @@ mod tests {
         assert!(item.lattice_payload.is_none());
         assert_eq!(item.rule.body().len(), 2);
         assert!(item.rule.body()[1].is_negative());
+    }
+
+    /// Wave 14 — the clause scanner honors `\"` escapes inside string literals
+    /// (mirrors `datalog::parser::parse_string`): a rule carrying a literal
+    /// double-quote (the quote-strip idiom over raw JS source literals) is ONE
+    /// clause, and its terminating `.` is found.
+    #[test]
+    fn clause_scan_skips_escaped_quotes_in_strings() {
+        let src = r#"q(X, P) :- raw(X, R), strip_prefix(R, "\"", T), strip_suffix(T, "\"", P)."#;
+        let prog = parse_ext_program(src).expect("escaped-quote clause parses");
+        assert_eq!(prog.items.len(), 1);
+        assert_eq!(head_pred(&prog.items[0]), "q");
+        assert_eq!(prog.items[0].rule.body().len(), 3);
     }
 
     #[test]

--- a/packages/rfdb-server/src/derive/plan.rs
+++ b/packages/rfdb-server/src/derive/plan.rs
@@ -635,7 +635,8 @@ fn positive_can_place_and_provides(
         // genuinely underivable stays unplaceable here (E-PLAN-002 unsafe rule) instead of
         // reaching eval and tripping a confusing E-PLAN-001.
         "concat" | "str_lower" | "basename" | "strip_quotes" | "strip_prefix" | "strip_suffix"
-        | "last_segment" | "replace_all" | "path_resolve" | "edge_attr" | "node_attr" => {
+        | "method_suffix" | "last_segment" | "replace_all" | "path_resolve" | "edge_attr"
+        | "node_attr" => {
             if args.is_empty() {
                 return (true, HashSet::new());
             }
@@ -698,6 +699,7 @@ fn is_filter_or_function(pred: &str) -> bool {
             | "strip_quotes"
             | "strip_prefix"
             | "strip_suffix"
+            | "method_suffix"
             | "last_segment"
             | "replace_all"
             | "path_resolve"

--- a/packages/rfdb-server/src/derive/stdlib.rs
+++ b/packages/rfdb-server/src/derive/stdlib.rs
@@ -300,6 +300,38 @@ pub const JS_RUNTIME_GLOBALS_EDGES_DL: &str = concat!(
 /// (the rank ladder) ⇒ scratch-only under maintain.
 pub const JS_MODULE_IMPORTS_DL: &str = include_str!("stdlib/js_module_imports.dl");
 
+/// Node half of the JS HTTP-route feature vertical (Wave 14, REG-1115 slice):
+/// `http:route` minting (sid `<file>::http:route::<name>::<callIdDecimal>`)
+/// + ROUTES_TO for Express/Fastify/Koa(+routers)/Hono registrations — the
+/// derive-pack REPLACEMENT for libraryCallbackEnricher.ts's HTTP slice (the
+/// 6 framework entries were retired from its LIBRARY_NODE_TYPE map in this
+/// wave; the enricher keeps only cli:command/mcp:tool/vscode:command —
+/// running both would mint duplicate http:route nodes with byte-different
+/// ids), driven by the effects-db callable registry as generated
+/// ground facts (effects_callable_facts.dl, prepended at compile time;
+/// regenerate via scripts/generate-effects-callable-facts.mjs). Receiver
+/// resolution = RECEIVER_CALL chain origin + IMPORT_BINDING `source` +
+/// CONSTANT/VARIABLE initializer hops (incl. factory calls — delta 2).
+/// Negation + minting ⇒ scratch-only under maintain.
+pub const JS_HTTP_ROUTES_NODES_DL: &str = concat!(
+    include_str!("stdlib/effects_callable_facts.dl"),
+    "\n",
+    include_str!("stdlib/js_http_routes_nodes.dl"),
+);
+
+/// Edge half of the JS HTTP-route vertical (Wave 14): EXPOSES
+/// (CALL → http:route) + HANDLES (http:route → callback), endpoints pinned by
+/// the exact `node_attr(R,"anchorCall") ⋈ attr(C,"id")` join — other
+/// producers' http:route nodes (axum_routes, the legacy enricher) are never
+/// joined. MUST run after `js_http_routes_nodes` (committed-EDB endpoint
+/// join — the js_builtins two-pack split). Both heads additive (EXPOSES /
+/// HANDLES are shared enricher vocabulary).
+pub const JS_HTTP_ROUTES_EDGES_DL: &str = concat!(
+    include_str!("stdlib/effects_callable_facts.dl"),
+    "\n",
+    include_str!("stdlib/js_http_routes_edges.dl"),
+);
+
 /// The named stdlib rule packs, addressable on the wire as `"@stdlib/<name>"`
 /// (`MaterializeDatalog` and the other empty-source-defaulting dispatchers), listed
 /// in CANONICAL RUN ORDER. The order is a CONTRACT, not cosmetics — producers run
@@ -356,7 +388,11 @@ pub const JS_MODULE_IMPORTS_DL: &str = include_str!("stdlib/js_module_imports.dl
 /// js_cross_file_calls → js_property_access_ns → js_property_access_full →
 /// js_builtins_nodes → js_builtins_edges → js_runtime_globals_nodes →
 /// js_runtime_globals_edges → depends → method_calls → shape_verifier →
-/// axum_routes.
+/// axum_routes → js_http_routes_nodes → js_http_routes_edges.
+/// - the Wave-14 feature-detection pair: `js_http_routes_nodes` MINTS the
+///   anchorCall-pinned http:route endpoints that `js_http_routes_edges` joins
+///   as committed EDB (strict nodes→edges order, the js_builtins split);
+///   both consume analyzer EDB only.
 pub const STDLIB_PACKS: &[(&str, &str)] = &[
     ("js_local_refs", JS_LOCAL_REFS_DL),
     ("js_same_file_calls", JS_SAME_FILE_CALLS_DL),
@@ -409,6 +445,13 @@ pub const STDLIB_PACKS: &[(&str, &str)] = &[
     ("method_calls", METHOD_CALLS_DL),
     ("shape_verifier", SHAPE_VERIFIER_DL),
     ("axum_routes", AXUM_ROUTES_DL),
+    // Wave 14 feature-detection vertical: js_http_routes_nodes MINTS the
+    // http:route endpoints (anchorCall-pinned) that js_http_routes_edges
+    // joins as committed EDB (strict nodes→edges order — the js_builtins
+    // two-pack split). Both consume analyzer EDB only and produce nothing any
+    // earlier pack reads, so they sit at the registry tail with axum_routes.
+    ("js_http_routes_nodes", JS_HTTP_ROUTES_NODES_DL),
+    ("js_http_routes_edges", JS_HTTP_ROUTES_EDGES_DL),
 ];
 
 /// Look up a bundled pack by its wire name (the `<name>` in `"@stdlib/<name>"`).
@@ -1272,6 +1315,8 @@ mod tests {
                 "method_calls",
                 "shape_verifier",
                 "axum_routes",
+                "js_http_routes_nodes",
+                "js_http_routes_edges",
             ],
             "canonical run order: Wave-1 resolver packs → Wave-1b packs \
              (rust_cross_methods_ctor after rust_calls — the CALLS EDB seam; the \
@@ -1286,8 +1331,10 @@ mod tests {
              js_class_inheritance produces EXTENDS for shape_verifier) → \
              depends (Wave 3c: AFTER every IMPORTS_FROM producer — legacy \
              import-resolution is gated, so the in-engine producers feed it) → \
-             method_calls → shape_verifier → axum_routes (producers strictly \
-             before consumers)"
+             method_calls → shape_verifier → axum_routes → \
+             js_http_routes_nodes → js_http_routes_edges (Wave 14: the nodes \
+             pack mints the anchorCall-pinned http:route endpoints the edges \
+             pack joins as committed EDB) (producers strictly before consumers)"
         );
         assert_eq!(stdlib_pack("depends"), Some(DEPENDS_DL));
         assert_eq!(stdlib_pack("js_local_refs"), Some(JS_LOCAL_REFS_DL));
@@ -1325,6 +1372,14 @@ mod tests {
         assert_eq!(stdlib_pack("method_calls"), Some(METHOD_CALLS_DL));
         assert_eq!(stdlib_pack("shape_verifier"), Some(SHAPE_VERIFIER_DL));
         assert_eq!(stdlib_pack("axum_routes"), Some(AXUM_ROUTES_DL));
+        assert_eq!(
+            stdlib_pack("js_http_routes_nodes"),
+            Some(JS_HTTP_ROUTES_NODES_DL)
+        );
+        assert_eq!(
+            stdlib_pack("js_http_routes_edges"),
+            Some(JS_HTTP_ROUTES_EDGES_DL)
+        );
         assert_eq!(stdlib_pack("nope"), None, "unknown pack name resolves to None");
     }
 
@@ -3644,6 +3699,305 @@ mod tests {
         assert_eq!(spec.meta, vec!["resolvedVia".to_string(), "globalCategory".to_string()]);
     }
 
+    /// Realistic small-corpus stats for the Wave-14 fixture tests: the
+    /// empty-graph `Stats::default()` (total_nodes = 0) degenerates every
+    /// keyed probe into a DERIVED relation to its FULL cardinality
+    /// (`k / total_nodes.max(1)` = k), so the deep ecb-fact join chain
+    /// multiplies past the E-PLAN-003 guard on estimates alone. Production
+    /// always plans with store-derived stats; the dogfood-scale plan gate
+    /// below covers these packs at full scale.
+    fn w14_stats() -> Stats {
+        let mut nodes_by_type = std::collections::HashMap::new();
+        for (ty, n) in [
+            ("CALL", 70_000u64),
+            ("LITERAL", 40_000),
+            ("VARIABLE", 15_500),
+            ("FUNCTION", 10_221),
+            ("CONSTANT", 6_700),
+            ("IMPORT_BINDING", 5_781),
+            ("http:route", 50),
+        ] {
+            nodes_by_type.insert(ty.to_string(), n);
+        }
+        Stats {
+            total_nodes: 500_000,
+            total_edges: 1_000_000,
+            nodes_by_type,
+        }
+    }
+
+    /// Wave 14 — js_http_routes_nodes framework arms, each pinned on the
+    /// live-verified analyzer shapes (IMPORT_BINDING metadata.source, CALL
+    /// metadata.kind="new", RECEIVER_CALL chains, PASSES_ARGUMENT
+    /// metadata.index, LITERAL name = raw quoted source text):
+    /// - express FACTORY initializer (delta 2): `const app = express();
+    ///   app.get('/users', handler)` — single-quote strip;
+    /// - hono NEW initializer + chained second registration (deltas 1, 9):
+    ///   `const app2 = new Hono(); app2.post("/items", h).put('/things', h2)`
+    ///   — double-quote strip (the Wave-14 parser escape) and the chained
+    ///   call's OWN path;
+    /// - @koa/router SUBPATH import + `del` verb: `import Router from
+    ///   '@koa/router/lib/router.js'; const router = new Router();
+    ///   router.del('/old', h3)` → DELETE;
+    /// - fastify `register` (callback at index 0, NO route path): minted as
+    ///   "<unnamed-http-route>", no ROUTES_TO (non-verb method);
+    /// - negatives: `.get` with an unresolvable receiver (map.get), a
+    ///   receiver imported from a NON-registry lib (lodash), and a verb call
+    ///   missing its callback argument (delta 8) all derive nothing.
+    #[test]
+    fn js_http_routes_nodes_framework_arms() {
+        let idx0 = r#"{"index":0}"#;
+        let idx1 = r#"{"index":1}"#;
+        let mut v = FixtureStorageView::new(1);
+
+        // a. express factory: import + const app = express() + app.get('/users', h).
+        named_node(&mut v, "b_express", "express", "IMPORT_BINDING", "app.ts");
+        v.put_node_metadata(id_of("b_express"), r#"{"source":"express"}"#);
+        named_node(&mut v, "k_app", "app", "CONSTANT", "app.ts");
+        named_node(&mut v, "c_factory", "express", "CALL", "app.ts");
+        edge(&mut v, "k_app", "c_factory", "ASSIGNED_FROM");
+        named_node(&mut v, "c_get", "app.get", "CALL", "app.ts");
+        named_node(&mut v, "p_users", "'/users'", "LITERAL", "app.ts");
+        named_node(&mut v, "h_users", "<arrow>", "FUNCTION", "app.ts");
+        edge_meta(&mut v, "c_get", "p_users", "PASSES_ARGUMENT", idx0);
+        edge_meta(&mut v, "c_get", "h_users", "PASSES_ARGUMENT", idx1);
+
+        // b. hono new + chain: const app2 = new Hono();
+        //    app2.post("/items", h).put('/things', h2).
+        named_node(&mut v, "b_hono", "Hono", "IMPORT_BINDING", "hono.ts");
+        v.put_node_metadata(id_of("b_hono"), r#"{"source":"hono"}"#);
+        named_node(&mut v, "k_app2", "app2", "CONSTANT", "hono.ts");
+        named_node(&mut v, "c_hono_new", "Hono", "CALL", "hono.ts");
+        v.put_node_metadata(id_of("c_hono_new"), r#"{"kind":"new"}"#);
+        edge(&mut v, "k_app2", "c_hono_new", "ASSIGNED_FROM");
+        named_node(&mut v, "c_post", "app2.post", "CALL", "hono.ts");
+        named_node(&mut v, "p_items", "\"/items\"", "LITERAL", "hono.ts");
+        named_node(&mut v, "h_items", "h", "FUNCTION", "hono.ts");
+        edge_meta(&mut v, "c_post", "p_items", "PASSES_ARGUMENT", idx0);
+        edge_meta(&mut v, "c_post", "h_items", "PASSES_ARGUMENT", idx1);
+        named_node(&mut v, "c_put", "<obj>.put", "CALL", "hono.ts");
+        edge(&mut v, "c_put", "c_post", "RECEIVER_CALL");
+        named_node(&mut v, "p_things", "'/things'", "LITERAL", "hono.ts");
+        named_node(&mut v, "h_things", "h2", "FUNCTION", "hono.ts");
+        edge_meta(&mut v, "c_put", "p_things", "PASSES_ARGUMENT", idx0);
+        edge_meta(&mut v, "c_put", "h_things", "PASSES_ARGUMENT", idx1);
+
+        // b2. hono `on` — data-driven NON-(0,1) indexes: app2.on(['GET'], '/x', h4)
+        //     (ROUTE_PATH at index 1, ENTRY_POINT_CALLBACK at index 2; "on" is
+        //     not a verb so the node minted carries no ROUTES_TO).
+        let idx2 = r#"{"index":2}"#;
+        named_node(&mut v, "c_on", "app2.on", "CALL", "hono.ts");
+        named_node(&mut v, "p_methods", "<array>", "LITERAL", "hono.ts");
+        named_node(&mut v, "p_x", "'/x'", "LITERAL", "hono.ts");
+        named_node(&mut v, "h_x", "h4", "FUNCTION", "hono.ts");
+        edge_meta(&mut v, "c_on", "p_methods", "PASSES_ARGUMENT", idx0);
+        edge_meta(&mut v, "c_on", "p_x", "PASSES_ARGUMENT", idx1);
+        edge_meta(&mut v, "c_on", "h_x", "PASSES_ARGUMENT", idx2);
+
+        // c. @koa/router subpath import + new Router() + router.del('/old', h3).
+        named_node(&mut v, "b_router", "Router", "IMPORT_BINDING", "koa.ts");
+        v.put_node_metadata(id_of("b_router"), r#"{"source":"@koa/router/lib/router.js"}"#);
+        named_node(&mut v, "k_router", "router", "CONSTANT", "koa.ts");
+        named_node(&mut v, "c_router_new", "Router", "CALL", "koa.ts");
+        v.put_node_metadata(id_of("c_router_new"), r#"{"kind":"new"}"#);
+        edge(&mut v, "k_router", "c_router_new", "ASSIGNED_FROM");
+        named_node(&mut v, "c_del", "router.del", "CALL", "koa.ts");
+        named_node(&mut v, "p_old", "'/old'", "LITERAL", "koa.ts");
+        named_node(&mut v, "h_old", "h3", "FUNCTION", "koa.ts");
+        edge_meta(&mut v, "c_del", "p_old", "PASSES_ARGUMENT", idx0);
+        edge_meta(&mut v, "c_del", "h_old", "PASSES_ARGUMENT", idx1);
+
+        // d. fastify register: const srv = fastify(); srv.register(plugin) —
+        //    callback at index 0, no ROUTE_PATH role.
+        named_node(&mut v, "b_fastify", "fastify", "IMPORT_BINDING", "f.ts");
+        v.put_node_metadata(id_of("b_fastify"), r#"{"source":"fastify"}"#);
+        named_node(&mut v, "k_srv", "srv", "CONSTANT", "f.ts");
+        named_node(&mut v, "c_ffactory", "fastify", "CALL", "f.ts");
+        edge(&mut v, "k_srv", "c_ffactory", "ASSIGNED_FROM");
+        named_node(&mut v, "c_register", "srv.register", "CALL", "f.ts");
+        named_node(&mut v, "h_plugin", "plugin", "FUNCTION", "f.ts");
+        edge_meta(&mut v, "c_register", "h_plugin", "PASSES_ARGUMENT", idx0);
+
+        // e. negatives.
+        named_node(&mut v, "c_map", "map.get", "CALL", "app.ts"); // no binding
+        edge_meta(&mut v, "c_map", "p_users", "PASSES_ARGUMENT", idx0);
+        edge_meta(&mut v, "c_map", "h_users", "PASSES_ARGUMENT", idx1);
+        named_node(&mut v, "b_other", "other", "IMPORT_BINDING", "app.ts");
+        v.put_node_metadata(id_of("b_other"), r#"{"source":"lodash"}"#);
+        named_node(&mut v, "c_other", "other.get", "CALL", "app.ts"); // non-registry lib
+        edge_meta(&mut v, "c_other", "p_users", "PASSES_ARGUMENT", idx0);
+        edge_meta(&mut v, "c_other", "h_users", "PASSES_ARGUMENT", idx1);
+        named_node(&mut v, "c_nocb", "app.options", "CALL", "app.ts"); // delta 8: no idx-1 arg
+        edge_meta(&mut v, "c_nocb", "p_users", "PASSES_ARGUMENT", idx0);
+
+        let (eval, specs, node_specs) = evaluate_with_materialize(
+            &v,
+            JS_HTTP_ROUTES_NODES_DL,
+            w14_stats(),
+            EvalLimits::none(),
+            EventLog::discard(),
+        )
+        .expect("js_http_routes_nodes.dl evaluates");
+
+        // ROUTES_TO: verb methods with a path; register is non-verb ⇒ absent.
+        let routes: BTreeSet<(u128, u128, String, String)> = eval
+            .facts("http_routes_to")
+            .into_iter()
+            .map(|r| {
+                (
+                    r[0].as_id().expect("src id"),
+                    r[1].as_id().expect("dst id"),
+                    r[2].as_str(),
+                    r[3].as_str(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            routes,
+            BTreeSet::from([
+                (id_of("c_get"), id_of("h_users"), "GET".to_string(), "/users".to_string()),
+                (id_of("c_post"), id_of("h_items"), "POST".to_string(), "/items".to_string()),
+                (id_of("c_put"), id_of("h_things"), "PUT".to_string(), "/things".to_string()),
+                (id_of("c_del"), id_of("h_old"), "DELETE".to_string(), "/old".to_string()),
+            ]),
+            "factory/new/chained/subpath arms route with stripped paths and \
+             mapped verbs; register (non-verb) and all negatives derive none"
+        );
+
+        // The minted nodes: sid <file>::http:route::<name>::<callIdDecimal>.
+        let minted: BTreeSet<(String, String, String, String, String)> = eval
+            .facts("http_route_js")
+            .into_iter()
+            .map(|r| (r[0].as_str(), r[1].as_str(), r[2].as_str(), r[3].as_str(), r[4].as_str()))
+            .collect();
+        let rn = |file: &str, name: &str, lib: &str, m: &str, call: &str| {
+            (
+                format!("{file}::http:route::{name}::{}", id_of(call)),
+                name.to_string(),
+                file.to_string(),
+                lib.to_string(),
+                m.to_string(),
+            )
+        };
+        assert_eq!(
+            minted,
+            BTreeSet::from([
+                rn("app.ts", "/users", "express", "get", "c_get"),
+                rn("hono.ts", "/items", "hono", "post", "c_post"),
+                rn("hono.ts", "/things", "hono", "put", "c_put"),
+                rn("koa.ts", "/old", "@koa/router", "del", "c_del"),
+                rn("f.ts", "<unnamed-http-route>", "fastify", "register", "c_register"),
+                rn("hono.ts", "/x", "hono", "on", "c_on"),
+            ]),
+            "one node per resolved registration call (chained .put names its \
+             OWN path — delta 9; pathless register is unnamed); negatives mint \
+             nothing"
+        );
+
+        // Specs: additive ROUTES_TO; provenance-scoped exclusive http:route node.
+        let rt = specs
+            .iter()
+            .find(|s| s.edge_type == "ROUTES_TO")
+            .expect("ROUTES_TO spec");
+        assert!(rt.additive, "ROUTES_TO is shared vocabulary — additive");
+        assert_eq!(rt.meta, vec!["method".to_string(), "path".to_string()]);
+        assert_eq!(node_specs.len(), 1, "exactly one node-materialized head");
+        let ns = &node_specs[0];
+        assert_eq!(ns.predicate, "http_route_js");
+        assert_eq!(ns.node_type, "http:route");
+        assert!(!ns.additive, "exclusive (provenance-scoped) node ownership");
+        assert_eq!(
+            ns.meta,
+            vec!["library".to_string(), "method".to_string(), "anchorCall".to_string()]
+        );
+    }
+
+    /// Wave 14 — js_http_routes_edges joins the COMMITTED http:route
+    /// endpoints by the exact anchorCall pin and reproduces the enricher's
+    /// edge vocabulary: EXPOSES (CALL → http:route) + HANDLES
+    /// (http:route → callback). Decoy http:route nodes — axum-style (no
+    /// anchorCall), enricher-style (anchorCall = wire semantic-id string),
+    /// and an anchorCall pointing at an UNRELATED call — are never joined.
+    #[test]
+    fn js_http_routes_edges_joins_minted_endpoints() {
+        let idx0 = r#"{"index":0}"#;
+        let idx1 = r#"{"index":1}"#;
+        let mut v = FixtureStorageView::new(1);
+
+        // The resolvable registration: const app = express(); app.get('/users', h).
+        named_node(&mut v, "b_express", "express", "IMPORT_BINDING", "app.ts");
+        v.put_node_metadata(id_of("b_express"), r#"{"source":"express"}"#);
+        named_node(&mut v, "k_app", "app", "CONSTANT", "app.ts");
+        named_node(&mut v, "c_factory", "express", "CALL", "app.ts");
+        edge(&mut v, "k_app", "c_factory", "ASSIGNED_FROM");
+        named_node(&mut v, "c_get", "app.get", "CALL", "app.ts");
+        named_node(&mut v, "p_users", "'/users'", "LITERAL", "app.ts");
+        named_node(&mut v, "h_users", "<arrow>", "FUNCTION", "app.ts");
+        edge_meta(&mut v, "c_get", "p_users", "PASSES_ARGUMENT", idx0);
+        edge_meta(&mut v, "c_get", "h_users", "PASSES_ARGUMENT", idx1);
+
+        // The COMMITTED node minted by js_http_routes_nodes (anchorCall pin).
+        let route_sid = format!("app.ts::http:route::/users::{}", id_of("c_get"));
+        named_node(&mut v, &route_sid, "/users", "http:route", "app.ts");
+        v.put_node_metadata(
+            id_of(&route_sid),
+            &format!(r#"{{"anchorCall":"{}","library":"express","method":"get"}}"#, id_of("c_get")),
+        );
+
+        // Decoys: axum-style (no anchorCall), enricher-style (wire-sid
+        // anchorCall), and an anchorCall anchored on a DIFFERENT call.
+        named_node(&mut v, "http:route::GET::/users", "/users", "http:route", "src/main.rs");
+        v.put_node_metadata(
+            id_of("http:route::GET::/users"),
+            r#"{"method":"GET","path":"/users"}"#,
+        );
+        named_node(&mut v, "app.ts::http:route::/users::wire", "/users", "http:route", "app.ts");
+        v.put_node_metadata(
+            id_of("app.ts::http:route::/users::wire"),
+            r#"{"anchorCall":"app.ts->CALL->app.get[0]","library":"express"}"#,
+        );
+        named_node(&mut v, "decoy_other_anchor", "/users", "http:route", "app.ts");
+        v.put_node_metadata(
+            id_of("decoy_other_anchor"),
+            &format!(r#"{{"anchorCall":"{}"}}"#, id_of("c_factory")),
+        );
+
+        let (eval, specs, _node_specs) = evaluate_with_materialize(
+            &v,
+            JS_HTTP_ROUTES_EDGES_DL,
+            w14_stats(),
+            EvalLimits::none(),
+            EventLog::discard(),
+        )
+        .expect("js_http_routes_edges.dl evaluates");
+
+        let pairs = |pred: &str| -> BTreeSet<(u128, u128)> {
+            eval.facts(pred)
+                .into_iter()
+                .map(|r| (r[0].as_id().expect("src id"), r[1].as_id().expect("dst id")))
+                .collect()
+        };
+        assert_eq!(
+            pairs("http_exposes"),
+            BTreeSet::from([(id_of("c_get"), id_of(&route_sid))]),
+            "EXPOSES joins exactly the anchorCall-pinned node — no decoy joins"
+        );
+        assert_eq!(
+            pairs("http_handles"),
+            BTreeSet::from([(id_of(&route_sid), id_of("h_users"))]),
+            "HANDLES: pinned node → the callback-index argument target"
+        );
+
+        for ty in ["EXPOSES", "HANDLES"] {
+            let s = specs
+                .iter()
+                .find(|s| s.edge_type == ty)
+                .unwrap_or_else(|| panic!("{ty} spec present"));
+            assert!(s.additive, "{ty} is shared enricher vocabulary — additive");
+            assert!(s.meta.is_empty(), "{ty} carries no meta columns");
+        }
+    }
+
     /// Wave 2b — js_cross_file_calls namespace arm through the visible() chain:
     /// `import * as barrel from './top'; barrel.deepFn()` where top.ts star
     /// re-exports mid.ts which directly exports deepFn — the member resolves to
@@ -4292,6 +4646,8 @@ mod tests {
             // Wave 3c: orchestrator-committed workspace facts (one per
             // discovered package + alias virtual packages; dogfood ~30).
             ("WORKSPACE_PACKAGE", 30),
+            // Wave 14: axum_routes + js_http_routes minted routes (dogfood 8).
+            ("http:route", 8),
         ] {
             nodes_by_type.insert(ty.to_string(), n);
         }

--- a/packages/rfdb-server/src/derive/stdlib/effects_callable_facts.dl
+++ b/packages/rfdb-server/src/derive/stdlib/effects_callable_facts.dl
@@ -1,0 +1,501 @@
+% ── GENERATED ground facts — DO NOT EDIT BY HAND ──────────────────────────
+% Source: effects-db/{runtimes,packages}/*.yaml — the structured-entry
+% callable registry (args[N].role / returns.type / channel) that
+% libraryCallbackEnricher consumes via EffectsLookup.getEntry.
+% Generator: scripts/generate-effects-callable-facts.mjs (Wave 14); re-run
+% it and replace this file when the registry changes.
+% 180 entries (152 arg roles, 65 returns, 91 channel rows).
+%
+% ecb_method(Lib, Full, Bare): one per role-or-channel-carrying entry;
+%   Lib = top-level YAML key VERBATIM, Bare = fn key after the last dot.
+% ecb_arg(Lib, Full, Idx, Role): role-annotated argument positions.
+% ecb_returns(Lib, Full, Type): declared returns.type of those entries.
+% ecb_channel(Lib, Full, Key, Spec): channel metadata rows (e.g. url -> arg[0]).
+ecb_method("@koa/router", "Router.all", "all").
+ecb_method("@koa/router", "Router.del", "del").
+ecb_method("@koa/router", "Router.delete", "delete").
+ecb_method("@koa/router", "Router.get", "get").
+ecb_method("@koa/router", "Router.head", "head").
+ecb_method("@koa/router", "Router.options", "options").
+ecb_method("@koa/router", "Router.param", "param").
+ecb_method("@koa/router", "Router.patch", "patch").
+ecb_method("@koa/router", "Router.post", "post").
+ecb_method("@koa/router", "Router.put", "put").
+ecb_method("@koa/router", "Router.use", "use").
+ecb_method("@modelcontextprotocol/sdk", "Server.setRequestHandler", "setRequestHandler").
+ecb_method("commander", "Command.action", "action").
+ecb_method("commander", "Command.addCommand", "addCommand").
+ecb_method("commander", "Command.command", "command").
+ecb_method("ecma:web", "fetch", "fetch").
+ecb_method("express", "Application.all", "all").
+ecb_method("express", "Application.delete", "delete").
+ecb_method("express", "Application.get", "get").
+ecb_method("express", "Application.head", "head").
+ecb_method("express", "Application.options", "options").
+ecb_method("express", "Application.patch", "patch").
+ecb_method("express", "Application.post", "post").
+ecb_method("express", "Application.put", "put").
+ecb_method("express", "Application.use", "use").
+ecb_method("express", "Router.all", "all").
+ecb_method("express", "Router.delete", "delete").
+ecb_method("express", "Router.get", "get").
+ecb_method("express", "Router.head", "head").
+ecb_method("express", "Router.options", "options").
+ecb_method("express", "Router.patch", "patch").
+ecb_method("express", "Router.post", "post").
+ecb_method("express", "Router.put", "put").
+ecb_method("express", "Router.use", "use").
+ecb_method("fastify", "FastifyInstance.addHook", "addHook").
+ecb_method("fastify", "FastifyInstance.all", "all").
+ecb_method("fastify", "FastifyInstance.delete", "delete").
+ecb_method("fastify", "FastifyInstance.get", "get").
+ecb_method("fastify", "FastifyInstance.head", "head").
+ecb_method("fastify", "FastifyInstance.options", "options").
+ecb_method("fastify", "FastifyInstance.patch", "patch").
+ecb_method("fastify", "FastifyInstance.post", "post").
+ecb_method("fastify", "FastifyInstance.put", "put").
+ecb_method("fastify", "FastifyInstance.register", "register").
+ecb_method("fastify", "FastifyInstance.setErrorHandler", "setErrorHandler").
+ecb_method("fastify", "FastifyInstance.setNotFoundHandler", "setNotFoundHandler").
+ecb_method("hono", "Hono.all", "all").
+ecb_method("hono", "Hono.delete", "delete").
+ecb_method("hono", "Hono.get", "get").
+ecb_method("hono", "Hono.notFound", "notFound").
+ecb_method("hono", "Hono.on", "on").
+ecb_method("hono", "Hono.onError", "onError").
+ecb_method("hono", "Hono.options", "options").
+ecb_method("hono", "Hono.patch", "patch").
+ecb_method("hono", "Hono.post", "post").
+ecb_method("hono", "Hono.put", "put").
+ecb_method("hono", "Hono.route", "route").
+ecb_method("hono", "Hono.use", "use").
+ecb_method("koa", "Koa.on", "on").
+ecb_method("koa", "Koa.use", "use").
+ecb_method("koa-router", "Router.all", "all").
+ecb_method("koa-router", "Router.del", "del").
+ecb_method("koa-router", "Router.delete", "delete").
+ecb_method("koa-router", "Router.get", "get").
+ecb_method("koa-router", "Router.head", "head").
+ecb_method("koa-router", "Router.options", "options").
+ecb_method("koa-router", "Router.param", "param").
+ecb_method("koa-router", "Router.patch", "patch").
+ecb_method("koa-router", "Router.post", "post").
+ecb_method("koa-router", "Router.put", "put").
+ecb_method("koa-router", "Router.use", "use").
+ecb_method("node:child_process", "exec", "exec").
+ecb_method("node:child_process", "execFile", "execFile").
+ecb_method("node:child_process", "execFileSync", "execFileSync").
+ecb_method("node:child_process", "execSync", "execSync").
+ecb_method("node:child_process", "fork", "fork").
+ecb_method("node:child_process", "spawn", "spawn").
+ecb_method("node:child_process", "spawnSync", "spawnSync").
+ecb_method("node:http", "get", "get").
+ecb_method("node:http", "request", "request").
+ecb_method("node:https", "request", "request").
+ecb_method("node:net", "Socket.connect", "connect").
+ecb_method("node:net", "connect", "connect").
+ecb_method("node:net", "createConnection", "createConnection").
+ecb_method("python:aiohttp", "ClientSession.delete", "delete").
+ecb_method("python:aiohttp", "ClientSession.get", "get").
+ecb_method("python:aiohttp", "ClientSession.head", "head").
+ecb_method("python:aiohttp", "ClientSession.patch", "patch").
+ecb_method("python:aiohttp", "ClientSession.post", "post").
+ecb_method("python:aiohttp", "ClientSession.put", "put").
+ecb_method("python:aiohttp", "ClientSession.request", "request").
+ecb_method("python:aiohttp", "ClientSession.ws_connect", "ws_connect").
+ecb_method("python:aiohttp", "request", "request").
+ecb_method("python:asyncio", "create_subprocess_exec", "create_subprocess_exec").
+ecb_method("python:asyncio", "create_subprocess_shell", "create_subprocess_shell").
+ecb_method("python:asyncio", "open_connection", "open_connection").
+ecb_method("python:asyncio", "open_unix_connection", "open_unix_connection").
+ecb_method("python:asyncio", "start_server", "start_server").
+ecb_method("python:asyncio", "start_unix_server", "start_unix_server").
+ecb_method("python:httpx", "AsyncClient.delete", "delete").
+ecb_method("python:httpx", "AsyncClient.get", "get").
+ecb_method("python:httpx", "AsyncClient.patch", "patch").
+ecb_method("python:httpx", "AsyncClient.post", "post").
+ecb_method("python:httpx", "AsyncClient.put", "put").
+ecb_method("python:httpx", "AsyncClient.request", "request").
+ecb_method("python:httpx", "Client.delete", "delete").
+ecb_method("python:httpx", "Client.get", "get").
+ecb_method("python:httpx", "Client.head", "head").
+ecb_method("python:httpx", "Client.patch", "patch").
+ecb_method("python:httpx", "Client.post", "post").
+ecb_method("python:httpx", "Client.put", "put").
+ecb_method("python:httpx", "Client.request", "request").
+ecb_method("python:httpx", "delete", "delete").
+ecb_method("python:httpx", "get", "get").
+ecb_method("python:httpx", "head", "head").
+ecb_method("python:httpx", "options", "options").
+ecb_method("python:httpx", "patch", "patch").
+ecb_method("python:httpx", "post", "post").
+ecb_method("python:httpx", "put", "put").
+ecb_method("python:httpx", "request", "request").
+ecb_method("python:httpx", "stream", "stream").
+ecb_method("python:os", "execl", "execl").
+ecb_method("python:os", "execle", "execle").
+ecb_method("python:os", "execlp", "execlp").
+ecb_method("python:os", "execlpe", "execlpe").
+ecb_method("python:os", "execv", "execv").
+ecb_method("python:os", "execve", "execve").
+ecb_method("python:os", "execvp", "execvp").
+ecb_method("python:os", "execvpe", "execvpe").
+ecb_method("python:os", "popen", "popen").
+ecb_method("python:os", "system", "system").
+ecb_method("python:paramiko", "SSHClient.connect", "connect").
+ecb_method("python:requests", "Session.delete", "delete").
+ecb_method("python:requests", "Session.get", "get").
+ecb_method("python:requests", "Session.head", "head").
+ecb_method("python:requests", "Session.patch", "patch").
+ecb_method("python:requests", "Session.post", "post").
+ecb_method("python:requests", "Session.put", "put").
+ecb_method("python:requests", "Session.request", "request").
+ecb_method("python:requests", "delete", "delete").
+ecb_method("python:requests", "get", "get").
+ecb_method("python:requests", "head", "head").
+ecb_method("python:requests", "options", "options").
+ecb_method("python:requests", "patch", "patch").
+ecb_method("python:requests", "post", "post").
+ecb_method("python:requests", "put", "put").
+ecb_method("python:requests", "request", "request").
+ecb_method("python:socket", "create_connection", "create_connection").
+ecb_method("python:socket", "create_server", "create_server").
+ecb_method("python:socket", "socket.bind", "bind").
+ecb_method("python:socket", "socket.connect", "connect").
+ecb_method("python:subprocess", "Popen", "Popen").
+ecb_method("python:subprocess", "call", "call").
+ecb_method("python:subprocess", "check_call", "check_call").
+ecb_method("python:subprocess", "check_output", "check_output").
+ecb_method("python:subprocess", "getoutput", "getoutput").
+ecb_method("python:subprocess", "getstatusoutput", "getstatusoutput").
+ecb_method("python:subprocess", "run", "run").
+ecb_method("python:urllib.request", "urlopen", "urlopen").
+ecb_method("vscode", "commands.registerCommand", "registerCommand").
+ecb_method("vscode", "commands.registerTextEditorCommand", "registerTextEditorCommand").
+ecb_method("vscode", "languages.registerCodeActionsProvider", "registerCodeActionsProvider").
+ecb_method("vscode", "languages.registerCodeLensProvider", "registerCodeLensProvider").
+ecb_method("vscode", "languages.registerCompletionItemProvider", "registerCompletionItemProvider").
+ecb_method("vscode", "languages.registerDefinitionProvider", "registerDefinitionProvider").
+ecb_method("vscode", "languages.registerDocumentFormattingEditProvider", "registerDocumentFormattingEditProvider").
+ecb_method("vscode", "languages.registerDocumentSymbolProvider", "registerDocumentSymbolProvider").
+ecb_method("vscode", "languages.registerHoverProvider", "registerHoverProvider").
+ecb_method("vscode", "languages.registerReferenceProvider", "registerReferenceProvider").
+ecb_method("vscode", "window.registerCustomEditorProvider", "registerCustomEditorProvider").
+ecb_method("vscode", "window.registerFileDecorationProvider", "registerFileDecorationProvider").
+ecb_method("vscode", "window.registerTreeDataProvider", "registerTreeDataProvider").
+ecb_method("vscode", "window.registerUriHandler", "registerUriHandler").
+ecb_method("vscode", "window.registerWebviewPanelSerializer", "registerWebviewPanelSerializer").
+ecb_method("vscode", "window.registerWebviewViewProvider", "registerWebviewViewProvider").
+ecb_method("vscode", "workspace.onDidChangeConfiguration", "onDidChangeConfiguration").
+ecb_method("vscode", "workspace.onDidChangeTextDocument", "onDidChangeTextDocument").
+ecb_method("vscode", "workspace.onDidCloseTextDocument", "onDidCloseTextDocument").
+ecb_method("vscode", "workspace.onDidOpenTextDocument", "onDidOpenTextDocument").
+ecb_method("vscode", "workspace.onDidSaveTextDocument", "onDidSaveTextDocument").
+ecb_arg("@koa/router", "Router.all", "0", "ROUTE_PATH").
+ecb_arg("@koa/router", "Router.all", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@koa/router", "Router.del", "0", "ROUTE_PATH").
+ecb_arg("@koa/router", "Router.del", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@koa/router", "Router.delete", "0", "ROUTE_PATH").
+ecb_arg("@koa/router", "Router.delete", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@koa/router", "Router.get", "0", "ROUTE_PATH").
+ecb_arg("@koa/router", "Router.get", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@koa/router", "Router.head", "0", "ROUTE_PATH").
+ecb_arg("@koa/router", "Router.head", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@koa/router", "Router.options", "0", "ROUTE_PATH").
+ecb_arg("@koa/router", "Router.options", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@koa/router", "Router.param", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@koa/router", "Router.patch", "0", "ROUTE_PATH").
+ecb_arg("@koa/router", "Router.patch", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@koa/router", "Router.post", "0", "ROUTE_PATH").
+ecb_arg("@koa/router", "Router.post", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@koa/router", "Router.put", "0", "ROUTE_PATH").
+ecb_arg("@koa/router", "Router.put", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@koa/router", "Router.use", "0", "MOUNTPOINT").
+ecb_arg("@koa/router", "Router.use", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@modelcontextprotocol/sdk", "Server.setRequestHandler", "0", "TOOL_SCHEMA").
+ecb_arg("@modelcontextprotocol/sdk", "Server.setRequestHandler", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("commander", "Command.action", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("commander", "Command.addCommand", "0", "COMMAND_NAME").
+ecb_arg("commander", "Command.command", "0", "COMMAND_NAME").
+ecb_arg("express", "Application.all", "0", "ROUTE_PATH").
+ecb_arg("express", "Application.all", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Application.delete", "0", "ROUTE_PATH").
+ecb_arg("express", "Application.delete", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Application.get", "0", "ROUTE_PATH").
+ecb_arg("express", "Application.get", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Application.head", "0", "ROUTE_PATH").
+ecb_arg("express", "Application.head", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Application.options", "0", "ROUTE_PATH").
+ecb_arg("express", "Application.options", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Application.patch", "0", "ROUTE_PATH").
+ecb_arg("express", "Application.patch", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Application.post", "0", "ROUTE_PATH").
+ecb_arg("express", "Application.post", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Application.put", "0", "ROUTE_PATH").
+ecb_arg("express", "Application.put", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Application.use", "0", "MOUNTPOINT").
+ecb_arg("express", "Application.use", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Router.all", "0", "ROUTE_PATH").
+ecb_arg("express", "Router.all", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Router.delete", "0", "ROUTE_PATH").
+ecb_arg("express", "Router.delete", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Router.get", "0", "ROUTE_PATH").
+ecb_arg("express", "Router.get", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Router.head", "0", "ROUTE_PATH").
+ecb_arg("express", "Router.head", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Router.options", "0", "ROUTE_PATH").
+ecb_arg("express", "Router.options", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Router.patch", "0", "ROUTE_PATH").
+ecb_arg("express", "Router.patch", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Router.post", "0", "ROUTE_PATH").
+ecb_arg("express", "Router.post", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Router.put", "0", "ROUTE_PATH").
+ecb_arg("express", "Router.put", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Router.use", "0", "MOUNTPOINT").
+ecb_arg("express", "Router.use", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.addHook", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.all", "0", "ROUTE_PATH").
+ecb_arg("fastify", "FastifyInstance.all", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.delete", "0", "ROUTE_PATH").
+ecb_arg("fastify", "FastifyInstance.delete", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.get", "0", "ROUTE_PATH").
+ecb_arg("fastify", "FastifyInstance.get", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.head", "0", "ROUTE_PATH").
+ecb_arg("fastify", "FastifyInstance.head", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.options", "0", "ROUTE_PATH").
+ecb_arg("fastify", "FastifyInstance.options", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.patch", "0", "ROUTE_PATH").
+ecb_arg("fastify", "FastifyInstance.patch", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.post", "0", "ROUTE_PATH").
+ecb_arg("fastify", "FastifyInstance.post", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.put", "0", "ROUTE_PATH").
+ecb_arg("fastify", "FastifyInstance.put", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.register", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.setErrorHandler", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.setNotFoundHandler", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.all", "0", "ROUTE_PATH").
+ecb_arg("hono", "Hono.all", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.delete", "0", "ROUTE_PATH").
+ecb_arg("hono", "Hono.delete", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.get", "0", "ROUTE_PATH").
+ecb_arg("hono", "Hono.get", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.notFound", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.on", "1", "ROUTE_PATH").
+ecb_arg("hono", "Hono.on", "2", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.onError", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.options", "0", "ROUTE_PATH").
+ecb_arg("hono", "Hono.options", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.patch", "0", "ROUTE_PATH").
+ecb_arg("hono", "Hono.patch", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.post", "0", "ROUTE_PATH").
+ecb_arg("hono", "Hono.post", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.put", "0", "ROUTE_PATH").
+ecb_arg("hono", "Hono.put", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.route", "0", "MOUNTPOINT").
+ecb_arg("hono", "Hono.use", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa", "Koa.on", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa", "Koa.use", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.all", "0", "ROUTE_PATH").
+ecb_arg("koa-router", "Router.all", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.del", "0", "ROUTE_PATH").
+ecb_arg("koa-router", "Router.del", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.delete", "0", "ROUTE_PATH").
+ecb_arg("koa-router", "Router.delete", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.get", "0", "ROUTE_PATH").
+ecb_arg("koa-router", "Router.get", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.head", "0", "ROUTE_PATH").
+ecb_arg("koa-router", "Router.head", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.options", "0", "ROUTE_PATH").
+ecb_arg("koa-router", "Router.options", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.param", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.patch", "0", "ROUTE_PATH").
+ecb_arg("koa-router", "Router.patch", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.post", "0", "ROUTE_PATH").
+ecb_arg("koa-router", "Router.post", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.put", "0", "ROUTE_PATH").
+ecb_arg("koa-router", "Router.put", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.use", "0", "MOUNTPOINT").
+ecb_arg("koa-router", "Router.use", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "commands.registerCommand", "0", "COMMAND_NAME").
+ecb_arg("vscode", "commands.registerCommand", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "commands.registerTextEditorCommand", "0", "COMMAND_NAME").
+ecb_arg("vscode", "commands.registerTextEditorCommand", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "languages.registerCodeActionsProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "languages.registerCodeLensProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "languages.registerCompletionItemProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "languages.registerDefinitionProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "languages.registerDocumentFormattingEditProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "languages.registerDocumentSymbolProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "languages.registerHoverProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "languages.registerReferenceProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "window.registerCustomEditorProvider", "0", "COMMAND_NAME").
+ecb_arg("vscode", "window.registerCustomEditorProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "window.registerFileDecorationProvider", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "window.registerTreeDataProvider", "0", "COMMAND_NAME").
+ecb_arg("vscode", "window.registerTreeDataProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "window.registerUriHandler", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "window.registerWebviewPanelSerializer", "0", "COMMAND_NAME").
+ecb_arg("vscode", "window.registerWebviewPanelSerializer", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "window.registerWebviewViewProvider", "0", "COMMAND_NAME").
+ecb_arg("vscode", "window.registerWebviewViewProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "workspace.onDidChangeConfiguration", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "workspace.onDidChangeTextDocument", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "workspace.onDidCloseTextDocument", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "workspace.onDidOpenTextDocument", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "workspace.onDidSaveTextDocument", "0", "ENTRY_POINT_CALLBACK").
+ecb_returns("@koa/router", "Router.all", "Router").
+ecb_returns("@koa/router", "Router.del", "Router").
+ecb_returns("@koa/router", "Router.delete", "Router").
+ecb_returns("@koa/router", "Router.get", "Router").
+ecb_returns("@koa/router", "Router.head", "Router").
+ecb_returns("@koa/router", "Router.options", "Router").
+ecb_returns("@koa/router", "Router.param", "Router").
+ecb_returns("@koa/router", "Router.patch", "Router").
+ecb_returns("@koa/router", "Router.post", "Router").
+ecb_returns("@koa/router", "Router.put", "Router").
+ecb_returns("@koa/router", "Router.use", "Router").
+ecb_returns("commander", "Command.action", "Command").
+ecb_returns("commander", "Command.addCommand", "Command").
+ecb_returns("commander", "Command.command", "Command").
+ecb_returns("express", "Application.all", "Application").
+ecb_returns("express", "Application.delete", "Application").
+ecb_returns("express", "Application.get", "Application").
+ecb_returns("express", "Application.head", "Application").
+ecb_returns("express", "Application.options", "Application").
+ecb_returns("express", "Application.patch", "Application").
+ecb_returns("express", "Application.post", "Application").
+ecb_returns("express", "Application.put", "Application").
+ecb_returns("express", "Application.use", "Application").
+ecb_returns("express", "Router.all", "Router").
+ecb_returns("express", "Router.delete", "Router").
+ecb_returns("express", "Router.get", "Router").
+ecb_returns("express", "Router.head", "Router").
+ecb_returns("express", "Router.options", "Router").
+ecb_returns("express", "Router.patch", "Router").
+ecb_returns("express", "Router.post", "Router").
+ecb_returns("express", "Router.put", "Router").
+ecb_returns("express", "Router.use", "Router").
+ecb_returns("fastify", "FastifyInstance.all", "FastifyInstance").
+ecb_returns("fastify", "FastifyInstance.delete", "FastifyInstance").
+ecb_returns("fastify", "FastifyInstance.get", "FastifyInstance").
+ecb_returns("fastify", "FastifyInstance.head", "FastifyInstance").
+ecb_returns("fastify", "FastifyInstance.options", "FastifyInstance").
+ecb_returns("fastify", "FastifyInstance.patch", "FastifyInstance").
+ecb_returns("fastify", "FastifyInstance.post", "FastifyInstance").
+ecb_returns("fastify", "FastifyInstance.put", "FastifyInstance").
+ecb_returns("fastify", "FastifyInstance.register", "FastifyInstance").
+ecb_returns("hono", "Hono.all", "Hono").
+ecb_returns("hono", "Hono.delete", "Hono").
+ecb_returns("hono", "Hono.get", "Hono").
+ecb_returns("hono", "Hono.notFound", "Hono").
+ecb_returns("hono", "Hono.on", "Hono").
+ecb_returns("hono", "Hono.onError", "Hono").
+ecb_returns("hono", "Hono.options", "Hono").
+ecb_returns("hono", "Hono.patch", "Hono").
+ecb_returns("hono", "Hono.post", "Hono").
+ecb_returns("hono", "Hono.put", "Hono").
+ecb_returns("hono", "Hono.route", "Hono").
+ecb_returns("hono", "Hono.use", "Hono").
+ecb_returns("koa", "Koa.use", "Koa").
+ecb_returns("koa-router", "Router.all", "Router").
+ecb_returns("koa-router", "Router.del", "Router").
+ecb_returns("koa-router", "Router.delete", "Router").
+ecb_returns("koa-router", "Router.get", "Router").
+ecb_returns("koa-router", "Router.head", "Router").
+ecb_returns("koa-router", "Router.options", "Router").
+ecb_returns("koa-router", "Router.param", "Router").
+ecb_returns("koa-router", "Router.patch", "Router").
+ecb_returns("koa-router", "Router.post", "Router").
+ecb_returns("koa-router", "Router.put", "Router").
+ecb_returns("koa-router", "Router.use", "Router").
+ecb_channel("ecma:web", "fetch", "url", "arg[0]").
+ecb_channel("node:child_process", "exec", "binary", "arg[0]").
+ecb_channel("node:child_process", "execFile", "binary", "arg[0]").
+ecb_channel("node:child_process", "execFileSync", "binary", "arg[0]").
+ecb_channel("node:child_process", "execSync", "binary", "arg[0]").
+ecb_channel("node:child_process", "fork", "binary", "arg[0]").
+ecb_channel("node:child_process", "spawn", "binary", "arg[0]").
+ecb_channel("node:child_process", "spawnSync", "binary", "arg[0]").
+ecb_channel("node:http", "get", "url", "arg[0]").
+ecb_channel("node:http", "request", "url", "arg[0]").
+ecb_channel("node:https", "request", "url", "arg[0]").
+ecb_channel("node:net", "Socket.connect", "path", "arg[0]").
+ecb_channel("node:net", "connect", "path", "arg[0]").
+ecb_channel("node:net", "createConnection", "path", "arg[0]").
+ecb_channel("python:aiohttp", "ClientSession.delete", "url", "arg[0]").
+ecb_channel("python:aiohttp", "ClientSession.get", "url", "arg[0]").
+ecb_channel("python:aiohttp", "ClientSession.head", "url", "arg[0]").
+ecb_channel("python:aiohttp", "ClientSession.patch", "url", "arg[0]").
+ecb_channel("python:aiohttp", "ClientSession.post", "url", "arg[0]").
+ecb_channel("python:aiohttp", "ClientSession.put", "url", "arg[0]").
+ecb_channel("python:aiohttp", "ClientSession.request", "url", "arg[1]").
+ecb_channel("python:aiohttp", "ClientSession.ws_connect", "url", "arg[0]").
+ecb_channel("python:aiohttp", "request", "url", "arg[1]").
+ecb_channel("python:asyncio", "create_subprocess_exec", "binary", "arg[0]").
+ecb_channel("python:asyncio", "create_subprocess_shell", "binary", "arg[0]").
+ecb_channel("python:asyncio", "open_connection", "host", "arg[0]").
+ecb_channel("python:asyncio", "open_connection", "port", "arg[1]").
+ecb_channel("python:asyncio", "open_unix_connection", "path", "arg[0]").
+ecb_channel("python:asyncio", "start_server", "host", "arg[1]").
+ecb_channel("python:asyncio", "start_server", "port", "arg[2]").
+ecb_channel("python:asyncio", "start_unix_server", "path", "arg[1]").
+ecb_channel("python:httpx", "AsyncClient.delete", "url", "arg[0]").
+ecb_channel("python:httpx", "AsyncClient.get", "url", "arg[0]").
+ecb_channel("python:httpx", "AsyncClient.patch", "url", "arg[0]").
+ecb_channel("python:httpx", "AsyncClient.post", "url", "arg[0]").
+ecb_channel("python:httpx", "AsyncClient.put", "url", "arg[0]").
+ecb_channel("python:httpx", "AsyncClient.request", "url", "arg[1]").
+ecb_channel("python:httpx", "Client.delete", "url", "arg[0]").
+ecb_channel("python:httpx", "Client.get", "url", "arg[0]").
+ecb_channel("python:httpx", "Client.head", "url", "arg[0]").
+ecb_channel("python:httpx", "Client.patch", "url", "arg[0]").
+ecb_channel("python:httpx", "Client.post", "url", "arg[0]").
+ecb_channel("python:httpx", "Client.put", "url", "arg[0]").
+ecb_channel("python:httpx", "Client.request", "url", "arg[1]").
+ecb_channel("python:httpx", "delete", "url", "arg[0]").
+ecb_channel("python:httpx", "get", "url", "arg[0]").
+ecb_channel("python:httpx", "head", "url", "arg[0]").
+ecb_channel("python:httpx", "options", "url", "arg[0]").
+ecb_channel("python:httpx", "patch", "url", "arg[0]").
+ecb_channel("python:httpx", "post", "url", "arg[0]").
+ecb_channel("python:httpx", "put", "url", "arg[0]").
+ecb_channel("python:httpx", "request", "url", "arg[1]").
+ecb_channel("python:httpx", "stream", "url", "arg[1]").
+ecb_channel("python:os", "execl", "binary", "arg[0]").
+ecb_channel("python:os", "execle", "binary", "arg[0]").
+ecb_channel("python:os", "execlp", "binary", "arg[0]").
+ecb_channel("python:os", "execlpe", "binary", "arg[0]").
+ecb_channel("python:os", "execv", "binary", "arg[0]").
+ecb_channel("python:os", "execve", "binary", "arg[0]").
+ecb_channel("python:os", "execvp", "binary", "arg[0]").
+ecb_channel("python:os", "execvpe", "binary", "arg[0]").
+ecb_channel("python:os", "popen", "binary", "arg[0]").
+ecb_channel("python:os", "system", "binary", "arg[0]").
+ecb_channel("python:paramiko", "SSHClient.connect", "host", "arg[0]").
+ecb_channel("python:requests", "Session.delete", "url", "arg[0]").
+ecb_channel("python:requests", "Session.get", "url", "arg[0]").
+ecb_channel("python:requests", "Session.head", "url", "arg[0]").
+ecb_channel("python:requests", "Session.patch", "url", "arg[0]").
+ecb_channel("python:requests", "Session.post", "url", "arg[0]").
+ecb_channel("python:requests", "Session.put", "url", "arg[0]").
+ecb_channel("python:requests", "Session.request", "url", "arg[1]").
+ecb_channel("python:requests", "delete", "url", "arg[0]").
+ecb_channel("python:requests", "get", "url", "arg[0]").
+ecb_channel("python:requests", "head", "url", "arg[0]").
+ecb_channel("python:requests", "options", "url", "arg[0]").
+ecb_channel("python:requests", "patch", "url", "arg[0]").
+ecb_channel("python:requests", "post", "url", "arg[0]").
+ecb_channel("python:requests", "put", "url", "arg[0]").
+ecb_channel("python:requests", "request", "url", "arg[1]").
+ecb_channel("python:socket", "create_connection", "addr", "arg[0]").
+ecb_channel("python:socket", "create_server", "addr", "arg[0]").
+ecb_channel("python:socket", "socket.bind", "addr", "arg[0]").
+ecb_channel("python:socket", "socket.connect", "addr", "arg[0]").
+ecb_channel("python:subprocess", "Popen", "binary", "arg[0]").
+ecb_channel("python:subprocess", "call", "binary", "arg[0]").
+ecb_channel("python:subprocess", "check_call", "binary", "arg[0]").
+ecb_channel("python:subprocess", "check_output", "binary", "arg[0]").
+ecb_channel("python:subprocess", "getoutput", "binary", "arg[0]").
+ecb_channel("python:subprocess", "getstatusoutput", "binary", "arg[0]").
+ecb_channel("python:subprocess", "run", "binary", "arg[0]").
+ecb_channel("python:urllib.request", "urlopen", "url", "arg[0]").

--- a/packages/rfdb-server/src/derive/stdlib/js_http_routes_edges.dl
+++ b/packages/rfdb-server/src/derive/stdlib/js_http_routes_edges.dl
@@ -1,0 +1,135 @@
+% js_http_routes_edges.dl — edge half of the JS HTTP-route feature vertical
+% (Wave 14): the libraryCallbackEnricher edge vocabulary over the http:route
+% nodes minted by js_http_routes_nodes.dl:
+%   EXPOSES : registration CALL -> http:route   (enricher :146-151)
+%   HANDLES : http:route -> callback target     (enricher :152-157)
+% MUST be declared AFTER js_http_routes_nodes in the pack runner: the minted
+% http:route endpoints are joined here as COMMITTED storage EDB (the
+% js_builtins two-pack split — a @materialize edge endpoint must be a node-ID
+% column, and a same-run-minted node's id exists only as the BLAKE3 of the
+% sid string the nodes pack builds).
+%
+% The match prelude (cand/corig/try/want/bnd/dnext/src_of/routed) is a
+% textual duplicate of js_http_routes_nodes.dl (derived relations are
+% per-program; the established per-pack include pattern), and the ecb_*
+% ground facts are PREPENDED at compile time from effects_callable_facts.dl
+% (stdlib.rs concat!). See the nodes pack header for the full enricher
+% provenance and NUMBERED DELTAS 1-9 — no additional edge-only deltas.
+%
+% ENDPOINT PIN: our http:route nodes carry meta `anchorCall` = the decimal
+% u128 id of the registration call (nodes pack delta 4/5) — the join
+% `node_attr(R, "anchorCall", Cid) ⋈ attr(C, "id", Cid)` is exact and 1:1.
+% Other producers' http:route nodes are NEVER joined: axum_routes' nodes
+% have no anchorCall key, and the legacy enricher's anchorCall holds a WIRE
+% semantic-id string (never equal to a decimal id rendering).
+%
+% EXPOSES / HANDLES are SHARED vocabulary (the enricher emits them for
+% cli:command / mcp:tool / vscode:command) ⇒ mode = "additive" is MANDATORY.
+% Additive edges do not retract: an EXPOSES/HANDLES edge whose http:route
+% node was retracted by the (exclusive) nodes pack dangles until the next
+% writer cleanup — the known additive-vocabulary class, same as the enricher.
+%
+% MAINTAIN ENVELOPE: negation ⇒ scratch-only under maintain (accepted).
+%
+% ORDERING (CONSUMER): strictly after js_http_routes_nodes (committed-EDB
+% endpoint join), enforced by both pack registries.
+
+% ── Registry slice + rules (duplicate prelude; see the nodes pack) ──────────
+hr_lib("express").
+hr_lib("fastify").
+hr_lib("koa").
+hr_lib("koa-router").
+hr_lib("@koa/router").
+hr_lib("hono").
+
+hr_rule(Lib, M, CbIdx) :-
+    hr_lib(Lib),
+    ecb_method(Lib, Full, M),
+    ecb_arg(Lib, Full, CbIdx, "ENTRY_POINT_CALLBACK").
+hr_m(M) :- hr_rule(_, M, _).
+
+% ── Candidate calls (8-ext gate; duplicate prelude) ─────────────────────────
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".js"),  attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".jsx"), attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".ts"),  attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".tsx"), attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".mjs"), attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".cjs"), attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".mts"), attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".cts"), attr(C, "name", N).
+
+% Two-step suffix gate: the builtin needs N bound, so the suffix rule is
+% planned off jcall alone; the registry gate joins the derived output
+% (the greedy planner would otherwise lead with the tiny hr_m relation
+% and strand method_suffix with both arguments free).
+msfx(C, F, M) :- jcall(C, F, N), method_suffix(N, M).
+cand(C, F, M) :- msfx(C, F, M), hr_m(M).
+
+% ── Receiver-chain machinery (duplicate prelude) ────────────────────────────
+rsrc(X)     :- edge(X, _, "RECEIVER_CALL").
+rpath(A, B) :- edge(A, B, "RECEIVER_CALL").
+rpath(A, B) :- rpath(A, X), edge(X, B, "RECEIVER_CALL").
+rorig(A, B) :- rpath(A, B), \+ rsrc(B).
+
+corig(C, O) :- cand(C, _, _), rorig(C, O).
+corig(C, C) :- cand(C, _, _), \+ rsrc(C).
+
+try(C, F, N) :- corig(C, O), attr(O, "name", N), attr(O, "file", F).
+try(C, F, R) :- try(C, F, N), method_suffix(N, S), concat(".", S, DS), strip_suffix(N, DS, R).
+
+want(F, N) :- try(_, F, N).
+want(F, N) :- dnext(F, _, N).
+
+bnd(F, N, Src) :-
+    want(F, N),
+    node(B, "IMPORT_BINDING"), attr(B, "file", F), attr(B, "name", N),
+    node_attr(B, "source", Src).
+
+dinit(F, N, I) :- want(F, N), node(D, "CONSTANT"), attr(D, "file", F), attr(D, "name", N), edge(D, I, "ASSIGNED_FROM"), node(I, "CALL").
+dinit(F, N, I) :- want(F, N), node(D, "VARIABLE"), attr(D, "file", F), attr(D, "name", N), edge(D, I, "ASSIGNED_FROM"), node(I, "CALL").
+dorig(F, N, O) :- dinit(F, N, I), rorig(I, O).
+dorig(F, N, I) :- dinit(F, N, I), \+ rsrc(I).
+dnext(F, N, ON) :- dorig(F, N, O), attr(O, "name", ON).
+dnext(F, N, R)  :- dnext(F, N, ON), method_suffix(ON, S), concat(".", S, DS), strip_suffix(ON, DS, R).
+
+src_of(F, N, Src) :- bnd(F, N, Src).
+src_of(F, N, Src) :- dnext(F, N, N2), src_of(F, N2, Src).
+
+res(C, Src) :- try(C, F, N), src_of(F, N, Src).
+
+% Library match: exact, or subpath import "<lib>/..." (enricher :114-117).
+% Subpath matching is the segment-shrink idiom (cf. js_runtime_globals dpfx):
+% every whole-"/"-segment prefix of the source is derived, then membership-
+% joined against hr_lib — the trailing-"/" boundary the enricher's
+% startsWith(lib + "/") enforces falls out of shrinking BY segments
+% ("@foo/barzooka" never shrinks to "@foo/bar").
+spfx(C, S) :- res(C, S).
+spfx(C, P) :- spfx(C, S), last_segment(S, "/", L), concat("/", L, T), strip_suffix(S, T, P).
+mlib(C, Lib) :- spfx(C, Lib), hr_lib(Lib).
+
+routed(C, Lib, M, H) :-
+    cand(C, _, M),
+    mlib(C, Lib),
+    hr_rule(Lib, M, CbIdx),
+    edge(C, H, "PASSES_ARGUMENT"),
+    edge_attr(C, H, "PASSES_ARGUMENT", "index", CbIdx).
+rnode(C) :- routed(C, _, _, _).
+
+% ── The materialized edges over the COMMITTED http:route endpoints ──────────
+% The decimal call id is read in its OWN rule so the attr leg always runs in
+% reader mode [B,B,F] off the bound call — fused into the join rule the
+% planner may bind Cid from the node_attr side first and flip attr into the
+% [F,B,B] reverse-lookup, which has no index for the "id" pseudo-attr.
+hcid(C, Cid, H) :- routed(C, _, _, H), attr(C, "id", Cid).
+
+@materialize(edge_type = "EXPOSES", mode = "additive")
+http_exposes(C, R) :-
+    hcid(C, Cid, _),
+    node(R, "http:route"),
+    node_attr(R, "anchorCall", Cid).
+
+@materialize(edge_type = "HANDLES", mode = "additive")
+http_handles(R, H) :-
+    hcid(C, Cid, H),
+    node(R, "http:route"),
+    node_attr(R, "anchorCall", Cid).

--- a/packages/rfdb-server/src/derive/stdlib/js_http_routes_nodes.dl
+++ b/packages/rfdb-server/src/derive/stdlib/js_http_routes_nodes.dl
@@ -1,0 +1,241 @@
+% js_http_routes_nodes.dl — node half of the JS HTTP-route feature vertical
+% (Wave 14, REG-1115 slice): Express / Fastify / Koa(+koa-router/@koa/router) /
+% Hono route registrations -> `http:route` nodes + ROUTES_TO edges, driven by
+% the effects-db callable registry (the `ecb_*` ground facts PREPENDED at
+% compile time from effects_callable_facts.dl; regenerate via
+% scripts/generate-effects-callable-facts.mjs). This is the derive-pack
+% REPLACEMENT for the HTTP slice of
+% packages/util/src/enrichers/libraryCallbackEnricher.ts: the 6 framework
+% entries (express/fastify/koa/koa-router/@koa/router/hono) were retired
+% from its LIBRARY_NODE_TYPE map in this wave, making this pack the SOLE
+% default producer of js http:route. (The enricher writes via
+% addNodes/addEdges — leaving both on would mint two http:route nodes per
+% registration: enricher id anchors the wire semantic id, pack sid anchors
+% the decimal u128 — plus duplicate EXPOSES/HANDLES and duplicate
+% SpecedContracts downstream in httpRouteExtractor.)
+%
+% WHAT THE ENRICHER DOES (the semantics being reproduced): for every CALL
+% whose name ends in ".<method>" where <method> carries an
+% ENTRY_POINT_CALLBACK arg role in effects-db, walk the RECEIVER_CALL chain
+% to its origin, resolve the receiver name to an import source (direct
+% IMPORT_BINDING `metadata.source`, or a CONSTANT/VARIABLE whose
+% ASSIGNED_FROM initializer chain originates in a constructor of an imported
+% class), match the source against the registry library (exact or
+% "<lib>/<subpath>"), then mint one domain node per registration call with
+% EXPOSES (call -> node) and HANDLES (node -> callback) edges. All shapes
+% live-verified on the dogfood copy 2026-06-12: IMPORT_BINDING
+% metadata.source, CALL metadata.kind="new", RECEIVER_CALL chains,
+% PASSES_ARGUMENT metadata.index, LITERAL `name` = RAW source text including
+% quotes ("'overview'").
+%
+% NUMBERED DELTAS vs libraryCallbackEnricher (all deliberate):
+%   1. Name decomposition is the FULL dot-suffix-strip chain (try/dnext probe
+%      the origin name plus every "strip one trailing .segment" variant); the
+%      enricher picks exactly one split (before-last-dot for receivers,
+%      first-segment for constructor names). Superset: a false hit needs a
+%      same-file binding named exactly one of the variants AND sourced from a
+%      registry lib.
+%   2. Factory initializers resolve: `const app = express(); app.get(...)`.
+%      The enricher's initializer arm requires a kind="new" chain origin, so
+%      it MISSES the primary express/fastify idiom (live-traced in its source,
+%      libraryCallbackEnricher.ts:404); this pack accepts ANY CALL origin and
+%      resolves its callee name. Superset, deliberate.
+%   3. "<obj>"-rooted chained-namespace receivers (the DERIVES_FROM[callee] /
+%      READS_FROM[receiver] metadata.base walk, enricher :295-330) are NOT
+%      implemented — subset; that arm exists for `vscode.commands.*`, and
+%      vscode is not in this pack's lib set. Placeholder names resolve to
+%      nothing naturally (no binding is named "<obj>...").
+%   4. Node identity: sid = "<file>::http:route::<name>::<callIdDecimal>" —
+%      the enricher anchors on the call's WIRE semantic id; the engine attr
+%      surface exposes the BLAKE3 u128 id only. Same per-registration-call
+%      granularity, different anchor encoding.
+%   5. Node metadata: meta(library, method, anchorCall) where method = the
+%      BARE method name. The enricher stored the FIRST matching rule's
+%      methodFullName ("Application.get" vs "Router.get" — object-iteration-
+%      order-dependent); the bare name makes the row set order-free.
+%   6. The node name / route path comes from the ROUTE_PATH-role argument's
+%      LITERAL only, quotes stripped (single/double/backtick matching pairs).
+%      The enricher probed COMMAND_NAME/TOOL_SCHEMA roles then arg 0
+%      regardless of role and accepted ANY node's `name` as a label; those
+%      junk name sources are deliberately dropped -> "<unnamed-http-route>".
+%   7. ROUTES_TO (CALL -> handler, meta(method, path)) is NEW vs the enricher
+%      (which emitted only EXPOSES/HANDLES; the wave mandates the axum_routes
+%      vocabulary here). Verbs map registration names (del -> DELETE,
+%      all -> ALL); non-verb registrations (use/on/register/addHook/...)
+%      derive no ROUTES_TO. Unlike axum_routes the path is NOT gated on a
+%      leading "/" (express accepts "*", regex-like strings, etc.).
+%   8. Handler-required gate: a node is minted only when the
+%      ENTRY_POINT_CALLBACK-index PASSES_ARGUMENT edge exists — enricher
+%      parity (it skipped calls without callbackArgId; note this DIFFERS from
+%      axum_routes delta 4, which mints handler-less nodes).
+%   9. Chained multi-route registrations `r.get('/a',h1).post('/b',h2)`: the
+%      enricher labeled EVERY route in the chain from the chain ORIGIN's
+%      arg 0; this pack reads each call's OWN ROUTE_PATH argument.
+%      Correctness divergence, deliberate.
+%
+% Meta-identity caveat (shared with axum_routes): if one call resolves to two
+% registry libs (same-file bindings to two frameworks under one name), the
+% node row set carries both library values for one sid — which lands is
+% set-order-defined. Not observed in any real corpus.
+%
+% `http:route` nodes: mode = "exclusive" is PROVENANCE-SCOPED (the engine
+% contract): only nodes stamped with THIS rule's _source are owned — the
+% axum_routes pack's nodes and the legacy enricher's nodes are never touched,
+% while a route removed from the code retracts its node on the next run.
+% ROUTES_TO is PRE-REGISTERED SHARED vocabulary (packages/types/src/edges.ts
+% RouteEdge) ⇒ mode = "additive" is MANDATORY.
+%
+% MAINTAIN ENVELOPE: negation + node minting ⇒ scratch-only under maintain
+% (accepted, same class as every resolver pack).
+%
+% ORDERING: consumes analyzer EDB only (CALL/IMPORT_BINDING/CONSTANT/VARIABLE
+% nodes; RECEIVER_CALL/ASSIGNED_FROM/PASSES_ARGUMENT edges + metadata) — no
+% pack-produced inputs. Registered at the registry tail after axum_routes;
+% js_http_routes_edges joins the nodes minted HERE as committed EDB, so this
+% pack MUST run strictly before it (the js_builtins two-pack split).
+
+% ── Registry slice: the libs that mint http:route (LIBRARY_NODE_TYPE's HTTP
+%    subset, libraryCallbackEnricher.ts:36-48) ────────────────────────────────
+hr_lib("express").
+hr_lib("fastify").
+hr_lib("koa").
+hr_lib("koa-router").
+hr_lib("@koa/router").
+hr_lib("hono").
+
+% Registration-method-name -> HTTP verb (ROUTES_TO meta; delta 7).
+hr_verb("get", "GET").
+hr_verb("post", "POST").
+hr_verb("put", "PUT").
+hr_verb("delete", "DELETE").
+hr_verb("del", "DELETE").
+hr_verb("patch", "PATCH").
+hr_verb("head", "HEAD").
+hr_verb("options", "OPTIONS").
+hr_verb("all", "ALL").
+
+% ── Rules from the generated facts: callback + path argument indexes ────────
+hr_rule(Lib, M, CbIdx) :-
+    hr_lib(Lib),
+    ecb_method(Lib, Full, M),
+    ecb_arg(Lib, Full, CbIdx, "ENTRY_POINT_CALLBACK").
+hr_pathidx(Lib, M, PIdx) :-
+    hr_lib(Lib),
+    ecb_method(Lib, Full, M),
+    ecb_arg(Lib, Full, PIdx, "ROUTE_PATH").
+hr_m(M) :- hr_rule(_, M, _).
+
+% ── Candidate calls: ".<method>" suffix in a JS-family file (8-ext gate) ────
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".js"),  attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".jsx"), attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".ts"),  attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".tsx"), attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".mjs"), attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".cjs"), attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".mts"), attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".cts"), attr(C, "name", N).
+
+% Two-step suffix gate: the builtin needs N bound, so the suffix rule is
+% planned off jcall alone; the registry gate joins the derived output
+% (the greedy planner would otherwise lead with the tiny hr_m relation
+% and strand method_suffix with both arguments free).
+msfx(C, F, M) :- jcall(C, F, N), method_suffix(N, M).
+cand(C, F, M) :- msfx(C, F, M), hr_m(M).
+
+% ── Receiver-chain machinery (RECEIVER_CALL closure; EDB-negation only) ─────
+rsrc(X)     :- edge(X, _, "RECEIVER_CALL").
+rpath(A, B) :- edge(A, B, "RECEIVER_CALL").
+rpath(A, B) :- rpath(A, X), edge(X, B, "RECEIVER_CALL").
+rorig(A, B) :- rpath(A, B), \+ rsrc(B).
+
+corig(C, O) :- cand(C, _, _), rorig(C, O).
+corig(C, C) :- cand(C, _, _), \+ rsrc(C).
+
+% ── Name variants probed at the call site (delta 1) ─────────────────────────
+try(C, F, N) :- corig(C, O), attr(O, "name", N), attr(O, "file", F).
+try(C, F, R) :- try(C, F, N), method_suffix(N, S), concat(".", S, DS), strip_suffix(N, DS, R).
+
+% ── Need-set-driven binding resolution (mutually recursive with the
+%    initializer hop — the enricher's bounded recursion as a fixpoint) ───────
+want(F, N) :- try(_, F, N).
+want(F, N) :- dnext(F, _, N).
+
+bnd(F, N, Src) :-
+    want(F, N),
+    node(B, "IMPORT_BINDING"), attr(B, "file", F), attr(B, "name", N),
+    node_attr(B, "source", Src).
+
+% const/var initializer hop: `const app = express()` / `= new Hono()` /
+% `= new Router().use(...)` — chain origin's callee name (+ variants) is the
+% next name to resolve (deltas 1, 2).
+dinit(F, N, I) :- want(F, N), node(D, "CONSTANT"), attr(D, "file", F), attr(D, "name", N), edge(D, I, "ASSIGNED_FROM"), node(I, "CALL").
+dinit(F, N, I) :- want(F, N), node(D, "VARIABLE"), attr(D, "file", F), attr(D, "name", N), edge(D, I, "ASSIGNED_FROM"), node(I, "CALL").
+dorig(F, N, O) :- dinit(F, N, I), rorig(I, O).
+dorig(F, N, I) :- dinit(F, N, I), \+ rsrc(I).
+dnext(F, N, ON) :- dorig(F, N, O), attr(O, "name", ON).
+dnext(F, N, R)  :- dnext(F, N, ON), method_suffix(ON, S), concat(".", S, DS), strip_suffix(ON, DS, R).
+
+src_of(F, N, Src) :- bnd(F, N, Src).
+src_of(F, N, Src) :- dnext(F, N, N2), src_of(F, N2, Src).
+
+res(C, Src) :- try(C, F, N), src_of(F, N, Src).
+
+% Library match: exact, or subpath import "<lib>/..." (enricher :114-117).
+% Subpath matching is the segment-shrink idiom (cf. js_runtime_globals dpfx):
+% every whole-"/"-segment prefix of the source is derived, then membership-
+% joined against hr_lib — the trailing-"/" boundary the enricher's
+% startsWith(lib + "/") enforces falls out of shrinking BY segments
+% ("@foo/barzooka" never shrinks to "@foo/bar").
+spfx(C, S) :- res(C, S).
+spfx(C, P) :- spfx(C, S), last_segment(S, "/", L), concat("/", L, T), strip_suffix(S, T, P).
+mlib(C, Lib) :- spfx(C, Lib), hr_lib(Lib).
+
+% ── Routed calls: lib-matched + the callback argument EXISTS (delta 8) ──────
+routed(C, Lib, M, H) :-
+    cand(C, _, M),
+    mlib(C, Lib),
+    hr_rule(Lib, M, CbIdx),
+    edge(C, H, "PASSES_ARGUMENT"),
+    edge_attr(C, H, "PASSES_ARGUMENT", "index", CbIdx).
+rnode(C) :- routed(C, _, _, _).
+
+% ── Route path: the ROUTE_PATH-role argument's LITERAL, quotes stripped
+%    (delta 6; live shape: LITERAL name keeps raw source quoting) ────────────
+praw(C, Raw) :-
+    routed(C, Lib, M, _),
+    hr_pathidx(Lib, M, PIdx),
+    edge(C, P, "PASSES_ARGUMENT"),
+    edge_attr(C, P, "PASSES_ARGUMENT", "index", PIdx),
+    node(P, "LITERAL"),
+    attr(P, "name", Raw).
+
+sq(C) :- praw(C, Raw), starts_with(Raw, "'").
+dq(C) :- praw(C, Raw), starts_with(Raw, "\"").
+bq(C) :- praw(C, Raw), starts_with(Raw, "`").
+pth(C, P)   :- praw(C, Raw), strip_prefix(Raw, "'", T),  strip_suffix(T, "'", P).
+pth(C, P)   :- praw(C, Raw), strip_prefix(Raw, "\"", T), strip_suffix(T, "\"", P).
+pth(C, P)   :- praw(C, Raw), strip_prefix(Raw, "`", T),  strip_suffix(T, "`", P).
+pth(C, Raw) :- praw(C, Raw), \+ sq(C), \+ dq(C), \+ bq(C).
+
+named(C) :- pth(C, _).
+nname(C, P) :- pth(C, P).
+nname(C, "<unnamed-http-route>") :- rnode(C), \+ named(C).
+
+% ── The materialized ROUTES_TO edge (verb methods with a path; delta 7) ─────
+@materialize(edge_type = "ROUTES_TO", mode = "additive", meta(method, path))
+http_routes_to(C, H, V, P) :-
+    routed(C, Lib, M, H),
+    hr_verb(M, V),
+    pth(C, P).
+
+% ── The materialized http:route NODE (deltas 4, 5, 8) ───────────────────────
+@materialize_node(node_type = "http:route", mode = "exclusive", meta(library, method, anchorCall))
+http_route_js(Sid, Name, F, Lib, M, Cid) :-
+    routed(C, Lib, M, _),
+    nname(C, Name),
+    attr(C, "file", F),
+    attr(C, "id", Cid),
+    concat(F, "::http:route::", S1),
+    concat(S1, Name, S2),
+    concat(S2, "::", S3),
+    concat(S3, Cid, Sid).

--- a/packages/util/src/enrichers/libraryCallbackEnricher.ts
+++ b/packages/util/src/enrichers/libraryCallbackEnricher.ts
@@ -37,14 +37,14 @@ const LIBRARY_NODE_TYPE: Record<string, string> = {
   commander: 'cli:command',
   '@modelcontextprotocol/sdk': 'mcp:tool',
   vscode: 'vscode:command',
-  // HTTP frameworks (REG-1115). Each route registration call becomes one
-  // `http:route` FEATURE; httpRouteExtractor builds the SpecedContract.
-  express: 'http:route',
-  fastify: 'http:route',
-  koa: 'http:route',
-  'koa-router': 'http:route',
-  '@koa/router': 'http:route',
-  hono: 'http:route',
+  // HTTP frameworks (REG-1115) — express/fastify/koa/koa-router/@koa/router/
+  // hono — were retired from this map in Wave 14: their `http:route` FEATURE
+  // nodes are now minted by the default-on derive packs
+  // (rfdb-server/src/derive/stdlib/js_http_routes_nodes.dl + _edges.dl).
+  // Keeping them here would make this enricher a second default producer of
+  // the same feature with byte-different node ids (wire-sid anchor vs the
+  // pack's decimal anchorCall), duplicating EXPOSES/HANDLES and the
+  // SpecedContracts httpRouteExtractor derives from them.
 };
 
 interface Rule {

--- a/scripts/generate-effects-callable-facts.mjs
+++ b/scripts/generate-effects-callable-facts.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+// Generate the effects-db CALLABLE-REGISTRY ground facts (Wave 14, feature
+// detection as derive packs) — the structured (v2/v3) entry surface that
+// packages/util/src/enrichers/libraryCallbackEnricher.ts consumes through
+// EffectsLookup.getEntry(): per-method argument ROLES (ENTRY_POINT_CALLBACK,
+// ROUTE_PATH, COMMAND_NAME, ...), declared returns.type, and channel metadata.
+//
+// DESIGN SPLIT (the wave decision): parsing/IO lives HERE (a deterministic,
+// re-run-safe generator over effects-db YAML); DERIVATION lives in the .dl
+// packs that join these facts against the graph (js_http_routes_* first).
+// JSON-schema parsing (MCP inputSchema, vscode contributes) is OUT of scope.
+//
+// INCLUSION RULE: an entry qualifies iff it carries ≥1 role-annotated arg
+// (`args[N].role`) OR a `channel` map. Returns-only fluent-chain entries
+// (e.g. commander's dozens of `returns: Command` setters) are EXCLUDED —
+// no pack consumes bare returns yet and they would triple the facts size;
+// `ecb_returns` rows are still emitted for QUALIFYING entries.
+//
+// Output (stdout) — the facts .dl block:
+//   ecb_method(Lib, Full, Bare).      one per qualifying entry; Bare = the
+//                                     segment after the LAST '.' of the fn key
+//                                     (libraryCallbackEnricher.ts:188-190).
+//   ecb_arg(Lib, Full, Idx, Role).    one per role-annotated arg; Idx is the
+//                                     YAML index VERBATIM as a string ("0").
+//   ecb_returns(Lib, Full, Type).     returns.type of qualifying entries.
+//   ecb_channel(Lib, Full, Key, Spec). channel rows of qualifying entries.
+// Lib is the top-level YAML key VERBATIM (incl. "node:"/"python:" prefixes
+// and scoped names like "@koa/router") — prefix normalization is a CONSUMER
+// concern (EffectsLookup.getEntry probes "node:"+module first).
+//
+// DETERMINISM / COLLISION POLICY (documented, mirrors EffectsLookup.load):
+//   - files are read in SORTED name order (legacy readdirSync order is
+//     OS-defined — recorded delta, same as the runtime-globals generator);
+//   - the same library key in TWO files of one subdir: the later file (in
+//     sorted order) wins WHOLESALE — EffectsLookup.load assigns
+//     db.packages[pkg] per file, so a later file replaces the whole lib;
+//     reported on stderr;
+//   - the same library key in runtimes/ AND packages/: runtimes wins
+//     (EffectsLookup.getEntry probes runtimes first); reported on stderr.
+//
+// FAILSAFE_SCHEMA is MANDATORY (the Wave-4 YAML bool-key lesson): js-yaml's
+// default schema resolves keys/values like `True:`/`on:` to booleans while
+// the legacy loaders keep mapping-key text verbatim. Under FAILSAFE all
+// scalars stay strings — which is also exactly what .dl literals need
+// (arg indexes arrive as "0"/"1" verbatim).
+//
+// Usage: node scripts/generate-effects-callable-facts.mjs \
+//          > packages/rfdb-server/src/derive/stdlib/effects_callable_facts.dl
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const dbDir = join(root, 'effects-db');
+
+// js-yaml is not a root dependency; resolve it out of the pnpm store.
+const yaml = (() => {
+  try {
+    return require('js-yaml');
+  } catch {
+    const store = join(root, 'node_modules', '.pnpm');
+    const hit = readdirSync(store).find((d) => d.startsWith('js-yaml@'));
+    if (!hit) throw new Error('js-yaml not found (root require failed and no .pnpm entry)');
+    return require(join(store, hit, 'node_modules', 'js-yaml'));
+  }
+})();
+
+/** Parse one fn entry (FAILSAFE: every scalar is a string). Returns the
+ *  qualifying-entry record or null. */
+function parseEntry(fnKey, val, where) {
+  if (!val || typeof val !== 'object' || Array.isArray(val)) return null;
+  const args = [];
+  if (Array.isArray(val.args)) {
+    for (const a of val.args) {
+      if (!a || typeof a !== 'object' || typeof a.role !== 'string') continue;
+      const idx = a.index;
+      if (typeof idx !== 'string' || !/^[0-9]+$/.test(idx)) {
+        console.error(`FATAL: non-numeric arg index ${JSON.stringify(idx)} at ${where} :: ${fnKey}`);
+        process.exit(1);
+      }
+      args.push({ index: idx, role: a.role });
+    }
+  }
+  const channel = [];
+  if (val.channel && typeof val.channel === 'object' && !Array.isArray(val.channel)) {
+    for (const [k, v] of Object.entries(val.channel)) {
+      if (typeof v === 'string') channel.push([k, v]);
+    }
+  }
+  if (args.length === 0 && channel.length === 0) return null;
+  const returns =
+    val.returns && typeof val.returns === 'object' && typeof val.returns.type === 'string'
+      ? val.returns.type
+      : null;
+  const dot = fnKey.lastIndexOf('.');
+  const bare = dot >= 0 ? fnKey.slice(dot + 1) : fnKey;
+  return { full: fnKey, bare, args, returns, channel };
+}
+
+/** Load one subdir → Map lib → { file, entries: Map full → entry }.
+ *  Later sorted file wins WHOLESALE per lib (EffectsLookup.load parity). */
+function loadSubdir(sub, reports) {
+  const dir = join(dbDir, sub);
+  const out = new Map();
+  if (!existsSync(dir)) return out;
+  const files = readdirSync(dir).filter((f) => f.endsWith('.yaml')).sort();
+  for (const f of files) {
+    const doc = yaml.load(readFileSync(join(dir, f), 'utf8'), { schema: yaml.FAILSAFE_SCHEMA });
+    if (!doc || typeof doc !== 'object' || Array.isArray(doc)) continue;
+    for (const [lib, fns] of Object.entries(doc)) {
+      if (!fns || typeof fns !== 'object' || Array.isArray(fns)) continue;
+      const entries = new Map();
+      for (const [fnKey, fnVal] of Object.entries(fns)) {
+        const e = parseEntry(fnKey, fnVal, `${sub}/${f}`);
+        if (e) entries.set(e.full, e);
+      }
+      if (out.has(lib)) {
+        reports.push(`lib collision in ${sub}/: "${lib}" redefined by ${f} (file ${out.get(lib).file}) — later file wins wholesale`);
+      }
+      if (entries.size > 0 || out.has(lib)) out.set(lib, { file: f, entries });
+    }
+  }
+  return out;
+}
+
+const reports = [];
+const runtimes = loadSubdir('runtimes', reports);
+const packages = loadSubdir('packages', reports);
+const db = new Map(packages);
+for (const [lib, rec] of runtimes) {
+  if (db.has(lib)) reports.push(`lib "${lib}" in BOTH runtimes/ and packages/ — runtimes wins (getEntry order)`);
+  db.set(lib, rec); // runtimes win
+}
+for (const r of reports) console.error('NOTE:', r);
+
+// Datalog string literals: keep facts escape-free (quote/backslash/newline
+// would need the parser's \"-escapes; nothing in the registry uses them).
+let rows = { method: [], arg: [], returns: [], channel: [] };
+const lit = (s) => {
+  if (s.includes('"') || s.includes('\\') || s.includes('\n')) {
+    console.error(`FATAL: value needs escaping in a .dl literal: ${JSON.stringify(s)}`);
+    process.exit(1);
+  }
+  return `"${s}"`;
+};
+for (const lib of [...db.keys()].sort()) {
+  const { entries } = db.get(lib);
+  for (const full of [...entries.keys()].sort()) {
+    const e = entries.get(full);
+    rows.method.push(`ecb_method(${lit(lib)}, ${lit(full)}, ${lit(e.bare)}).`);
+    for (const a of e.args) rows.arg.push(`ecb_arg(${lit(lib)}, ${lit(full)}, ${lit(a.index)}, ${lit(a.role)}).`);
+    if (e.returns) rows.returns.push(`ecb_returns(${lit(lib)}, ${lit(full)}, ${lit(e.returns)}).`);
+    for (const [k, v] of e.channel) rows.channel.push(`ecb_channel(${lit(lib)}, ${lit(full)}, ${lit(k)}, ${lit(v)}).`);
+  }
+}
+
+const lines = [];
+lines.push('% ── GENERATED ground facts — DO NOT EDIT BY HAND ──────────────────────────');
+lines.push('% Source: effects-db/{runtimes,packages}/*.yaml — the structured-entry');
+lines.push('% callable registry (args[N].role / returns.type / channel) that');
+lines.push('% libraryCallbackEnricher consumes via EffectsLookup.getEntry.');
+lines.push('% Generator: scripts/generate-effects-callable-facts.mjs (Wave 14); re-run');
+lines.push('% it and replace this file when the registry changes.');
+lines.push(`% ${rows.method.length} entries (${rows.arg.length} arg roles, ${rows.returns.length} returns, ${rows.channel.length} channel rows).`);
+lines.push('%');
+lines.push('% ecb_method(Lib, Full, Bare): one per role-or-channel-carrying entry;');
+lines.push('%   Lib = top-level YAML key VERBATIM, Bare = fn key after the last dot.');
+lines.push('% ecb_arg(Lib, Full, Idx, Role): role-annotated argument positions.');
+lines.push('% ecb_returns(Lib, Full, Type): declared returns.type of those entries.');
+lines.push('% ecb_channel(Lib, Full, Key, Spec): channel metadata rows (e.g. url -> arg[0]).');
+for (const k of ['method', 'arg', 'returns', 'channel']) lines.push(...rows[k]);
+console.log(lines.join('\n'));
+console.error(
+  `OK: ${rows.method.length} entries, ${rows.arg.length} arg roles, ` +
+    `${rows.returns.length} returns, ${rows.channel.length} channel rows, ${reports.length} collisions`,
+);


### PR DESCRIPTION
First feature-detection vertical on the derive engine: parsing/IO → checked-in facts, derivation → packs (the axum_routes pattern). The TS enricher's HTTP slice is retired (review caught dual default producers); other domain slices stay native pending their own packs. Includes three small engine fixes found en route (parser escapes, clause scanner, method_suffix planner placement), each with tests. Full numbers and 9 numbered DELTAs in the pack headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)