### PR TITLE
fix(js-analyzer): position-disambiguate EXPORT sids so multiple export statements don't merge

### DIFF
--- a/packages/js-analyzer/src/Rules/Declarations.hs
+++ b/packages/js-analyzer/src/Rules/Declarations.hs
@@ -614,7 +614,12 @@ ruleExportNamedDeclaration :: ASTNode -> Analyzer (Maybe Text)
 ruleExportNamedDeclaration node = do
   file <- askFile
   let sp     = astNodeSpan node
-      nodeId = semanticId file "EXPORT" "named" Nothing Nothing
+      -- Disambiguate by source position: a file can hold many `export …`
+      -- statements, each a distinct ExportNamedDeclaration. Without the hash
+      -- they all collapse onto the constant sid `file->EXPORT->named` and merge
+      -- into one node (losing every statement's identity but the last).
+      hash   = contentHash [("k", "named"), ("start", T.pack (show (spanStart sp)))]
+      nodeId = semanticId file "EXPORT" "named" Nothing (Just hash)
 
   emitNode GraphNode
     { gnId = nodeId, gnType = "EXPORT", gnName = "named"
@@ -692,7 +697,10 @@ ruleExportAllDeclaration node = do
       source = case getChildrenMaybe "source" node of
                  Just srcNode -> getTextFieldOr "value" "" srcNode
                  Nothing      -> ""
-      nodeId = semanticId file "EXPORT" ("*:" <> source) Nothing Nothing
+      -- Same positional disambiguation as the named arm: the source alone does
+      -- not separate two `export * from './same'` statements in one file.
+      hash   = contentHash [("k", "*:" <> source), ("start", T.pack (show (spanStart sp)))]
+      nodeId = semanticId file "EXPORT" ("*:" <> source) Nothing (Just hash)
 
   emitNode GraphNode
     { gnId = nodeId, gnType = "EXPORT", gnName = "*:" <> source

--- a/packages/js-analyzer/test/Spec.hs
+++ b/packages/js-analyzer/test/Spec.hs
@@ -7,6 +7,7 @@ import Data.Aeson (eitherDecode)
 import qualified Data.Text
 import Data.Text (Text)
 import qualified Data.Map.Strict as Map
+import Data.List (nub)
 
 import AST.Types (ASTNode)
 import AST.Decode ()
@@ -218,6 +219,51 @@ exportTests = do
           , "]}"
           ]
     hasExport "*" ReExport fa `shouldBe` True
+
+  -- Test 8b: two `export function` statements in one file must NOT collapse into
+  -- a single EXPORT node. On HEAD both ExportNamedDeclarations mint the constant
+  -- sid `test.js->EXPORT->named` (Declarations.hs:617), so they merge in-graph —
+  -- the second statement's node identity and position are lost. Each statement
+  -- must own a distinct EXPORT node.
+  it "emits a distinct EXPORT node per named-export statement" $ do
+    let fa = analyzeAST $ BL.concat
+          [ "{\"type\":\"Program\",\"start\":0,\"end\":62,\"body\":["
+          , "{\"type\":\"ExportNamedDeclaration\",\"start\":0,\"end\":30,"
+          , "\"declaration\":{\"type\":\"FunctionDeclaration\",\"start\":7,\"end\":30,"
+          , "\"id\":{\"type\":\"Identifier\",\"start\":16,\"end\":19,\"name\":\"foo\"},"
+          , "\"params\":[],\"body\":{\"type\":\"BlockStatement\",\"start\":22,\"end\":24,\"body\":[]},"
+          , "\"async\":false,\"generator\":false},"
+          , "\"specifiers\":[]},"
+          , "{\"type\":\"ExportNamedDeclaration\",\"start\":31,\"end\":61,"
+          , "\"declaration\":{\"type\":\"FunctionDeclaration\",\"start\":38,\"end\":61,"
+          , "\"id\":{\"type\":\"Identifier\",\"start\":47,\"end\":50,\"name\":\"baz\"},"
+          , "\"params\":[],\"body\":{\"type\":\"BlockStatement\",\"start\":53,\"end\":55,\"body\":[]},"
+          , "\"async\":false,\"generator\":false},"
+          , "\"specifiers\":[]}"
+          , "]}"
+          ]
+    -- both names reach the export index (true on HEAD already — sanity)
+    hasExport "foo" NamedExport fa `shouldBe` True
+    hasExport "baz" NamedExport fa `shouldBe` True
+    -- but the two statements must be TWO distinct EXPORT nodes, not one merged id
+    let exportIds = nub (map gnId (findNodes "EXPORT" "named" fa))
+    length exportIds `shouldBe` 2
+
+  -- Test 8c: the same sid-collision class on the star arm — two
+  -- `export * from './utils'` statements (duplicate source) mint the constant
+  -- sid `test.js->EXPORT->*:./utils` (Declarations.hs:695) and merge. Each
+  -- statement must own a distinct EXPORT node.
+  it "emits a distinct EXPORT node per star re-export statement (duplicate source)" $ do
+    let fa = analyzeAST $ BL.concat
+          [ "{\"type\":\"Program\",\"start\":0,\"end\":50,\"body\":["
+          , "{\"type\":\"ExportAllDeclaration\",\"start\":0,\"end\":25,"
+          , "\"source\":{\"type\":\"Literal\",\"start\":14,\"end\":23,\"value\":\"./utils\",\"raw\":\"'./utils'\"}},"
+          , "{\"type\":\"ExportAllDeclaration\",\"start\":26,\"end\":50,"
+          , "\"source\":{\"type\":\"Literal\",\"start\":40,\"end\":49,\"value\":\"./utils\",\"raw\":\"'./utils'\"}}"
+          , "]}"
+          ]
+    let exportIds = nub (map gnId (findNodes "EXPORT" "*:./utils" fa))
+    length exportIds `shouldBe` 2
 
 
 edgeCaseTests :: Spec


### PR DESCRIPTION
Fixes the **EXPORT semantic-id collision** recorded in `_ai/gaps.md` (2026-06-10, "Two JS-analyzer producer bugs found by Wave-0 live probing", item 2) and explicitly deferred as an out-of-scope sibling in #394 / PR #396. No dedicated GH issue — surfaced by live probing, root-caused at HEAD here.

## Spec

**Invariant restored:** each `export …` statement in a file is a distinct `EXPORT` node. Node identity must not collapse across statements.

**Given** a module with two export statements — `export function foo(){}; export function baz(){}` (or two `export * from './same'`)
**When** the file is analyzed
**Then** the graph holds **two** distinct `EXPORT` nodes (distinct `gnId`), one per statement — not one merged node.

**Entities:** `EXPORT` node, its `gnId` (semantic id), `EXPORTS` edges.

## Root cause (HEAD `9ac0681`)

`ruleExportNamedDeclaration` minted a **positionally-constant** sid (`Declarations.hs:617`):

```haskell
nodeId = semanticId file "EXPORT" "named" Nothing Nothing   -- file->EXPORT->named, constant
```

So every `ExportNamedDeclaration` in a file produced the **same** id `file->EXPORT->named` and merged in-graph — every statement's identity/position but the last was lost. `ruleExportAllDeclaration` (`:695`) had the same latent collision for two `export * from './same'` (same source ⇒ same `file->EXPORT->*:./same`).

## Fix (minimal — mirrors the existing BRANCH/CASE convention)

`BRANCH`/`CASE` nodes already disambiguate co-located statements by folding the source position into the sid hash (`Statements.hs:83`: `contentHash [("k","if"),("line", show (spanStart sp))]`). I apply the identical pattern to both EXPORT arms:

```haskell
hash   = contentHash [("k", "named"), ("start", T.pack (show (spanStart sp)))]
nodeId = semanticId file "EXPORT" "named" Nothing (Just hash)
```

`spanStart` is a **char offset** (`AST/Span.hs:17`), distinct per statement, so the only residual collision is a 1/65536 FNV-1a hash collision on distinct offsets — the same risk every BRANCH/CASE node already accepts.

**Crucially, only `gnId` changes — the `name` attr stays `"named"` / `"*:source"`.** The import-resolution derive rules key `EXPORT` nodes by **type + file + name + `EXPORTS` edges**, never the sid string (`js_import_bindings.dl:128-135`, `js_module_imports.dl:126-128`), so resolution output is unchanged; the fix only restores correct node identity.

## Before / after (evidence)

Env: GHC 9.4.7 + cabal 3.8.1.0 (apt). In-process Hspec harness (`analyzeAST` inspects graph shape directly — no orchestrator/RFDB). New tests assert distinct EXPORT `gnId` count.

**Before** (new tests on HEAD — red for the right reason):
```
Exports
  emits a distinct EXPORT node per named-export statement [x]
  emits a distinct EXPORT node per star re-export statement (duplicate source) [x]
test/Spec.hs:250: expected: 2 but got: 1
test/Spec.hs:266: expected: 2 but got: 1
27 examples, 3 failures
```

**After** (`cabal test spec`):
```
Exports
  emits a distinct EXPORT node per named-export statement [v]
  emits a distinct EXPORT node per star re-export statement (duplicate source) [v]
27 examples, 1 failure
```

The single remaining failure is **pre-existing and unrelated** — `TypeScript Interfaces / creates METHOD_SIGNATURE with HAS_PROPERTY edge from interface` (fails identically on clean HEAD: baseline was `25 examples, 1 failure` at `Spec.hs:430:53`; same assertion, shifted to `:476:53` after my +46 test lines). Not touched here.

`cabal build grafema-analyzer` (the production component — `-Wall -Werror -O2`) links clean with the change.

## Adversarial review

- **A — Correctness:** single-export files unchanged (existing "detects named export function" still `[v]`). Two statements can't share `spanStart` (distinct char offsets) ⇒ no within-file collision modulo the 1/65536 FNV collision shared by all BRANCH/CASE nodes. `EXPORTS` edges use `geSource = nodeId` ⇒ internally consistent; `emitExport` keys by name/childId (not the EXPORT sid) ⇒ unaffected. Empty `source` ("") still position-disambiguated.
- **B — Fragility:** `Declarations.hs` is 866 lines — a **pre-existing** god-file (>500); splitting is out of scope (same stance as #396). Change is +6 lines, reusing already-imported `contentHash`/`spanStart` — no new imports.
- **C — Class-not-instance:** swept all EXPORT sid sites. Fixed: `named` + `*:source`. **`default`** (`:664`) can't collide — two `export default` is a JS SyntaxError (acorn won't emit two). **`EXPORT_BINDING`** (`:732`) already carries `localName`+parent. Grepped the whole repo: **no** fixture/snapshot/JS/TS/JSON encodes the old `EXPORT->named` / `EXPORT->*:` sid, so nothing downstream breaks.

## Blast radius

`gnId` of `EXPORT` nodes only. Import-resolution packs key on type+file+name+edges (verified above), so derived `IMPORTS_FROM`/`RE_EXPORTS` output is unchanged. The change only *adds* node identity (splits one merged node into N real nodes); it removes no edge or export-index entry. The orchestrator uses the prebuilt analyzer binary — this Haskell source change requires a rebuild/`cabal install` to take effect end-to-end (not done here; the in-process Hspec harness is the issue's stated acceptance).

## Verification scope (honest note)

The change is isolated to the Haskell `grafema-analyzer` package; its gate is `cabal test spec` (green, see above) + `cabal build grafema-analyzer` under `-Wall -Werror` (clean). The Node/Rust gate (`pnpm build && test && typecheck && lint`) is orthogonal — no TS/Rust file is touched and no fixture encodes the EXPORT sid.

## Follow-ups (not in this PR)

- The multi-declarator export bug (`export const a=1,b=2`) — separate, fixed by open PR #396 / #394.
- A general audit of other positionally-constant-sid node types (beyond EXPORT) for the same latent class — candidate for a future sweep.

🤖 Generated by Claude Code (autonomous bug-fix run).

---
_Generated by [Claude Code](https://claude.ai/code/session_0163JwyyLTxvEtFQrBarTdkL)_