### PR TITLE
feat(kotlin): inheritance lands in the graph — analyzer stamps + kotlin_inheritance pack

### DIFF
--- a/packages/grafema-orchestrator/src/main.rs
+++ b/packages/grafema-orchestrator/src/main.rs
@@ -48,7 +48,7 @@ use std::path::PathBuf;
 /// js_import_bindings → js_class_inheritance → js_cross_file_calls →
 /// js_property_access_ns → js_property_access_full → js_builtins_nodes →
 /// js_builtins_edges → js_runtime_globals_nodes → js_runtime_globals_edges →
-/// depends → method_calls → shape_verifier → axum_routes.
+/// kotlin_inheritance → depends → method_calls → shape_verifier → axum_routes.
 /// Wave 3c moved depends INTO this list, after every IMPORTS_FROM producer:
 /// with legacy import-resolution gated, the IMPORT-level edges depends
 /// consumes are produced by the packs above it (it ran separately FIRST while
@@ -94,6 +94,11 @@ const STDLIB_RULE_PACKS: &[&str] = &[
     // producer — before method_calls/shape_verifier.
     "@stdlib/js_runtime_globals_nodes",
     "@stdlib/js_runtime_globals_edges",
+    // Kotlin wave: kotlin_inheritance PRODUCES EXTENDS (for shape_verifier's
+    // EXTENDS-closed member lookup) + IMPLEMENTS from the kotlin-analyzer's
+    // CLASS metadata stamps — consumes analyzer EDB only, precedes the
+    // negators below.
+    "@stdlib/kotlin_inheritance",
     // Wave 3c: depends CONSUMES IMPORTS_FROM (every edge of the shared
     // vocabulary, module- and binding-level). Legacy import-resolution /
     // rust-imports are gated (GRAFEMA_SKIP_RESOLVE_STEPS), so depends must
@@ -535,6 +540,7 @@ fn pack_owned_slice(pack: &str) -> &'static str {
         "@stdlib/js_builtins_edges" => "node-builtin IMPORTS_FROM + CALLS",
         "@stdlib/js_runtime_globals_nodes" => "js runtime-global GLOBAL_DEFINITION nodes",
         "@stdlib/js_runtime_globals_edges" => "js runtime-global CALLS",
+        "@stdlib/kotlin_inheritance" => "kotlin EXTENDS + IMPLEMENTS",
         "@stdlib/depends" => "MODULE→MODULE DEPENDS_ON",
         "@stdlib/method_calls" => "fuzzy method-call CALLS fallback",
         "@stdlib/shape_verifier" => "shape-violation ISSUE diagnostics",
@@ -3354,10 +3360,17 @@ mod tests {
     ) -> std::path::PathBuf {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+        // Process-wide sequence number: two tests starting concurrently can
+        // draw the SAME SystemTime nanos, and the remove_file→bind pair below
+        // is then a TOCTOU race (observed: `bind fake socket: AlreadyExists`
+        // flakes). The counter makes the name unique within the process.
+        static FAKE_SOCK_SEQ: std::sync::atomic::AtomicU64 =
+            std::sync::atomic::AtomicU64::new(0);
         let dir = std::env::temp_dir();
         let sock = dir.join(format!(
-            "grafema-fake-rfdb-{}-{}.sock",
+            "grafema-fake-rfdb-{}-{}-{}.sock",
             std::process::id(),
+            FAKE_SOCK_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()

--- a/packages/kotlin-analyzer/src/KotlinAST.hs
+++ b/packages/kotlin-analyzer/src/KotlinAST.hs
@@ -26,7 +26,9 @@ module KotlinAST
   ) where
 
 import Data.Text (Text)
-import Data.Aeson (FromJSON(..), withObject, (.:), (.:?), (.!=))
+import qualified Data.Text as T
+import Data.Aeson (FromJSON(..), Value(..), withObject, (.:), (.:?), (.!=))
+import qualified Data.Aeson.KeyMap as KM
 import Data.Aeson.Types (Parser)
 
 -- Position & Span
@@ -66,17 +68,35 @@ data KotlinDecl
       , kdTypeParams       :: ![KotlinTypeParam]
       , kdPrimaryConstructor :: !(Maybe KotlinPrimaryConstructor)
       , kdSuperTypes       :: ![KotlinType]
+        -- ^ Decoded from the "superTypes" key — the live kotlin-parser never
+        -- emits that key for classes (it emits "extends"/"implements",
+        -- KotlinAstSerializer.kt:99-123), so this list is empty on real
+        -- parser output; kept for the deferred-ref path and old fixtures.
+      , kdExtendsNames     :: ![Text]
+        -- ^ Supertype names from the parser's "extends" entries
+        -- (KtSuperTypeCallEntry — the constructor-call '()' suffix marks the
+        -- class supertype). Scope-qualified when the parser provides "scope".
+      , kdImplementsNames  :: ![Text]
+        -- ^ Supertype names from the parser's "implements" entries (bare
+        -- KtSuperTypeEntry / delegated KtDelegatedSuperTypeEntry — interfaces,
+        -- plus the no-primary-constructor class supertype ambiguity; see
+        -- Rules.Declarations.inheritanceMeta).
       , kdMembers          :: ![KotlinMember]
       , kdAnnotations      :: ![KotlinAnnotation]
       , kdSpan             :: !Span
       }
   | ObjectDecl
-      { kdName        :: !Text
-      , kdModifiers   :: ![Text]
-      , kdSuperTypes  :: ![KotlinType]
-      , kdMembers     :: ![KotlinMember]
-      , kdAnnotations :: ![KotlinAnnotation]
-      , kdSpan        :: !Span
+      { kdName            :: !Text
+      , kdModifiers       :: ![Text]
+      , kdSuperTypes      :: ![KotlinType]
+      , kdExtendsNames    :: ![Text]
+        -- ^ Constructor-call entries of the parser's mixed "supertypes" array
+        -- (KotlinAstSerializer.kt:148-171).
+      , kdImplementsNames :: ![Text]
+        -- ^ Bare/delegated entries of the same array.
+      , kdMembers         :: ![KotlinMember]
+      , kdAnnotations     :: ![KotlinAnnotation]
+      , kdSpan            :: !Span
       }
   | FunDecl
       { kdName         :: !Text
@@ -495,23 +515,39 @@ instance FromJSON KotlinDecl where
   parseJSON = withObject "KotlinDecl" $ \v -> do
     ty <- v .: "type" :: Parser Text
     case ty of
-      "ClassDecl" -> ClassDecl
-        <$> v .:  "name"
-        <*> v .:? "kind" .!= "class"
-        <*> v .:? "modifiers" .!= []
-        <*> v .:? "typeParameters" .!= []
-        <*> v .:? "primaryConstructor"
-        <*> v .:? "superTypes" .!= []
-        <*> v .:? "members" .!= []
-        <*> v .:? "annotations" .!= []
-        <*> v .:  "span"
-      "ObjectDecl" -> ObjectDecl
-        <$> v .:  "name"
-        <*> v .:? "modifiers" .!= []
-        <*> v .:? "superTypes" .!= []
-        <*> v .:? "members" .!= []
-        <*> v .:? "annotations" .!= []
-        <*> v .:  "span"
+      "ClassDecl" -> do
+        -- The live parser splits the supertype list into "extends"
+        -- (constructor-call entries) and "implements" (bare/delegated);
+        -- see parseSuperTypeEntry.
+        extEntries  <- v .:? "extends"    .!= []
+        implEntries <- v .:? "implements" .!= []
+        ClassDecl
+          <$> v .:  "name"
+          <*> v .:? "kind" .!= "class"
+          <*> v .:? "modifiers" .!= []
+          <*> v .:? "typeParameters" .!= []
+          <*> v .:? "primaryConstructor"
+          <*> v .:? "superTypes" .!= []
+          <*> pure (superTypeEntryNames extEntries)
+          <*> pure (superTypeEntryNames implEntries)
+          <*> v .:? "members" .!= []
+          <*> v .:? "annotations" .!= []
+          <*> v .:  "span"
+      "ObjectDecl" -> do
+        -- The live parser emits ONE mixed "supertypes" array for objects;
+        -- constructor-call entries (wrapped, with "args") are the class
+        -- supertype, the rest are interfaces.
+        entries <- v .:? "supertypes" .!= []
+        let pairs = map parseSuperTypeEntry entries
+        ObjectDecl
+          <$> v .:  "name"
+          <*> v .:? "modifiers" .!= []
+          <*> v .:? "superTypes" .!= []
+          <*> pure [ n | (True,  n) <- pairs, not (T.null n) ]
+          <*> pure [ n | (False, n) <- pairs, not (T.null n) ]
+          <*> v .:? "members" .!= []
+          <*> v .:? "annotations" .!= []
+          <*> v .:  "span"
       "FunDecl" -> FunDecl
         <$> v .:  "name"
         <*> v .:? "modifiers" .!= []
@@ -542,6 +578,58 @@ instance FromJSON KotlinDecl where
         <*> v .:  "span"
       _ -> DeclUnknown
         <$> v .: "span"
+
+-- Supertype-list entry decoding (the live kotlin-parser vocabulary).
+--
+-- serializeClass (KotlinAstSerializer.kt:99-123) emits
+--   "extends"    = [{type: <typeref>, args, span}]            (KtSuperTypeCallEntry)
+--   "implements" = [<typeref> | {type: <typeref>, delegate, span}]
+--                                  (KtSuperTypeEntry / KtDelegatedSuperTypeEntry)
+-- and serializeObject (:148-171) one mixed "supertypes" array of the same two
+-- shapes. The typeref itself is {"type":"ClassType","name":N,"scope":Q?,...}.
+-- Both helpers are total: malformed entries yield "" and are dropped upstream.
+
+-- | One supertype-list entry → (isConstructorCall, supertype name).
+-- A wrapped entry holds the typeref under "type" (an Object, vs the String
+-- discriminator of a direct typeref); "args" marks the constructor-call form.
+parseSuperTypeEntry :: Value -> (Bool, Text)
+parseSuperTypeEntry (Object v) =
+  case KM.lookup "type" v of
+    Just inner@(Object _) -> (KM.member "args" v, superTypeRefName inner)
+    _                     -> (False, superTypeRefName (Object v))
+parseSuperTypeEntry _ = (False, "")
+
+-- | All non-empty names of a supertype-entry list (classification dropped —
+-- the ClassDecl keys are pre-classified by the parser).
+superTypeEntryNames :: [Value] -> [Text]
+superTypeEntryNames = filter (not . T.null) . map (snd . parseSuperTypeEntry)
+
+-- | The name of a supertype reference, scope-qualified when the parser
+-- provides "scope" ("java.util" + "AbstractList" → "java.util.AbstractList").
+-- Type arguments are NOT part of the name (generics stripped). Accepts the
+-- live parser tag "ClassType" and the analyzer-internal/test tag "SimpleType";
+-- nullable wrappers unwrap; anything else (function types, star projections,
+-- unknowns) yields "".
+superTypeRefName :: Value -> Text
+superTypeRefName (Object v) =
+  case KM.lookup "type" v of
+    Just (String "ClassType")  -> qualifiedName
+    Just (String "SimpleType") -> qualifiedName
+    Just (String "NullableType") ->
+      case KM.lookup "inner" v of
+        Just inner -> superTypeRefName inner
+        Nothing    -> ""
+    _ -> ""
+  where
+    qualifiedName =
+      let n = case KM.lookup "name" v of
+                Just (String t) -> t
+                _               -> ""
+          mScope = case KM.lookup "scope" v of
+                     Just (String s) -> Just s
+                     _               -> Nothing
+      in if T.null n then "" else maybe n (\s -> s <> "." <> n) mScope
+superTypeRefName _ = ""
 
 instance FromJSON KotlinMember where
   parseJSON = withObject "KotlinMember" $ \v -> do

--- a/packages/kotlin-analyzer/src/Rules/Annotations.hs
+++ b/packages/kotlin-analyzer/src/Rules/Annotations.hs
@@ -35,14 +35,14 @@ import Grafema.SemanticId (semanticId, contentHash)
 
 walkDeclAnnotations :: KotlinDecl -> Analyzer ()
 
-walkDeclAnnotations (ClassDecl name _kind _mods _tps _ctor _supers members annots sp) = do
+walkDeclAnnotations (ClassDecl name _kind _mods _tps _ctor _supers _exts _impls members annots sp) = do
   file   <- askFile
   parent <- askNamedParent
   let itemId = semanticId file "CLASS" name parent Nothing
   mapM_ (walkAnnotation file itemId sp) annots
   mapM_ (walkMemberAnnotations file) members
 
-walkDeclAnnotations (ObjectDecl name _mods _supers members annots sp) = do
+walkDeclAnnotations (ObjectDecl name _mods _supers _exts _impls members annots sp) = do
   file   <- askFile
   parent <- askNamedParent
   let itemId = semanticId file "CLASS" name parent Nothing

--- a/packages/kotlin-analyzer/src/Rules/Declarations.hs
+++ b/packages/kotlin-analyzer/src/Rules/Declarations.hs
@@ -73,13 +73,35 @@ visibilityText mods
 isExportable :: [Text] -> Bool
 isExportable mods = not (isPrivate mods)
 
+-- | Supertype metadata stamps on CLASS nodes — the analyzer-side unblock for
+-- kotlin inheritance edges (the deferred InheritanceResolve refs are dropped
+-- by the orchestrator, so these names must live on the node itself):
+--   "extends"          = the single class supertype (the parser's
+--                        constructor-call entry; first wins if the parser
+--                        ever yields several — invalid Kotlin),
+--   "implements_0..n"  = indexed interface supertypes (the list-valued
+--                        metadata convention: node_attr-addressable today,
+--                        no split builtin needed).
+-- Kotlin nuance: a class with NO primary constructor may extend a class via a
+-- bare supertype entry (`class X : Base { constructor() : super() }`) — the
+-- parser classifies bare entries as "implements", so such a superclass lands
+-- in implements_N; the consuming kotlin_inheritance.dl pack re-classifies by
+-- the resolved declaration's own `kind` (interface → IMPLEMENTS, else
+-- EXTENDS). Names arrive pre-filtered non-empty from the KotlinAST decoder.
+-- Consumed by the kotlin_inheritance.dl stdlib pack.
+inheritanceMeta :: [Text] -> [Text] -> [(Text, MetaValue)]
+inheritanceMeta extNames implNames =
+  [ ("extends", MetaText e) | e <- take 1 extNames ]
+  ++ [ ("implements_" <> T.pack (show i), MetaText n)
+     | (i, n) <- zip [0 :: Int ..] implNames ]
+
 -- Top-level declaration walker
 
 -- | Walk a single top-level or nested declaration.
 walkDeclaration :: KotlinDecl -> Analyzer ()
 
 -- Class declaration (class, data, sealed, enum, inner, value, annotation)
-walkDeclaration (ClassDecl name kind mods _typeParams mPrimaryCtor _supers members _annots sp) = do
+walkDeclaration (ClassDecl name kind mods _typeParams mPrimaryCtor _supers extNames implNames members _annots sp) = do
   file     <- askFile
   scopeId  <- askScopeId
   parent   <- askNamedParent
@@ -110,6 +132,7 @@ walkDeclaration (ClassDecl name kind mods _typeParams mPrimaryCtor _supers membe
         , ("inner",      MetaBool (kind == "inner" || "inner" `elem` mods))
         , ("value",      MetaBool (kind == "value"))
         ]
+        ++ inheritanceMeta extNames implNames
     }
 
   emitEdge GraphEdge
@@ -138,7 +161,7 @@ walkDeclaration (ClassDecl name kind mods _typeParams mPrimaryCtor _supers membe
       mapM_ walkMember members
 
 -- Object declaration
-walkDeclaration (ObjectDecl name mods _supers members _annots sp) = do
+walkDeclaration (ObjectDecl name mods _supers extNames implNames members _annots sp) = do
   file     <- askFile
   scopeId  <- askScopeId
   parent   <- askNamedParent
@@ -159,11 +182,12 @@ walkDeclaration (ObjectDecl name mods _supers members _annots sp) = do
     , gnEndLine   = posLine (spanEnd sp)
     , gnEndColumn = posCol  (spanEnd sp)
     , gnExported  = objExported
-    , gnMetadata  = Map.fromList
+    , gnMetadata  = Map.fromList $
         [ ("kind",       MetaText "object")
         , ("visibility", MetaText (visibilityText mods))
         , ("singleton",  MetaBool True)
         ]
+        ++ inheritanceMeta extNames implNames
     }
 
   emitEdge GraphEdge
@@ -860,8 +884,8 @@ walkParam fnId param = do
 -- Helpers
 
 declName' :: KotlinDecl -> Text
-declName' (ClassDecl n _ _ _ _ _ _ _ _)       = n
-declName' (ObjectDecl n _ _ _ _ _)            = n
+declName' (ClassDecl n _ _ _ _ _ _ _ _ _ _)   = n
+declName' (ObjectDecl n _ _ _ _ _ _ _)        = n
 declName' (FunDecl n _ _ _ _ _ _ _ _)         = n
 declName' (PropertyDecl n _ _ _ _ _ _ _ _ _)  = n
 declName' (TypeAliasDecl n _ _ _ _ _)         = n

--- a/packages/kotlin-analyzer/src/Rules/Exports.hs
+++ b/packages/kotlin-analyzer/src/Rules/Exports.hs
@@ -33,7 +33,7 @@ isPrivate mods = "private" `elem` mods
 walkDeclExports :: KotlinDecl -> Analyzer ()
 
 -- Public class (default) -> NamedExport + walk members
-walkDeclExports (ClassDecl name _kind mods _tps _ctor _supers members _annots _sp)
+walkDeclExports (ClassDecl name _kind mods _tps _ctor _supers _exts _impls members _annots _sp)
   | not (isPrivate mods) = do
     file   <- askFile
     _parent <- askNamedParent
@@ -46,7 +46,7 @@ walkDeclExports (ClassDecl name _kind mods _tps _ctor _supers members _annots _s
       }
     mapM_ (walkMemberExports file name) members
 
-walkDeclExports (ObjectDecl name mods _supers members _annots _sp)
+walkDeclExports (ObjectDecl name mods _supers _exts _impls members _annots _sp)
   | not (isPrivate mods) = do
     file   <- askFile
     _parent <- askNamedParent

--- a/packages/kotlin-analyzer/src/Rules/Types.hs
+++ b/packages/kotlin-analyzer/src/Rules/Types.hs
@@ -40,7 +40,7 @@ import Grafema.SemanticId (semanticId, contentHash)
 walkDeclTypeRefs :: KotlinDecl -> Analyzer ()
 
 -- Class: superTypes + type params + member types
-walkDeclTypeRefs (ClassDecl name _kind _mods typeParams _mCtor supers members _annots sp) = do
+walkDeclTypeRefs (ClassDecl name _kind _mods typeParams _mCtor supers _exts _impls members _annots sp) = do
   file   <- askFile
   parent <- askNamedParent
   let nodeId = semanticId file "CLASS" name parent Nothing
@@ -58,7 +58,7 @@ walkDeclTypeRefs (ClassDecl name _kind _mods typeParams _mCtor supers members _a
   mapM_ (walkMemberTypeRefs file nodeId) members
 
 -- Object: superTypes + member types
-walkDeclTypeRefs (ObjectDecl name _mods supers members _annots sp) = do
+walkDeclTypeRefs (ObjectDecl name _mods supers _exts _impls members _annots sp) = do
   file   <- askFile
   parent <- askNamedParent
   let nodeId = semanticId file "CLASS" name parent Nothing

--- a/packages/kotlin-analyzer/test/Spec.hs
+++ b/packages/kotlin-analyzer/test/Spec.hs
@@ -101,7 +101,7 @@ emptyBlock = BlockStmt [] (mkSpan 3 0 3 2)
 
 mkClassDecl :: Text -> Text -> [Text] -> [KotlinType] -> [KotlinMember] -> KotlinDecl
 mkClassDecl name kind mods supers members = ClassDecl
-  name kind mods [] Nothing supers members [] (mkSpan 1 0 10 1)
+  name kind mods [] Nothing supers [] [] members [] (mkSpan 1 0 10 1)
 
 mkFunDecl :: Text -> [Text] -> [KotlinParam] -> Maybe KotlinType -> Maybe KotlinStmt -> KotlinDecl
 mkFunDecl name mods params retType body = FunDecl
@@ -209,11 +209,88 @@ main = hspec $ do
           containsEdges = findEdgesByType "CONTAINS" fa
       length containsEdges `shouldSatisfy` (> 0)
 
+  -- Declarations: Inheritance metadata stamps (the kotlin_inheritance.dl EDB).
+  -- JSON fixtures use the LIVE kotlin-parser vocabulary (KotlinAstSerializer.kt):
+  -- ClassDecl carries "extends" (wrapped constructor-call entries) and
+  -- "implements" (bare/delegated typerefs); ObjectDecl one mixed "supertypes"
+  -- array; typerefs are tagged "ClassType" with optional "scope"/"typeArgs".
+
+  describe "Declarations.InheritanceMeta" $ do
+    let sp = "{\"start\": {\"line\": 1, \"col\": 0}, \"end\": {\"line\": 1, \"col\": 10}}"
+        ref name = "{\"type\": \"ClassType\", \"name\": \"" ++ name ++ "\", \"span\": " ++ sp ++ "}"
+        callEntry name = "{\"type\": " ++ ref name ++ ", \"args\": [], \"span\": " ++ sp ++ "}"
+        delegEntry name = "{\"type\": " ++ ref name ++ ", \"delegate\": {\"type\": \"NameExpr\", \"name\": \"g\", \"span\": " ++ sp ++ "}, \"span\": " ++ sp ++ "}"
+        classJson name extra =
+          "{\"declarations\": [{\"type\": \"ClassDecl\", \"name\": \"" ++ name
+            ++ "\", \"kind\": \"class\"" ++ extra ++ ", \"span\": " ++ sp ++ "}]}"
+        analyzed json = case parseKotlinFile json of
+          Left err -> error ("Parse failed: " ++ err)
+          Right file -> analyzeText file
+        classNode name fa = case find (\n -> gnType n == "CLASS" && gnName n == name) (faNodes fa) of
+          Nothing -> error ("No CLASS node " ++ show name)
+          Just node -> node
+
+    it "stamps extends for a constructor-call supertype" $ do
+      let fa = analyzed (classJson "Simple" (", \"extends\": [" ++ callEntry "Base" ++ "]"))
+          node = classNode "Simple" fa
+      getMetaText "extends" node `shouldBe` Just "Base"
+      getMetaText "implements_0" node `shouldBe` Nothing
+
+    it "stamps indexed implements for interface supertypes" $ do
+      let fa = analyzed (classJson "Impl" (", \"implements\": [" ++ ref "Greeter" ++ ", " ++ ref "Closer" ++ "]"))
+          node = classNode "Impl" fa
+      getMetaText "extends" node `shouldBe` Nothing
+      getMetaText "implements_0" node `shouldBe` Just "Greeter"
+      getMetaText "implements_1" node `shouldBe` Just "Closer"
+      getMetaText "implements_2" node `shouldBe` Nothing
+
+    it "stamps combined extends + implements" $ do
+      let fa = analyzed (classJson "Multi"
+                 (", \"extends\": [" ++ callEntry "Base" ++ "], \"implements\": ["
+                   ++ ref "Greeter" ++ ", " ++ ref "Closer" ++ "]"))
+          node = classNode "Multi" fa
+      getMetaText "extends" node `shouldBe` Just "Base"
+      getMetaText "implements_0" node `shouldBe` Just "Greeter"
+      getMetaText "implements_1" node `shouldBe` Just "Closer"
+
+    it "strips generic type args and keeps the scope qualifier" $ do
+      -- class GenericSuper : java.util.AbstractList<String>(), Comparable<Simple>
+      let absList = "{\"type\": \"ClassType\", \"name\": \"AbstractList\", \"scope\": \"java.util\", \"typeArgs\": [{\"type\": " ++ ref "String" ++ ", \"span\": " ++ sp ++ "}], \"span\": " ++ sp ++ "}"
+          cmp = "{\"type\": \"ClassType\", \"name\": \"Comparable\", \"typeArgs\": [{\"type\": " ++ ref "Simple" ++ ", \"span\": " ++ sp ++ "}], \"span\": " ++ sp ++ "}"
+          fa = analyzed (classJson "GenericSuper"
+                 (", \"extends\": [{\"type\": " ++ absList ++ ", \"args\": [], \"span\": " ++ sp ++ "}], \"implements\": [" ++ cmp ++ "]"))
+          node = classNode "GenericSuper" fa
+      getMetaText "extends" node `shouldBe` Just "java.util.AbstractList"
+      getMetaText "implements_0" node `shouldBe` Just "Comparable"
+
+    it "stamps nothing for a class without supertypes" $ do
+      let fa = analyzed (classJson "NoSupers" "")
+          node = classNode "NoSupers" fa
+      getMetaText "extends" node `shouldBe` Nothing
+      getMetaText "implements_0" node `shouldBe` Nothing
+
+    it "classifies a delegated supertype entry as implements" $ do
+      -- class Delegated(g: Greeter) : Greeter by g
+      let fa = analyzed (classJson "Delegated" (", \"implements\": [" ++ delegEntry "Greeter" ++ "]"))
+          node = classNode "Delegated" fa
+      getMetaText "extends" node `shouldBe` Nothing
+      getMetaText "implements_0" node `shouldBe` Just "Greeter"
+
+    it "partitions an object's mixed supertypes array by the constructor-call marker" $ do
+      -- object Singleton : Base(9), Greeter
+      let json = "{\"declarations\": [{\"type\": \"ObjectDecl\", \"name\": \"Singleton\", \"supertypes\": ["
+                   ++ callEntry "Base" ++ ", " ++ ref "Greeter" ++ "], \"span\": " ++ sp ++ "}]}"
+          fa = analyzed json
+          node = classNode "Singleton" fa
+      getMetaText "kind" node `shouldBe` Just "object"
+      getMetaText "extends" node `shouldBe` Just "Base"
+      getMetaText "implements_0" node `shouldBe` Just "Greeter"
+
   -- Declarations: Object
 
   describe "Declarations.Object" $ do
     it "emits CLASS node with kind=object and singleton=true" $ do
-      let obj = ObjectDecl "AppConfig" [] [] [] [] (mkSpan 1 0 5 1)
+      let obj = ObjectDecl "AppConfig" [] [] [] [] [] [] (mkSpan 1 0 5 1)
           fa = analyzeText (KotlinFile Nothing [] [obj])
       case findNodeByType "CLASS" fa of
         Nothing -> expectationFailure "No CLASS node"
@@ -343,7 +420,7 @@ main = hspec $ do
 
     it "emits TYPE_PARAMETER nodes with variance" $ do
       let tp = KotlinTypeParam "T" (Just "out") [] False (mkSpan 1 10 1 15)
-          cls = ClassDecl "Box" "class" [] [tp] Nothing [] [] [] (mkSpan 1 0 5 1)
+          cls = ClassDecl "Box" "class" [] [tp] Nothing [] [] [] [] [] (mkSpan 1 0 5 1)
           fa = analyzeText (KotlinFile Nothing [] [cls])
           tpNodes = findNodesByType "TYPE_PARAMETER" fa
       length tpNodes `shouldBe` 1
@@ -357,7 +434,7 @@ main = hspec $ do
   describe "Annotations" $ do
     it "emits ATTRIBUTE node for marker annotation" $ do
       let ann = MarkerAnnotation "Deprecated" Nothing (mkSpan 2 2 2 13)
-          cls = ClassDecl "Old" "class" [] [] Nothing [] [] [ann] (mkSpan 3 0 5 1)
+          cls = ClassDecl "Old" "class" [] [] Nothing [] [] [] [] [ann] (mkSpan 3 0 5 1)
           fa = analyzeText (KotlinFile Nothing [] [cls])
           attrs = findNodesByType "ATTRIBUTE" fa
       case find (\n -> gnName n == "Deprecated") attrs of
@@ -366,7 +443,7 @@ main = hspec $ do
 
     it "emits HAS_ATTRIBUTE edge" $ do
       let ann = MarkerAnnotation "Deprecated" Nothing (mkSpan 2 2 2 13)
-          cls = ClassDecl "Old" "class" [] [] Nothing [] [] [ann] (mkSpan 3 0 5 1)
+          cls = ClassDecl "Old" "class" [] [] Nothing [] [] [] [] [ann] (mkSpan 3 0 5 1)
           fa = analyzeText (KotlinFile Nothing [] [cls])
           hasAttrEdges = findEdgesByType "HAS_ATTRIBUTE" fa
       length hasAttrEdges `shouldBe` 1

--- a/packages/kotlin-resolve/src/TypeResolution.hs
+++ b/packages/kotlin-resolve/src/TypeResolution.hs
@@ -4,13 +4,23 @@
 -- Resolves type references from node metadata to produce typed edges:
 --   - RETURNS edges: function -> return type class
 --   - TYPE_OF edges: variable -> type class
---   - EXTENDS edges: class -> superclass
---   - IMPLEMENTS edges: class -> interface
 --   - THROWS_TYPE edges: function -> exception class
 --
 -- Uses class index to find targets within the project.
 -- External types (stdlib, third-party), primitives, and Kotlin built-in
 -- types are silently skipped.
+--
+-- EXTENDS / IMPLEMENTS are owned by the kotlin_inheritance.dl stdlib pack
+-- (rfdb-server derive/stdlib/kotlin_inheritance.dl), which resolves the
+-- analyzer's `extends` / `implements_0..n` CLASS stamps with file/directory
+-- scoping and an ambiguity discipline. The resolveExtends/resolveImplements
+-- arms that used to live here were retired in the same wave that introduced
+-- those stamps: they had been dead (the analyzer never stamped `extends` /
+-- `implements` before, so their production output was provably ZERO), and the
+-- new `extends` stamp would have woken resolveExtends into a second EXTENDS
+-- producer routed through the UNSCOPED project-wide last-wins simple-name
+-- index below — silent wrong cross-package edges the pack deliberately
+-- refuses.
 module TypeResolution (run, resolveAll) where
 
 import Grafema.Types (GraphNode(..), GraphEdge(..), MetaValue(..))
@@ -150,37 +160,6 @@ resolveTypeOf classIdx = concatMap go
                 Nothing      -> []
                 Just classId -> [mkEdge (gnId node) classId "TYPE_OF"]
 
--- | Resolve EXTENDS edges: CLASS nodes with extends metadata.
-resolveExtends :: ClassIndex -> [GraphNode] -> [PluginCommand]
-resolveExtends classIdx = concatMap go
-  where
-    classTypes = Set.fromList ["CLASS", "INTERFACE", "ENUM", "OBJECT"]
-
-    go node
-      | not (Set.member (gnType node) classTypes) = []
-      | otherwise =
-          case getMetaText "extends" node of
-            Nothing -> []
-            Just extendsName ->
-              case lookupType classIdx extendsName of
-                Nothing      -> []
-                Just classId -> [mkEdge (gnId node) classId "EXTENDS"]
-
--- | Resolve IMPLEMENTS edges: CLASS nodes with implements metadata (comma-separated).
-resolveImplements :: ClassIndex -> [GraphNode] -> [PluginCommand]
-resolveImplements classIdx = concatMap go
-  where
-    go node
-      | gnType node /= "CLASS" && gnType node /= "ENUM" = []
-      | otherwise =
-          case getMetaText "implements" node of
-            Nothing -> []
-            Just implStr ->
-              [ mkEdge (gnId node) ifaceId "IMPLEMENTS"
-              | typeName <- splitTypes implStr
-              , Just ifaceId <- [lookupType classIdx typeName]
-              ]
-
 -- | Resolve THROWS_TYPE edges: FUNCTION nodes with throws metadata (comma-separated).
 resolveThrows :: ClassIndex -> [GraphNode] -> [PluginCommand]
 resolveThrows classIdx = concatMap go
@@ -213,19 +192,14 @@ resolveAll nodes = do
 
   let returnsEdges    = resolveReturns classIdx nodes
       typeOfEdges     = resolveTypeOf classIdx nodes
-      extendsEdges    = resolveExtends classIdx nodes
-      implementsEdges = resolveImplements classIdx nodes
       throwsEdges     = resolveThrows classIdx nodes
 
-      allEdges = returnsEdges ++ typeOfEdges ++ extendsEdges
-              ++ implementsEdges ++ throwsEdges
+      allEdges = returnsEdges ++ typeOfEdges ++ throwsEdges
 
   hPutStrLn stderr $
     "kotlin-type-resolve: " ++ show (length allEdges) ++ " type edges"
     ++ " (RETURNS=" ++ show (length returnsEdges)
     ++ ", TYPE_OF=" ++ show (length typeOfEdges)
-    ++ ", EXTENDS=" ++ show (length extendsEdges)
-    ++ ", IMPLEMENTS=" ++ show (length implementsEdges)
     ++ ", THROWS_TYPE=" ++ show (length throwsEdges) ++ ")"
 
   return allEdges

--- a/packages/kotlin-resolve/test/Spec.hs
+++ b/packages/kotlin-resolve/test/Spec.hs
@@ -131,7 +131,13 @@ main = hspec $ do
 
   describe "TypeResolution" $ do
 
-    it "resolves EXTENDS metadata to CLASS node" $ do
+    -- EXTENDS / IMPLEMENTS are owned by the kotlin_inheritance.dl stdlib
+    -- pack; the retired resolveExtends/resolveImplements arms must NOT come
+    -- back — the analyzer now stamps `extends` on CLASS nodes, and a revived
+    -- arm would be a second, unscoped EXTENDS producer (last-wins
+    -- simple-name index, no ambiguity discipline). These are regression
+    -- guards: the stamps that wake the pack must leave this plugin silent.
+    it "does NOT resolve the analyzer's extends stamp (pack-owned)" $ do
       let child = mkNodeMeta
             "f1->CLASS->Child" "CLASS" "Child" "f1.kt"
             [("extends", MetaText "Parent")]
@@ -139,34 +145,22 @@ main = hspec $ do
             "f2->CLASS->Parent" "CLASS" "Parent" "f2.kt"
           nodes = [child, parent]
       cmds <- TypeResolution.resolveAll nodes
-      let extends = findEdgesOfType "EXTENDS" cmds
-      length extends `shouldBe` 1
-      geSource (head extends) `shouldBe` "f1->CLASS->Child"
-      geTarget (head extends) `shouldBe` "f2->CLASS->Parent"
+      countEdgeType "EXTENDS" cmds `shouldBe` 0
 
-    it "resolves IMPLEMENTS metadata to INTERFACE node" $ do
+    it "does NOT resolve implements metadata (pack-owned)" $ do
       let cls = mkNodeMeta
             "f1->CLASS->Impl" "CLASS" "Impl" "f1.kt"
-            [("implements", MetaText "Serializable")]
-          iface = mkNode
-            "f2->INTERFACE->Serializable" "INTERFACE" "Serializable" "f2.kt"
-          nodes = [cls, iface]
-      cmds <- TypeResolution.resolveAll nodes
-      let impls = findEdgesOfType "IMPLEMENTS" cmds
-      length impls `shouldBe` 1
-      geTarget (head impls) `shouldBe` "f2->INTERFACE->Serializable"
-
-    it "resolves multiple implements" $ do
-      let cls = mkNodeMeta
-            "f1->CLASS->Impl" "CLASS" "Impl" "f1.kt"
-            [("implements", MetaText "Serializable,Comparable")]
+            [ ("implements", MetaText "Serializable")
+            , ("implements_0", MetaText "Comparable")
+            ]
           iface1 = mkNode
             "f2->INTERFACE->Serializable" "INTERFACE" "Serializable" "f2.kt"
           iface2 = mkNode
             "f3->INTERFACE->Comparable" "INTERFACE" "Comparable" "f3.kt"
           nodes = [cls, iface1, iface2]
       cmds <- TypeResolution.resolveAll nodes
-      countEdgeType "IMPLEMENTS" cmds `shouldBe` 2
+      countEdgeType "IMPLEMENTS" cmds `shouldBe` 0
+      countEdgeType "EXTENDS" cmds `shouldBe` 0
 
     it "resolves return_type metadata to RETURNS edge" $ do
       let fn = mkNodeMeta
@@ -376,11 +370,14 @@ main = hspec $ do
   describe "Edge integrity" $ do
 
     it "never produces edges with empty source or target" $ do
-      let cls = mkNodeMeta
-            "f1->CLASS->Foo" "CLASS" "Foo" "f1.kt"
-            [("extends", MetaText "Bar")]
-          nodes = [cls]
+      let fn = mkNodeMeta
+            "f1->FUNCTION->make[in:Foo,h:x]" "FUNCTION" "make" "f1.kt"
+            [("return_type", MetaText "Bar")]
+          cls = mkNode
+            "f2->CLASS->Bar" "CLASS" "Bar" "f2.kt"
+          nodes = [fn, cls]
       cmds <- TypeResolution.resolveAll nodes
+      countEdgeType "RETURNS" cmds `shouldBe` 1
       let badEdges = [ e | EmitEdge e <- cmds
                          , geSource e == "" || geTarget e == "" ]
       badEdges `shouldBe` []

--- a/packages/rfdb-server/src/derive/stdlib.rs
+++ b/packages/rfdb-server/src/derive/stdlib.rs
@@ -283,6 +283,25 @@ pub const JS_RUNTIME_GLOBALS_EDGES_DL: &str = concat!(
     include_str!("stdlib/js_runtime_globals_edges.dl"),
 );
 
+/// The Kotlin inheritance pack — EXTENDS (class supertype) + IMPLEMENTS
+/// (interface supertypes) from the kotlin-analyzer's CLASS metadata stamps
+/// (`extends` single key + `implements_0..n` indexed keys — the list-valued
+/// metadata convention). Closes the lang-spec-kotlin step-5 gap: kotlin
+/// classes had ZERO inheritance edges in production (the analyzer's deferred
+/// InheritanceResolve refs are dropped by the orchestrator, and the legacy
+/// kotlin-resolve metadata arms read keys the analyzer never stamped) — every
+/// edge is a declared superset vs legacy-zero. Resolution scope: same-file +
+/// same-package-by-directory arms only (cross-file via imports = next wave,
+/// SUBSET delta). Bare class supertypes of no-primary-constructor classes
+/// (the Kotlin syntactic ambiguity) are re-classified by the resolved
+/// declaration's `kind` (interface → IMPLEMENTS, else EXTENDS recovery arms).
+/// Both edge types are pre-registered SHARED vocabulary
+/// (`packages/types/src/edges.ts`) ⇒ `mode = "additive"` on all heads,
+/// `resolvedVia = "kotlin-inheritance"` meta. PRODUCER of EXTENDS — must run
+/// before shape_verifier (its EXTENDS-closed member lookup); consumes
+/// analyzer EDB only. node_attr ⇒ scratch floor under maintain.
+pub const KOTLIN_INHERITANCE_DL: &str = include_str!("stdlib/kotlin_inheritance.dl");
+
 /// The JS module-path kernel pack (Wave 3b, path/string-kit-unblocked): the
 /// in-engine replacement for the module-level arms of `ImportResolution.hs` —
 /// IMPORT → MODULE `IMPORTS_FROM` (`resolveModuleImports`) and star re-export
@@ -400,6 +419,10 @@ pub const STDLIB_PACKS: &[(&str, &str)] = &[
     // (shape_verifier).
     ("js_runtime_globals_nodes", JS_RUNTIME_GLOBALS_NODES_DL),
     ("js_runtime_globals_edges", JS_RUNTIME_GLOBALS_EDGES_DL),
+    // Kotlin wave: kotlin_inheritance PRODUCES EXTENDS for shape_verifier's
+    // EXTENDS-closed member lookup — strictly before the negators; consumes
+    // analyzer EDB only (CLASS metadata stamps), so no run-after seam.
+    ("kotlin_inheritance", KOTLIN_INHERITANCE_DL),
     // Wave 3c: depends CONSUMES IMPORTS_FROM (every edge, module- and
     // binding-level) — with legacy import-resolution gated it must run after
     // ALL in-engine IMPORTS_FROM producers (rust_imports, js_module_imports,
@@ -1268,6 +1291,7 @@ mod tests {
                 "js_builtins_edges",
                 "js_runtime_globals_nodes",
                 "js_runtime_globals_edges",
+                "kotlin_inheritance",
                 "depends",
                 "method_calls",
                 "shape_verifier",
@@ -2528,6 +2552,207 @@ mod tests {
         assert!(triples(&eval, "ext_chain").is_empty());
         assert!(triples(&eval, "ext_builtin_import").is_empty());
         assert!(triples(&eval, "ext_builtin_global").is_empty());
+    }
+
+    /// The bundled kotlin_inheritance pack derives EXTENDS/IMPLEMENTS from the
+    /// kotlin-analyzer's CLASS metadata stamps (`extends` + `implements_0..n`,
+    /// the EXACT shapes the analyzer emits — verified e2e against the live
+    /// kotlin-parser → analyzer pipeline, see the `.dl` header):
+    /// - same-file extends / implements (`kt_ext_file` / `kt_impl_file`);
+    /// - same-directory fall-through arms (`kt_ext_dir` / `kt_impl_dir`) —
+    ///   fire only with NO same-file candidate;
+    /// - the DELTA-2 recovery arms (`kt_ext_rec_*`): an implements_N stamp
+    ///   resolving to a NON-interface (the bare no-primary-ctor class
+    ///   supertype) derives EXTENDS;
+    /// - the DELTA-8 sealed refusal: `sealed interface` serializes
+    ///   kind="sealed" (parser cascade checks isSealed before isInterface),
+    ///   so a bare entry naming a sealed declaration derives NOTHING from the
+    ///   recovery arms (was: silent wrong EXTENDS toward an interface), while
+    ///   a ctor-call `: SealedClass()` (the `extends` stamp) still derives
+    ///   EXTENDS — kt_ext_file/dir carry no kind guard;
+    /// - the \+ ambig discipline (same-file and same-dir duplicate names skip);
+    /// - negatives: self-edge refusal, out-of-directory scope (SUBSET DELTA 1),
+    ///   the .kt/.kts file gate.
+    #[test]
+    fn kotlin_inheritance_arms_on_analyzer_stamp_shapes() {
+        let mut v = FixtureStorageView::new(1);
+        let dir_a = "src/main/kotlin/com/ex"; // shared directory ("package")
+
+        // a.kt: Greeter (interface), Base, Simple : Base(),
+        //       Multi : Base(), Greeter, Closer (Closer lives in b.kt),
+        //       object Singleton : Base(), Greeter
+        let a = format!("{dir_a}/a.kt");
+        named_node(&mut v, "kt_greeter", "Greeter", "CLASS", &a);
+        v.put_node_metadata(id_of("kt_greeter"), r#"{"kind":"interface"}"#);
+        named_node(&mut v, "kt_base", "Base", "CLASS", &a);
+        v.put_node_metadata(id_of("kt_base"), r#"{"kind":"class"}"#);
+        named_node(&mut v, "kt_simple", "Simple", "CLASS", &a);
+        v.put_node_metadata(id_of("kt_simple"), r#"{"kind":"class","extends":"Base"}"#);
+        named_node(&mut v, "kt_multi", "Multi", "CLASS", &a);
+        v.put_node_metadata(
+            id_of("kt_multi"),
+            r#"{"kind":"class","extends":"Base","implements_0":"Greeter","implements_1":"Closer"}"#,
+        );
+        named_node(&mut v, "kt_singleton", "Singleton", "CLASS", &a);
+        v.put_node_metadata(
+            id_of("kt_singleton"),
+            r#"{"kind":"object","singleton":true,"extends":"Base","implements_0":"Greeter"}"#,
+        );
+
+        // b.kt (same directory): Closer (interface), Helper,
+        //       NoCtorDerived : Base   (bare entry → implements_0, Base is a
+        //                               CLASS in a.kt → EXTENDS recovery, dir arm)
+        //       NoCtor2 : Helper       (bare entry, same-file non-interface →
+        //                               EXTENDS recovery, file arm)
+        //       DirExt : Simple()      (extends, candidate only in a.kt → dir arm)
+        let b = format!("{dir_a}/b.kt");
+        named_node(&mut v, "kt_closer", "Closer", "CLASS", &b);
+        v.put_node_metadata(id_of("kt_closer"), r#"{"kind":"interface"}"#);
+        named_node(&mut v, "kt_helper", "Helper", "CLASS", &b);
+        v.put_node_metadata(id_of("kt_helper"), r#"{"kind":"class"}"#);
+        named_node(&mut v, "kt_noctor", "NoCtorDerived", "CLASS", &b);
+        v.put_node_metadata(id_of("kt_noctor"), r#"{"kind":"class","implements_0":"Base"}"#);
+        named_node(&mut v, "kt_noctor2", "NoCtor2", "CLASS", &b);
+        v.put_node_metadata(id_of("kt_noctor2"), r#"{"kind":"class","implements_0":"Helper"}"#);
+        named_node(&mut v, "kt_dirext", "DirExt", "CLASS", &b);
+        v.put_node_metadata(id_of("kt_dirext"), r#"{"kind":"class","extends":"Simple"}"#);
+
+        // Ambiguity (DELTA 3): c.kt has TWO classes "Dup" — Twin : Dup() skips
+        // (same-file ambig; the dir arm is suppressed by the same-file
+        // candidates). "DD" exists once in a.kt and once in b.kt — DDX : DD()
+        // in c.kt has no same-file candidate and the DIR index is ambiguous.
+        let c = format!("{dir_a}/c.kt");
+        named_node(&mut v, "kt_dup1", "Dup", "CLASS", &c);
+        named_node(&mut v, "kt_dup2", "Dup", "CLASS", &c);
+        named_node(&mut v, "kt_twin", "Twin", "CLASS", &c);
+        v.put_node_metadata(id_of("kt_twin"), r#"{"kind":"class","extends":"Dup"}"#);
+        named_node(&mut v, "kt_dd_a", "DD", "CLASS", &a);
+        named_node(&mut v, "kt_dd_b", "DD", "CLASS", &b);
+        named_node(&mut v, "kt_ddx", "DDX", "CLASS", &c);
+        v.put_node_metadata(id_of("kt_ddx"), r#"{"kind":"class","extends":"DD"}"#);
+
+        // Self-edge refusal: Selfy : Selfy — the only candidate is itself.
+        named_node(&mut v, "kt_selfy", "Selfy", "CLASS", &c);
+        v.put_node_metadata(id_of("kt_selfy"), r#"{"kind":"class","extends":"Selfy"}"#);
+
+        // DELTA 8 — sealed targets. `sealed interface Event` and
+        // `sealed class State` BOTH serialize kind="sealed" (the parser's
+        // isSealed-before-isInterface cascade): bare entries naming them are
+        // unclassifiable and the recovery arms refuse them.
+        // a.kt: Event (sealed interface), State (sealed class),
+        //       Click : Event   (bare → implements_0, sealed target, SAME
+        //                        file → kt_ext_rec_file must NOT fire)
+        named_node(&mut v, "kt_event", "Event", "CLASS", &a);
+        v.put_node_metadata(id_of("kt_event"), r#"{"kind":"sealed","sealed":true}"#);
+        named_node(&mut v, "kt_state", "State", "CLASS", &a);
+        v.put_node_metadata(id_of("kt_state"), r#"{"kind":"sealed","sealed":true}"#);
+        named_node(&mut v, "kt_click", "Click", "CLASS", &a);
+        v.put_node_metadata(id_of("kt_click"), r#"{"kind":"class","implements_0":"Event"}"#);
+        // b.kt: Render : Event   (bare, sealed target in a.kt → the DIR
+        //                         recovery arm must NOT fire either)
+        //       Loading : State() (ctor-call → `extends` stamp; sealed CLASS
+        //                          target still derives EXTENDS via the dir
+        //                          arm — DELTA 8 does not touch kt_ext_*)
+        named_node(&mut v, "kt_render", "Render", "CLASS", &b);
+        v.put_node_metadata(id_of("kt_render"), r#"{"kind":"class","implements_0":"Event"}"#);
+        named_node(&mut v, "kt_loading", "Loading", "CLASS", &b);
+        v.put_node_metadata(id_of("kt_loading"), r#"{"kind":"class","extends":"State"}"#);
+
+        // Scope bound (SUBSET DELTA 1): Far : Base() in another directory —
+        // Base is out of scope, no edge.
+        named_node(&mut v, "kt_far", "Far", "CLASS", "other/pkg/far.kt");
+        v.put_node_metadata(id_of("kt_far"), r#"{"kind":"class","extends":"Base"}"#);
+
+        // File gate: the same stamp shape in a .rs file derives nothing.
+        named_node(&mut v, "rs_base", "RsBase", "CLASS", "src/x.rs");
+        named_node(&mut v, "rs_child", "RsChild", "CLASS", "src/x.rs");
+        v.put_node_metadata(id_of("rs_child"), r#"{"kind":"class","extends":"RsBase"}"#);
+
+        let (eval, specs, _node_specs) = evaluate_with_materialize(
+            &v,
+            KOTLIN_INHERITANCE_DL,
+            Stats::default(),
+            EvalLimits::none(),
+            EventLog::discard(),
+        )
+        .expect("kotlin_inheritance.dl evaluates");
+
+        let via = |pairs: &[(&str, &str)]| -> BTreeSet<(u128, u128, String)> {
+            pairs
+                .iter()
+                .map(|(s, t)| (id_of(s), id_of(t), "kotlin-inheritance".to_string()))
+                .collect()
+        };
+        assert_eq!(
+            triples(&eval, "kt_ext_file"),
+            via(&[
+                ("kt_simple", "kt_base"),
+                ("kt_multi", "kt_base"),
+                ("kt_singleton", "kt_base"),
+            ]),
+            "same-file extends; Twin (ambig Dup), Selfy (self-edge), Far \
+             (out of scope) and the .rs shape derive nothing"
+        );
+        assert_eq!(
+            triples(&eval, "kt_ext_dir"),
+            via(&[("kt_dirext", "kt_simple"), ("kt_loading", "kt_state")]),
+            "directory fall-through extends; the ctor-call `extends` stamp \
+             reaches a SEALED CLASS target (DELTA 8 guards only the recovery \
+             arms); DDX skips (dir-ambiguous DD), same-file candidates \
+             suppress the arm everywhere else"
+        );
+        assert_eq!(
+            triples(&eval, "kt_impl_file"),
+            via(&[("kt_multi", "kt_greeter"), ("kt_singleton", "kt_greeter")]),
+            "same-file implements_N resolving to kind=interface"
+        );
+        assert_eq!(
+            triples(&eval, "kt_impl_dir"),
+            via(&[("kt_multi", "kt_closer")]),
+            "directory fall-through implements (Closer lives in b.kt)"
+        );
+        assert_eq!(
+            triples(&eval, "kt_ext_rec_file"),
+            via(&[("kt_noctor2", "kt_helper")]),
+            "DELTA 2 recovery, same file: bare class supertype stamped as \
+             implements_0 re-classified to EXTENDS by the target's kind; \
+             Click : Event (sealed target, same file) derives NOTHING — \
+             DELTA 8 refuses kind=sealed in the recovery arms"
+        );
+        assert_eq!(
+            triples(&eval, "kt_ext_rec_dir"),
+            via(&[("kt_noctor", "kt_base")]),
+            "DELTA 2 recovery, directory fall-through; Render : Event \
+             (sealed target in a.kt) derives NOTHING — DELTA 8 dir arm"
+        );
+        // DELTA 8 cross-check: the sealed-interface bare entries derive no
+        // IMPLEMENTS either (kind=sealed ≠ kind=interface), so Click/Render
+        // carry ZERO inheritance edges — a documented gap, not a wrong edge.
+        for rel in ["kt_impl_file", "kt_impl_dir", "kt_ext_file"] {
+            assert!(
+                !triples(&eval, rel)
+                    .iter()
+                    .any(|(s, _, _)| *s == id_of("kt_click") || *s == id_of("kt_render")),
+                "{rel} must not derive for the sealed-interface implementors"
+            );
+        }
+
+        // Heads: 4 EXTENDS + 2 IMPLEMENTS, all additive (shared vocabulary),
+        // resolvedVia projected on all.
+        let ext: Vec<_> = specs.iter().filter(|s| s.edge_type == "EXTENDS").collect();
+        assert_eq!(ext.len(), 4, "EXTENDS heads: file + dir + 2 recovery arms");
+        let imp: Vec<_> = specs.iter().filter(|s| s.edge_type == "IMPLEMENTS").collect();
+        assert_eq!(imp.len(), 2, "IMPLEMENTS heads: file + dir arms");
+        assert!(
+            specs.iter().all(|s| s.additive),
+            "EXTENDS/IMPLEMENTS are shared vocabulary — additive is mandatory"
+        );
+        assert!(
+            specs
+                .iter()
+                .all(|s| s.meta == vec!["resolvedVia".to_string()]),
+            "resolvedVia is projected on all heads"
+        );
     }
 
     /// The bundled js_import_bindings pack (Wave 2, node_attr) resolves the

--- a/packages/rfdb-server/src/derive/stdlib/kotlin_inheritance.dl
+++ b/packages/rfdb-server/src/derive/stdlib/kotlin_inheritance.dl
@@ -1,0 +1,186 @@
+% kotlin_inheritance.dl — Kotlin EXTENDS / IMPLEMENTS edges from the analyzer's
+% supertype metadata stamps. Closes the kotlin-spec step-5 gap (lang-spec-kotlin
+% §Step 5): kotlin classes had ZERO inheritance edges in production — supertypes
+% went ONLY into deferred InheritanceResolve refs (kotlin-analyzer Types.hs
+% emitInheritanceEdge) which the orchestrator drops (FileAnalysis has no
+% unresolvedRefs field, analyzer.rs:41-49), and the kotlin-resolve
+% resolveExtends/resolveImplements arms read `extends`/`implements` metadata the
+% analyzer never stamped (those arms are retired in this wave — DELTA 7).
+% EVERYTHING this pack derives is therefore a declared SUPERSET vs the
+% legacy-zero baseline (DELTA 7 below).
+%
+% EDB CONTRACT (the analyzer-side stamps, Rules/Declarations.hs inheritanceMeta):
+%   CLASS node metadata
+%     "extends"          — the single class supertype name (the parser's
+%                          constructor-call supertype entry; `class C : Base(1)`),
+%     "implements_0..n"  — indexed interface supertype names (bare / delegated
+%                          entries; the list-valued metadata convention —
+%                          node_attr-addressable, no split builtin needed).
+%   Names are simple ("Base") or scope-qualified as written ("java.util.List");
+%   generic type arguments are stripped at stamp time. Interfaces / enums /
+%   objects are all CLASS nodes with a `kind` metadata discriminator
+%   (kind = "interface" marks interfaces — kotlin-analyzer emits NO INTERFACE
+%   node type). CAVEAT: the parser's kind cascade checks isSealed() BEFORE
+%   isInterface() (kotlin-parser KotlinAstSerializer.kt:83-92), so a
+%   `sealed interface` serializes kind = "sealed" — indistinguishable from a
+%   sealed CLASS in the EDB. See DELTA 8.
+%
+% CLASSIFICATION RULE (the Kotlin syntactic ambiguity): the parser classifies a
+% supertype entry by the constructor-call '()' suffix — `Base(1)` → "extends",
+% bare `Greeter` → "implements". A class with NO primary constructor may extend
+% a class via a BARE entry (`class X : Base { constructor() : super() }`), which
+% lands in implements_N. This pack re-classifies by the RESOLVED declaration's
+% own kind: target kind = "interface" → IMPLEMENTS, anything else → EXTENDS
+% (the recovery arms). The ambiguity is thus resolved whenever the declaration
+% is in scope; out-of-scope names derive nothing either way (DELTA 2).
+%
+% RESOLUTION SCOPE (SUBSET DELTA 1): same-file + same-package-by-directory arms
+% ONLY. Kotlin import resolution is a separate migration step (lang-spec-kotlin
+% steps 1-2); cross-file resolution through imports is the next wave. Bound =
+% stamps whose names resolve only via an import.
+%
+% NUMBERED DELTAS (vs legacy kotlin-resolve AND vs ideal Kotlin semantics):
+%   DELTA 1 (scope subset): same-file + same-directory arms only — see above.
+%   DELTA 2 (classification): bare class supertypes of no-primary-ctor classes
+%     arrive in implements_N; re-classified by target kind (recovery arms).
+%     Residual: such a supertype that is OUT of resolution scope derives no
+%     edge — same as every out-of-scope name.
+%   DELTA 3 (ambiguity discipline): duplicate same-name declarations in the
+%     resolution scope are SKIPPED (the \+ ambig idiom — js_this_method_calls
+%     precedent), not derived per-candidate. Bound = duplicate (scope, name)
+%     pairs, measurable.
+%   DELTA 4 (index cap): want_impl enumerates implements_0..15 — a class with
+%     more than 16 interface supertypes loses the tail (real Kotlin: unheard of).
+%   DELTA 5 (qualified stamps): dotted names ("java.util.AbstractList") join
+%     only a declaration literally so named — practically never; external
+%     supertypes derive nothing (parity with the legacy zero).
+%   DELTA 6 (directory ≈ package): the same-package arm joins by the file's
+%     directory prefix (last_segment/strip_suffix peel), not the MODULE
+%     `package` metadata — files in one directory with different package
+%     declarations (or one package split across directories) deviate from true
+%     package scope. Top-level files (no '/') share the "" directory.
+%   DELTA 7 (baseline): legacy production output is ZERO (header) — every edge
+%     is new, resolvedVia = "kotlin-inheritance" meta marks the producer.
+%     KEPT TRUE BY CONSTRUCTION: the kotlin-resolve resolveExtends /
+%     resolveImplements arms (which read the same `extends` / un-suffixed
+%     `implements` metadata through an UNSCOPED project-wide last-wins
+%     simple-name index) are retired in the same wave that lands the analyzer
+%     stamps — otherwise the `extends` stamp would wake resolveExtends into a
+%     second, scope-undisciplined EXTENDS producer (kotlin-resolve
+%     TypeResolution.hs — see the retirement note there).
+%   DELTA 8 (sealed targets of bare entries): kind = "sealed" is BOTH sealed
+%     classes and sealed interfaces (the parser cascade, EDB contract above).
+%     A bare supertype entry (implements_N stamp) resolving to a kind="sealed"
+%     declaration is therefore unclassifiable — the recovery arms refuse it
+%     (\+ kind=sealed guard) rather than derive EXTENDS toward what may be a
+%     sealed INTERFACE. Bound = bare entries naming an in-scope sealed
+%     declaration: `class C : SealedIface` derives nothing (was: silent wrong
+%     EXTENDS). Constructor-call supertypes are unaffected — `class C :
+%     SealedClass()` arrives as the `extends` stamp and kt_ext_file/dir carry
+%     no kind guard. Full fix is parser-side (an explicit interface flag).
+%
+% MAINTAIN ENVELOPE: node_attr reads metadata blobs outside the delta algebra —
+% maintain-incremental refuses this pack; it runs at the scratch floor (the
+% accepted stance of every node_attr pack — js_class_inheritance precedent).
+%
+% ORDERING (producer): EXTENDS is consumed by shape_verifier's EXTENDS-closed
+% member lookup — this pack MUST run before shape_verifier. It consumes
+% analyzer EDB only (no pack-produced inputs), so it has no run-after seam.
+
+% Every CLASS in a Kotlin file — file gate inlined per base relation
+% (ends_with is a filter, it cannot generate F; config.rs:749 maps both
+% .kt and .kts to Language::Kotlin).
+ktc(C, F) :- node(C, "CLASS"), attr(C, "file", F), ends_with(F, ".kt").
+ktc(C, F) :- node(C, "CLASS"), attr(C, "file", F), ends_with(F, ".kts").
+
+% The stamped class-supertype want: one per class ("extends" is single-valued).
+want_ext(C, F, N) :- ktc(C, F), node_attr(C, "extends", N), neq(N, "").
+
+% The stamped interface-supertype wants: many per class, one clause per
+% indexed key implements_0..15 (DELTA 4) — node_attr requires a bound key and
+% a fact-table key generator is a planner-rejected cross-join (E-PLAN-003,
+% observed on this pack), so the keys are inlined per clause (the
+% one-clause-per-constant idiom — js file-extension gates precedent).
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_0", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_1", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_2", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_3", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_4", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_5", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_6", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_7", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_8", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_9", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_10", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_11", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_12", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_13", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_14", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_15", N), neq(N, "").
+
+% Same-file declaration index (file, name) → CLASS node.
+cls_in(F, N, T) :- ktc(T, F), attr(T, "name", N), neq(N, "").
+
+% Duplicate same-name declarations in one file — the exactly-one guard.
+amb_f(F, N) :- cls_in(F, N, T1), cls_in(F, N, T2), neq(T1, T2).
+
+% Directory of a kotlin file: F = D ++ Base, Base the post-'/' tail
+% (identity when no '/' → D = "", DELTA 6).
+dir_of(F, D) :- ktc(_, F), last_segment(F, "/", B), strip_suffix(F, B, D).
+
+% Same-directory declaration index + its exactly-one guard (same-file
+% duplicates are dir duplicates too — the dir arm inherits the skip).
+cls_dir(D, N, T) :- cls_in(F, N, T), dir_of(F, D).
+amb_d(D, N) :- cls_dir(D, N, T1), cls_dir(D, N, T2), neq(T1, T2).
+
+% Interface discriminator (kotlin interfaces are CLASS kind=interface).
+iface(T) :- ktc(T, _), node_attr(T, "kind", "interface").
+
+% Sealed discriminator — covers sealed classes AND sealed interfaces (the
+% parser cascade collapses both to kind="sealed", DELTA 8).
+sealed_t(T) :- ktc(T, _), node_attr(T, "kind", "sealed").
+
+% Fall-through gates: a same-file candidate suppresses the directory arm
+% (js_class_inheritance has_local precedent; per-name for the multi-valued
+% implements list).
+has_f_ext(C) :- want_ext(C, F, N), cls_in(F, N, _).
+has_f_impl(C, N) :- want_impl(C, F, N), cls_in(F, N, _).
+
+% ── EXTENDS from the "extends" stamp ────────────────────────────────────────
+
+@materialize(edge_type = "EXTENDS", mode = "additive", meta(resolvedVia))
+kt_ext_file(C, T, "kotlin-inheritance") :-
+    want_ext(C, F, N), cls_in(F, N, T), \+ amb_f(F, N), neq(C, T).
+
+@materialize(edge_type = "EXTENDS", mode = "additive", meta(resolvedVia))
+kt_ext_dir(C, T, "kotlin-inheritance") :-
+    want_ext(C, F, N), \+ has_f_ext(C),
+    dir_of(F, D), cls_dir(D, N, T), \+ amb_d(D, N), neq(C, T).
+
+% ── IMPLEMENTS from implements_N stamps resolving to an interface ───────────
+
+@materialize(edge_type = "IMPLEMENTS", mode = "additive", meta(resolvedVia))
+kt_impl_file(C, T, "kotlin-inheritance") :-
+    want_impl(C, F, N), cls_in(F, N, T), iface(T), \+ amb_f(F, N), neq(C, T).
+
+@materialize(edge_type = "IMPLEMENTS", mode = "additive", meta(resolvedVia))
+kt_impl_dir(C, T, "kotlin-inheritance") :-
+    want_impl(C, F, N), \+ has_f_impl(C, N),
+    dir_of(F, D), cls_dir(D, N, T), iface(T), \+ amb_d(D, N), neq(C, T).
+
+% ── EXTENDS recovery: implements_N stamp resolving to a NON-interface — the
+%    no-primary-constructor bare class supertype (DELTA 2). kind = "sealed"
+%    targets are REFUSED (DELTA 8): sealed interfaces also serialize
+%    kind="sealed", so re-classifying a bare entry toward a sealed target as
+%    EXTENDS would silently mis-edge `class C : SealedIface` ────────────────
+
+@materialize(edge_type = "EXTENDS", mode = "additive", meta(resolvedVia))
+kt_ext_rec_file(C, T, "kotlin-inheritance") :-
+    want_impl(C, F, N), cls_in(F, N, T), \+ iface(T), \+ sealed_t(T),
+    \+ amb_f(F, N), neq(C, T).
+
+@materialize(edge_type = "EXTENDS", mode = "additive", meta(resolvedVia))
+kt_ext_rec_dir(C, T, "kotlin-inheritance") :-
+    want_impl(C, F, N), \+ has_f_impl(C, N),
+    dir_of(F, D), cls_dir(D, N, T), \+ iface(T), \+ sealed_t(T),
+    \+ amb_d(D, N), neq(C, T).


### PR DESCRIPTION
Kotlin classes get inheritance edges for the first time. The spec's dead-arm finding went deeper than predicted: a parser↔decoder key drift meant supertypes never reached even the deferred refs. Review caught two majors before landing (sealed-interface misclassification → wrong EXTENDS; the new stamp waking a dormant unscoped legacy resolver arm) — both closed in-wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)