### PR TITLE
feat(derive): java resolver as 4 derive packs (spec-driven, parity-or-better)

### DIFF
--- a/packages/grafema-orchestrator/src/main.rs
+++ b/packages/grafema-orchestrator/src/main.rs
@@ -48,7 +48,13 @@ use std::path::PathBuf;
 /// js_import_bindings → js_class_inheritance → js_cross_file_calls →
 /// js_property_access_ns → js_property_access_full → js_builtins_nodes →
 /// js_builtins_edges → js_runtime_globals_nodes → js_runtime_globals_edges →
+/// java_imports → java_types → java_calls → java_annotations →
 /// depends → method_calls → shape_verifier → axum_routes.
+/// The Java packs (java-resolve migration): `java_imports` PRODUCES java
+/// IMPORTS_FROM, so it runs strictly before `depends` (which consumes EVERY
+/// IMPORTS_FROM edge node-type-agnostically via the file join);
+/// `java_calls` PRODUCES CALLS, so it runs strictly before the CALLS
+/// negators `method_calls` / `shape_verifier`.
 /// Wave 3c moved depends INTO this list, after every IMPORTS_FROM producer:
 /// with legacy import-resolution gated, the IMPORT-level edges depends
 /// consumes are produced by the packs above it (it ran separately FIRST while
@@ -94,6 +100,13 @@ const STDLIB_RULE_PACKS: &[&str] = &[
     // producer — before method_calls/shape_verifier.
     "@stdlib/js_runtime_globals_nodes",
     "@stdlib/js_runtime_globals_edges",
+    // Java packs (java-resolve migration): java_imports PRODUCES java
+    // IMPORTS_FROM — strictly before depends; java_calls PRODUCES CALLS —
+    // strictly before the negators method_calls / shape_verifier.
+    "@stdlib/java_imports",
+    "@stdlib/java_types",
+    "@stdlib/java_calls",
+    "@stdlib/java_annotations",
     // Wave 3c: depends CONSUMES IMPORTS_FROM (every edge of the shared
     // vocabulary, module- and binding-level). Legacy import-resolution /
     // rust-imports are gated (GRAFEMA_SKIP_RESOLVE_STEPS), so depends must
@@ -535,6 +548,10 @@ fn pack_owned_slice(pack: &str) -> &'static str {
         "@stdlib/js_builtins_edges" => "node-builtin IMPORTS_FROM + CALLS",
         "@stdlib/js_runtime_globals_nodes" => "js runtime-global GLOBAL_DEFINITION nodes",
         "@stdlib/js_runtime_globals_edges" => "js runtime-global CALLS",
+        "@stdlib/java_imports" => "java IMPORTS_FROM (IMPORT + IMPORT_BINDING → declaration)",
+        "@stdlib/java_types" => "java RETURNS/TYPE_OF/EXTENDS/IMPLEMENTS/THROWS_TYPE",
+        "@stdlib/java_calls" => "java INSTANTIATES + CALLS (ctor/same-class/static/super-this)",
+        "@stdlib/java_annotations" => "java ANNOTATION_RESOLVES_TO",
         "@stdlib/depends" => "MODULE→MODULE DEPENDS_ON",
         "@stdlib/method_calls" => "fuzzy method-call CALLS fallback",
         "@stdlib/shape_verifier" => "shape-violation ISSUE diagnostics",

--- a/packages/rfdb-server/src/derive/differential.rs
+++ b/packages/rfdb-server/src/derive/differential.rs
@@ -3039,3 +3039,226 @@ fn w8_cancel_overhead_pack_probe_times() {
     }
     eprintln!("=== W8 probe times: printed ===\n");
 }
+
+// ── Java packs: shadow differential against a java-corpus graph copy ───────
+
+/// Shadow differential for the four java packs (`java_imports` / `java_types`
+/// / `java_calls` / `java_annotations`) against the LEGACY `java-resolve`
+/// slices committed in a java-corpus graph (lang-spec-java.md §8 — the wave3b
+/// harness pattern). The dogfood graph has ZERO java nodes (spec §7, config
+/// gap), so this is the CHECKED-IN acceptance procedure for the corpus run.
+///
+/// SETUP (spec §8): build the corpus DB with `grafema analyze` over a java
+/// codebase with the legacy resolver ON and the java packs OFF — legacy edges
+/// then carry `_source = "java-resolution"` (the `commit_resolve_output`
+/// stamp, orchestrator main.rs:1604), which is how the legacy slice is cut
+/// (pack-written edges carry a rule-hash `_source`; analyzer-emitted CALLS
+/// carry no java-resolution stamp — the 3-way-diff concern resolves to the
+/// stamp). Copy it to the dataset path; NEVER point this at the live store.
+///
+/// Dataset: `GRAFEMA_JAVA_DIFF_DB` (default `/tmp/wave-java.rfdb`, a
+/// caller-made copy). The store is copied again into a tempdir so a
+/// concurrently-running server on the copy cannot contend.
+///
+/// PREDICTIONS, declared BEFORE the diff (spec §8, verified D1/D2/D3):
+/// - P1: the legacy IMPORT_BINDING → decl IMPORTS_FROM slice is EXACTLY 0
+///   (D1 — `resolveBinding` reads metadata `source` that never exists).
+/// - P2: legacy plain-call CALLS rows occur ONLY inside constructors (D3 —
+///   the [in:] probe matches only where method name == class name).
+/// - P3: glob IMPORTs have no IMPORTS_FROM on EITHER side (D2).
+/// If any prediction fails, the spec §2 reading is wrong — STOP, re-derive.
+///
+/// DELTA classes that absorb PACK-EXTRA rows (spec §5; witness each row with
+/// `explain_datalog_fact` before accepting): 1 dup-name set semantics,
+/// 2 all-overloads/all-ctors vs head-pick, 3 binding edges (the P1 declared
+/// superset, bounded below), 4 non-ctor same-class calls (the D3 fix),
+/// 5 local-class ctor membership. Class 6 (multi-element implements/throws
+/// SUBSET) is CLOSED by the right-peel split (verdict C1) — the pack must
+/// never MISS a legacy row, with ONE carve-out: an EXTENDS self-loop
+/// (java_types DELTA 2, `neq(C,T)`).
+///
+///   GRAFEMA_JAVA_DIFF_DB=/tmp/wave-java.rfdb \
+///   cargo test --release --lib java_packs_shadow_differential -- --ignored --nocapture
+#[test]
+#[ignore = "manual real-data shadow differential; needs a java-corpus graph copy"]
+fn java_packs_shadow_differential() {
+    use crate::derive::evaluate_with_materialize;
+
+    let dataset = std::env::var("GRAFEMA_JAVA_DIFF_DB")
+        .unwrap_or_else(|_| "/tmp/wave-java.rfdb".to_string());
+    let dataset = PathBuf::from(dataset);
+    if !dataset.join("db_config.json").exists() {
+        panic!(
+            "dataset not found at {} — build a java-corpus graph first (legacy resolver ON, \
+             packs OFF) and copy it: cp -R <corpus>/.grafema/graph.rfdb /tmp/wave-java.rfdb",
+            dataset.display()
+        );
+    }
+
+    let tmp = tempfile::tempdir().expect("temp");
+    let work = tmp.path().join("graph.rfdb");
+    copy_dir_all(&dataset, &work).expect("copy dataset");
+    let _ = std::fs::remove_file(work.join("LOCK"));
+    let manifest = ManifestStore::open(&work).expect("manifest");
+    let store = MultiShardStore::open(&work, &manifest).expect("store");
+    let store = Arc::new(store);
+    let view = LsmStorageView::capture(store.clone(), &manifest);
+
+    let snap = store.snapshot(&manifest);
+    let all_nodes = store.find_nodes_at(&snap, None, None);
+    let mut nbt: std::collections::HashMap<String, u64> = std::collections::HashMap::new();
+    for n in &all_nodes {
+        *nbt.entry(n.node_type.clone()).or_insert(0) += 1;
+    }
+    let stats = Stats {
+        total_nodes: all_nodes.len() as u64,
+        total_edges: store.iter_all_edges_at(&snap).len() as u64,
+        nodes_by_type: nbt,
+    };
+    eprintln!(
+        "\n=== java packs shadow differential (nodes={}, edges={}) ===",
+        stats.total_nodes, stats.total_edges
+    );
+
+    let pairs = |eval: &crate::derive::exec::Evaluation, pred: &str| -> BTreeSet<(u128, u128)> {
+        eval.facts(pred)
+            .iter()
+            .filter_map(|r| Some((r.first()?.as_id()?, r.get(1)?.as_id()?)))
+            .collect()
+    };
+
+    // ── The LEGACY slices: committed edges stamped by commit_resolve_output.
+    //    Every edge type except CALLS has exactly one producer step (spec §8);
+    //    CALLS partitions structurally by the source CALL node. ──
+    let legacy_src = r#"
+        leg_if_imp(I, T) :- node(I, "IMPORT"), attr(I, "file", F), ends_with(F, ".java"),
+            edge(I, T, "IMPORTS_FROM"), edge_attr(I, T, "IMPORTS_FROM", "_source", "java-resolution").
+        leg_if_bind(B, T) :- node(B, "IMPORT_BINDING"), attr(B, "file", F), ends_with(F, ".java"),
+            edge(B, T, "IMPORTS_FROM"), edge_attr(B, T, "IMPORTS_FROM", "_source", "java-resolution").
+        leg_returns(S, D) :- edge(S, D, "RETURNS"), edge_attr(S, D, "RETURNS", "_source", "java-resolution").
+        leg_type_of(S, D) :- edge(S, D, "TYPE_OF"), edge_attr(S, D, "TYPE_OF", "_source", "java-resolution").
+        leg_extends(S, D) :- edge(S, D, "EXTENDS"), edge_attr(S, D, "EXTENDS", "_source", "java-resolution").
+        leg_implements(S, D) :- edge(S, D, "IMPLEMENTS"), edge_attr(S, D, "IMPLEMENTS", "_source", "java-resolution").
+        leg_throws(S, D) :- edge(S, D, "THROWS_TYPE"), edge_attr(S, D, "THROWS_TYPE", "_source", "java-resolution").
+        leg_inst(S, D) :- edge(S, D, "INSTANTIATES"), edge_attr(S, D, "INSTANTIATES", "_source", "java-resolution").
+        leg_ann(S, D) :- edge(S, D, "ANNOTATION_RESOLVES_TO"),
+            edge_attr(S, D, "ANNOTATION_RESOLVES_TO", "_source", "java-resolution").
+
+        leg_calls(C, M) :- edge(C, M, "CALLS"), edge_attr(C, M, "CALLS", "_source", "java-resolution").
+        is_new(C) :- leg_calls(C, M), attr(C, "name", N), starts_with(N, "new ").
+        is_st(C) :- leg_calls(C, M), attr(C, "name", "super").
+        is_st(C) :- leg_calls(C, M), attr(C, "name", "this").
+        has_rv(C) :- leg_calls(C, M), node_attr(C, "receiver", R), neq(R, ""), neq(R, "this").
+        leg_calls_ctor(C, M) :- leg_calls(C, M), is_new(C).
+        leg_calls_st(C, M) :- leg_calls(C, M), is_st(C).
+        leg_calls_static(C, M) :- leg_calls(C, M), has_rv(C), \+ is_new(C), \+ is_st(C).
+        leg_calls_plain(C, M) :- leg_calls(C, M), \+ is_new(C), \+ is_st(C), \+ has_rv(C).
+
+        % P2 probe: a legacy plain-call row whose enclosing FUNCTION is NOT a
+        % constructor falsifies the D3 reading.
+        plain_encl(C, Fn) :- leg_calls_plain(C, M), edge(Fn, C, "CONTAINS"), node(Fn, "FUNCTION").
+        ctor_encl(C) :- plain_encl(C, Fn), node_attr(Fn, "kind", "constructor").
+        p2_violation(C) :- plain_encl(C, Fn), \+ ctor_encl(C).
+
+        % P3 probe: glob imports with a resolved edge, either producer.
+        glob_imp(I) :- node(I, "IMPORT"), attr(I, "file", F), ends_with(F, ".java"),
+            attr(I, "name", N), ends_with(N, ".*").
+        p3_violation(I, T) :- glob_imp(I), edge(I, T, "IMPORTS_FROM").
+    "#;
+    let legacy_eval = evaluate(&view, legacy_src, stats.clone(), EvalLimits::none(), EventLog::discard())
+        .expect("legacy slice eval");
+
+    // PREDICTIONS first (spec §8: a failed prediction = wrong premise, STOP).
+    let leg_bind = pairs(&legacy_eval, "leg_if_bind");
+    assert!(
+        leg_bind.is_empty(),
+        "P1 FALSIFIED: legacy IMPORT_BINDING IMPORTS_FROM slice has {} rows (expected \
+         EXACTLY 0 — D1 says resolveBinding is production-dead); re-derive spec §2 before \
+         trusting any other slice",
+        leg_bind.len()
+    );
+    let p2 = legacy_eval.facts("p2_violation").len();
+    assert_eq!(
+        p2, 0,
+        "P2 FALSIFIED: {p2} legacy plain-call CALLS rows outside constructor bodies — \
+         D3 reading wrong, STOP"
+    );
+    let p3 = legacy_eval.facts("p3_violation").len();
+    assert_eq!(p3, 0, "P3 FALSIFIED: {p3} glob IMPORTs carry IMPORTS_FROM edges");
+
+    // ── The PACKS, evaluated read-only over the same pinned view. ──
+    let run = |name: &str| -> crate::derive::exec::Evaluation {
+        let src = crate::derive::stdlib::stdlib_pack(name).expect("registered pack");
+        let (eval, _s, _n) =
+            evaluate_with_materialize(&view, src, stats.clone(), EvalLimits::none(), EventLog::discard())
+                .unwrap_or_else(|e| panic!("{name} evaluates on the real graph: {e}"));
+        eval
+    };
+    let ev_imp = run("java_imports");
+    let ev_typ = run("java_types");
+    let ev_cal = run("java_calls");
+    let ev_ann = run("java_annotations");
+
+    // Non-vacuity floors: the packs genuinely saw a JAVA graph (a corpus copy
+    // with zero java nodes would pass every 0 ≡ 0 slice on a broken pack).
+    let count = |eval: &crate::derive::exec::Evaluation, pred: &str| eval.facts(pred).len();
+    eprintln!(
+        "intermediates: jdecl={} qual_class={} jimport={} jbinding={} jcall={} jattr={} jann={}",
+        count(&ev_imp, "jdecl"), count(&ev_imp, "qual_class"), count(&ev_imp, "jimport"),
+        count(&ev_imp, "jbinding"), count(&ev_cal, "jcall"), count(&ev_ann, "jattr"),
+        count(&ev_ann, "jann"),
+    );
+    assert!(count(&ev_imp, "jdecl") > 0, "non-vacuity: java declarations present");
+    assert!(count(&ev_imp, "jimport") > 0, "non-vacuity: java imports present");
+    assert!(count(&ev_cal, "jcall") > 0, "non-vacuity: java calls present");
+
+    // ── Per-slice diff: NO pack-missing rows (class 6 is closed); pack-extra
+    //    rows are reported for witnessing against delta classes 1-5. ──
+    let mut pack_calls_st = pairs(&ev_cal, "this_ctor_calls");
+    pack_calls_st.extend(pairs(&ev_cal, "super_ctor_calls"));
+    let slices: Vec<(&str, BTreeSet<(u128, u128)>, BTreeSet<(u128, u128)>, bool)> = vec![
+        // (slice, legacy, pack, self-loop-misses-allowed)
+        ("IMPORTS_FROM/import", pairs(&legacy_eval, "leg_if_imp"), pairs(&ev_imp, "import_target"), false),
+        ("IMPORTS_FROM/binding", leg_bind, pairs(&ev_imp, "binding_target"), false),
+        ("RETURNS", pairs(&legacy_eval, "leg_returns"), pairs(&ev_typ, "returns"), false),
+        ("TYPE_OF", pairs(&legacy_eval, "leg_type_of"), pairs(&ev_typ, "type_of"), false),
+        ("EXTENDS", pairs(&legacy_eval, "leg_extends"), pairs(&ev_typ, "extends"), true),
+        ("IMPLEMENTS", pairs(&legacy_eval, "leg_implements"), pairs(&ev_typ, "implements"), false),
+        ("THROWS_TYPE", pairs(&legacy_eval, "leg_throws"), pairs(&ev_typ, "throws_type"), false),
+        ("INSTANTIATES", pairs(&legacy_eval, "leg_inst"), pairs(&ev_cal, "instantiates"), false),
+        ("CALLS/ctor", pairs(&legacy_eval, "leg_calls_ctor"), pairs(&ev_cal, "ctor_calls"), false),
+        ("CALLS/plain", pairs(&legacy_eval, "leg_calls_plain"), pairs(&ev_cal, "same_class_calls"), false),
+        ("CALLS/static", pairs(&legacy_eval, "leg_calls_static"), pairs(&ev_cal, "static_calls"), false),
+        ("CALLS/super-this", pairs(&legacy_eval, "leg_calls_st"), pack_calls_st, false),
+        ("ANNOTATION_RESOLVES_TO", pairs(&legacy_eval, "leg_ann"), pairs(&ev_ann, "ann_resolves"), false),
+    ];
+    let mut bad_misses = 0usize;
+    for (name, legacy, pack, self_loop_ok) in &slices {
+        let missing: Vec<_> = legacy.difference(pack).collect();
+        let extra: Vec<_> = pack.difference(legacy).collect();
+        eprintln!(
+            "{name}: legacy={} pack={} missing={} extra={}",
+            legacy.len(), pack.len(), missing.len(), extra.len()
+        );
+        for (s, d) in missing.iter().take(20) {
+            let carved = *self_loop_ok && s == d;
+            if !carved {
+                bad_misses += 1;
+            }
+            eprintln!(
+                "  MISSING ({s}, {d}){} — pack must not lose a legacy row; witness via \
+                 the legacy stderr counters",
+                if carved { " [EXTENDS self-loop carve-out]" } else { "" }
+            );
+        }
+        for (s, d) in extra.iter().take(20) {
+            eprintln!("  EXTRA ({s}, {d}) — classify against delta classes 1-5 (explain_datalog_fact)");
+        }
+    }
+    assert_eq!(
+        bad_misses, 0,
+        "pack-missing rows outside the EXTENDS self-loop carve-out — class 6 is closed \
+         (verdict C1), so any miss is a pack bug"
+    );
+    eprintln!("=== java packs shadow differential: slices printed; witness extras before accepting ===\n");
+}

--- a/packages/rfdb-server/src/derive/stdlib.rs
+++ b/packages/rfdb-server/src/derive/stdlib.rs
@@ -300,6 +300,40 @@ pub const JS_RUNTIME_GLOBALS_EDGES_DL: &str = concat!(
 /// (the rank ladder) ⇒ scratch-only under maintain.
 pub const JS_MODULE_IMPORTS_DL: &str = include_str!("stdlib/js_module_imports.dl");
 
+// ── Java packs (the java-resolve migration, lang-spec-java.md) ─────────────
+
+/// Java import resolution — replaces `ImportResolution.hs` of `java-resolve`:
+/// IMPORT → declaration `IMPORTS_FROM` (qualified-name kernel) plus the
+/// IMPORT_BINDING arm via the graph-native IMPORT-CONTAINS-binding edge (a
+/// DECLARED SUPERSET: the legacy metadata-`source` path was production-dead,
+/// spec §2 D1). PRODUCER of java `IMPORTS_FROM` — must precede `depends`
+/// (verdict C3: depends consumes EVERY IMPORTS_FROM edge node-type-
+/// agnostically). node_attr + negation ⇒ scratch-only under maintain.
+pub const JAVA_IMPORTS_DL: &str = include_str!("stdlib/java_imports.dl");
+
+/// Java type-position resolution — replaces `TypeResolution.hs`: RETURNS /
+/// TYPE_OF / EXTENDS / IMPLEMENTS / THROWS_TYPE against the simple-name class
+/// kernel. Multi-element `implements`/`throws` are comma-split via the
+/// right-peel recursion (verdict C1 — full parity, delta class 6 closed);
+/// EXTENDS keeps the legacy no-split miss exactly. node_attr + negation ⇒
+/// scratch-only under maintain.
+pub const JAVA_TYPES_DL: &str = include_str!("stdlib/java_types.dl");
+
+/// Java call resolution — replaces `CallResolution.hs`: INSTANTIATES + ctor
+/// CALLS, same-class no-receiver CALLS (a DECLARED SUPERSET — the legacy sid
+/// probe fired only inside constructors, spec §2 D3), static-style CALLS and
+/// super()/this() delegation, all on graph-native HAS_METHOD/CONTAINS
+/// membership instead of sid parses. PRODUCER of `CALLS` — must precede the
+/// CALLS negators `method_calls`/`shape_verifier` (verdict C3). node_attr +
+/// negation ⇒ scratch-only under maintain.
+pub const JAVA_CALLS_DL: &str = include_str!("stdlib/java_calls.dl");
+
+/// Java annotation resolution — replaces `AnnotationResolution.hs`:
+/// ANNOTATION_RESOLVES_TO from ATTRIBUTE usages to same-named
+/// ANNOTATION_TYPE declarations, .java-gated on BOTH legs (kotlin emits both
+/// node types). No node_attr, no negation — maintain-eligible.
+pub const JAVA_ANNOTATIONS_DL: &str = include_str!("stdlib/java_annotations.dl");
+
 /// The named stdlib rule packs, addressable on the wire as `"@stdlib/<name>"`
 /// (`MaterializeDatalog` and the other empty-source-defaulting dispatchers), listed
 /// in CANONICAL RUN ORDER. The order is a CONTRACT, not cosmetics — producers run
@@ -342,12 +376,21 @@ pub const JS_MODULE_IMPORTS_DL: &str = include_str!("stdlib/js_module_imports.dl
 ///   IMPORT→MODULE `IMPORTS_FROM` seam and `RE_EXPORTS` (the star seam) that
 ///   `js_import_bindings` (`b_mod`/`resolved_at`/`star_src`) and the Wave-1b
 ///   hybrid packs read as committed EDB, so it runs strictly before them.
+/// - the Java packs (the java-resolve migration, canonical intra-family
+///   order java_imports → java_types → java_calls → java_annotations):
+///   `java_imports` PRODUCES java `IMPORTS_FROM`, so it precedes `depends`
+///   (verdict C3 — depends consumes EVERY IMPORTS_FROM edge node-type-
+///   agnostically via the file join); `java_calls` PRODUCES `CALLS`, so it
+///   precedes the CALLS negators `method_calls`/`shape_verifier`
+///   (shape_verifier negates `edge(C,_,"CALLS")` with NO file gate). The
+///   packs have no inter-pack EDB seams among themselves.
 /// - `depends` (Wave 3c position) CONSUMES IMPORTS_FROM — every edge of the
 ///   shared vocabulary, module- and binding-level — so with legacy
 ///   import-resolution GATED (GRAFEMA_SKIP_RESOLVE_STEPS) it runs after ALL
 ///   in-engine IMPORTS_FROM producers: `rust_imports`, `js_module_imports`,
-///   `js_import_bindings`, `js_builtins_edges`. (It ran first while the
-///   legacy resolver pre-committed those edges at analysis time.)
+///   `js_import_bindings`, `js_builtins_edges`, `java_imports`. (It ran
+///   first while the legacy resolver pre-committed those edges at analysis
+///   time.)
 /// An orchestrator running the packs sequentially must preserve this order:
 /// js_local_refs → js_same_file_calls → js_this_method_calls →
 /// rust_calls → rust_cross_methods_ctor → rust_trait_resolve →
@@ -355,7 +398,8 @@ pub const JS_MODULE_IMPORTS_DL: &str = include_str!("stdlib/js_module_imports.dl
 /// js_import_bindings → js_class_inheritance →
 /// js_cross_file_calls → js_property_access_ns → js_property_access_full →
 /// js_builtins_nodes → js_builtins_edges → js_runtime_globals_nodes →
-/// js_runtime_globals_edges → depends → method_calls → shape_verifier →
+/// js_runtime_globals_edges → java_imports → java_types → java_calls →
+/// java_annotations → depends → method_calls → shape_verifier →
 /// axum_routes.
 pub const STDLIB_PACKS: &[(&str, &str)] = &[
     ("js_local_refs", JS_LOCAL_REFS_DL),
@@ -400,6 +444,14 @@ pub const STDLIB_PACKS: &[(&str, &str)] = &[
     // (shape_verifier).
     ("js_runtime_globals_nodes", JS_RUNTIME_GLOBALS_NODES_DL),
     ("js_runtime_globals_edges", JS_RUNTIME_GLOBALS_EDGES_DL),
+    // Java packs (java-resolve migration): java_imports PRODUCES java
+    // IMPORTS_FROM — strictly before depends (verdict C3); java_calls
+    // PRODUCES CALLS — strictly before the negators method_calls /
+    // shape_verifier. No inter-pack seams among the four.
+    ("java_imports", JAVA_IMPORTS_DL),
+    ("java_types", JAVA_TYPES_DL),
+    ("java_calls", JAVA_CALLS_DL),
+    ("java_annotations", JAVA_ANNOTATIONS_DL),
     // Wave 3c: depends CONSUMES IMPORTS_FROM (every edge, module- and
     // binding-level) — with legacy import-resolution gated it must run after
     // ALL in-engine IMPORTS_FROM producers (rust_imports, js_module_imports,
@@ -1268,6 +1320,10 @@ mod tests {
                 "js_builtins_edges",
                 "js_runtime_globals_nodes",
                 "js_runtime_globals_edges",
+                "java_imports",
+                "java_types",
+                "java_calls",
+                "java_annotations",
                 "depends",
                 "method_calls",
                 "shape_verifier",
@@ -1284,6 +1340,8 @@ mod tests {
              packs (js_import_bindings PRODUCES the IMPORTS_FROM seam, so it \
              precedes js_class_inheritance and the js hybrid consumers; \
              js_class_inheritance produces EXTENDS for shape_verifier) → \
+             java packs (java_imports PRODUCES java IMPORTS_FROM — before \
+             depends; java_calls PRODUCES CALLS — before the negators) → \
              depends (Wave 3c: AFTER every IMPORTS_FROM producer — legacy \
              import-resolution is gated, so the in-engine producers feed it) → \
              method_calls → shape_verifier → axum_routes (producers strictly \
@@ -4292,6 +4350,16 @@ mod tests {
             // Wave 3c: orchestrator-committed workspace facts (one per
             // discovered package + alias virtual packages; dogfood ~30).
             ("WORKSPACE_PACKAGE", 30),
+            // Java packs: the dogfood graph has ZERO java nodes (config gap,
+            // lang-spec-java.md §7), so an unknown type would estimate 0 and
+            // make the gate VACUOUS for the java-only vocabulary. Model a
+            // mid-size java corpus folded into this graph (the shared types —
+            // CALL/FUNCTION/VARIABLE/CLASS/IMPORT/… — already carry
+            // dogfood-scale counts above, which is the harsher test).
+            ("ENUM", 200),
+            ("RECORD", 100),
+            ("ANNOTATION_TYPE", 80),
+            ("ATTRIBUTE", 15_000),
         ] {
             nodes_by_type.insert(ty.to_string(), n);
         }
@@ -4319,6 +4387,530 @@ mod tests {
             "packs must plan under dogfood-scale stats (E-PLAN-003 is a \
              production rejection, not a perf hint):\n{}",
             failed.join("\n")
+        );
+    }
+
+    // ── Java packs (java-resolve migration, lang-spec-java.md) ─────────────
+
+    /// VERDICT C2 pin (lang-spec-java.md): a NEGATED BUILTIN literal is a
+    /// legal per-row anti-join — the executor's negated path keeps the exact
+    /// per-row fallback for non-special-cased shapes (exec.rs), and the
+    /// stratifier creates NO dependency edge for base/builtin literals
+    /// (stratify.rs "base relation or builtin — no dependency edge"), so
+    /// `\+ string_contains(...)` is stratification-free. No stdlib pack used
+    /// the form before the java packs; this fixture pins the semantics
+    /// java_types.dl's normalizeType filters rely on, BEFORE relying on it
+    /// (the verdict's explicit precondition).
+    #[test]
+    fn negated_builtin_literal_is_a_per_row_anti_join() {
+        let mut v = FixtureStorageView::new(1);
+        named_node(&mut v, "c_plain", "Alpha", "CLASS", "a.java");
+        named_node(&mut v, "c_comma", "Alpha,Beta", "CLASS", "b.java");
+
+        let eval = evaluate(
+            &v,
+            r#"cand(X, N) :- node(X, "CLASS"), attr(X, "name", N).
+               kept(X) :- cand(X, N), \+ string_contains(N, ",")."#,
+            Stats::default(),
+            EvalLimits::none(),
+            EventLog::discard(),
+        )
+        .expect("negated-builtin program evaluates");
+
+        let kept: BTreeSet<u128> = eval
+            .facts("kept")
+            .iter()
+            .filter_map(|r| r[0].as_id())
+            .collect();
+        assert_eq!(
+            kept,
+            BTreeSet::from([id_of("c_plain")]),
+            "\\+ string_contains must drop exactly the comma-bearing row"
+        );
+    }
+
+    /// Shared collector: the (src, dst) id pairs of one derived predicate.
+    fn id_pairs(eval: &crate::derive::exec::Evaluation, pred: &str) -> BTreeSet<(u128, u128)> {
+        eval.facts(pred)
+            .iter()
+            .filter_map(|r| Some((r.first()?.as_id()?, r.get(1)?.as_id()?)))
+            .collect()
+    }
+
+    /// java_imports.dl — every arm of the S1/S2/S3 surface on one fixture:
+    /// - S2 happy path: IMPORT "com.lib.Foo" → the packaged CLASS Foo;
+    /// - DELTA 1 pin (spec §5 class 1): a SECOND "com.lib.Foo" declaration —
+    ///   set semantics derives an edge per candidate (legacy Map kept one);
+    /// - DELTA 2 pin (spec §5 class 3, the D1 fix): the IMPORT_BINDING — with
+    ///   NO `source` metadata, exactly as the analyzer stamps it — resolves
+    ///   via the parent-IMPORT CONTAINS edge; legacy production derived ZERO
+    ///   here (resolveBinding read a key that never exists);
+    /// - default-package arm: a declaration in a package-less file is keyed
+    ///   by its BARE name;
+    /// - P3 parity pin: a glob IMPORT ("com.lib.*") derives nothing;
+    /// - static-member parity pin: "com.lib.Foo.bar" derives nothing;
+    /// - dead-arm zero: a binding whose parent IMPORT resolves nothing
+    ///   derives nothing;
+    /// - .java gate: a same-qualified kotlin declaration never matches.
+    #[test]
+    fn java_imports_pack_resolves_imports_and_bindings() {
+        let mut v = FixtureStorageView::new(1);
+        // Declaration side: com.lib.Foo (packaged), twice (DELTA 1).
+        named_node(&mut v, "m_lib", "lib", "MODULE", "com/lib/Foo.java");
+        v.put_node_metadata(id_of("m_lib"), r#"{"package":"com.lib"}"#);
+        named_node(&mut v, "c_foo", "Foo", "CLASS", "com/lib/Foo.java");
+        named_node(&mut v, "m_lib2", "lib2", "MODULE", "com/lib2/Foo.java");
+        v.put_node_metadata(id_of("m_lib2"), r#"{"package":"com.lib"}"#);
+        named_node(&mut v, "c_foo2", "Foo", "CLASS", "com/lib2/Foo.java");
+        // .java gate: kotlin twin of the same qualified name.
+        named_node(&mut v, "m_kt", "ktlib", "MODULE", "com/lib/Foo.kt");
+        v.put_node_metadata(id_of("m_kt"), r#"{"package":"com.lib"}"#);
+        named_node(&mut v, "c_kt", "Foo", "CLASS", "com/lib/Foo.kt");
+        // Default-package declaration (MODULE has NO package key —
+        // Walker.hs:37-51 omits it entirely).
+        named_node(&mut v, "m_def", "def", "MODULE", "Def.java");
+        named_node(&mut v, "c_bare", "Bare", "CLASS", "Def.java");
+
+        // Importing side.
+        named_node(&mut v, "i1", "com.lib.Foo", "IMPORT", "app/App.java");
+        named_node(&mut v, "b1", "Foo", "IMPORT_BINDING", "app/App.java");
+        v.put_node_metadata(
+            id_of("b1"),
+            r#"{"imported_name":"Foo","local_name":"Foo","static":false}"#,
+        );
+        edge(&mut v, "i1", "b1", "CONTAINS");
+        named_node(&mut v, "i2", "com.lib.*", "IMPORT", "app/App.java");
+        named_node(&mut v, "i3", "com.lib.Foo.bar", "IMPORT", "app/App.java");
+        named_node(&mut v, "i4", "Bare", "IMPORT", "app/App.java");
+        named_node(&mut v, "i5", "com.none.Nope", "IMPORT", "app/App.java");
+        named_node(&mut v, "b5", "Nope", "IMPORT_BINDING", "app/App.java");
+        edge(&mut v, "i5", "b5", "CONTAINS");
+
+        let (eval, specs, _node_specs) = evaluate_with_materialize(
+            &v,
+            JAVA_IMPORTS_DL,
+            Stats::default(),
+            EvalLimits::none(),
+            EventLog::discard(),
+        )
+        .expect("java_imports.dl evaluates");
+
+        assert_eq!(
+            id_pairs(&eval, "import_target"),
+            BTreeSet::from([
+                (id_of("i1"), id_of("c_foo")),
+                (id_of("i1"), id_of("c_foo2")),
+                (id_of("i4"), id_of("c_bare")),
+            ]),
+            "S2: qualified + default-package imports resolve; glob/static/unknown derive nothing"
+        );
+        assert_eq!(
+            id_pairs(&eval, "binding_target"),
+            BTreeSet::from([
+                (id_of("b1"), id_of("c_foo")),
+                (id_of("b1"), id_of("c_foo2")),
+            ]),
+            "S3 (DELTA 2): bindings resolve via the parent IMPORT, source-metadata-free; \
+             the unresolvable-parent binding derives nothing"
+        );
+        assert!(
+            specs
+                .iter()
+                .all(|s| s.edge_type == "IMPORTS_FROM" && s.additive && s.meta.is_empty()),
+            "both heads are additive empty-meta IMPORTS_FROM; got {:?}",
+            specs.iter().map(|s| (&s.predicate, &s.edge_type)).collect::<Vec<_>>()
+        );
+        assert_eq!(specs.len(), 2, "exactly the S2 + S3 heads materialize");
+    }
+
+    /// java_types.dl — every arm of S5-S9 on one fixture:
+    /// - RETURNS: plain name resolves; "Alpha[]" strips; "int" (primitive),
+    ///   "?" (wildcard) and "<unknown>" (C4 dead-letter vocabulary) derive
+    ///   nothing; the .kt twin is gated out;
+    /// - TYPE_OF: interface type resolves; "boolean[]" strips to a primitive
+    ///   and derives nothing;
+    /// - EXTENDS: single name resolves; the interface multi-extends
+    ///   "Alpha,Beta" derives NOTHING (the legacy no-split miss, reproduced
+    ///   exactly — spec §3 S7); the dup-named self-extend derives only the
+    ///   OTHER candidate (DELTA 2's neq(C,T));
+    /// - IMPLEMENTS (VERDICT C1, delta class 6 CLOSED): single element,
+    ///   3-element right-peel split (recursion depth 2), ENUM arm; the
+    ///   RECORD's implements is NOT read (legacy reads CLASS+ENUM only,
+    ///   TypeResolution.hs:163 — parity dead-arm zero);
+    /// - THROWS_TYPE (C1): single + 2-element split.
+    #[test]
+    fn java_types_pack_resolves_type_positions_with_split() {
+        let mut v = FixtureStorageView::new(1);
+        named_node(&mut v, "c_a", "Alpha", "CLASS", "a.java");
+        named_node(&mut v, "i_b", "Beta", "INTERFACE", "b.java");
+        named_node(&mut v, "i_g", "Gamma", "INTERFACE", "g.java");
+        named_node(&mut v, "i_z", "Zeta", "INTERFACE", "z.java");
+        named_node(&mut v, "c_io", "IOExc", "CLASS", "io.java");
+        named_node(&mut v, "c_sql", "SqlExc", "CLASS", "sql.java");
+
+        // S5 RETURNS.
+        named_node(&mut v, "f1", "mk", "FUNCTION", "m.java");
+        v.put_node_metadata(id_of("f1"), r#"{"kind":"method","return_type":"Alpha"}"#);
+        named_node(&mut v, "f2", "count", "FUNCTION", "m.java");
+        v.put_node_metadata(id_of("f2"), r#"{"kind":"method","return_type":"int"}"#);
+        named_node(&mut v, "f3", "arr", "FUNCTION", "m.java");
+        v.put_node_metadata(id_of("f3"), r#"{"kind":"method","return_type":"Alpha[]"}"#);
+        named_node(&mut v, "f4", "wild", "FUNCTION", "m.java");
+        v.put_node_metadata(id_of("f4"), r#"{"kind":"method","return_type":"?"}"#);
+        named_node(&mut v, "f5", "unk", "FUNCTION", "m.java");
+        v.put_node_metadata(id_of("f5"), r#"{"kind":"method","return_type":"<unknown>"}"#);
+        named_node(&mut v, "f_kt", "mk", "FUNCTION", "m.kt");
+        v.put_node_metadata(id_of("f_kt"), r#"{"kind":"method","return_type":"Alpha"}"#);
+
+        // S6 TYPE_OF.
+        named_node(&mut v, "v1", "b", "VARIABLE", "m.java");
+        v.put_node_metadata(id_of("v1"), r#"{"kind":"field","type":"Beta"}"#);
+        named_node(&mut v, "v2", "flags", "VARIABLE", "m.java");
+        v.put_node_metadata(id_of("v2"), r#"{"kind":"field","type":"boolean[]"}"#);
+
+        // S7 EXTENDS.
+        named_node(&mut v, "c_sub", "Sub", "CLASS", "sub.java");
+        v.put_node_metadata(id_of("c_sub"), r#"{"extends":"Alpha"}"#);
+        named_node(&mut v, "i_multi", "Both", "INTERFACE", "im.java");
+        v.put_node_metadata(id_of("i_multi"), r#"{"extends":"Alpha,Beta"}"#);
+        named_node(&mut v, "c_x", "X", "CLASS", "x.java");
+        v.put_node_metadata(id_of("c_x"), r#"{"extends":"X"}"#);
+        named_node(&mut v, "c_x2", "X", "CLASS", "x2.java");
+
+        // S8 IMPLEMENTS.
+        named_node(&mut v, "c_one", "One", "CLASS", "one.java");
+        v.put_node_metadata(id_of("c_one"), r#"{"implements":"Beta"}"#);
+        named_node(&mut v, "c_multi", "Multi", "CLASS", "multi.java");
+        v.put_node_metadata(id_of("c_multi"), r#"{"implements":"Beta,Gamma,Zeta"}"#);
+        named_node(&mut v, "e_en", "En", "ENUM", "en.java");
+        v.put_node_metadata(id_of("e_en"), r#"{"implements":"Beta"}"#);
+        named_node(&mut v, "r_rec", "Rec", "RECORD", "rec.java");
+        v.put_node_metadata(id_of("r_rec"), r#"{"implements":"Beta"}"#);
+
+        // S9 THROWS_TYPE.
+        named_node(&mut v, "f7", "one", "FUNCTION", "t.java");
+        v.put_node_metadata(id_of("f7"), r#"{"kind":"method","throws":"IOExc"}"#);
+        named_node(&mut v, "f8", "two", "FUNCTION", "t.java");
+        v.put_node_metadata(id_of("f8"), r#"{"kind":"method","throws":"IOExc,SqlExc"}"#);
+
+        let (eval, specs, _node_specs) = evaluate_with_materialize(
+            &v,
+            JAVA_TYPES_DL,
+            Stats::default(),
+            EvalLimits::none(),
+            EventLog::discard(),
+        )
+        .expect("java_types.dl evaluates");
+
+        assert_eq!(
+            id_pairs(&eval, "returns"),
+            BTreeSet::from([(id_of("f1"), id_of("c_a")), (id_of("f3"), id_of("c_a"))]),
+            "RETURNS: plain + []-stripped resolve; primitive/wildcard/<unknown>/.kt derive nothing"
+        );
+        assert_eq!(
+            id_pairs(&eval, "type_of"),
+            BTreeSet::from([(id_of("v1"), id_of("i_b"))]),
+            "TYPE_OF: interface type resolves; boolean[] strips to a primitive and is rejected"
+        );
+        assert_eq!(
+            id_pairs(&eval, "extends"),
+            BTreeSet::from([(id_of("c_sub"), id_of("c_a")), (id_of("c_x"), id_of("c_x2"))]),
+            "EXTENDS: single name resolves; comma-joined multi-extends misses (legacy parity); \
+             neq(C,T) keeps the dup-name self-loop out (DELTA 2)"
+        );
+        assert_eq!(
+            id_pairs(&eval, "implements"),
+            BTreeSet::from([
+                (id_of("c_one"), id_of("i_b")),
+                (id_of("c_multi"), id_of("i_b")),
+                (id_of("c_multi"), id_of("i_g")),
+                (id_of("c_multi"), id_of("i_z")),
+                (id_of("e_en"), id_of("i_b")),
+            ]),
+            "IMPLEMENTS: C1 right-peel splits all 3 elements; ENUM arm works; \
+             RECORD implements is not read (legacy parity dead-arm)"
+        );
+        assert_eq!(
+            id_pairs(&eval, "throws_type"),
+            BTreeSet::from([
+                (id_of("f7"), id_of("c_io")),
+                (id_of("f8"), id_of("c_io")),
+                (id_of("f8"), id_of("c_sql")),
+            ]),
+            "THROWS_TYPE: C1 right-peel splits the 2-element throws clause"
+        );
+        let expect: std::collections::BTreeMap<&str, &str> = [
+            ("returns", "RETURNS"),
+            ("type_of", "TYPE_OF"),
+            ("extends", "EXTENDS"),
+            ("implements", "IMPLEMENTS"),
+            ("throws_type", "THROWS_TYPE"),
+        ]
+        .into_iter()
+        .collect();
+        let got: std::collections::BTreeMap<&str, &str> = specs
+            .iter()
+            .map(|s| (s.predicate.as_str(), s.edge_type.as_str()))
+            .collect();
+        assert_eq!(got, expect, "all 5 type heads materialize");
+        assert!(
+            specs.iter().all(|s| s.additive && s.meta.is_empty()),
+            "every head additive with empty meta (legacy metadata was empty)"
+        );
+    }
+
+    /// java_calls.dl — every arm of S10-S13 on one fixture:
+    /// - S10: "new Service" → INSTANTIATES + CALLS to BOTH ctors (DELTA 2,
+    ///   all-ctors vs legacy head-pick); a RECORD's compact constructor is
+    ///   reached through the CONTAINS arm (it has NO HAS_METHOD —
+    ///   Declarations.hs:534-539); "new Missing" derives nothing;
+    /// - S11 (DELTA 3, the D3 fix): a receiverless call inside an ORDINARY
+    ///   method body resolves to the same-class method — the declared
+    ///   superset (legacy fired only where [in:] == class name); receiver
+    ///   "this" counts as plain; lambdas are CLOSURE nodes (Expressions.hs:
+    ///   352-355, :399-404 — NOT FUNCTION), and the jbody/fn_owner recursion
+    ///   lifts a CLOSURE-nested call, a CLOSURE-in-CLOSURE-nested call, and
+    ///   the ctor-expression-lambda LEGACY-PARITY arm (LambdaExpr pushes no
+    ///   withEnclosingFn, Expressions.hs:343-386, so legacy resolves via the
+    ///   leaked [in:ctorName] — the pack must not lose that row); a
+    ///   foreign-receiver call, a field-initializer call, and a call in a
+    ///   field-initializer LAMBDA (the CLOSURE's CONTAINS parent is the
+    ///   CLASS — fn_owner chain stops) derive nothing;
+    /// - S12: a class-named receiver resolves to that class's method; the
+    ///   non-class receiver derives nothing (Hs test :243-249 parity);
+    /// - S13: this() → all same-class ctors; super() → the superclass ctor
+    ///   via the extends metadata;
+    /// - .java gate: a kotlin "new Service" call derives nothing.
+    #[test]
+    fn java_calls_pack_resolves_call_families() {
+        let mut v = FixtureStorageView::new(1);
+        // class Service extends Base, with 2 ctors + 2 methods.
+        named_node(&mut v, "c_svc", "Service", "CLASS", "svc.java");
+        v.put_node_metadata(id_of("c_svc"), r#"{"extends":"Base"}"#);
+        named_node(&mut v, "m_ctor", "Service", "FUNCTION", "svc.java");
+        v.put_node_metadata(id_of("m_ctor"), r#"{"kind":"constructor"}"#);
+        edge(&mut v, "c_svc", "m_ctor", "HAS_METHOD");
+        named_node(&mut v, "m_ctor2", "Service", "FUNCTION", "svc.java");
+        v.put_node_metadata(id_of("m_ctor2"), r#"{"kind":"constructor"}"#);
+        edge(&mut v, "c_svc", "m_ctor2", "HAS_METHOD");
+        named_node(&mut v, "m_helper", "helper", "FUNCTION", "svc.java");
+        v.put_node_metadata(id_of("m_helper"), r#"{"kind":"method"}"#);
+        edge(&mut v, "c_svc", "m_helper", "HAS_METHOD");
+        named_node(&mut v, "m_run", "run", "FUNCTION", "svc.java");
+        v.put_node_metadata(id_of("m_run"), r#"{"kind":"method"}"#);
+        edge(&mut v, "c_svc", "m_run", "HAS_METHOD");
+        // class Base (the super() target).
+        named_node(&mut v, "c_base", "Base", "CLASS", "base.java");
+        named_node(&mut v, "m_bctor", "Base", "FUNCTION", "base.java");
+        v.put_node_metadata(id_of("m_bctor"), r#"{"kind":"constructor"}"#);
+        edge(&mut v, "c_base", "m_bctor", "HAS_METHOD");
+        // class Util (the static-receiver target).
+        named_node(&mut v, "c_util", "Util", "CLASS", "util.java");
+        named_node(&mut v, "m_stat", "format", "FUNCTION", "util.java");
+        v.put_node_metadata(id_of("m_stat"), r#"{"kind":"method"}"#);
+        edge(&mut v, "c_util", "m_stat", "HAS_METHOD");
+        // record Pt with a compact constructor (CONTAINS-only, NO HAS_METHOD).
+        named_node(&mut v, "r_pt", "Pt", "RECORD", "pt.java");
+        named_node(&mut v, "m_cc", "Pt", "FUNCTION", "pt.java");
+        v.put_node_metadata(id_of("m_cc"), r#"{"kind":"compact_constructor"}"#);
+        edge(&mut v, "r_pt", "m_cc", "CONTAINS");
+
+        // S10: constructor calls.
+        named_node(&mut v, "c_new", "new Service", "CALL", "app.java");
+        edge(&mut v, "m_run", "c_new", "CONTAINS");
+        named_node(&mut v, "c_newpt", "new Pt", "CALL", "app.java");
+        edge(&mut v, "m_run", "c_newpt", "CONTAINS");
+        named_node(&mut v, "c_newmiss", "new Missing", "CALL", "app.java");
+        edge(&mut v, "m_run", "c_newmiss", "CONTAINS");
+        named_node(&mut v, "c_kt", "new Service", "CALL", "app.kt");
+
+        // S11: same-class plain calls.
+        named_node(&mut v, "c_plain", "helper", "CALL", "svc.java");
+        v.put_node_metadata(id_of("c_plain"), r#"{"method":true,"argCount":0}"#);
+        edge(&mut v, "m_run", "c_plain", "CONTAINS");
+        named_node(&mut v, "c_this_recv", "helper", "CALL", "svc.java");
+        v.put_node_metadata(id_of("c_this_recv"), r#"{"method":true,"argCount":0,"receiver":"this"}"#);
+        edge(&mut v, "m_run", "c_this_recv", "CONTAINS");
+        named_node(&mut v, "c_recv", "helper", "CALL", "svc.java");
+        v.put_node_metadata(id_of("c_recv"), r#"{"method":true,"argCount":0,"receiver":"other"}"#);
+        edge(&mut v, "m_run", "c_recv", "CONTAINS");
+        // Field-initializer call: CONTAINS parent is the CLASS node.
+        named_node(&mut v, "c_field", "helper", "CALL", "svc.java");
+        v.put_node_metadata(id_of("c_field"), r#"{"method":true,"argCount":0}"#);
+        edge(&mut v, "c_svc", "c_field", "CONTAINS");
+        // Lambda-nested call: lambdas are CLOSURE nodes (no HAS_METHOD);
+        // fn_owner lifts through the CLOSURE to the method's class.
+        named_node(&mut v, "f_lambda", "<lambda>", "CLOSURE", "svc.java");
+        edge(&mut v, "m_run", "f_lambda", "CONTAINS");
+        named_node(&mut v, "c_inlam", "helper", "CALL", "svc.java");
+        v.put_node_metadata(id_of("c_inlam"), r#"{"method":true,"argCount":0}"#);
+        edge(&mut v, "f_lambda", "c_inlam", "CONTAINS");
+        // Nested lambda (CLOSURE inside CLOSURE): pins the CLOSURE→CLOSURE
+        // hop of the fn_owner recursion.
+        named_node(&mut v, "f_nested", "<lambda>", "CLOSURE", "svc.java");
+        edge(&mut v, "f_lambda", "f_nested", "CONTAINS");
+        named_node(&mut v, "c_innested", "helper", "CALL", "svc.java");
+        v.put_node_metadata(id_of("c_innested"), r#"{"method":true,"argCount":0}"#);
+        edge(&mut v, "f_nested", "c_innested", "CONTAINS");
+        // Expression-body lambda inside a CONSTRUCTOR — the LEGACY-PARITY
+        // arm: LambdaExpr pushes no withEnclosingFn, so legacy emits this
+        // edge via the leaked [in:Service] sid; the pack must too.
+        named_node(&mut v, "f_lamctor", "<lambda>", "CLOSURE", "svc.java");
+        edge(&mut v, "m_ctor", "f_lamctor", "CONTAINS");
+        named_node(&mut v, "c_inlamctor", "helper", "CALL", "svc.java");
+        v.put_node_metadata(id_of("c_inlamctor"), r#"{"method":true,"argCount":0}"#);
+        edge(&mut v, "f_lamctor", "c_inlamctor", "CONTAINS");
+        // Lambda in a FIELD INITIALIZER: the CLOSURE's CONTAINS parent is
+        // the CLASS — the fn_owner chain stops, nothing derives (legacy:
+        // nothing on both lambda kinds).
+        named_node(&mut v, "f_lamfield", "<lambda>", "CLOSURE", "svc.java");
+        edge(&mut v, "c_svc", "f_lamfield", "CONTAINS");
+        named_node(&mut v, "c_inlamfield", "helper", "CALL", "svc.java");
+        v.put_node_metadata(id_of("c_inlamfield"), r#"{"method":true,"argCount":0}"#);
+        edge(&mut v, "f_lamfield", "c_inlamfield", "CONTAINS");
+
+        // S12: static-style call.
+        named_node(&mut v, "c_static", "format", "CALL", "svc.java");
+        v.put_node_metadata(id_of("c_static"), r#"{"method":true,"argCount":1,"receiver":"Util"}"#);
+        edge(&mut v, "m_run", "c_static", "CONTAINS");
+
+        // S13: this() / super() inside the first ctor.
+        named_node(&mut v, "c_thisc", "this", "CALL", "svc.java");
+        v.put_node_metadata(
+            id_of("c_thisc"),
+            r#"{"kind":"constructor_call","method":false,"argCount":0,"isThis":true}"#,
+        );
+        edge(&mut v, "m_ctor", "c_thisc", "CONTAINS");
+        named_node(&mut v, "c_superc", "super", "CALL", "svc.java");
+        v.put_node_metadata(
+            id_of("c_superc"),
+            r#"{"kind":"constructor_call","method":false,"argCount":0,"isThis":false}"#,
+        );
+        edge(&mut v, "m_ctor", "c_superc", "CONTAINS");
+
+        let (eval, specs, _node_specs) = evaluate_with_materialize(
+            &v,
+            JAVA_CALLS_DL,
+            Stats::default(),
+            EvalLimits::none(),
+            EventLog::discard(),
+        )
+        .expect("java_calls.dl evaluates");
+
+        assert_eq!(
+            id_pairs(&eval, "instantiates"),
+            BTreeSet::from([(id_of("c_new"), id_of("c_svc")), (id_of("c_newpt"), id_of("r_pt"))]),
+            "INSTANTIATES: class + record; unknown class and the .kt call derive nothing"
+        );
+        assert_eq!(
+            id_pairs(&eval, "ctor_calls"),
+            BTreeSet::from([
+                (id_of("c_new"), id_of("m_ctor")),
+                (id_of("c_new"), id_of("m_ctor2")),
+                (id_of("c_newpt"), id_of("m_cc")),
+            ]),
+            "ctor CALLS: ALL ctors (DELTA 2) + the compact ctor via the CONTAINS arm"
+        );
+        assert_eq!(
+            id_pairs(&eval, "same_class_calls"),
+            BTreeSet::from([
+                (id_of("c_plain"), id_of("m_helper")),
+                (id_of("c_this_recv"), id_of("m_helper")),
+                (id_of("c_inlam"), id_of("m_helper")),
+                (id_of("c_innested"), id_of("m_helper")),
+                (id_of("c_inlamctor"), id_of("m_helper")),
+            ]),
+            "same-class CALLS (DELTA 3): ordinary-method-body + this-receiver + CLOSURE-lifted \
+             (single, nested, and the ctor-expression-lambda LEGACY-PARITY arm) resolve; \
+             foreign receiver, field-initializer, and field-initializer-lambda derive nothing"
+        );
+        assert_eq!(
+            id_pairs(&eval, "static_calls"),
+            BTreeSet::from([(id_of("c_static"), id_of("m_stat"))]),
+            "static-style CALLS: class-named receiver only"
+        );
+        assert_eq!(
+            id_pairs(&eval, "this_ctor_calls"),
+            BTreeSet::from([
+                (id_of("c_thisc"), id_of("m_ctor")),
+                (id_of("c_thisc"), id_of("m_ctor2")),
+            ]),
+            "this() delegation: all same-class ctors (DELTA 2)"
+        );
+        assert_eq!(
+            id_pairs(&eval, "super_ctor_calls"),
+            BTreeSet::from([(id_of("c_superc"), id_of("m_bctor"))]),
+            "super() delegation: the superclass ctor via extends metadata"
+        );
+        let calls_heads: BTreeSet<&str> = specs
+            .iter()
+            .filter(|s| s.edge_type == "CALLS")
+            .map(|s| s.predicate.as_str())
+            .collect();
+        assert_eq!(
+            calls_heads,
+            BTreeSet::from([
+                "ctor_calls",
+                "same_class_calls",
+                "static_calls",
+                "this_ctor_calls",
+                "super_ctor_calls"
+            ]),
+            "the 5 CALLS producers materialize"
+        );
+        assert!(
+            specs.iter().any(|s| s.edge_type == "INSTANTIATES" && s.predicate == "instantiates"),
+            "INSTANTIATES materializes"
+        );
+        assert!(
+            specs.iter().all(|s| s.additive && s.meta.is_empty()),
+            "every head additive with empty meta"
+        );
+    }
+
+    /// java_annotations.dl — the S14 surface:
+    /// - happy path: ATTRIBUTE "Marker" → ANNOTATION_TYPE Marker;
+    /// - DELTA 1 pin: a duplicate same-named ANNOTATION_TYPE — an edge per
+    ///   candidate (legacy Map kept one);
+    /// - .java gates BOTH ways (load-bearing — kotlin emits both node
+    ///   types): a .kt ATTRIBUTE never resolves, and a .kt ANNOTATION_TYPE
+    ///   is never a target;
+    /// - unknown annotation name derives nothing.
+    #[test]
+    fn java_annotations_pack_resolves_attributes() {
+        let mut v = FixtureStorageView::new(1);
+        named_node(&mut v, "an_1", "Marker", "ANNOTATION_TYPE", "marker.java");
+        named_node(&mut v, "an_2", "Marker", "ANNOTATION_TYPE", "marker2.java");
+        named_node(&mut v, "an_kt", "KMark", "ANNOTATION_TYPE", "mark.kt");
+        named_node(&mut v, "at_1", "Marker", "ATTRIBUTE", "app.java");
+        named_node(&mut v, "at_kt", "Marker", "ATTRIBUTE", "app.kt");
+        named_node(&mut v, "at_k2", "KMark", "ATTRIBUTE", "app.java");
+        named_node(&mut v, "at_none", "NoSuch", "ATTRIBUTE", "app.java");
+
+        let (eval, specs, _node_specs) = evaluate_with_materialize(
+            &v,
+            JAVA_ANNOTATIONS_DL,
+            Stats::default(),
+            EvalLimits::none(),
+            EventLog::discard(),
+        )
+        .expect("java_annotations.dl evaluates");
+
+        assert_eq!(
+            id_pairs(&eval, "ann_resolves"),
+            BTreeSet::from([
+                (id_of("at_1"), id_of("an_1")),
+                (id_of("at_1"), id_of("an_2")),
+            ]),
+            "ANNOTATION_RESOLVES_TO: both same-named candidates (DELTA 1); the .kt \
+             attribute, the .kt-declared target and the unknown name derive nothing"
+        );
+        assert_eq!(specs.len(), 1, "one head");
+        assert!(
+            specs[0].edge_type == "ANNOTATION_RESOLVES_TO"
+                && specs[0].additive
+                && specs[0].meta.is_empty(),
+            "additive empty-meta ANNOTATION_RESOLVES_TO"
         );
     }
 

--- a/packages/rfdb-server/src/derive/stdlib/java_annotations.dl
+++ b/packages/rfdb-server/src/derive/stdlib/java_annotations.dl
@@ -1,0 +1,31 @@
+% java_annotations.dl — in-engine replacement for AnnotationResolution.hs of
+% the java-resolve binary (packages/java-resolve/src/AnnotationResolution.hs:
+% 26-44): ANNOTATION_RESOLVES_TO from every annotation usage (ATTRIBUTE,
+% Annotations.hs) to the same-named ANNOTATION_TYPE declaration. Both names
+% are first-class — the simplest pack of the java family.
+% Lang-spec: _ai/research/lang-spec-java.md §4.4.
+%
+% LEGACY SEMANTICS: an ANNOTATION_TYPE index by bare name (Map last-wins),
+% probed with each ATTRIBUTE's name; emit with EMPTY metadata (Hs:46-53) ⇒
+% no meta(...) columns; additive (shared rollout discipline).
+%
+% The .java gates on BOTH legs are load-bearing: kotlin-analyzer emits
+% ATTRIBUTE and ANNOTATION_TYPE too (and cpp/python/swift emit ATTRIBUTE);
+% legacy only ever saw Java-streamed nodes (main.rs:1578) — without the gates
+% the pack would invent java↔kotlin edges legacy never derived.
+%
+% NUMBERED DELTAS vs the legacy resolver (everything not listed is exact):
+%   DELTA 1 (superset, spec §5 class 1): set semantics on duplicate
+%     annotation names — an edge per same-named ANNOTATION_TYPE candidate vs
+%     the Map's arbitrary last-wins winner.
+%   DELTA 2 (metadata): engine provenance _source/_generation (rust DELTA 6).
+%
+% MAINTAIN ENVELOPE: no node_attr, no negation — maintain-incremental
+% eligible (the negation-light end of the java family, spec §4 note).
+
+jattr(A, N) :- node(A, "ATTRIBUTE"), attr(A, "file", F), ends_with(F, ".java"),
+    attr(A, "name", N), neq(N, "").
+jann(N, T)  :- node(T, "ANNOTATION_TYPE"), attr(T, "file", F), ends_with(F, ".java"),
+    attr(T, "name", N), neq(N, "").
+@materialize(edge_type = "ANNOTATION_RESOLVES_TO", mode = "additive")
+ann_resolves(A, T) :- jattr(A, N), jann(N, T).

--- a/packages/rfdb-server/src/derive/stdlib/java_calls.dl
+++ b/packages/rfdb-server/src/derive/stdlib/java_calls.dl
@@ -1,0 +1,133 @@
+% java_calls.dl — in-engine replacement for CallResolution.hs of the
+% java-resolve binary (packages/java-resolve/src/CallResolution.hs):
+% INSTANTIATES + ctor CALLS (resolveConstructorCalls, Hs:146-176), same-class
+% method CALLS (resolveSameClassCalls, Hs:182-205 — production-latent-bugged,
+% spec §2 D3), static-style CALLS (resolveStaticCalls, Hs:208-226) and
+% super()/this() delegation CALLS (resolveSuperThisCalls, Hs:232-257).
+% Lang-spec: _ai/research/lang-spec-java.md §4.3 + VERDICT C3 (this pack is a
+% CALLS producer and MUST precede the CALLS negators method_calls /
+% shape_verifier in both registries).
+%
+% LEGACY SEMANTICS: class index by simple name (Hs:44-52, Map last-wins);
+% ctor index = FUNCTION kind ∈ {constructor, compact_constructor} keyed by
+% the sid's [in:Class] marker (Hs:70-85); method index keyed by
+% (className, methodName) from the FUNCTION sid (Hs:56-66). The pack replaces
+% every sid parse with GRAPH-NATIVE membership: HAS_METHOD covers methods and
+% constructors (Declarations.hs:402-410, :477-483); compact constructors get
+% CONTAINS-only from the record scope (:534-539) — the second ctor_of arm.
+% A CALL's enclosing body is its CONTAINS parent (blocks push no scopes,
+% spec §1). Java lambdas are CLOSURE nodes, NOT FUNCTIONs (Expressions.hs:
+% 352-355 expression body, :399-404 block body; both push the lambda scope,
+% so a CALL inside either lambda kind has the CLOSURE as CONTAINS parent) —
+% jbody = FUNCTION|CLOSURE and the fn_owner recursion hops CONTAINS parents
+% of either type, lifting lambda and local-fn nesting (CLOSUREs have no
+% HAS_METHOD). All edges EMPTY metadata (Hs:132-139) ⇒ no meta(...) columns;
+% every head additive (CALLS/INSTANTIATES shared vocab).
+%
+% NUMBERED DELTAS vs the legacy resolver (everything not listed is exact):
+%   DELTA 1 (superset, spec §5 class 1): set semantics on duplicate simple
+%     class names — an edge per candidate vs Map last-wins.
+%   DELTA 2 (superset, spec §5 class 2): ALL overloads/ctors derived vs
+%     legacy's head-of-list pick (Hs:174-175 — the argCount comment is NOT
+%     implemented). Neither side does real Java overload resolution
+%     (spec §10.2); exactly-one-edge semantics belongs to the binding-table/
+%     semiring layer, not a rule hack.
+%   DELTA 3 (DECLARED SUPERSET, spec §5 class 4 — the D3 fix): same-class
+%     no-receiver calls resolve in ALL method bodies. Legacy's method index
+%     is keyed by class name but probed with the CALL sid's [in:] marker —
+%     the enclosing METHOD name (Expressions.hs:101-103) — so it matched only
+%     where [in:] == class name: constructor bodies, PLUS expression-body
+%     lambdas directly under a constructor (LambdaExpr pushes no
+%     withEnclosingFn, Expressions.hs:343-386, so the [in:ctorName] sid leaks
+%     into the lambda body — that arm is PARITY, not delta). The pack's
+%     CONTAINS→HAS_METHOD route restores the resolver's documented intent
+%     (Hs:12-13; test/Spec.hs:214 fabricates [in:Service] to pass). Bound =
+%     plain calls outside ctor bodies and outside ctor expression-lambdas
+%     (ordinary methods, block lambdas — withEnclosingFn at :431 rebinds
+%     [in:] to "<lambda>"). No false-positive vector: the join requires an
+%     actual same-class method of that name.
+%   DELTA 4 (superset/fix, rare, spec §5 class 5): local classes nested in
+%     method bodies — legacy keyed their ctors under the WRONG name (sid
+%     parent = enclosing method); the edge-based ctor_of is correct.
+%   DELTA 5 (metadata): engine provenance _source/_generation (rust DELTA 6).
+% PARITY PINS (no delta):
+%   - field-initializer calls (CONTAINS parent is the CLASS node, not a
+%     FUNCTION/CLOSURE): nothing on BOTH sides — legacy's [in:] is absent,
+%     the pack's encl_fn requires a jbody-typed parent. Same for a lambda IN
+%     a field initializer: its CONTAINS parent is the CLASS, so the fn_owner
+%     recursion stops (legacy: no [in:] for the expression kind, dead
+%     [in:<lambda>] probe for the block kind).
+%   - expression-body lambda directly inside a constructor: legacy DOES emit
+%     (the [in:ctorName] leak above) and the pack's CLOSURE lift emits too —
+%     exact modulo DELTA 2's all-overloads.
+%   - a receiver naming a non-class identifier ("foo.bar()"): nothing on both
+%     sides (Hs test :243-249).
+%   - "new Unknown" (no such class): nothing on both sides.
+%
+% MAINTAIN ENVELOPE: node_attr + negation ⇒ scratch-only under maintain.
+
+% Java-gated kernels (§3 self-contained connectivity discipline).
+jdecl(T, F, N) :- node(T, "CLASS"),     attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "INTERFACE"), attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "ENUM"),      attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "RECORD"),    attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jclass_named(N, T) :- jdecl(T, F, N).
+
+jcall(C, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".java"), attr(C, "name", N).
+jfn(Fn) :- node(Fn, "FUNCTION"), attr(Fn, "file", F), ends_with(F, ".java").
+% A callable BODY a CALL can sit in: methods/ctors (FUNCTION) and lambdas
+% (CLOSURE — Expressions.hs:352-355, :399-404).
+jbody(B) :- jfn(B).
+jbody(B) :- node(B, "CLOSURE"), attr(B, "file", F), ends_with(F, ".java").
+
+% — classification (Hs:260-270) —
+ctor_call(C, CN) :- jcall(C, N), strip_prefix(N, "new ", CN), neq(CN, "").
+is_ctor_call(C)  :- ctor_call(C, CN).
+is_ctor_call(C)  :- jcall(C, N), node_attr(C, "kind", "constructor_call").
+this_call(C)  :- jcall(C, "this").
+this_call(C)  :- jcall(C, N), node_attr(C, "isThis", "true").
+super_call(C) :- jcall(C, "super").
+super_this(C) :- this_call(C).
+super_this(C) :- super_call(C).
+has_recv(C) :- jcall(C, N), node_attr(C, "receiver", R), neq(R, ""), neq(R, "this").
+
+% — membership (graph-native replacement of the [in:Class] sid parse) —
+ctor_of(Cls, Fn) :- jfn(Fn), edge(Cls, Fn, "HAS_METHOD"), node_attr(Fn, "kind", "constructor").
+ctor_of(Cls, Fn) :- jfn(Fn), node(Cls, "RECORD"), edge(Cls, Fn, "CONTAINS"),
+    node_attr(Fn, "kind", "compact_constructor").
+% Nearest FUNCTION/CLOSURE ancestor of a CALL, then the HAS_METHOD owner;
+% the recursion hops CONTAINS parents of EITHER body type, lifting lambda
+% (CLOSURE) and local-fn nesting (CLOSUREs never carry HAS_METHOD, so only
+% the FUNCTION base arm grounds the chain).
+encl_fn(C, B) :- jcall(C, N), edge(B, C, "CONTAINS"), jbody(B).
+fn_owner(Fn, Cls) :- jfn(Fn), edge(Cls, Fn, "HAS_METHOD").
+fn_owner(B, Cls) :- jbody(B), edge(Outer, B, "CONTAINS"), jbody(Outer),
+    fn_owner(Outer, Cls).
+encl_class(C, Cls) :- encl_fn(C, Fn), fn_owner(Fn, Cls).
+
+% S10 — constructor calls: INSTANTIATES to the class + CALLS to its ctors.
+@materialize(edge_type = "INSTANTIATES", mode = "additive")
+instantiates(C, Cls) :- ctor_call(C, CN), jclass_named(CN, Cls).
+@materialize(edge_type = "CALLS", mode = "additive")
+ctor_calls(C, Fn) :- ctor_call(C, CN), jclass_named(CN, Cls), ctor_of(Cls, Fn).
+
+% S11 — same-class no-receiver calls (DELTA 3).
+plain_call(C, N) :- jcall(C, N), \+ is_ctor_call(C), \+ super_this(C), \+ has_recv(C).
+@materialize(edge_type = "CALLS", mode = "additive")
+same_class_calls(C, M) :- plain_call(C, N), encl_class(C, Cls),
+    edge(Cls, M, "HAS_METHOD"), attr(M, "name", N).
+
+% S12 — static-style calls (the receiver IS a class simple name).
+recv_class(C, N, Cls) :- jcall(C, N), \+ is_ctor_call(C), \+ super_this(C),
+    node_attr(C, "receiver", R), neq(R, ""), neq(R, "this"), jclass_named(R, Cls).
+@materialize(edge_type = "CALLS", mode = "additive")
+static_calls(C, M) :- recv_class(C, N, Cls), edge(Cls, M, "HAS_METHOD"), attr(M, "name", N).
+
+% S13 — this()/super() delegating ctor calls (legacy works here by the D3
+% accident — [in:ctorName] == class name inside constructors; exact parity
+% modulo DELTA 2's all-ctors).
+@materialize(edge_type = "CALLS", mode = "additive")
+this_ctor_calls(C, Fn) :- this_call(C), encl_class(C, Cls), ctor_of(Cls, Fn).
+@materialize(edge_type = "CALLS", mode = "additive")
+super_ctor_calls(C, Fn) :- super_call(C), encl_class(C, Cls),
+    node_attr(Cls, "extends", SN), neq(SN, ""), jclass_named(SN, SCls), ctor_of(SCls, Fn).

--- a/packages/rfdb-server/src/derive/stdlib/java_imports.dl
+++ b/packages/rfdb-server/src/derive/stdlib/java_imports.dl
@@ -1,0 +1,80 @@
+% java_imports.dl — in-engine replacement for ImportResolution.hs of the
+% java-resolve binary (packages/java-resolve/src/ImportResolution.hs), the
+% IMPORTS_FROM producer of the `java-all` daemon command: IMPORT → class
+% declaration (resolveImport, Hs:75-92) and IMPORT_BINDING → class declaration
+% (resolveBinding, Hs:99-131). Lang-spec: _ai/research/lang-spec-java.md §4.1
+% + VERDICT C3 (this pack feeds @stdlib/depends and MUST precede it).
+%
+% LEGACY SEMANTICS: buildModuleIndex (Hs:41-50) maps file → MODULE metadata
+% `package`; buildClassIndex (Hs:53-68) keys CLASS/INTERFACE/ENUM/RECORD by
+% "<package>.<name>" — or the bare name for default-package files (the
+% pkg-or-empty discipline, Hs:63-66). resolveImport looks the IMPORT's name
+% (the full dotted path, first-class — Imports.hs:65-81) up in that index and
+% emits IMPORT -IMPORTS_FROM-> decl with EMPTY metadata (Hs:85-91).
+%
+% PRODUCTION-DEAD LEGACY ARMS (spec §2, differential predictions P1/P3):
+% - resolveBinding (Hs:99-131) reads node metadata `source`, which the
+%   analyzer NEVER stamps (Imports.hs:107-111: imported_name/local_name/
+%   static only); the intended source travels in DeferredRef.drSource, which
+%   the orchestrator's FileAnalysis struct DROPS (analyzer.rs:41-49 has no
+%   unresolvedRefs field). Legacy phase 3 emits ZERO edges in production.
+% - the `asterisk` glob skip reads a key the analyzer spells `glob`
+%   (Hs:78 vs Imports.hs:78) — benign: a glob IMPORT is *named*
+%   "com.example.*", which can never equal a qualified class name, so the
+%   no-edge outcome is identical and the pack inherits it for free.
+%
+% IMPORTS_FROM is SHARED vocabulary ⇒ mode = "additive". Legacy metadata is
+% empty ⇒ no meta(...) columns.
+%
+% NUMBERED DELTAS vs the legacy resolver (everything not listed is exact):
+%   DELTA 1 (superset, spec §5 class 1): set semantics on duplicate qualified
+%     names — legacy's Map.fromList kept ONE arbitrary last-wins winner per
+%     qualified name (Hs:57); the pack derives an edge per candidate.
+%     Bound = qualified names with >1 declaration node.
+%   DELTA 2 (DECLARED SUPERSET, spec §5 class 3 — the feature): IMPORT_BINDING
+%     edges are derived from the graph-native IMPORT -CONTAINS-> IMPORT_BINDING
+%     edge (Imports.hs:114-120 emits exactly it) + the parent IMPORT's resolved
+%     target, instead of the never-present metadata `source` — restoring the
+%     resolver's documented intent (Hs header :20, test/Spec.hs:79-91, which
+%     fabricates `source`). Legacy production derives 0 (P1); bound = java
+%     IMPORT_BINDINGs whose parent IMPORT name ∈ qual_class.
+%   DELTA 3 (metadata): engine provenance _source/_generation on every pack
+%     edge (the standing rust DELTA 6).
+% PARITY PINS (no delta): glob imports resolve nothing (P3, above); static
+% member imports ("com.example.Foo.bar") resolve nothing on BOTH sides — the
+% full-path lookup fails (a deliberate non-superset, spec §3 S2 honesty note).
+%
+% MAINTAIN ENVELOPE: node_attr (package probe) + stratified negation (the
+% default-package arm) ⇒ maintain-incremental refuses; scratch floor applies.
+%
+% ENCODING NOTE (§3 connectivity, the rust_trait_resolve discipline):
+% name-keyed lookups are SELF-CONTAINED derived relations joined on strings;
+% node/attr legs are never inlined next to a foreign leg.
+
+% Java-gated EDB surfaces. The daemon streamed ONLY Language::Java nodes
+% (main.rs:1578), so the .java gate on every leg IS legacy parity — the
+% vocabulary is shared polyglot-wide (kotlin emits the same node types).
+jmodule(M, F) :- node(M, "MODULE"), attr(M, "file", F), ends_with(F, ".java").
+jdecl(T, F, N) :- node(T, "CLASS"),     attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "INTERFACE"), attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "ENUM"),      attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "RECORD"),    attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+
+% S1 — the qualified-class kernel. MODULE metadata `package` exists only when
+% the file has a package declaration (Walker.hs:37-51 — no key otherwise);
+% default-package files contribute the bare class name (Hs:63-66).
+pkg_of(F, P) :- jmodule(M, F), node_attr(M, "package", P), neq(P, "").
+has_pkg(F)  :- pkg_of(F, P).
+qual_class(Q, T) :- jdecl(T, F, N), pkg_of(F, P), concat(P, ".", P1), concat(P1, N, Q).
+qual_class(N, T) :- jdecl(T, F, N), \+ has_pkg(F).
+
+% S2 — IMPORT → declaration. The IMPORT's first-class name IS the full dotted
+% path (Imports.hs:65-81); glob imports ("com.example.*") fall out naturally.
+jimport(I, Q, F) :- node(I, "IMPORT"), attr(I, "file", F), ends_with(F, ".java"), attr(I, "name", Q).
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+import_target(I, T) :- jimport(I, Q, F), qual_class(Q, T).
+
+% S3 — IMPORT_BINDING → declaration via the parent IMPORT (DELTA 2).
+jbinding(B, F) :- node(B, "IMPORT_BINDING"), attr(B, "file", F), ends_with(F, ".java").
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+binding_target(B, T) :- jbinding(B, F), edge(I, B, "CONTAINS"), jimport(I, Q, F), qual_class(Q, T).

--- a/packages/rfdb-server/src/derive/stdlib/java_types.dl
+++ b/packages/rfdb-server/src/derive/stdlib/java_types.dl
@@ -1,0 +1,107 @@
+% java_types.dl — in-engine replacement for TypeResolution.hs of the
+% java-resolve binary (packages/java-resolve/src/TypeResolution.hs):
+% RETURNS (resolveReturns, Hs:115-126), TYPE_OF (resolveTypeOf, Hs:129-140),
+% EXTENDS (resolveExtends, Hs:143-156), IMPLEMENTS (resolveImplements,
+% Hs:159-171) and THROWS_TYPE (resolveThrows, Hs:174-186).
+% Lang-spec: _ai/research/lang-spec-java.md §4.2 + VERDICT C1 (the right-peel
+% comma split CLOSES delta class 6 — S8/S9 multi-element values are full
+% parity, not a subset) + C2 (negated builtins are legal per-row anti-joins,
+% pinned by stdlib.rs::negated_builtin_literal_is_a_per_row_anti_join) +
+% C4 (the "<unknown>" skip is dead-letter on both sides).
+%
+% LEGACY SEMANTICS: buildClassIndex by SIMPLE name (Hs:41-50, Map last-wins);
+% normalizeType (Hs:81-94) strips ALL "[]", rejects the 10 primitives,
+% '?'-wildcards and the resolver-internal "<unknown>"; splitTypes (Hs:97-98)
+% comma-splits implements/throws (the analyzer comma-joins with NO spaces —
+% T.intercalate ",", Declarations.hs:118/169/219/272/391/467 — so legacy's
+% T.strip is a no-op and is not replicated). All edges carry EMPTY metadata
+% (Hs:188-195) ⇒ no meta(...) columns; every head additive (shared vocab).
+%
+% NUMBERED DELTAS vs the legacy resolver (everything not listed is exact):
+%   DELTA 1 (superset, spec §5 class 1): set semantics on duplicate SIMPLE
+%     names across the project — an edge per same-named candidate vs the
+%     Map's arbitrary last-wins winner. Bound = simple names with >1 decl.
+%   DELTA 2 (subset, pathological): EXTENDS carries neq(C, T) — the pack
+%     never derives a self-loop; legacy COULD (a dup-named class whose Map
+%     winner is the extending node itself). Self-EXTENDS is junk by
+%     construction; deliberately excluded.
+%   DELTA 3 (metadata): engine provenance _source/_generation (rust DELTA 6).
+% PARITY PINS (no delta):
+%   - S7 interface multi-extends ("extends A,B" comma-joined,
+%     Declarations.hs:169): legacy does NOT split extends — it looks up the
+%     literal "A,B" and fails (Hs:146-156). The comma-bearing string matches
+%     no class name here either: 0 edges on BOTH sides, exactly. (The split
+%     fix is available — C1 — but would be a deliberate superset; not taken.)
+%   - S8/S9 multi-element implements/throws: SPLIT on both sides (C1 closed
+%     the draft's subset) — one edge per resolved element, exact parity
+%     modulo DELTA 1.
+%   - the "<unknown>" reject never fires (C4): the analyzer's typeToName
+%     emits "<type>" for unhandled types (Expressions.hs:1114), never
+%     "<unknown>" — kept only as resolver-vocabulary parity.
+%
+% MAINTAIN ENVELOPE: node_attr generators + negation ⇒ maintain-incremental
+% refuses; the scratch floor applies (the standing Wave-2 expectation).
+
+prim("boolean"). prim("byte"). prim("char"). prim("short"). prim("int").
+prim("long"). prim("float"). prim("double"). prim("void"). prim("var").
+
+% Java-gated declaration kernel (S4) — simple-name keyed, self-contained
+% (§3 connectivity discipline).
+jdecl(T, F, N) :- node(T, "CLASS"),     attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "INTERFACE"), attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "ENUM"),      attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "RECORD"),    attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jclass_named(N, T) :- jdecl(T, F, N).
+
+% S5 — RETURNS from FUNCTION metadata return_type (methods stamp it,
+% Declarations.hs:376-391). normalizeType = strip-all-[] + the reject set,
+% spelled as direct negated-builtin filters (C2: lighter than aux relations,
+% and stratification-free — stratify.rs adds no edge for builtin literals).
+ret_strip(Fn, N) :- node(Fn, "FUNCTION"), attr(Fn, "file", F), ends_with(F, ".java"),
+    node_attr(Fn, "return_type", Raw), neq(Raw, ""), replace_all(Raw, "[]", "", N), neq(N, "").
+@materialize(edge_type = "RETURNS", mode = "additive")
+returns(Fn, T) :- ret_strip(Fn, N), \+ prim(N), \+ string_contains(N, "?"),
+    neq(N, "<unknown>"), jclass_named(N, T).
+
+% S6 — TYPE_OF from VARIABLE metadata type (fields/locals/params).
+vty_strip(V, N) :- node(V, "VARIABLE"), attr(V, "file", F), ends_with(F, ".java"),
+    node_attr(V, "type", Raw), neq(Raw, ""), replace_all(Raw, "[]", "", N), neq(N, "").
+@materialize(edge_type = "TYPE_OF", mode = "additive")
+type_of(V, T) :- vty_strip(V, N), \+ prim(N), \+ string_contains(N, "?"),
+    neq(N, "<unknown>"), jclass_named(N, T).
+
+% S7 — EXTENDS: all 4 decl types carry the metadata (Hs:146); NO split
+% (parity pin above); neq(C, T) is DELTA 2.
+ext_strip(C, N) :- jdecl(C, F, CN), node_attr(C, "extends", Raw), neq(Raw, ""),
+    replace_all(Raw, "[]", "", N), neq(N, "").
+@materialize(edge_type = "EXTENDS", mode = "additive")
+extends(C, T) :- ext_strip(C, N), \+ prim(N), \+ string_contains(N, "?"),
+    neq(N, "<unknown>"), jclass_named(N, T), neq(C, T).
+
+% S8 — IMPLEMENTS (CLASS + ENUM only, Hs:163 — the analyzer also stamps
+% RECORD `implements`, which legacy never read: parity keeps the omission).
+% The comma split is the right-peel recursion (C1; the js_module_imports
+% spec_pfx idiom): peel the last ","-segment off a strictly-shrinking list —
+% the fixpoint terminates at element depth; last_segment is identity on
+% separator-free strings, so single elements surface unchanged.
+impl_raw(C, L) :- node(C, "CLASS"), attr(C, "file", F), ends_with(F, ".java"),
+    node_attr(C, "implements", L), neq(L, "").
+impl_raw(C, L) :- node(C, "ENUM"),  attr(C, "file", F), ends_with(F, ".java"),
+    node_attr(C, "implements", L), neq(L, "").
+impl_list(C, L) :- impl_raw(C, L).
+impl_list(C, R) :- impl_list(C, L), last_segment(L, ",", E),
+    concat(",", E, Tail), strip_suffix(L, Tail, R).
+impl_elem(C, E) :- impl_list(C, L), last_segment(L, ",", E).
+@materialize(edge_type = "IMPLEMENTS", mode = "additive")
+implements(C, T) :- impl_elem(C, N), jclass_named(N, T).
+
+% S9 — THROWS_TYPE from FUNCTION metadata throws (comma-joined,
+% Declarations.hs:391/467), same right-peel split.
+throws_raw(Fn, L) :- node(Fn, "FUNCTION"), attr(Fn, "file", F), ends_with(F, ".java"),
+    node_attr(Fn, "throws", L), neq(L, "").
+throws_list(Fn, L) :- throws_raw(Fn, L).
+throws_list(Fn, R) :- throws_list(Fn, L), last_segment(L, ",", E),
+    concat(",", E, Tail), strip_suffix(L, Tail, R).
+throws_elem(Fn, E) :- throws_list(Fn, L), last_segment(L, ",", E).
+@materialize(edge_type = "THROWS_TYPE", mode = "additive")
+throws_type(Fn, T) :- throws_elem(Fn, N), jclass_named(N, T).


### PR DESCRIPTION
Java joins the derive engine: 4 packs from the verified migration spec (PR #395), with the verdict corrections applied and a review-caught CLOSURE-lambda fix (a miss shared by the spec and its verdict — caught at the pack layer). Legacy java-resolve stays wired until a java corpus runs the checked-in shadow differential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)