### PR TITLE
fix(js-analyzer): index every binding of a destructuring export

### DIFF
--- a/packages/js-analyzer/src/Rules/Declarations.hs
+++ b/packages/js-analyzer/src/Rules/Declarations.hs
@@ -248,6 +248,20 @@ handleDestructuringDecl patternNode declaratorNode _parentDecl nodeType kind dk 
               , geMetadata = Map.singleton "source" (MetaText "default")
               }
         Nothing -> return ()
+      -- Destructuring under `export const { a, b } = …` / `export const [a, b] = …`:
+      -- each binding must enter the file export index so a consumer's
+      -- `import { a } from './x'` resolves. The simple-identifier export path emits
+      -- this in ruleExportNamedDeclaration via getDeclName, which returns "" for a
+      -- pattern, so destructured bindings would otherwise be absent from the export
+      -- surface despite gnExported=True. `exported'` is True only under withExported
+      -- (a top-level `export`), so non-exported destructuring is unaffected. `name`
+      -- is the LOCAL binding (non-empty — extractBindingInfo drops empties), i.e. the
+      -- importable name (`{ e: f }` exports `f`, not the key `e`).
+      if exported'
+        then emitExport ExportInfo
+               { eiName = name, eiNodeId = nodeId
+               , eiKind = NamedExport, eiSource = Nothing }
+        else return ()
       let firstId' = case firstId of
             Nothing -> Just nodeId
             _       -> firstId

--- a/packages/js-analyzer/test/Spec.hs
+++ b/packages/js-analyzer/test/Spec.hs
@@ -265,6 +265,73 @@ exportTests = do
     let exportIds = nub (map gnId (findNodes "EXPORT" "*:./utils" fa))
     length exportIds `shouldBe` 2
 
+  -- Test 8d: `export const { a, b } = obj` must put EVERY destructured binding in
+  -- the file export index, so a consumer `import { a } from './x'` resolves. On
+  -- HEAD the binding NODES are created (gnExported=True) by handleDestructuringDecl,
+  -- but no emitExport runs for them — ruleExportNamedDeclaration emits a single
+  -- entry whose name is getDeclName(pattern) = "" — so neither `a` nor `b` reaches
+  -- the export surface. (Recorded in _ai/gaps.md as the destructuring-export gap,
+  -- sibling of #394.)
+  it "exports every binding of an object destructuring export" $ do
+    let fa = analyzeAST $ BL.concat
+          [ "{\"type\":\"Program\",\"start\":0,\"end\":40,\"body\":["
+          , "{\"type\":\"ExportNamedDeclaration\",\"start\":0,\"end\":40,"
+          , "\"declaration\":{\"type\":\"VariableDeclaration\",\"start\":7,\"end\":39,\"kind\":\"const\",\"declarations\":["
+          , "{\"type\":\"VariableDeclarator\",\"start\":13,\"end\":38,"
+          , "\"id\":{\"type\":\"ObjectPattern\",\"start\":13,\"end\":19,\"properties\":["
+          , "{\"type\":\"Property\",\"start\":15,\"end\":16,\"shorthand\":true,"
+          , "\"key\":{\"type\":\"Identifier\",\"start\":15,\"end\":16,\"name\":\"a\"},"
+          , "\"value\":{\"type\":\"Identifier\",\"start\":15,\"end\":16,\"name\":\"a\"}},"
+          , "{\"type\":\"Property\",\"start\":18,\"end\":19,\"shorthand\":true,"
+          , "\"key\":{\"type\":\"Identifier\",\"start\":18,\"end\":19,\"name\":\"b\"},"
+          , "\"value\":{\"type\":\"Identifier\",\"start\":18,\"end\":19,\"name\":\"b\"}}"
+          , "]},"
+          , "\"init\":{\"type\":\"Identifier\",\"start\":22,\"end\":25,\"name\":\"obj\"}}"
+          , "]},\"specifiers\":[]}"
+          , "]}"
+          ]
+    -- both destructured bindings must reach the export index
+    hasExport "a" NamedExport fa `shouldBe` True
+    hasExport "b" NamedExport fa `shouldBe` True
+    -- sanity: the binding nodes themselves exist (true on HEAD)
+    aNode <- requireNode "CONSTANT" "a" fa
+    bNode <- requireNode "CONSTANT" "b" fa
+    gnExported aNode `shouldBe` True
+    gnExported bNode `shouldBe` True
+
+  -- Test 8e: the same invariant for array patterns and renamed object props.
+  -- `export const [c, d] = arr` exports c,d; `export const { e: f } = obj` exports
+  -- the LOCAL binding name `f` (what `import { f }` would reference), not the key `e`.
+  it "exports array and renamed destructuring export bindings" $ do
+    let fa = analyzeAST $ BL.concat
+          [ "{\"type\":\"Program\",\"start\":0,\"end\":80,\"body\":["
+          , "{\"type\":\"ExportNamedDeclaration\",\"start\":0,\"end\":40,"
+          , "\"declaration\":{\"type\":\"VariableDeclaration\",\"start\":7,\"end\":39,\"kind\":\"const\",\"declarations\":["
+          , "{\"type\":\"VariableDeclarator\",\"start\":13,\"end\":38,"
+          , "\"id\":{\"type\":\"ArrayPattern\",\"start\":13,\"end\":19,\"elements\":["
+          , "{\"type\":\"Identifier\",\"start\":14,\"end\":15,\"name\":\"c\"},"
+          , "{\"type\":\"Identifier\",\"start\":17,\"end\":18,\"name\":\"d\"}"
+          , "]},"
+          , "\"init\":{\"type\":\"Identifier\",\"start\":22,\"end\":25,\"name\":\"arr\"}}"
+          , "]},\"specifiers\":[]},"
+          , "{\"type\":\"ExportNamedDeclaration\",\"start\":41,\"end\":79,"
+          , "\"declaration\":{\"type\":\"VariableDeclaration\",\"start\":48,\"end\":78,\"kind\":\"const\",\"declarations\":["
+          , "{\"type\":\"VariableDeclarator\",\"start\":54,\"end\":77,"
+          , "\"id\":{\"type\":\"ObjectPattern\",\"start\":54,\"end\":62,\"properties\":["
+          , "{\"type\":\"Property\",\"start\":56,\"end\":60,\"shorthand\":false,"
+          , "\"key\":{\"type\":\"Identifier\",\"start\":56,\"end\":57,\"name\":\"e\"},"
+          , "\"value\":{\"type\":\"Identifier\",\"start\":59,\"end\":60,\"name\":\"f\"}}"
+          , "]},"
+          , "\"init\":{\"type\":\"Identifier\",\"start\":65,\"end\":68,\"name\":\"obj\"}}"
+          , "]},\"specifiers\":[]}"
+          , "]}"
+          ]
+    hasExport "c" NamedExport fa `shouldBe` True
+    hasExport "d" NamedExport fa `shouldBe` True
+    hasExport "f" NamedExport fa `shouldBe` True
+    -- the object KEY `e` is not a local binding and must NOT be exported
+    hasExport "e" NamedExport fa `shouldBe` False
+
 
 edgeCaseTests :: Spec
 edgeCaseTests = do


### PR DESCRIPTION
## Spec

**Invariant restored:** a top-level `export const { a, b } = obj` / `export const [a, b] = obj` puts **every** destructured binding into the file export index (`NamedExport`), so a consumer's `import { a } from './x'` resolves.

**Given** a module `export const { a, b } = obj;`
**When** the file is analyzed
**Then** the file export index contains both `a` and `b` as `NamedExport`, matching the `CONSTANT` binding nodes (which already carry `gnExported=True`).

**Entities:** export-index (`emitExport` → `FileAnalysis.faExports`), destructured `CONSTANT`/`VARIABLE` binding nodes.

This is the **destructuring-export gap** flagged as out-of-scope in #394 / PR #396 ("destructuring binding-name remains a pre-existing gap") and recorded in `_ai/gaps.md`.

## Root cause (HEAD `a4d891f`)

`handleDestructuringDecl` (`packages/js-analyzer/src/Rules/Declarations.hs:188`) creates one binding node per destructured name via `extractBindingInfo` and stamps `gnExported=isExported` — but it **never calls `emitExport`**. The export-index entry is emitted once, back in `ruleExportNamedDeclaration` (`Declarations.hs:640-643`), as `emitExport { eiName = getDeclName decl, … }` — and `getDeclName` returns `""` for a pattern (`Declarations.hs:856-866`). So destructured bindings are created as exported nodes yet are **absent from the export surface** — invisible to cross-module import resolution.

## Fix (minimal, co-located, non-overlapping)

In `handleDestructuringDecl`'s per-binding emitter (`emitBindings`), when the declaration is exported (`exported'` — set only under `withExported`, i.e. a top-level `export`), emit a `NamedExport` for each binding's **local** name (`+14` lines):

```haskell
if exported'
  then emitExport ExportInfo { eiName = name, eiNodeId = nodeId, eiKind = NamedExport, eiSource = Nothing }
  else return ()
```

`extractBindingInfo` already yields the importable local name for object shorthand (`{ a }`), array elements (`[a, b]`), renamed props (`{ e: f }` → `f`), defaults (`{ a = 1 }` → `a`) and rest (`{ ...rest }` → `rest`), dropping empties — so the index now matches the binding nodes for the full pattern grammar.

**Why this site, not `ruleExportNamedDeclaration`:** that function + `ruleVariableDeclaration` are being rewritten by in-flight **PR #396** (the multi-declarator export fix, #394). Fixing destructuring at the node-creation site keeps this PR **disjoint** from #396 — no merge conflict, and the two compose cleanly (post-#396 the simple-identifier path skips `name==""`, so no double-emit for destructuring).

## Before / after (actual `cabal test spec`, GHC 9.4.7 / cabal 3.8.1.0)

```
# BEFORE (red, for the right reason — binding nodes exist, index entries don't)
Exports
  exports every binding of an object destructuring export [x]
  exports array and renamed destructuring export bindings [x]
  test/Spec.hs:294: expected: True but got: False   -- hasExport "a" NamedExport
29 examples, 3 failures

# AFTER
Exports
  exports every binding of an object destructuring export [v]
  exports array and renamed destructuring export bindings [v]
29 examples, 1 failure
```

The single remaining failure is **pre-existing and unrelated** — `TypeScript Interfaces / METHOD_SIGNATURE … HAS_PROPERTY` (`Spec.hs:543`), which failed identically in the **red** run when I had made **zero** source changes (same case noted as pre-existing in PR #396). `cabal build grafema-analyzer` links clean under `-Wall -Werror -O2`.

## Tests

`packages/js-analyzer/test/Spec.hs` — two cases in `exportTests` asserting the export index contains every binding:
- object shorthand `export const { a, b } = obj` → exports `a`, `b`;
- array `export const [c, d] = arr` → exports `c`, `d`; renamed `export const { e: f } = obj` → exports the **local** `f` and **not** the key `e`.

The in-process Hspec harness (`analyzeAST`) inspects `FileAnalysis.faExports` directly — the analyzer's real output, no orchestrator needed.

## Adversarial review

- **A — Correctness:** empty pattern `{}` → `extractBindingInfo`=[] → no entry (no junk); non-exported `const {a}=obj` (function-local or top-level non-export) → `exported'`=False → skipped (full suite's existing destructuring tests unregressed); nested `{ a: { b } }` → exports `b`; default `{ a = 1 }` → `a`; rest `{ ...rest }` → `rest`; renamed `{ e: f }` → `f` not `e` (asserted); array holes `[, a]` → null element dropped by `getChildren`, `a` exported. `export let/var` destructuring uses the same path → also indexed.
- **B — Structural:** the export emission is co-located with the binding-node emission in `handleDestructuringDecl` (single source of truth for "what does this pattern bind") — no duplicated pattern-walking. No new imports (`emitExport`/`ExportInfo`/`NamedExport` already used in the module). `Declarations.hs` is a **pre-existing** god-file (>500 lines, flagged in #396); this `+14`-line change does not create that condition and splitting it is out of scope.
- **C — Class / siblings:** `export default` cannot destructure-declare (takes an expression) → `ruleExportDefaultDeclaration` unaffected. CommonJS `module.exports = {…}` is a different mechanism (`Rules/Statements.hs`), not this class. The per-binding **EXPORTS graph edge** for destructured bindings 2+ still lives in `ruleExportNamedDeclaration` (only `firstId` gets it today) — left as a follow-up to avoid overlapping #396; the export **index** (what import resolution consumes, per #394) is the load-bearing fix and is complete here.

## Blast radius

`handleDestructuringDecl` is reached only from `ruleVariableDeclarator` (`Declarations.hs:83-84`) for `ObjectPattern`/`ArrayPattern` ids. The change only **adds** export-index entries, and only when `exported'` is True (top-level `export`). No previously-correct output changes. Pre-`#396`, a harmless `eiName=""` entry from `ruleExportNamedDeclaration` still co-exists (pre-existing, removed when #396 lands); my entries use the real binding names, so there is no collision.

## Follow-ups (not in this PR)

- Per-binding `EXPORTS` graph edge for destructured bindings 2+ (currently only the first binding gets the edge) — owned by `ruleExportNamedDeclaration`, deferred to avoid conflict with in-flight #396.

🤖 https://claude.ai/code/session_01NUamapMGRZJoQqVUAubtr6

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUamapMGRZJoQqVUAubtr6)_