### PR TITLE
feat(derive): go resolver as 6 derive packs (+first_segment builtin, go.mod facts)

### DIFF
--- a/packages/grafema-orchestrator/src/analyzer.rs
+++ b/packages/grafema-orchestrator/src/analyzer.rs
@@ -841,6 +841,43 @@ pub fn workspace_packages_to_wire(
     nodes
 }
 
+/// The GO module-path fact (precondition P1 of the go pack migration): the
+/// go.mod module path the legacy `go-resolve` daemon consumed over the wire
+/// (`workspace_packages` — main.rs wraps `discover_go_module_path` as a single
+/// WorkspacePackageWire) becomes a graph fact the go packs can join:
+/// `go_mod(MP) :- node(W, "WORKSPACE_PACKAGE"), node_attr(W, "language", "go"),
+/// attr(W, "name", MP)` (go_imports.dl / go_calls.dl).
+///
+/// Shape (the [`workspace_packages_to_wire`] conventions, plus the language
+/// discriminator):
+/// - `name` = the Go module path (e.g. `"github.com/user/project"`);
+/// - `file` = `"go.mod"` (the declaring file — js workspace facts never carry
+///   it, so the js packs' `ws_pkg` arms cannot confuse the fact with an npm
+///   package, and vice versa the go packs key on `language`);
+/// - `metadata.language` = `"go"` — the discriminator the packs join;
+/// - `metadata.package_dir` = the project root.
+///
+/// Semantic id `go.mod->WORKSPACE_PACKAGE-><module path>` (stable across runs;
+/// re-emitted every analyze like the js facts — upsert dedups).
+pub fn go_module_workspace_fact(module_path: &str, root: &str, authority: &str) -> WireNode {
+    let compact_id = format!("go.mod->WORKSPACE_PACKAGE->{module_path}");
+    let node_id = compact_to_uri(&compact_id, authority);
+
+    let mut meta = HashMap::new();
+    meta.insert("language".to_string(), serde_json::json!("go"));
+    meta.insert("package_dir".to_string(), serde_json::json!(root));
+
+    WireNode {
+        id: node_id.clone(),
+        semantic_id: Some(node_id),
+        node_type: Some("WORKSPACE_PACKAGE".to_string()),
+        name: Some(module_path.to_string()),
+        file: Some("go.mod".to_string()),
+        exported: false,
+        metadata: Some(serde_json::to_string(&meta).unwrap()),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Single-file analysis
 // ---------------------------------------------------------------------------
@@ -7513,5 +7550,26 @@ mod tests {
     #[test]
     fn workspace_packages_to_wire_empty_is_empty() {
         assert!(workspace_packages_to_wire(&[], "github.com/o/r").is_empty());
+    }
+
+    /// The GO module-path fact (P1): the go packs join
+    /// `node_attr(W, "language", "go")` × `attr(W, "name", MP)` — the language
+    /// discriminator MUST ride metadata and the module path MUST be the
+    /// first-class name; ids stable across runs (upsert dedups).
+    #[test]
+    fn go_module_workspace_fact_shape_and_stability() {
+        let a = go_module_workspace_fact("github.com/user/project", ".", "github.com/o/r");
+        assert_eq!(a.node_type.as_deref(), Some("WORKSPACE_PACKAGE"));
+        assert_eq!(a.name.as_deref(), Some("github.com/user/project"));
+        assert_eq!(a.file.as_deref(), Some("go.mod"));
+        assert!(!a.exported);
+        let meta: serde_json::Value =
+            serde_json::from_str(a.metadata.as_deref().unwrap()).unwrap();
+        assert_eq!(meta["language"], "go", "the go packs' discriminator key");
+        assert_eq!(meta["package_dir"], ".");
+        let b = go_module_workspace_fact("github.com/user/project", ".", "github.com/o/r");
+        assert_eq!(a.id, b.id, "stable id across runs");
+        assert_eq!(a.semantic_id.as_deref(), Some(a.id.as_str()));
+        assert!(a.id.contains("WORKSPACE_PACKAGE"), "typed id: {}", a.id);
     }
 }

--- a/packages/grafema-orchestrator/src/main.rs
+++ b/packages/grafema-orchestrator/src/main.rs
@@ -94,6 +94,21 @@ const STDLIB_RULE_PACKS: &[&str] = &[
     // producer — before method_calls/shape_verifier.
     "@stdlib/js_runtime_globals_nodes",
     "@stdlib/js_runtime_globals_edges",
+    // Go wave: go_imports / go_imports_nomod PRODUCE IMPORTS_FROM — strictly
+    // before depends (verdict C4). The nomod entry is the orchestrator-selected
+    // VARIANT (P3): a pack cannot test "the go.mod fact is absent" (§3
+    // cross-join), so `run_stdlib_rule_packs` SKIPS it unless go files exist
+    // AND go.mod did not resolve — both names stay registered so the
+    // cross-registry order pin below holds. go_calls PRODUCES CALLS for
+    // go_context (P2 producer-before-consumer) and precedes the CALLS
+    // negators (method_calls / shape_verifier — C4). go_interfaces / go_types
+    // consume analyzer EDB only.
+    "@stdlib/go_imports",
+    "@stdlib/go_imports_nomod",
+    "@stdlib/go_calls",
+    "@stdlib/go_interfaces",
+    "@stdlib/go_types",
+    "@stdlib/go_context",
     // Wave 3c: depends CONSUMES IMPORTS_FROM (every edge of the shared
     // vocabulary, module- and binding-level). Legacy import-resolution /
     // rust-imports are gated (GRAFEMA_SKIP_RESOLVE_STEPS), so depends must
@@ -535,6 +550,12 @@ fn pack_owned_slice(pack: &str) -> &'static str {
         "@stdlib/js_builtins_edges" => "node-builtin IMPORTS_FROM + CALLS",
         "@stdlib/js_runtime_globals_nodes" => "js runtime-global GLOBAL_DEFINITION nodes",
         "@stdlib/js_runtime_globals_edges" => "js runtime-global CALLS",
+        "@stdlib/go_imports" => "go same-module IMPORT→MODULE IMPORTS_FROM",
+        "@stdlib/go_imports_nomod" => "go no-go.mod suffix-fallback IMPORTS_FROM",
+        "@stdlib/go_calls" => "go CALLS (package-qualified / same-package / method)",
+        "@stdlib/go_interfaces" => "go structural IMPLEMENTS (duck typing)",
+        "@stdlib/go_types" => "go TYPE_OF + RETURNS",
+        "@stdlib/go_context" => "go PROPAGATES/SPAWNS/DEFERS context flow",
         "@stdlib/depends" => "MODULE→MODULE DEPENDS_ON",
         "@stdlib/method_calls" => "fuzzy method-call CALLS fallback",
         "@stdlib/shape_verifier" => "shape-violation ISSUE diagnostics",
@@ -570,13 +591,29 @@ fn pack_failure_summary(failures: &[(String, String)]) -> String {
 /// later packs depend on earlier ones only through committed edges, so a failed
 /// producer degrades but does not invalidate them), then the phase FAILS with
 /// [`pack_failure_summary`] naming every failed pack and its owned slice.
+///
+/// PACK-VARIANT SELECTION (go P3): `go_nomod_fallback` is the ONE runtime
+/// selection condition — `@stdlib/go_imports_nomod` (the legacy
+/// empty-module-path suffix fallback, GoImportResolution.hs findBySuffix) runs
+/// ONLY when go files exist and go.mod did NOT resolve. The condition lives
+/// here because a pack cannot test "the go.mod fact is absent" (a global
+/// has-fact literal is the §3 cross-join the planner refuses — and per the
+/// spec verdict C2 a filter-connected suffix spelling is equally rejected);
+/// the orchestrator, which discovered go.mod, owns the branch — the faithful
+/// translation of legacy's `T.null modulePath` global. The main `go_imports`
+/// pack always runs: without the P1 fact its module-prefix arms derive
+/// nothing (fixture-proven), so the two variants never both fire.
 async fn run_stdlib_rule_packs(
     rfdb: &mut rfdb::RfdbClient,
     prof: Option<&profiler::Profiler>,
     imports_from_hint: usize,
+    go_nomod_fallback: bool,
 ) -> Result<()> {
     let mut failed_packs: Vec<(String, String)> = Vec::new();
     for pack in STDLIB_RULE_PACKS {
+        if *pack == "@stdlib/go_imports_nomod" && !go_nomod_fallback {
+            continue;
+        }
         let pack_start = std::time::Instant::now();
         match rfdb.materialize_datalog(pack).await {
             Ok(pack_edges) => {
@@ -2032,13 +2069,45 @@ async fn main() -> Result<()> {
                 tracing::info!(count = n_ws, "WORKSPACE_PACKAGE facts committed");
             }
 
+            // 8n-go. Commit the GO module-path fact (go pack precondition P1):
+            // the go.mod module path the legacy daemon consumed over the wire
+            // (main.rs go_ws_packages above) becomes a WORKSPACE_PACKAGE node
+            // with metadata language="go" that go_imports.dl / go_calls.dl
+            // join. Must land BEFORE the pack phase below. The P3 variant
+            // selection (no-go.mod suffix fallback) keys off the same
+            // discovery — see `run_stdlib_rule_packs`.
+            let go_module_path_for_packs = if go_files.is_empty() {
+                None
+            } else {
+                config::discover_go_module_path(&cfg.root)
+            };
+            let go_nomod_fallback = !go_files.is_empty() && go_module_path_for_packs.is_none();
+            if let Some(ref go_mp) = go_module_path_for_packs {
+                let mut go_fact = analyzer::go_module_workspace_fact(
+                    go_mp,
+                    &cfg.root.display().to_string(),
+                    &authority,
+                );
+                gc::stamp_node_metadata(&mut go_fact.metadata, generation, "workspace-packages");
+                rfdb.commit_batch(&[], &[go_fact], &[], true)
+                    .await
+                    .context("Failed to commit GO module-path fact")?;
+                tracing::info!(module_path = %go_mp, "GO module-path WORKSPACE_PACKAGE fact committed");
+            }
+
             // 9. Rule-pack phase. The server's capability was asserted at
             // connect time (fail-fast above), so this phase ALWAYS runs — see
             // `run_stdlib_rule_packs` for the ordering contract and the Wave-6
             // failure policy (any failed pack fails the run at end of phase).
             let depends_on_start = std::time::Instant::now();
             profile!("depends_on_start", "imports_from_edges" => all_imports_from_edges.len());
-            run_stdlib_rule_packs(&mut rfdb, prof.as_ref(), all_imports_from_edges.len()).await?;
+            run_stdlib_rule_packs(
+                &mut rfdb,
+                prof.as_ref(),
+                all_imports_from_edges.len(),
+                go_nomod_fallback,
+            )
+            .await?;
             let depends_on_ms = depends_on_start.elapsed().as_millis() as u64;
 
             // 10. Generate unresolved diagnostics — AFTER the pack phase (Wave 3c):
@@ -2850,7 +2919,19 @@ async fn main() -> Result<()> {
             // too — and BEFORE the unresolved diagnostics below, whose negation
             // queries would otherwise flag every pack-resolved node.
             let depends_on_start = std::time::Instant::now();
-            run_stdlib_rule_packs(&mut rfdb, None, all_imports_from_edges.len()).await?;
+            // P3 selection in the resolve-only pass: the graph already holds
+            // (or lacks) the P1 fact from the prior analyze; re-discover
+            // go.mod for the variant condition (cheap file read). Go presence
+            // comes from the detected-language scan above.
+            let go_nomod_fallback = detected_langs.contains(&config::Language::Go)
+                && config::discover_go_module_path(&cfg.root).is_none();
+            run_stdlib_rule_packs(
+                &mut rfdb,
+                None,
+                all_imports_from_edges.len(),
+                go_nomod_fallback,
+            )
+            .await?;
             let depends_on_ms = depends_on_start.elapsed().as_millis() as u64;
 
             // Unresolved diagnostics
@@ -3354,10 +3435,14 @@ mod tests {
     ) -> std::path::PathBuf {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+        // pid + a per-process counter: two tests binding in the same instant
+        // collided on a nanos-only name (macOS clock granularity).
+        static SOCK_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         let dir = std::env::temp_dir();
         let sock = dir.join(format!(
-            "grafema-fake-rfdb-{}-{}.sock",
+            "grafema-fake-rfdb-{}-{}-{}.sock",
             std::process::id(),
+            SOCK_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
@@ -3466,7 +3551,7 @@ mod tests {
             vec!["@stdlib/js_local_refs".to_string(), "@stdlib/axum_routes".to_string()],
         );
         let mut client = rfdb::RfdbClient::connect(&sock).await.expect("connect fake server");
-        let err = run_stdlib_rule_packs(&mut client, None, 0)
+        let err = run_stdlib_rule_packs(&mut client, None, 0, false)
             .await
             .expect_err("a failed pack must fail the phase");
         let msg = format!("{err:#}");
@@ -3479,9 +3564,47 @@ mod tests {
         // All packs green → Ok.
         let sock2 = spawn_fake_rfdb_server(features, vec![]);
         let mut client2 = rfdb::RfdbClient::connect(&sock2).await.expect("connect fake server");
-        run_stdlib_rule_packs(&mut client2, None, 0)
+        run_stdlib_rule_packs(&mut client2, None, 0, false)
             .await
             .expect("green pack phase passes");
+        let _ = std::fs::remove_file(&sock2);
+    }
+
+    /// Go P3 — the pack-VARIANT selection, end-to-end through the production
+    /// pack loop: `@stdlib/go_imports_nomod` (the no-go.mod suffix fallback)
+    /// runs ONLY when `go_nomod_fallback` is true. Proven via the fake-server
+    /// failure mechanism: the variant is FORCED to fail, so its presence in
+    /// the run is observable — skipped (Ok) when go.mod resolved, run (Err
+    /// naming it) when it did not.
+    #[tokio::test]
+    async fn go_imports_nomod_variant_is_selected_by_the_go_nomod_flag() {
+        let features = vec!["datalogDerive".to_string()];
+
+        // go.mod resolved (or no go files) → the variant must be SKIPPED:
+        // even though the fake server would fail it, the phase is green.
+        let sock = spawn_fake_rfdb_server(
+            features.clone(),
+            vec!["@stdlib/go_imports_nomod".to_string()],
+        );
+        let mut client = rfdb::RfdbClient::connect(&sock).await.expect("connect fake server");
+        run_stdlib_rule_packs(&mut client, None, 0, false)
+            .await
+            .expect("variant skipped when go.mod resolved — phase green");
+        let _ = std::fs::remove_file(&sock);
+
+        // go files present + no go.mod → the variant RUNS (and here fails,
+        // proving it was selected and that its owned slice is named).
+        let sock2 = spawn_fake_rfdb_server(
+            features,
+            vec!["@stdlib/go_imports_nomod".to_string()],
+        );
+        let mut client2 = rfdb::RfdbClient::connect(&sock2).await.expect("connect fake server");
+        let err = run_stdlib_rule_packs(&mut client2, None, 0, true)
+            .await
+            .expect_err("variant selected without go.mod — forced failure surfaces");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("@stdlib/go_imports_nomod"), "variant named: {msg}");
+        assert!(msg.contains("suffix-fallback"), "owned slice named: {msg}");
         let _ = std::fs::remove_file(&sock2);
     }
 

--- a/packages/rfdb-server/src/derive/builtin.rs
+++ b/packages/rfdb-server/src/derive/builtin.rs
@@ -966,6 +966,32 @@ fn eval_last_segment(_v: &dyn StorageView, out: &mut Batch, spec: &ArgSpec) -> B
     Ok(())
 }
 
+/// `first_segment(S, Sep, Seg)` — the substring before the FIRST occurrence of the bound
+/// separator `Sep` (`first_segment("github.com/user/proj", "/", X)` → `"github.com"`);
+/// identity when `S` contains no `Sep` (the dual of `last_segment`'s no-separator stance —
+/// a one-segment path IS its own first segment). NO row when the produced segment is
+/// empty — a leading separator (`"/a"`), or the degenerate empty `Sep` (which "matches"
+/// at the very start): an empty segment names nothing (the `last_segment` discipline).
+/// Built for the Go packs: the EXACT spelling of Go's `isStdLib` test ("first path
+/// segment contains a dot", GoImportResolution.hs:86-89) and the left-peel that derives
+/// the '/'-boundary SUFFIXES of an import path (the no-go.mod fallback arm — the
+/// right-peel `last_segment` idiom mirrored). Free arg2 binds; bound arg2
+/// equality-filters.
+fn eval_first_segment(_v: &dyn StorageView, out: &mut Batch, spec: &ArgSpec) -> BuiltinResult<()> {
+    let (Some(s), Some(sep)) = (bound_str(&spec.args[0]), bound_str(&spec.args[1])) else {
+        return Ok(());
+    };
+    let produced = match s.find(sep.as_str()) {
+        Some(i) => &s[..i],
+        None => s.as_str(),
+    };
+    if produced.is_empty() {
+        return Ok(());
+    }
+    bind_or_check(out, spec, 2, produced);
+    Ok(())
+}
+
 /// `replace_all(S, From, To, Out)` — `Out` is `S` with EVERY occurrence of `From`
 /// replaced by `To`, non-overlapping left-to-right (`replace_all("foo/bar", "/", "::",
 /// X)` → `"foo::bar"`; the file-path → Rust-module-path separator rewrite,
@@ -1153,9 +1179,9 @@ const METHOD_SUFFIX_MODES: &[Mode] = &[Mode { args: &[B, F] }, Mode { args: &[B,
 /// the same discipline as [`METHOD_SUFFIX_MODES`].
 const STR_FN2_MODES: &[Mode] = &[Mode { args: &[B, F] }, Mode { args: &[B, B] }];
 
-/// `concat/3`/`strip_prefix/3`/`strip_suffix/3`/`last_segment/3`/`path_resolve/3`
-/// modes: both inputs bound; the output (last position) is free (bind) or bound
-/// (equality check).
+/// `concat/3`/`strip_prefix/3`/`strip_suffix/3`/`last_segment/3`/`first_segment/3`/
+/// `path_resolve/3` modes: both inputs bound; the output (last position) is free (bind)
+/// or bound (equality check).
 const CONCAT_MODES: &[Mode] = &[Mode { args: &[B, B, F] }, Mode { args: &[B, B, B] }];
 
 /// `replace_all/4` modes: the three inputs (subject, pattern, replacement) bound; the
@@ -1342,6 +1368,13 @@ pub fn registry() -> Vec<BuiltinDef> {
             eval: eval_last_segment,
         },
         BuiltinDef {
+            name: "first_segment",
+            arity: 3,
+            modes: CONCAT_MODES,
+            kind: BuiltinKind::Function,
+            eval: eval_first_segment,
+        },
+        BuiltinDef {
             name: "replace_all",
             arity: 4,
             modes: REPLACE_ALL_MODES,
@@ -1486,6 +1519,7 @@ mod tests {
             "strip_prefix",
             "strip_suffix",
             "last_segment",
+            "first_segment",
             "replace_all",
             "path_resolve",
             "edge_attr",
@@ -2455,6 +2489,61 @@ mod tests {
         let err = def.check_mode(&spec).unwrap_err();
         assert_eq!(err.code.as_str(), "E-PLAN-001");
         assert!(err.required_bindings.contains(&0), "must name the free input");
+    }
+
+    // ── first_segment ──────────────────────────────────────────────
+
+    #[test]
+    fn first_segment_before_first_separator_identity_and_empty_skip() {
+        // [B, B, F] — the Go isStdLib shape: the first '/'-segment of an import path.
+        let path = ArgSpec::new(vec![
+            ArgValue::Bound(s("github.com/user/proj")),
+            ArgValue::Bound(s("/")),
+            ArgValue::Free { slot: 0 },
+        ]);
+        let out = run("first_segment", path);
+        assert_eq!(out.rows.len(), 1);
+        assert_eq!(out.rows[0][0], s("github.com"));
+
+        // No separator occurrence → identity ("fmt" IS its own first segment).
+        let flat = ArgSpec::new(vec![
+            ArgValue::Bound(s("fmt")),
+            ArgValue::Bound(s("/")),
+            ArgValue::Free { slot: 0 },
+        ]);
+        let out = run("first_segment", flat);
+        assert_eq!(out.rows.len(), 1);
+        assert_eq!(out.rows[0][0], s("fmt"));
+
+        // Leading separator → empty segment → NO row.
+        let leading = ArgSpec::new(vec![
+            ArgValue::Bound(s("/abs/path")),
+            ArgValue::Bound(s("/")),
+            ArgValue::Free { slot: 0 },
+        ]);
+        assert_eq!(run("first_segment", leading).rows.len(), 0);
+
+        // Empty separator "matches" at the very start → empty segment → NO row.
+        let empty_sep = ArgSpec::new(vec![
+            ArgValue::Bound(s("Bar")),
+            ArgValue::Bound(s("")),
+            ArgValue::Free { slot: 0 },
+        ]);
+        assert_eq!(run("first_segment", empty_sep).rows.len(), 0);
+
+        // [B, B, B] — equality check: pass and non-match.
+        let hit = ArgSpec::new(vec![
+            ArgValue::Bound(s("a/b/c")),
+            ArgValue::Bound(s("/")),
+            ArgValue::Bound(s("a")),
+        ]);
+        assert_eq!(run("first_segment", hit).rows.len(), 1);
+        let miss = ArgSpec::new(vec![
+            ArgValue::Bound(s("a/b/c")),
+            ArgValue::Bound(s("/")),
+            ArgValue::Bound(s("b")),
+        ]);
+        assert_eq!(run("first_segment", miss).rows.len(), 0);
     }
 
     // ── last_segment ───────────────────────────────────────────────

--- a/packages/rfdb-server/src/derive/differential.rs
+++ b/packages/rfdb-server/src/derive/differential.rs
@@ -3039,3 +3039,205 @@ fn w8_cancel_overhead_pack_probe_times() {
     }
     eprintln!("=== W8 probe times: printed ===\n");
 }
+
+// ── Go wave: pack-vs-legacy differential on a real analyzed Go module ──────
+
+/// The Go packs' REPO-STRATUM differential (the spec's mandatory live
+/// confirmation — the dogfood graph has ZERO Go nodes, so this runs against a
+/// caller-built analyze of a real Go module, canonically `packages/go-parser`,
+/// a 4-file single-package module).
+///
+/// Dataset: `GRAFEMA_GO_DIFF_DB` (default `/tmp/go-diff.rfdb`) — a DB produced
+/// by `grafema-orchestrator analyze` over a Go module with the LEGACY
+/// go-resolve daemon ON, copied here (NEVER the live store). Provenance
+/// discrimination (re-run-safety, the wave3c precedent): legacy edges are
+/// stamped `_source = "go-resolution"` by the orchestrator's gc stamp at
+/// commit time (or carry no stamp on pre-stamp graphs); pack-written edges
+/// carry a rule-hash `_source` and are excluded from the legacy slice. The
+/// `.go`-file gate on the src node also excludes the synthetic
+/// unresolved-diagnostics nodes (verdict C5).
+///
+/// PREDICTIONS, declared BEFORE the diff (the §3 harness discipline):
+/// - legacy-only rows = 0 on EVERY edge type (the packs cover everything
+///   legacy resolved; every divergence class is pack-⊇-legacy);
+/// - pack-only rows classify into the numbered SUPERSET deltas (G2-2 / G3-1 /
+///   G5-1 / G6-2 / G6-3 / G7-1) — printed with names for classification;
+/// - PROPAGATES_CONTEXT: legacy = 0 EXACTLY (DELTA G9-3 — the wire node ids
+///   are percent-encoded URIs, so the legacy `[in:` parse never matches; and
+///   even unencoded, the parsed name keeps the ",h:xxxx" hash); the pack
+///   derives the intended edges (corpus-proven: legacy=0, pack=5);
+/// - IMPLEMENTS: legacy ≈ 0 on post-URI graphs (DELTA G6-1 — the same
+///   `[in:` parse class is dead under percent-encoding; corpus-proven:
+///   legacy=0, pack=1 correct edge) — reported, not hard-asserted (an
+///   unencoded-id-era graph could legitimately carry legacy rows);
+/// - SPAWNS/DEFERS: exact (caller-independent, unaffected by G9-3).
+///
+///   GRAFEMA_GO_DIFF_DB=/tmp/go-diff.rfdb \
+///   cargo test --release --lib go_packs_differential_against_real_go_module -- --ignored --nocapture
+#[test]
+#[ignore = "manual real-data differential; needs an analyzed Go-module DB — run with --ignored"]
+fn go_packs_differential_against_real_go_module() {
+    use crate::derive::stdlib::{
+        GO_CALLS_DL, GO_CONTEXT_DL, GO_IMPORTS_DL, GO_IMPORTS_NOMOD_DL, GO_INTERFACES_DL,
+        GO_TYPES_DL,
+    };
+    use std::collections::HashMap;
+
+    let dataset = std::env::var("GRAFEMA_GO_DIFF_DB")
+        .unwrap_or_else(|_| "/tmp/go-diff.rfdb".to_string());
+    let dataset = PathBuf::from(dataset);
+    if !dataset.join("db_config.json").exists() {
+        panic!(
+            "dataset not found at {} — analyze a Go module first (legacy go-resolve ON), \
+             e.g. grafema-orchestrator analyze over packages/go-parser into a /tmp DB, \
+             then point GRAFEMA_GO_DIFF_DB at the copied graph dir",
+            dataset.display()
+        );
+    }
+
+    let tmp = tempfile::tempdir().expect("temp");
+    let work = tmp.path().join("graph.rfdb");
+    copy_dir_all(&dataset, &work).expect("copy dataset");
+    let _ = std::fs::remove_file(work.join("LOCK"));
+    let manifest = ManifestStore::open(&work).expect("manifest");
+    let store = MultiShardStore::open(&work, &manifest).expect("store");
+    let store = Arc::new(store);
+    let view = LsmStorageView::capture(store.clone(), &manifest);
+
+    let snap = store.snapshot(&manifest);
+    let all_nodes = store.find_nodes_at(&snap, None, None);
+    let mut nodes_by_type: HashMap<String, u64> = HashMap::new();
+    for n in &all_nodes {
+        *nodes_by_type.entry(n.node_type.clone()).or_insert(0) += 1;
+    }
+    let stats = Stats {
+        total_nodes: all_nodes.len() as u64,
+        total_edges: store.iter_all_edges_at(&snap).len() as u64,
+        nodes_by_type: nodes_by_type.clone(),
+    };
+
+    // id → (name, file, type) for row classification + the .go src gate.
+    let mut info: HashMap<u128, (String, String, String)> = HashMap::new();
+    for n in &all_nodes {
+        info.insert(n.id, (n.name.clone(), n.file.clone(), n.node_type.clone()));
+    }
+    let is_go_src = |id: &u128| info.get(id).map(|(_, f, _)| f.ends_with(".go")).unwrap_or(false);
+
+    // The P1 fact decides the variant (the orchestrator's P3 selection mirrored).
+    let has_go_mod_fact = all_nodes.iter().any(|n| {
+        n.node_type == "WORKSPACE_PACKAGE"
+            && view
+                .node_metadata(n.id)
+                .map(|m| m.contains("\"language\":\"go\""))
+                .unwrap_or(false)
+    });
+    eprintln!(
+        "\n=== go packs differential (nodes={}, edges={}, go.mod fact={}) ===",
+        stats.total_nodes, stats.total_edges, has_go_mod_fact
+    );
+
+    // ── LEGACY slices: committed edges per type, src in a .go file,
+    //    provenance ∈ {go-resolution, unstamped} (NOT pack rule-hashes). ──
+    let legacy_slice = |edge_type: &str| -> BTreeSet<(u128, u128)> {
+        store
+            .iter_all_edges_at(&snap)
+            .into_iter()
+            .filter(|e| e.edge_type == edge_type && is_go_src(&e.src))
+            .filter(|e| match view.edge_metadata(e.src, e.dst, edge_type) {
+                None => true,
+                Some(blob) => match serde_json::from_str::<serde_json::Value>(&blob) {
+                    Ok(v) => match v.get("_source").and_then(|s| s.as_str()) {
+                        None => true,
+                        Some(src) => src == "go-resolution",
+                    },
+                    Err(_) => true,
+                },
+            })
+            .map(|e| (e.src, e.dst))
+            .collect()
+    };
+
+    // ── PACK slices: head facts of the go packs over the same view. ──
+    let pack_facts = |src: &str, preds: &[&str]| -> BTreeSet<(u128, u128)> {
+        let eval = evaluate(
+            &view,
+            src,
+            stats.clone(),
+            crate::datalog::EvalLimits::none(),
+            EventLog::discard(),
+        )
+        .unwrap_or_else(|e| panic!("go pack evaluates: {e}"));
+        let mut out = BTreeSet::new();
+        for p in preds {
+            for r in eval.facts(p) {
+                out.insert((r[0].as_id().expect("src"), r[1].as_id().expect("dst")));
+            }
+        }
+        out
+    };
+
+    let mut pack_imports = pack_facts(GO_IMPORTS_DL, &["go_import_from"]);
+    if !has_go_mod_fact {
+        pack_imports.extend(pack_facts(GO_IMPORTS_NOMOD_DL, &["go_import_suffix"]));
+    }
+    let pack_calls = pack_facts(GO_CALLS_DL, &["go_call_s1", "go_call_s2", "go_call_s3"]);
+    let pack_impls = pack_facts(GO_INTERFACES_DL, &["go_implements"]);
+    let pack_typeof = pack_facts(GO_TYPES_DL, &["go_type_of"]);
+    let pack_returns = pack_facts(GO_TYPES_DL, &["go_returns"]);
+    let pack_prop = pack_facts(GO_CONTEXT_DL, &["go_prop", "go_prop_u"]);
+    let pack_spawn = pack_facts(GO_CONTEXT_DL, &["go_spawn", "go_spawn_u"]);
+    let pack_defer = pack_facts(GO_CONTEXT_DL, &["go_defer", "go_defer_u"]);
+
+    let name_of = |id: &u128| {
+        info.get(id)
+            .map(|(n, f, t)| format!("{t} {n} ({f})"))
+            .unwrap_or_else(|| format!("{id}"))
+    };
+    let mut hard_failures: Vec<String> = Vec::new();
+    let mut diff = |label: &str, pack: &BTreeSet<(u128, u128)>, legacy: &BTreeSet<(u128, u128)>, legacy_must_be_empty: bool| {
+        let both = pack.intersection(legacy).count();
+        let pack_only: Vec<_> = pack.difference(legacy).collect();
+        let legacy_only: Vec<_> = legacy.difference(pack).collect();
+        eprintln!(
+            "{label:<22} pack={:<5} legacy={:<5} both={both:<5} pack_only={:<4} legacy_only={}",
+            pack.len(),
+            legacy.len(),
+            pack_only.len(),
+            legacy_only.len()
+        );
+        for (s, d) in pack_only.iter().take(20) {
+            eprintln!("  PACK-ONLY  {} -> {}  (classify against the numbered SUPERSET deltas)", name_of(s), name_of(d));
+        }
+        for (s, d) in legacy_only.iter().take(20) {
+            eprintln!("  LEGACY-ONLY {} -> {}", name_of(s), name_of(d));
+        }
+        if !legacy_only.is_empty() {
+            hard_failures.push(format!(
+                "{label}: {} legacy-only rows — the pack must cover everything legacy resolved",
+                legacy_only.len()
+            ));
+        }
+        if legacy_must_be_empty && !legacy.is_empty() {
+            hard_failures.push(format!(
+                "{label}: predicted legacy = 0 (DELTA G9-3) but found {}",
+                legacy.len()
+            ));
+        }
+    };
+
+    diff("IMPORTS_FROM", &pack_imports, &legacy_slice("IMPORTS_FROM"), false);
+    diff("CALLS", &pack_calls, &legacy_slice("CALLS"), false);
+    diff("IMPLEMENTS", &pack_impls, &legacy_slice("IMPLEMENTS"), false);
+    diff("TYPE_OF", &pack_typeof, &legacy_slice("TYPE_OF"), false);
+    diff("RETURNS", &pack_returns, &legacy_slice("RETURNS"), false);
+    diff("PROPAGATES_CONTEXT", &pack_prop, &legacy_slice("PROPAGATES_CONTEXT"), true);
+    diff("SPAWNS_WITH_CONTEXT", &pack_spawn, &legacy_slice("SPAWNS_WITH_CONTEXT"), false);
+    diff("DEFERS_WITH_CONTEXT", &pack_defer, &legacy_slice("DEFERS_WITH_CONTEXT"), false);
+
+    assert!(
+        hard_failures.is_empty(),
+        "go differential predictions violated:\n{}",
+        hard_failures.join("\n")
+    );
+    eprintln!("=== go packs differential: predictions hold (pack ⊇ legacy everywhere; legacy PROPAGATES = 0) ===\n");
+}

--- a/packages/rfdb-server/src/derive/plan.rs
+++ b/packages/rfdb-server/src/derive/plan.rs
@@ -635,7 +635,8 @@ fn positive_can_place_and_provides(
         // genuinely underivable stays unplaceable here (E-PLAN-002 unsafe rule) instead of
         // reaching eval and tripping a confusing E-PLAN-001.
         "concat" | "str_lower" | "basename" | "strip_quotes" | "strip_prefix" | "strip_suffix"
-        | "last_segment" | "replace_all" | "path_resolve" | "edge_attr" | "node_attr" => {
+        | "last_segment" | "first_segment" | "replace_all" | "path_resolve" | "edge_attr"
+        | "node_attr" => {
             if args.is_empty() {
                 return (true, HashSet::new());
             }
@@ -699,6 +700,7 @@ fn is_filter_or_function(pred: &str) -> bool {
             | "strip_prefix"
             | "strip_suffix"
             | "last_segment"
+            | "first_segment"
             | "replace_all"
             | "path_resolve"
             | "edge_attr"

--- a/packages/rfdb-server/src/derive/stdlib.rs
+++ b/packages/rfdb-server/src/derive/stdlib.rs
@@ -72,6 +72,61 @@ pub const SHAPE_VERIFIER_DL: &str = include_str!("stdlib/shape_verifier.dl");
 /// head is exclusive (provenance-scoped, safe on the shared `http:route` type).
 pub const AXUM_ROUTES_DL: &str = include_str!("stdlib/axum_routes.dl");
 
+/// The bundled Go same-module import-resolution pack — the in-engine
+/// replacement for the import slice of the `go-resolve` daemon
+/// (`GoImportResolution.hs`): IMPORT → MODULE `IMPORTS_FROM`, driven by the
+/// GO module-path WORKSPACE_PACKAGE fact (orchestrator precondition P1).
+/// The exact `isStdLib` gate rides the `first_segment` builtin; the
+/// module-prefix arm is the C1-legal prefix-peel equality join. `IMPORTS_FROM`
+/// is SHARED vocabulary ⇒ additive. Deltas numbered in the `.dl` header
+/// (G2-2 first-MODULE multiplicity is the only live one).
+pub const GO_IMPORTS_DL: &str = include_str!("stdlib/go_imports.dl");
+
+/// The NO-go.mod VARIANT of [`GO_IMPORTS_DL`] — the legacy empty-module-path
+/// suffix fallback (`findBySuffix`), '/'-boundary suffixes by `first_segment`
+/// left-peel. A pack cannot test "the go.mod fact is absent" (the §3
+/// cross-join), so the ORCHESTRATOR selects the variant: this pack runs ONLY
+/// when go.mod did not resolve (run_stdlib_rule_packs' selection condition);
+/// both variants stay registered so the cross-registry order pin holds.
+pub const GO_IMPORTS_NOMOD_DL: &str = include_str!("stdlib/go_imports_nomod.dl");
+
+/// The bundled Go call-resolution pack — the in-engine replacement for the
+/// `GoCallResolution.hs` slice of `go-resolve`: the three legacy strategies
+/// (package-qualified via same-file import alias + the C1-legal peel-join
+/// package index; same-package receiverless; same-package method by global
+/// (receiver, name) index), exclusive dispatch on the CALL's `receiver`
+/// metadata. `CALLS` additive, NO meta (legacy stamps none). Bounded
+/// last-wins SUPERSET deltas numbered in the `.dl` header.
+pub const GO_CALLS_DL: &str = include_str!("stdlib/go_calls.dl");
+
+/// The bundled Go interface-satisfaction pack — the in-engine replacement for
+/// the `GoInterfaceSatisfaction.hs` slice of `go-resolve`: structural
+/// duck-typing CLASS → INTERFACE `IMPLEMENTS` by method-name subset, the
+/// ∀-subset spelled as two strata of negation seeded through a shared method
+/// name (the planner-legal substitute for the CLASS×INTERFACE product).
+/// Structural INTERFACE-CONTAINS-FUNCTION membership replaces the legacy
+/// `[in:Iface]` semantic-id parse — which is DEAD on real (percent-encoded)
+/// wire ids, so the pack RESTORES interface satisfaction (`.dl` DELTA G6-1).
+/// Additive; G6-2/G6-3 (struct- and interface-side name merges) numbered in
+/// the `.dl` header.
+pub const GO_INTERFACES_DL: &str = include_str!("stdlib/go_interfaces.dl");
+
+/// The bundled Go type-resolution pack — the in-engine replacement for the
+/// `GoTypeResolution.hs` slice of `go-resolve`: VARIABLE → type `TYPE_OF` and
+/// FUNCTION → type `RETURNS` (comma-peeled `return_type`, recursive `*`/`[]`
+/// strip, 21 primitive ground facts). Both heads additive, no meta.
+pub const GO_TYPES_DL: &str = include_str!("stdlib/go_types.dl");
+
+/// The bundled Go context-propagation pack — the in-engine replacement for
+/// the `GoContextPropagation.hs` slice of `go-resolve`:
+/// `PROPAGATES_CONTEXT` (enclosing fn → target) plus `SPAWNS_WITH_CONTEXT` /
+/// `DEFERS_WITH_CONTEXT` (call → target), `unresolved="true"` meta iff the
+/// TARGET is only possibly-context. CONSUMES committed CALLS on .go files —
+/// MUST run after [`GO_CALLS_DL`] (precondition P2). The CONTAINS-parent
+/// enclosing-fn join REFINES a legacy defect (the `[in:parent,h:xxxx]` parse
+/// never matched a real function name — `.dl` DELTA G9-3).
+pub const GO_CONTEXT_DL: &str = include_str!("stdlib/go_context.dl");
+
 /// The bundled JS/TS local-reference resolution pack — the in-engine replacement
 /// for the `JsLocalRefs.hs` resolver (the #1 edge producer per the perf memory:
 /// REFERENCE → same-file declaration `READS_FROM` over 8 declaration types,
@@ -348,6 +403,12 @@ pub const JS_MODULE_IMPORTS_DL: &str = include_str!("stdlib/js_module_imports.dl
 ///   in-engine IMPORTS_FROM producers: `rust_imports`, `js_module_imports`,
 ///   `js_import_bindings`, `js_builtins_edges`. (It ran first while the
 ///   legacy resolver pre-committed those edges at analysis time.)
+/// - the Go wave packs: `go_imports` / `go_imports_nomod` PRODUCE
+///   IMPORTS_FROM (before `depends`, verdict C4); `go_calls` PRODUCES CALLS
+///   for `go_context` (the P2 producer-before-consumer seam) and precedes the
+///   CALLS negators (`method_calls` / `shape_verifier`); the nomod VARIANT is
+///   selected by the orchestrator at runtime (P3 — only when go.mod is
+///   absent), but stays in BOTH registries so the order pin holds.
 /// An orchestrator running the packs sequentially must preserve this order:
 /// js_local_refs → js_same_file_calls → js_this_method_calls →
 /// rust_calls → rust_cross_methods_ctor → rust_trait_resolve →
@@ -355,8 +416,9 @@ pub const JS_MODULE_IMPORTS_DL: &str = include_str!("stdlib/js_module_imports.dl
 /// js_import_bindings → js_class_inheritance →
 /// js_cross_file_calls → js_property_access_ns → js_property_access_full →
 /// js_builtins_nodes → js_builtins_edges → js_runtime_globals_nodes →
-/// js_runtime_globals_edges → depends → method_calls → shape_verifier →
-/// axum_routes.
+/// js_runtime_globals_edges → go_imports → go_imports_nomod → go_calls →
+/// go_interfaces → go_types → go_context → depends → method_calls →
+/// shape_verifier → axum_routes.
 pub const STDLIB_PACKS: &[(&str, &str)] = &[
     ("js_local_refs", JS_LOCAL_REFS_DL),
     ("js_same_file_calls", JS_SAME_FILE_CALLS_DL),
@@ -400,6 +462,18 @@ pub const STDLIB_PACKS: &[(&str, &str)] = &[
     // (shape_verifier).
     ("js_runtime_globals_nodes", JS_RUNTIME_GLOBALS_NODES_DL),
     ("js_runtime_globals_edges", JS_RUNTIME_GLOBALS_EDGES_DL),
+    // Go wave: go_imports / go_imports_nomod PRODUCE IMPORTS_FROM — strictly
+    // before depends (verdict C4); the nomod VARIANT is orchestrator-selected
+    // (P3: runs only when go.mod is absent — both registered, runtime skip).
+    // go_calls PRODUCES CALLS — strictly before its consumer go_context (P2)
+    // and before the CALLS negators method_calls / shape_verifier (C4).
+    // go_interfaces / go_types consume analyzer EDB only.
+    ("go_imports", GO_IMPORTS_DL),
+    ("go_imports_nomod", GO_IMPORTS_NOMOD_DL),
+    ("go_calls", GO_CALLS_DL),
+    ("go_interfaces", GO_INTERFACES_DL),
+    ("go_types", GO_TYPES_DL),
+    ("go_context", GO_CONTEXT_DL),
     // Wave 3c: depends CONSUMES IMPORTS_FROM (every edge, module- and
     // binding-level) — with legacy import-resolution gated it must run after
     // ALL in-engine IMPORTS_FROM producers (rust_imports, js_module_imports,
@@ -1268,6 +1342,12 @@ mod tests {
                 "js_builtins_edges",
                 "js_runtime_globals_nodes",
                 "js_runtime_globals_edges",
+                "go_imports",
+                "go_imports_nomod",
+                "go_calls",
+                "go_interfaces",
+                "go_types",
+                "go_context",
                 "depends",
                 "method_calls",
                 "shape_verifier",
@@ -4322,4 +4402,533 @@ mod tests {
         );
     }
 
+    // ── Go wave: fixture tests per arm (ports of go-resolve/test/Spec.hs:50-301
+    //    plus the numbered-delta predictions — predictions FIRST, in the assert
+    //    messages). The dogfood graph has ZERO Go nodes (spec probe + the
+    //    Datalog re-probe), so these fixtures + the GRAFEMA_GO_DIFF_DB repo
+    //    harness in differential.rs ARE the differential ground truth. ──────
+
+    /// The GO module-path WORKSPACE_PACKAGE fact (orchestrator P1 shape).
+    fn go_mod_fact(v: &mut FixtureStorageView, module_path: &str) {
+        let sid = format!("go.mod->WORKSPACE_PACKAGE->{module_path}");
+        named_node(v, &sid, module_path, "WORKSPACE_PACKAGE", "go.mod");
+        v.put_node_metadata(id_of(&sid), r#"{"language":"go"}"#);
+    }
+
+    fn derived_pairs(v: &FixtureStorageView, src: &str, pred: &str) -> BTreeSet<(u128, u128)> {
+        let eval = evaluate(v, src, Stats::default(), EvalLimits::none(), EventLog::discard())
+            .unwrap_or_else(|e| panic!("pack evaluates: {e}"));
+        eval.facts(pred)
+            .into_iter()
+            .map(|r| {
+                (
+                    r[0].as_id().expect("src id"),
+                    r[1].as_id().expect("dst id"),
+                )
+            })
+            .collect()
+    }
+
+    /// go_imports — Spec.hs:52-92 ported: same-module hit, stdlib skip,
+    /// third-party skip, the root-package arm, the per-MODULE multiplicity
+    /// (DELTA G2-2), the exact-isStdLib dot-less-module-path skip (DELTA G2-1
+    /// CLOSED), the plain-stripPrefix boundary bug removal, and pack inertness
+    /// without the P1 fact.
+    #[test]
+    fn go_imports_same_module_arms_on_fixture() {
+        let mut v = FixtureStorageView::new(1);
+        go_mod_fact(&mut v, "github.com/user/project");
+        // Target package with TWO files (DELTA G2-2) + a root-level module.
+        node(&mut v, "mod_auth1", "MODULE", "pkg/auth/auth.go");
+        node(&mut v, "mod_auth2", "MODULE", "pkg/auth/token.go");
+        node(&mut v, "mod_root", "MODULE", "main.go");
+        // Importers (all metadata `path`, the analyzer contract Imports.hs:73-79).
+        named_node(&mut v, "imp_auth", "github.com/user/project/pkg/auth", "IMPORT", "cmd/main.go");
+        v.put_node_metadata(id_of("imp_auth"), r#"{"path":"github.com/user/project/pkg/auth"}"#);
+        named_node(&mut v, "imp_fmt", "fmt", "IMPORT", "cmd/main.go");
+        v.put_node_metadata(id_of("imp_fmt"), r#"{"path":"fmt"}"#);
+        named_node(&mut v, "imp_3p", "github.com/sirupsen/logrus", "IMPORT", "cmd/main.go");
+        v.put_node_metadata(id_of("imp_3p"), r#"{"path":"github.com/sirupsen/logrus"}"#);
+        named_node(&mut v, "imp_root", "github.com/user/project", "IMPORT", "cmd/main.go");
+        v.put_node_metadata(id_of("imp_root"), r#"{"path":"github.com/user/project"}"#);
+        // The legacy plain-stripPrefix boundary bug shape: module path is a
+        // non-'/'-boundary string prefix — must NOT resolve (legacy missed too).
+        node(&mut v, "mod_p2", "MODULE", "roject2/x/x.go");
+        named_node(&mut v, "imp_p2", "github.com/user/project2/x", "IMPORT", "cmd/main.go");
+        v.put_node_metadata(id_of("imp_p2"), r#"{"path":"github.com/user/project2/x"}"#);
+        // A non-go IMPORT with a go-looking path must be gated out (DELTA-5 file gate).
+        named_node(&mut v, "imp_js", "github.com/user/project/pkg/auth", "IMPORT", "app.ts");
+        v.put_node_metadata(id_of("imp_js"), r#"{"path":"github.com/user/project/pkg/auth"}"#);
+
+        let pairs = derived_pairs(&v, GO_IMPORTS_DL, "go_import_from");
+        assert_eq!(
+            pairs,
+            BTreeSet::from([
+                // PREDICTION DELTA G2-2: one edge per MODULE in the package dir
+                // (legacy: first module only).
+                (id_of("imp_auth"), id_of("mod_auth1")),
+                (id_of("imp_auth"), id_of("mod_auth2")),
+                // Root-package arm: P == module path → the "" directory.
+                (id_of("imp_root"), id_of("mod_root")),
+            ]),
+            "stdlib/third-party/boundary-bug/non-go importers derive nothing; \
+             same-module derives per-MODULE (G2-2); root import hits main.go"
+        );
+
+        // Dot-less module path (G2-1 CLOSED): legacy isStdLib skips
+        // "myapp/util" BEFORE prefix-stripping — the exact first_segment gate
+        // reproduces the skip.
+        let mut v2 = FixtureStorageView::new(1);
+        go_mod_fact(&mut v2, "myapp");
+        node(&mut v2, "mod_util", "MODULE", "util/u.go");
+        named_node(&mut v2, "imp_util", "myapp/util", "IMPORT", "main.go");
+        v2.put_node_metadata(id_of("imp_util"), r#"{"path":"myapp/util"}"#);
+        assert!(
+            derived_pairs(&v2, GO_IMPORTS_DL, "go_import_from").is_empty(),
+            "dot-less module path: legacy isStdLib skips it — exact gate, no edge (G2-1 closed)"
+        );
+
+        // No P1 fact ⇒ the module-prefix arms are inert (the nomod VARIANT
+        // owns that world — orchestrator-selected, P3).
+        let mut v3 = FixtureStorageView::new(1);
+        node(&mut v3, "mod_a", "MODULE", "pkg/auth/auth.go");
+        named_node(&mut v3, "imp_a", "example.com/pkg/auth", "IMPORT", "main.go");
+        v3.put_node_metadata(id_of("imp_a"), r#"{"path":"example.com/pkg/auth"}"#);
+        assert!(
+            derived_pairs(&v3, GO_IMPORTS_DL, "go_import_from").is_empty(),
+            "without the go.mod fact the main pack derives nothing"
+        );
+    }
+
+    /// go_imports_nomod — Spec.hs:80-85 ported (empty-modPath suffix fallback)
+    /// plus the G2-3a all-matches SUPERSET and the G2-3b '/'-boundary
+    /// refinement predictions.
+    #[test]
+    fn go_imports_nomod_suffix_fallback_on_fixture() {
+        let mut v = FixtureStorageView::new(1);
+        node(&mut v, "mod_auth", "MODULE", "pkg/auth/auth.go");
+        named_node(&mut v, "imp_auth", "example.com/pkg/auth", "IMPORT", "main.go");
+        v.put_node_metadata(id_of("imp_auth"), r#"{"path":"example.com/pkg/auth"}"#);
+        // G2-3b: dir "auth" is a RAW suffix of ".../oauth" (legacy false
+        // positive) but NOT a '/'-boundary suffix — pack must NOT match.
+        named_node(&mut v, "imp_oauth", "example.com/pkg/oauth", "IMPORT", "main.go");
+        v.put_node_metadata(id_of("imp_oauth"), r#"{"path":"example.com/pkg/oauth"}"#);
+        node(&mut v, "mod_rawauth", "MODULE", "auth/a.go");
+        // stdlib skip applies in the fallback too ("fmt" — even with a local
+        // dir literally named fmt).
+        named_node(&mut v, "imp_fmt", "fmt", "IMPORT", "main.go");
+        v.put_node_metadata(id_of("imp_fmt"), r#"{"path":"fmt"}"#);
+        node(&mut v, "mod_fmt", "MODULE", "fmt/f.go");
+        // G2-3a: two dirs share the boundary suffix → ALL matches derived.
+        node(&mut v, "mod_u1", "MODULE", "a/util/u.go");
+        node(&mut v, "mod_u2", "MODULE", "util/u.go");
+        named_node(&mut v, "imp_util", "example.com/a/util", "IMPORT", "main.go");
+        v.put_node_metadata(id_of("imp_util"), r#"{"path":"example.com/a/util"}"#);
+
+        let pairs = derived_pairs(&v, GO_IMPORTS_NOMOD_DL, "go_import_suffix");
+        assert_eq!(
+            pairs,
+            BTreeSet::from([
+                // "pkg/auth" and "auth" are both '/'-boundary suffixes of the
+                // auth import — but only pkg/auth/... has modules at "pkg/auth";
+                // "auth/a.go"'s dir IS "auth", also a boundary suffix → both.
+                (id_of("imp_auth"), id_of("mod_auth")),
+                (id_of("imp_auth"), id_of("mod_rawauth")),
+                // PREDICTION G2-3a: all suffix matches (legacy: alphabetical first).
+                (id_of("imp_util"), id_of("mod_u1")),
+                (id_of("imp_util"), id_of("mod_u2")),
+            ]),
+            "boundary-suffix matches only (G2-3b drops the …/oauth raw-suffix \
+             false positive); stdlib skipped; all matches derived (G2-3a)"
+        );
+    }
+
+    /// go_calls — Spec.hs:98-146 ported: the three strategies, the EXCLUSIVE
+    /// dispatch, the stdlib skip on S1, closure/interface_method exclusion,
+    /// the cross-package S2 miss, and the G3-1 duplicate-(dir,name) SUPERSET.
+    #[test]
+    fn go_calls_three_strategies_and_dispatch_on_fixture() {
+        let mut v = FixtureStorageView::new(1);
+        go_mod_fact(&mut v, "github.com/user/project");
+
+        // S1: package-qualified via same-file import alias.
+        node(&mut v, "mod_utils", "MODULE", "pkg/utils/utils.go");
+        named_node(&mut v, "fn_do", "DoStuff", "FUNCTION", "pkg/utils/utils.go");
+        v.put_node_metadata(id_of("fn_do"), r#"{"kind":"function"}"#);
+        named_node(&mut v, "imp_utils", "github.com/user/project/pkg/utils", "IMPORT", "cmd/main.go");
+        v.put_node_metadata(
+            id_of("imp_utils"),
+            r#"{"path":"github.com/user/project/pkg/utils","local_name":"utils"}"#,
+        );
+        named_node(&mut v, "call_do", "utils.DoStuff", "CALL", "cmd/main.go");
+        v.put_node_metadata(id_of("call_do"), r#"{"receiver":"utils"}"#);
+
+        // S1 stdlib skip: alias to "fmt" — even with a same-name local function.
+        named_node(&mut v, "imp_fmt", "fmt", "IMPORT", "cmd/main.go");
+        v.put_node_metadata(id_of("imp_fmt"), r#"{"path":"fmt","local_name":"fmt"}"#);
+        named_node(&mut v, "call_println", "fmt.Println", "CALL", "cmd/main.go");
+        v.put_node_metadata(id_of("call_println"), r#"{"receiver":"fmt"}"#);
+        named_node(&mut v, "fn_println", "Println", "FUNCTION", "fmt/print.go");
+        v.put_node_metadata(id_of("fn_println"), r#"{"kind":"function"}"#);
+
+        // Dispatch exclusivity: receiver matches an alias whose path is
+        // stdlib AND a method index entry exists for (receiver, name) —
+        // legacy dispatches S1 ONLY (alias match), which skips; S3 must NOT
+        // fire (Hs:163-174).
+        named_node(&mut v, "m_trap", "Println", "FUNCTION", "pkg/trap.go");
+        v.put_node_metadata(id_of("m_trap"), r#"{"kind":"method","receiver":"fmt"}"#);
+
+        // S2: same-package receiverless call (sub-dir AND root-dir shapes).
+        named_node(&mut v, "fn_helper", "helper", "FUNCTION", "pkg/util.go");
+        v.put_node_metadata(id_of("fn_helper"), r#"{"kind":"function"}"#);
+        named_node(&mut v, "call_helper", "helper", "CALL", "pkg/main.go");
+        named_node(&mut v, "fn_rootfn", "rootFn", "FUNCTION", "tool.go");
+        v.put_node_metadata(id_of("fn_rootfn"), r#"{"kind":"function"}"#);
+        named_node(&mut v, "call_rootfn", "rootFn", "CALL", "main.go");
+        // Cross-package S2 miss (Spec.hs:134-139).
+        named_node(&mut v, "call_cross", "helper", "CALL", "cmd/main.go");
+        // Closure exclusion (Spec.hs:141-146): kind=closure never indexed.
+        named_node(&mut v, "fn_clo", "<closure>", "FUNCTION", "pkg/main.go");
+        v.put_node_metadata(id_of("fn_clo"), r#"{"kind":"closure"}"#);
+        named_node(&mut v, "call_clo", "<closure>", "CALL", "pkg/main.go");
+        // G3-1: duplicate (dir, name) — a _test.go sibling defines helper too.
+        named_node(&mut v, "fn_helper2", "helper", "FUNCTION", "pkg/util_test.go");
+        v.put_node_metadata(id_of("fn_helper2"), r#"{"kind":"function"}"#);
+
+        // S3: method call where a variable shares the type's name (Spec.hs:120-127).
+        named_node(&mut v, "m_start", "Start", "FUNCTION", "pkg/server.go");
+        v.put_node_metadata(id_of("m_start"), r#"{"kind":"method","receiver":"Server"}"#);
+        named_node(&mut v, "call_start", "s.Start", "CALL", "pkg/main.go");
+        v.put_node_metadata(id_of("call_start"), r#"{"receiver":"Server"}"#);
+        // Unknown receiver (Spec.hs:128-132): no edge.
+        named_node(&mut v, "call_unk", "x.Unknown", "CALL", "pkg/main.go");
+        v.put_node_metadata(id_of("call_unk"), r#"{"receiver":"x"}"#);
+
+        let eval = evaluate(&v, GO_CALLS_DL, Stats::default(), EvalLimits::none(), EventLog::discard())
+            .expect("go_calls.dl evaluates");
+        let mut pairs: BTreeSet<(u128, u128)> = BTreeSet::new();
+        for pred in ["go_call_s1", "go_call_s2", "go_call_s3"] {
+            for r in eval.facts(pred) {
+                pairs.insert((r[0].as_id().unwrap(), r[1].as_id().unwrap()));
+            }
+        }
+        assert_eq!(
+            pairs,
+            BTreeSet::from([
+                (id_of("call_do"), id_of("fn_do")),
+                // PREDICTION G3-1: both same-(dir,name) functions derived
+                // (legacy last-wins picked one).
+                (id_of("call_helper"), id_of("fn_helper")),
+                (id_of("call_helper"), id_of("fn_helper2")),
+                (id_of("call_rootfn"), id_of("fn_rootfn")),
+                (id_of("call_start"), id_of("m_start")),
+            ]),
+            "S1 alias hit; S1 stdlib skip; S1-only dispatch (no S3 fallback for \
+             alias receivers); S2 same-dir + root-dir; S2 cross-package miss; \
+             closure excluded; S3 type-named receiver; unknown receiver miss"
+        );
+    }
+
+    /// go_interfaces — Spec.hs:152-210 ported: subset hit, missing-method
+    /// miss, empty-interface miss, multi-struct fan-out, pointer receiver;
+    /// plus the G6-2 (struct-side) and G6-3 (interface-side, verdict C3)
+    /// name-merge predictions.
+    #[test]
+    fn go_interfaces_subset_satisfaction_on_fixture() {
+        let mut v = FixtureStorageView::new(1);
+        // Reader{Read} ⊆ MyReader{Read} → IMPLEMENTS.
+        node(&mut v, "iface_reader", "INTERFACE", "io.go");
+        named_node(&mut v, "im_read", "Read", "FUNCTION", "io.go");
+        v.put_node_metadata(id_of("im_read"), r#"{"kind":"interface_method"}"#);
+        edge(&mut v, "iface_reader", "im_read", "CONTAINS");
+        named_node(&mut v, "cls_myreader", "MyReader", "CLASS", "reader.go");
+        named_node(&mut v, "sm_read", "Read", "FUNCTION", "reader.go");
+        v.put_node_metadata(id_of("sm_read"), r#"{"kind":"method","receiver":"MyReader","pointer_receiver":true}"#);
+        // ReadWriter{Read,Write} ⊄ MyReader{Read} → no edge (missing Write).
+        node(&mut v, "iface_rw", "INTERFACE", "io.go");
+        named_node(&mut v, "im_read2", "Read", "FUNCTION", "io.go");
+        v.put_node_metadata(id_of("im_read2"), r#"{"kind":"interface_method"}"#);
+        named_node(&mut v, "im_write", "Write", "FUNCTION", "io.go");
+        v.put_node_metadata(id_of("im_write"), r#"{"kind":"interface_method"}"#);
+        edge(&mut v, "iface_rw", "im_read2", "CONTAINS");
+        edge(&mut v, "iface_rw", "im_write", "CONTAINS");
+        // Empty interface → never satisfied (the non-empty gate via cand seeding).
+        node(&mut v, "iface_empty", "INTERFACE", "types.go");
+        named_node(&mut v, "cls_any", "Anything", "CLASS", "impl.go");
+        // Second struct also implementing Reader (multi-struct fan-out).
+        named_node(&mut v, "cls_fr", "FileReader", "CLASS", "file.go");
+        named_node(&mut v, "sm_fread", "Read", "FUNCTION", "file.go");
+        v.put_node_metadata(id_of("sm_fread"), r#"{"kind":"method","receiver":"FileReader"}"#);
+
+        let pairs = derived_pairs(&v, GO_INTERFACES_DL, "go_implements");
+        assert_eq!(
+            pairs,
+            BTreeSet::from([
+                (id_of("cls_myreader"), id_of("iface_reader")),
+                (id_of("cls_fr"), id_of("iface_reader")),
+            ]),
+            "subset hit (pointer receiver matches by bare name); missing-method \
+             and empty-interface miss; one edge per implementing struct"
+        );
+
+        // PREDICTION G6-3 (verdict C3): duplicate interface NAMES — legacy
+        // unions their method sets ({Read} ∪ {Close} = {Read,Close}, rejecting
+        // a Read-only struct) and the per-NODE pack accepts the {Read} node.
+        let mut v2 = FixtureStorageView::new(1);
+        named_node(&mut v2, "if_a", "Reader", "INTERFACE", "a.go");
+        named_node(&mut v2, "ifm_a", "Read", "FUNCTION", "a.go");
+        v2.put_node_metadata(id_of("ifm_a"), r#"{"kind":"interface_method"}"#);
+        edge(&mut v2, "if_a", "ifm_a", "CONTAINS");
+        named_node(&mut v2, "if_b", "Reader", "INTERFACE", "b.go");
+        named_node(&mut v2, "ifm_b", "Close", "FUNCTION", "b.go");
+        v2.put_node_metadata(id_of("ifm_b"), r#"{"kind":"interface_method"}"#);
+        edge(&mut v2, "if_b", "ifm_b", "CONTAINS");
+        named_node(&mut v2, "cls_r", "R", "CLASS", "r.go");
+        named_node(&mut v2, "rm", "Read", "FUNCTION", "r.go");
+        v2.put_node_metadata(id_of("rm"), r#"{"kind":"method","receiver":"R"}"#);
+        // PREDICTION G6-2: a same-named CLASS twin also receives the edge.
+        named_node(&mut v2, "cls_r2", "R", "CLASS", "r2.go");
+        let pairs2 = derived_pairs(&v2, GO_INTERFACES_DL, "go_implements");
+        assert_eq!(
+            pairs2,
+            BTreeSet::from([
+                (id_of("cls_r"), id_of("if_a")),
+                (id_of("cls_r2"), id_of("if_a")),
+            ]),
+            "G6-3: per-NODE requirement sets (legacy's name-union rejected this); \
+             G6-2: every same-named CLASS gets the edge (legacy last-wins one)"
+        );
+    }
+
+    /// go_types — TYPE_OF + RETURNS: recursive prefix strip, primitive skip,
+    /// comma-peel of return_type, map/chan non-resolution, INTERFACE targets,
+    /// and the G7-1 duplicate-type-name SUPERSET.
+    #[test]
+    fn go_types_type_of_and_returns_on_fixture() {
+        let mut v = FixtureStorageView::new(1);
+        named_node(&mut v, "cls_user", "User", "CLASS", "user.go");
+        named_node(&mut v, "if_store", "Store", "INTERFACE", "store.go");
+        // *User → User; []byte → primitive skip; []*User → User;
+        // map[string]User → no type_node key; int → primitive skip.
+        named_node(&mut v, "var_ptr", "u", "VARIABLE", "main.go");
+        v.put_node_metadata(id_of("var_ptr"), r#"{"type":"*User"}"#);
+        named_node(&mut v, "var_bytes", "b", "VARIABLE", "main.go");
+        v.put_node_metadata(id_of("var_bytes"), r#"{"type":"[]byte"}"#);
+        named_node(&mut v, "var_slice", "us", "VARIABLE", "main.go");
+        v.put_node_metadata(id_of("var_slice"), r#"{"type":"[]*User"}"#);
+        named_node(&mut v, "var_map", "m", "VARIABLE", "main.go");
+        v.put_node_metadata(id_of("var_map"), r#"{"type":"map[string]User"}"#);
+        named_node(&mut v, "var_int", "n", "VARIABLE", "main.go");
+        v.put_node_metadata(id_of("var_int"), r#"{"type":"int"}"#);
+        named_node(&mut v, "var_iface", "s", "VARIABLE", "main.go");
+        v.put_node_metadata(id_of("var_iface"), r#"{"type":"Store"}"#);
+
+        let pairs = derived_pairs(&v, GO_TYPES_DL, "go_type_of");
+        assert_eq!(
+            pairs,
+            BTreeSet::from([
+                (id_of("var_ptr"), id_of("cls_user")),
+                (id_of("var_slice"), id_of("cls_user")),
+                (id_of("var_iface"), id_of("if_store")),
+            ]),
+            "*/[] strip recursion; primitives and map types never resolve; \
+             INTERFACE is a type target"
+        );
+
+        // RETURNS: "*User,error" → User only (error is a primitive);
+        // "User,Store" → both; single "Config" → identity (no comma).
+        named_node(&mut v, "fn_a", "loadUser", "FUNCTION", "main.go");
+        v.put_node_metadata(id_of("fn_a"), r#"{"kind":"function","return_type":"*User,error"}"#);
+        named_node(&mut v, "fn_b", "both", "FUNCTION", "main.go");
+        v.put_node_metadata(id_of("fn_b"), r#"{"kind":"function","return_type":"User,Store"}"#);
+        named_node(&mut v, "cls_cfg", "Config", "CLASS", "cfg.go");
+        named_node(&mut v, "fn_c", "cfg", "FUNCTION", "main.go");
+        v.put_node_metadata(id_of("fn_c"), r#"{"kind":"function","return_type":"Config"}"#);
+        // G7-1: a duplicate type name — both nodes derived (legacy last-wins).
+        named_node(&mut v, "cls_cfg2", "Config", "CLASS", "cfg2.go");
+
+        let pairs = derived_pairs(&v, GO_TYPES_DL, "go_returns");
+        assert_eq!(
+            pairs,
+            BTreeSet::from([
+                (id_of("fn_a"), id_of("cls_user")),
+                (id_of("fn_b"), id_of("cls_user")),
+                (id_of("fn_b"), id_of("if_store")),
+                (id_of("fn_c"), id_of("cls_cfg")),
+                // PREDICTION G7-1: duplicate type names fan out.
+                (id_of("fn_c"), id_of("cls_cfg2")),
+            ]),
+            "comma-peel splits return_type exactly; error primitive skipped; \
+             duplicate type names fan out (G7-1)"
+        );
+    }
+
+    /// go_context — Spec.hs:216-302 ported onto the structural CONTAINS seam:
+    /// the certain/possible target × caller matrix, goroutine/deferred arms,
+    /// the unresolved meta column, closure- and module-contained calls
+    /// (G9-1/G9-3 — the pack derives what legacy INTENDED; on real analyzer
+    /// ids legacy's caller lookup never matched, see the .dl header).
+    #[test]
+    fn go_context_propagation_matrix_on_fixture() {
+        let mut v = FixtureStorageView::new(1);
+        // fnA (accepts) contains callB → fnB (accepts): PROPAGATES, no meta.
+        named_node(&mut v, "fn_a", "A", "FUNCTION", "pkg/handler.go");
+        v.put_node_metadata(id_of("fn_a"), r#"{"kind":"function","accepts_context":true}"#);
+        named_node(&mut v, "fn_b", "B", "FUNCTION", "pkg/service.go");
+        v.put_node_metadata(id_of("fn_b"), r#"{"kind":"function","accepts_context":true}"#);
+        named_node(&mut v, "call_b", "B", "CALL", "pkg/handler.go");
+        edge(&mut v, "fn_a", "call_b", "CONTAINS");
+        edge(&mut v, "call_b", "fn_b", "CALLS");
+        // goroutine: SPAWNS + PROPAGATES (Spec.hs:231-243).
+        named_node(&mut v, "fn_worker", "worker", "FUNCTION", "pkg/main.go");
+        v.put_node_metadata(id_of("fn_worker"), r#"{"kind":"function","accepts_context":true}"#);
+        named_node(&mut v, "call_w", "worker", "CALL", "pkg/main.go");
+        v.put_node_metadata(id_of("call_w"), r#"{"goroutine":true}"#);
+        edge(&mut v, "fn_a2", "call_w", "CONTAINS");
+        named_node(&mut v, "fn_a2", "main", "FUNCTION", "pkg/main.go");
+        v.put_node_metadata(id_of("fn_a2"), r#"{"kind":"function","accepts_context":true}"#);
+        edge(&mut v, "call_w", "fn_worker", "CALLS");
+        // deferred: DEFERS + PROPAGATES (Spec.hs:257-269).
+        named_node(&mut v, "fn_cleanup", "cleanup", "FUNCTION", "pkg/api.go");
+        v.put_node_metadata(id_of("fn_cleanup"), r#"{"kind":"function","accepts_context":true}"#);
+        named_node(&mut v, "call_d", "cleanup", "CALL", "pkg/api.go");
+        v.put_node_metadata(id_of("call_d"), r#"{"deferred":true}"#);
+        edge(&mut v, "fn_a", "call_d", "CONTAINS");
+        edge(&mut v, "call_d", "fn_cleanup", "CALLS");
+        // No-context target: nothing (Spec.hs:245-255).
+        named_node(&mut v, "fn_c", "C", "FUNCTION", "pkg/util.go");
+        v.put_node_metadata(id_of("fn_c"), r#"{"kind":"function"}"#);
+        named_node(&mut v, "call_c", "C", "CALL", "pkg/handler.go");
+        edge(&mut v, "fn_a", "call_c", "CONTAINS");
+        edge(&mut v, "call_c", "fn_c", "CALLS");
+        // possible → possible: meta unresolved="true" (Spec.hs:271-286).
+        named_node(&mut v, "fn_pa", "PA", "FUNCTION", "pkg/p.go");
+        v.put_node_metadata(id_of("fn_pa"), r#"{"kind":"function","possible_context":true}"#);
+        named_node(&mut v, "fn_pb", "PB", "FUNCTION", "pkg/p.go");
+        v.put_node_metadata(id_of("fn_pb"), r#"{"kind":"function","possible_context":true}"#);
+        named_node(&mut v, "call_pb", "PB", "CALL", "pkg/p.go");
+        edge(&mut v, "fn_pa", "call_pb", "CONTAINS");
+        edge(&mut v, "call_pb", "fn_pb", "CALLS");
+        // possible caller → CERTAIN target: plain edge, NO meta (Spec.hs:288-301).
+        named_node(&mut v, "call_b2", "B", "CALL", "pkg/p.go");
+        edge(&mut v, "fn_pa", "call_b2", "CONTAINS");
+        edge(&mut v, "call_b2", "fn_b", "CALLS");
+        // Call inside a CLOSURE: no PROPAGATES (caller excluded) but SPAWNS
+        // still fires (caller-independent).
+        named_node(&mut v, "fn_clo", "<closure>", "FUNCTION", "pkg/z.go");
+        v.put_node_metadata(id_of("fn_clo"), r#"{"kind":"closure"}"#);
+        named_node(&mut v, "call_z", "B", "CALL", "pkg/z.go");
+        v.put_node_metadata(id_of("call_z"), r#"{"goroutine":true}"#);
+        edge(&mut v, "fn_clo", "call_z", "CONTAINS");
+        edge(&mut v, "call_z", "fn_b", "CALLS");
+        // Top-level call (CONTAINS from MODULE): no PROPAGATES.
+        node(&mut v, "mod_top", "MODULE", "pkg/t.go");
+        named_node(&mut v, "call_t", "B", "CALL", "pkg/t.go");
+        edge(&mut v, "mod_top", "call_t", "CONTAINS");
+        edge(&mut v, "call_t", "fn_b", "CALLS");
+
+        let eval = evaluate(&v, GO_CONTEXT_DL, Stats::default(), EvalLimits::none(), EventLog::discard())
+            .expect("go_context.dl evaluates");
+        let prop: BTreeSet<(u128, u128)> = eval
+            .facts("go_prop")
+            .into_iter()
+            .map(|r| (r[0].as_id().unwrap(), r[1].as_id().unwrap()))
+            .collect();
+        assert_eq!(
+            prop,
+            BTreeSet::from([
+                (id_of("fn_a"), id_of("fn_b")),
+                (id_of("fn_a2"), id_of("fn_worker")),
+                (id_of("fn_a"), id_of("fn_cleanup")),
+                // Possible caller + certain target rides the PLAIN head.
+                (id_of("fn_pa"), id_of("fn_b")),
+            ]),
+            "certain-target PROPAGATES: enclosing fn via CONTAINS; closure- and \
+             module-contained calls excluded; no-context target inert"
+        );
+        let prop_u: BTreeSet<(u128, u128, String)> = eval
+            .facts("go_prop_u")
+            .into_iter()
+            .map(|r| (r[0].as_id().unwrap(), r[1].as_id().unwrap(), r[2].as_str()))
+            .collect();
+        assert_eq!(
+            prop_u,
+            BTreeSet::from([(id_of("fn_pa"), id_of("fn_pb"), "true".to_string())]),
+            "possible-target edges carry unresolved=\"true\" (G9-2 projection); \
+             the certain-target row must NOT appear here (Spec.hs:288-301)"
+        );
+        let spawns: BTreeSet<(u128, u128)> = eval
+            .facts("go_spawn")
+            .into_iter()
+            .map(|r| (r[0].as_id().unwrap(), r[1].as_id().unwrap()))
+            .collect();
+        assert_eq!(
+            spawns,
+            BTreeSet::from([
+                (id_of("call_w"), id_of("fn_worker")),
+                // Caller-independent: the closure-contained goroutine still spawns.
+                (id_of("call_z"), id_of("fn_b")),
+            ]),
+            "SPAWNS is caller-independent (legacy :177-185)"
+        );
+        let defers: BTreeSet<(u128, u128)> = eval
+            .facts("go_defer")
+            .into_iter()
+            .map(|r| (r[0].as_id().unwrap(), r[1].as_id().unwrap()))
+            .collect();
+        assert_eq!(
+            defers,
+            BTreeSet::from([(id_of("call_d"), id_of("fn_cleanup"))]),
+            "DEFERS for deferred calls with certain-context targets"
+        );
+    }
+
+    /// Every go pack declares its @materialize heads with the expected edge
+    /// types and ADDITIVE mode (shared vocabulary — never tombstone), and the
+    /// unresolved meta column rides only the *_u context heads.
+    #[test]
+    fn go_packs_declare_additive_materialization() {
+        let mut v = FixtureStorageView::new(1);
+        node(&mut v, "m", "MODULE", "a.go");
+        for (src, expected) in [
+            (GO_IMPORTS_DL, vec!["IMPORTS_FROM"]),
+            (GO_IMPORTS_NOMOD_DL, vec!["IMPORTS_FROM"]),
+            (GO_CALLS_DL, vec!["CALLS", "CALLS", "CALLS"]),
+            (GO_INTERFACES_DL, vec!["IMPLEMENTS"]),
+            (GO_TYPES_DL, vec!["TYPE_OF", "RETURNS"]),
+            (
+                GO_CONTEXT_DL,
+                vec![
+                    "PROPAGATES_CONTEXT",
+                    "PROPAGATES_CONTEXT",
+                    "SPAWNS_WITH_CONTEXT",
+                    "SPAWNS_WITH_CONTEXT",
+                    "DEFERS_WITH_CONTEXT",
+                    "DEFERS_WITH_CONTEXT",
+                ],
+            ),
+        ] {
+            let (_eval, specs, node_specs) = evaluate_with_materialize(
+                &v,
+                src,
+                Stats::default(),
+                EvalLimits::none(),
+                EventLog::discard(),
+            )
+            .expect("go pack evaluates with materialize");
+            let mut types: Vec<&str> = specs.iter().map(|s| s.edge_type.as_str()).collect();
+            let mut want = expected.clone();
+            types.sort_unstable();
+            want.sort_unstable();
+            assert_eq!(types, want, "edge-type heads of a go pack");
+            assert!(
+                specs.iter().all(|s| s.additive),
+                "every go head is additive (shared vocabulary)"
+            );
+            assert!(
+                node_specs.is_empty(),
+                "go packs materialize edges only, no nodes"
+            );
+        }
+    }
 }

--- a/packages/rfdb-server/src/derive/stdlib/go_calls.dl
+++ b/packages/rfdb-server/src/derive/stdlib/go_calls.dl
@@ -1,0 +1,136 @@
+% go_calls.dl — in-engine replacement for the GoCallResolution.hs resolver
+% (packages/go-resolve/src/GoCallResolution.hs): CALL → FUNCTION CALLS edges,
+% three strategies dispatched on the CALL's `receiver` metadata against the
+% SAME-FILE import aliases (resolveCall :157-174 — the dispatch is exclusive:
+% alias-receiver → strategy 1 ONLY, non-alias receiver → strategy 3 ONLY,
+% no receiver → strategy 2 ONLY; a strategy that misses has NO fallback):
+%
+%   S1 package-qualified (`utils.DoStuff()` where `utils` is an import's
+%      local_name): import path → package dir (PackageIndex :118-128, three
+%      key families: modPath<>"/"<>dir, modPath→"", bare dir→dir; plus the
+%      modPath-strip fallback :197-201) → (dir, callName) FunctionIndex.
+%   S2 same-package (`helper()`, no receiver): (callerDir, callName) lookup
+%      (:213-222).
+%   S3 same-package method (`s.Method()`, receiver not an alias): GLOBAL
+%      (receiverNAME, method) MethodIndex (:227-236) — only hits when a
+%      variable shares its TYPE's name (the known legacy weakness; receiver
+%      typing is the named Wave-2 refinement, NOT attempted — parity).
+%
+% callName = after the last '.' (extractCallName :54-57) — `method_suffix`
+% for the dotted S1/S3 names; S2 names are never dotted (a receiver-less
+% CALL's name is the bare ident or "<expr>", go-analyzer Calls.hs:74-77).
+%
+% PLANNER-LEGAL SPELLING (verdict C1): the import-path → dir map cannot be a
+% standalone `pkg_dir` relation (the modPath×dirs product is disconnected).
+% Consumers inline the peel-join: '/'-boundary prefixes of the alias's import
+% path (spec_pfx right-peel) equality-join `go_mod`, then the bound RelDir
+% joins `func_in_dir`. The legacy "dir must hold MODULEs" key condition is
+% IMPLIED here: a FUNCTION in dir d ⇒ its .go file is in d ⇒ that file's
+% MODULE is in d (the analyzer emits one MODULE per file, Walker.hs:32-44) —
+% so the func_in_dir join subsumes the PackageIndex membership test, exactly.
+%
+% NUMBERED DELTAS vs the resolver (everything not listed is exact):
+%   DELTA G3-1 (SUPERSET, bounded): FunctionIndex is Map.fromList = LAST-wins
+%     on duplicate (dir, name) keys (:91-100) — build-tag twins / _test.go
+%     siblings defining one name in one directory. Set semantics derives all
+%     candidates. Bound: #same-name functions per directory (≈1-2).
+%   DELTA G3-2 (CLOSED, was an approximation in the spec): the isStdLib gate
+%     on S1 import paths (:193) is EXACT via `first_segment` (M1 shipped) —
+%     first '/'-segment contains a dot. No "foo/bar.v2" residue, and no
+%     stdlib-named local dir ("errors/", "log/") can capture a qualified call.
+%   DELTA G3-3 (SUPERSET, pathological-only): legacy PackageIndex is ONE map —
+%     when P == modPath AND a directory literally named P exists, fromList
+%     order makes the bare key win (dir = P, not ""); the pack derives both
+%     arms. Requires a directory literally named like a module path (0 real).
+%   DELTA G3-4 (SUPERSET, compile-error-only): the per-file ImportAliasIndex
+%     is Map.fromList = last-wins on duplicate local_name in ONE file — a Go
+%     compile error except for `_`/`.` names, which can never appear as a
+%     call receiver. Set semantics derives per alias row. Bound 0 on code
+%     that compiles.
+%   DELTA G5-1 (SUPERSET, bounded): the S3 MethodIndex is GLOBAL last-wins
+%     across packages (:103-112) — same-named type with same-named method in
+%     two packages: legacy picks one arbitrary winner, the pack derives all.
+%     Bound: #duplicate (receiver-type-name, method) pairs. The dir-scoped
+%     REFINEMENT is deliberately deferred to the differential (rust_imports
+%     DELTA-1 governed-arm precedent).
+%   File gate: ends_with .go on every base relation (orchestrator stream
+%     filter; CALL/FUNCTION/IMPORT/MODULE are shared vocabulary).
+%   Metadata: legacy CALLS edges carry EMPTY metadata (emitCallsEdge
+%     :241-248) and stamp NO resolvedVia — no meta projected, exact parity.
+%
+% MAINTAIN ENVELOPE: negation (dispatch guards) + node_attr ⇒ scratch floor.
+%
+% ORDERING (PRODUCER): produces CALLS — must run BEFORE go_context (which
+% consumes committed CALLS on .go files — precondition P2; legacy did this
+% in-process, Main.hs:78-79 extractCallEdges) and BEFORE the CALLS negators
+% method_calls / shape_verifier (verdict C4: shape_verifier.dl negates
+% `edge(C, _, "CALLS")` with no file gate).
+
+% ── Shared sources ───────────────────────────────────────────────────────────
+go_call(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".go"),
+                    attr(C, "name", N).
+call_recv(C, R)  :- go_call(C, _, _), node_attr(C, "receiver", R).
+has_recv(C)      :- go_call(C, _, _), node_attr(C, "receiver", _).
+import_alias(F, L, P) :- node(I, "IMPORT"), attr(I, "file", F),
+                         ends_with(F, ".go"), node_attr(I, "local_name", L),
+                         node_attr(I, "path", P).
+
+% (dir, name) → FUNCTION kind=function (buildFunctionIndex :91-100; closures
+% and interface_methods excluded by the kind gate — Spec.hs:141-148).
+go_fn(T)             :- node(T, "FUNCTION"), attr(T, "file", TF),
+                        ends_with(TF, ".go"), node_attr(T, "kind", "function").
+fn_dir(T, D)         :- go_fn(T), attr(T, "file", TF), basename(TF, B),
+                        concat("/", B, SB), strip_suffix(TF, SB, D).
+fn_subdir(T)         :- fn_dir(T, _).
+func_in_dir(D, N, T) :- fn_dir(T, D), attr(T, "name", N).
+func_in_dir("", N, T) :- go_fn(T), \+ fn_subdir(T), attr(T, "name", N).
+
+go_mod(MP) :- node(W, "WORKSPACE_PACKAGE"), node_attr(W, "language", "go"),
+              attr(W, "name", MP).
+
+% ── Strategy 1: package-qualified calls ──────────────────────────────────────
+% Receiver matches a same-file import alias (the dispatch test :165).
+s1_path(C, P) :- call_recv(C, R), go_call(C, F, _), import_alias(F, R, P).
+% Exact isStdLib gate (:193, via first_segment — DELTA G3-2 closed).
+s1_ok(C, P)   :- s1_path(C, P), first_segment(P, "/", S1), string_contains(S1, ".").
+
+% '/'-boundary prefixes of S1 import paths (the spec_pfx right-peel).
+s1_pfx(P, P) :- s1_ok(_, P).
+s1_pfx(P, D) :- s1_pfx(P, X), last_segment(X, "/", L),
+                concat("/", L, Tail), strip_suffix(X, Tail, D).
+
+% Import path → target package dir, all three legacy key families
+% (buildPackageIndex :118-128 + the strip fallback :197-201), Rel/"" bound
+% as builtin outputs (the C1 discipline — see go_imports.dl):
+%   (a) modPath-prefixed → relative dir;
+%   (b) P == modPath     → root dir "";
+%   (c) bare dir key     → P itself names a local package directory.
+s1_dir(P, Rel) :- s1_pfx(P, MP), go_mod(MP), concat(MP, "/", MPS),
+                  strip_prefix(P, MPS, Rel).
+s1_dir(P, Rel) :- s1_ok(_, P), go_mod(P), strip_prefix(P, P, Rel).
+s1_dir(P, P)   :- s1_ok(_, P).
+
+@materialize(edge_type = "CALLS", mode = "additive")
+go_call_s1(C, T) :- s1_ok(C, P), s1_dir(P, D), go_call(C, _, N),
+                    method_suffix(N, MN), func_in_dir(D, MN, T).
+
+% ── Strategy 2: same-package function calls (no receiver) ───────────────────
+call_dir(C, D)  :- go_call(C, F, _), basename(F, B), concat("/", B, SB),
+                   strip_suffix(F, SB, D).
+call_subdir(C)  :- call_dir(C, _).
+
+@materialize(edge_type = "CALLS", mode = "additive")
+go_call_s2(C, T) :- go_call(C, _, N), \+ has_recv(C), call_dir(C, D),
+                    func_in_dir(D, N, T).
+go_call_s2(C, T) :- go_call(C, _, N), \+ has_recv(C), \+ call_subdir(C),
+                    func_in_dir("", N, T).
+
+% ── Strategy 3: same-package method calls (receiver is not an alias) ────────
+alias_recv(C) :- call_recv(C, R), go_call(C, F, _), import_alias(F, R, _).
+method_in(RT, MN, T) :- node(T, "FUNCTION"), attr(T, "file", TF),
+                        ends_with(TF, ".go"), node_attr(T, "kind", "method"),
+                        node_attr(T, "receiver", RT), attr(T, "name", MN).
+
+@materialize(edge_type = "CALLS", mode = "additive")
+go_call_s3(C, T) :- call_recv(C, R), \+ alias_recv(C), go_call(C, _, N),
+                    method_suffix(N, MN), method_in(R, MN, T).

--- a/packages/rfdb-server/src/derive/stdlib/go_context.dl
+++ b/packages/rfdb-server/src/derive/stdlib/go_context.dl
@@ -1,0 +1,103 @@
+% go_context.dl — in-engine replacement for the GoContextPropagation.hs
+% resolver (packages/go-resolve/src/GoContextPropagation.hs): context.Context
+% flow over resolved CALLS edges.
+%
+%   PROPAGATES_CONTEXT (enclosing FUNCTION → target FUNCTION, :167-176):
+%     target accepts context (certainly or possibly) AND the call's enclosing
+%     function accepts context (certainly or possibly).
+%   SPAWNS_WITH_CONTEXT / DEFERS_WITH_CONTEXT (CALL → target FUNCTION,
+%     :177-194): target accepts (certainly or possibly) and the CALL carries
+%     the goroutine / deferred flag — INDEPENDENT of the caller's own context
+%     status.
+%   Edge metadata (:148-152): `unresolved = true` iff the TARGET is only
+%     "possible" — on ALL three edge types; the caller's certainty never
+%     affects metadata (fixture Spec.hs:288-301). accepts_context /
+%     possible_context are mutually exclusive per function (the analyzer's
+%     contextMeta picks one, Declarations.hs:97-103) — no `\+ ctx_fn(T)`
+%     guard is needed on the possible arms.
+%
+% INPUT SEAM (precondition P2): consumes COMMITTED CALLS edges on .go files —
+% produced by go_calls, which MUST run first (legacy fed go-calls output
+% in-process, Main.hs:78-79 extractCallEdges). Graph CALLS on .go files come
+% exclusively from the go packs / go-resolve (the analyzer's own CALLS
+% DeferredRefs are dropped at the serde boundary — verdict C5), so the seam
+% sees exactly the go_calls slice (plus, during legacy coexistence, the
+% legacy edges — the same set modulo the go_calls deltas).
+%
+% NUMBERED DELTAS vs the resolver (everything not listed is exact):
+%   DELTA G9-1 (structural substitute, REFINED): the enclosing function is
+%     the CALL's literal CONTAINS parent (only function/method/closure bodies
+%     push a scope — ControlFlow.hs has ZERO withScope sites — so the parent
+%     IS the enclosing function) instead of the legacy (dir, parsed-name)
+%     lookup, whose map is also last-wins (:104-112). Calls inside closures:
+%     EXACT on both sides — legacy finds no index entry (closures excluded
+%     :107-108), the pack's parent is the closure node, excluded by
+%     \+ closure_fn.
+%   DELTA G9-2 (metadata representation): `unresolved` rides the meta()
+%     projection as the string "true" vs legacy MetaBool true — consumers
+%     reading the node_attr/edge_attr string surface see the identical
+%     "true" (the js packs' resolvedVia-projection class).
+%   DELTA G9-3 (NEW — legacy caller-lookup defect, pack REFINES; found
+%     implementing, missed by both the spec and its verdict — TWO independent
+%     failure layers):
+%     (a) the node ids the daemon receives are the orchestrator's
+%         PERCENT-ENCODED URIs (`…#CALL-%3Echeck%5Bin:Validate,h:e1be%5D`,
+%         live-probed) — `T.breakOn "[in:"` (:53) never matches `%5Bin:`;
+%     (b) even unencoded, analyzer CALL ids ALWAYS carry a position hash
+%         (Calls.hs:106), and extractEnclosingName (:57-59) takes everything
+%         up to "]" — "Validate,h:e1be" can never equal a function name in
+%         the (dir, name) lookup.
+%     On real analyzer output legacy emits ZERO PROPAGATES_CONTEXT edges
+%     (its Spec.hs fixtures pass only because the handcrafted ids are
+%     unencoded and hash-free). The pack's CONTAINS parent restores the
+%     intended semantics; the differential asserts legacy = 0 and classifies
+%     every pack row here (proven on the multi-package corpus: legacy=0,
+%     pack=5 — exactly the intended caller→callee context edges).
+%     SPAWNS/DEFERS are unaffected (no caller lookup) — corpus-proven exact.
+%   File gate: ends_with .go on the CALL side (orchestrator stream filter).
+%
+% MAINTAIN ENVELOPE: negation + node_attr ⇒ scratch floor (accepted).
+%
+% ORDERING (CONSUMER): MUST run after go_calls (P2 — reads its CALLS as
+% committed EDB; this program does not materialize CALLS, so the read is
+% legal EDB consumption, the shape_verifier precedent).
+
+% ── Context-accepting functions (:79-94; bools surface as "true") ───────────
+ctx_fn(T)  :- node(T, "FUNCTION"), node_attr(T, "accepts_context", "true").
+poss_fn(T) :- node(T, "FUNCTION"), node_attr(T, "possible_context", "true").
+
+% ── Resolved go CALLS edges (the P2 seam) ───────────────────────────────────
+go_calls_e(C, T) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".go"),
+                    edge(C, T, "CALLS"), node(T, "FUNCTION").
+
+% ── Enclosing function (DELTA G9-1/G9-3): the CONTAINS parent ────────────────
+closure_fn(EF) :- node(EF, "FUNCTION"), node_attr(EF, "kind", "closure").
+iface_fn(EF)   :- node(EF, "FUNCTION"), node_attr(EF, "kind", "interface_method").
+enc_fn(C, EF)  :- go_calls_e(C, _), edge(EF, C, "CONTAINS"),
+                  node(EF, "FUNCTION"), \+ closure_fn(EF), \+ iface_fn(EF).
+caller_ok(C)   :- enc_fn(C, EF), ctx_fn(EF).
+caller_ok(C)   :- enc_fn(C, EF), poss_fn(EF).
+
+% ── PROPAGATES_CONTEXT: enclosing fn → target (:167-176) ────────────────────
+@materialize(edge_type = "PROPAGATES_CONTEXT", mode = "additive")
+go_prop(EF, T) :- go_calls_e(C, T), ctx_fn(T), caller_ok(C), enc_fn(C, EF).
+
+@materialize(edge_type = "PROPAGATES_CONTEXT", mode = "additive", meta(unresolved))
+go_prop_u(EF, T, "true") :- go_calls_e(C, T), poss_fn(T), caller_ok(C),
+                            enc_fn(C, EF).
+
+% ── SPAWNS_WITH_CONTEXT / DEFERS_WITH_CONTEXT: call → target (:177-194) ─────
+% goroutine/deferred are MetaBool, stamped only when true (Calls.hs:127-128).
+@materialize(edge_type = "SPAWNS_WITH_CONTEXT", mode = "additive")
+go_spawn(C, T) :- go_calls_e(C, T), ctx_fn(T), node_attr(C, "goroutine", "true").
+
+@materialize(edge_type = "SPAWNS_WITH_CONTEXT", mode = "additive", meta(unresolved))
+go_spawn_u(C, T, "true") :- go_calls_e(C, T), poss_fn(T),
+                            node_attr(C, "goroutine", "true").
+
+@materialize(edge_type = "DEFERS_WITH_CONTEXT", mode = "additive")
+go_defer(C, T) :- go_calls_e(C, T), ctx_fn(T), node_attr(C, "deferred", "true").
+
+@materialize(edge_type = "DEFERS_WITH_CONTEXT", mode = "additive", meta(unresolved))
+go_defer_u(C, T, "true") :- go_calls_e(C, T), poss_fn(T),
+                            node_attr(C, "deferred", "true").

--- a/packages/rfdb-server/src/derive/stdlib/go_imports.dl
+++ b/packages/rfdb-server/src/derive/stdlib/go_imports.dl
@@ -1,0 +1,100 @@
+% go_imports.dl — in-engine replacement for the GoImportResolution.hs resolver
+% (packages/go-resolve/src/GoImportResolution.hs): same-module IMPORT → MODULE
+% IMPORTS_FROM edges, driven by the GO module-path fact (precondition P1: the
+% orchestrator commits the go.mod module path as a WORKSPACE_PACKAGE node with
+% node_attr language="go" — main.rs P1 commit; before that fact the module
+% path was wire-only and invisible to packs).
+%
+% LEGACY ALGORITHM (resolveOneImport, Hs:116-145):
+%   * skip stdlib imports — "first path segment has no dot" (isStdLib :86-89);
+%   * strip the module-path prefix (PLAIN T.stripPrefix + dropWhile '/', :123-126)
+%     to a relative package directory;
+%   * look up the dir in the PackageIndex (dir → MODULE ids, buildPackageIndex
+%     :57-64) and emit IMPORTS_FROM to the FIRST module id (:129);
+%   * import path == module path resolves to the ROOT directory ("" key).
+%   The empty-module-path suffix fallback (findBySuffix :152-163) is NOT here —
+%   it is the separate `go_imports_nomod` VARIANT pack the orchestrator selects
+%   when go.mod is absent (precondition P3: an in-pack "fact is absent" test is
+%   the §3 cross-join the planner refuses).
+%
+% PLANNER-LEGAL SPELLING (verdict C1): `go_mod(MP)` may not appear as a leg
+% disconnected from the import path. The established respelling is the
+% js_module_imports `spec_pfx` idiom — derive every '/'-boundary PREFIX of the
+% import path by right-peel (strictly shrinking ⇒ terminates), EQUALITY-join
+% `go_mod` on the peeled prefix, then strip the "/"-boundary and join
+% `module_in_dir` on the BOUND relative dir. The root case (P == module path)
+% is its own clause with `go_mod(P)` as a bound filter-join. Requiring the
+% "/" boundary removes the legacy plain-stripPrefix boundary bug ("…/p"
+% string-prefix-matches "…/project2", then the dir lookup misses anyway) — no
+% edge-set effect (the legacy miss is reproduced as a non-match).
+%
+% NUMBERED DELTAS vs the resolver (everything not listed is exact):
+%   DELTA G2-1 (CLOSED, was REFINED in the spec): the spec's draft dropped the
+%     isStdLib guard from the same-module arm and accepted a divergence for
+%     dot-less module paths (`module myapp` — legacy's isStdLib skips
+%     "myapp/util" BEFORE prefix-stripping). With the `first_segment` builtin
+%     (the spec's missing capability M1, now shipped) the guard is spelled
+%     EXACTLY: first '/'-segment contains a dot. No residue.
+%   DELTA G2-2 (SUPERSET, bounded by files-per-package): legacy emits ONE edge
+%     to the FIRST module id in the target directory (`tid : _`, Hs:129 —
+%     insertion order, nondeterministic across runs); set semantics derives one
+%     edge per MODULE node (= per .go file) in the package directory. Arguably
+%     truer — a Go package IS the directory. Bound: #files in the imported
+%     package.
+%   DELTA G2-3 moved to the `go_imports_nomod` variant pack (the fallback arm
+%     lives there).
+%   File gate (the rust_imports DELTA-5 class): the legacy input gate was the
+%     orchestrator's Language::Go stream filter (config.rs:751/796) — encoded
+%     here as ends_with(F, ".go") on every base relation; MODULE/IMPORT are
+%     shared vocabulary across analyzers.
+%   Diagnostics: none in legacy either (no stderr edge-count for imports).
+%   Metadata: legacy edges carry EMPTY metadata (Hs:142) — no meta projected,
+%     exact parity (engine provenance _source/_generation only).
+%
+% MAINTAIN ENVELOPE: negation (\+ mod_subdir) + node_attr ⇒ scratch floor
+% (accepted, same stance as every import pack).
+%
+% ORDERING (PRODUCER): produces IMPORTS_FROM — must run BEFORE depends (which
+% derives MODULE-level DEPENDS_ON from every IMPORTS_FROM edge,
+% node-type-agnostically — verdict C4; the legacy go branch fed the
+% orchestrator's all_imports_from_edges the same way, main.rs:1699-1703).
+
+% ── The GO module-path fact (P1) ─────────────────────────────────────────────
+go_mod(MP) :- node(W, "WORKSPACE_PACKAGE"), node_attr(W, "language", "go"),
+              attr(W, "name", MP).
+
+% ── Package-directory kernel (buildPackageIndex :57-64) ─────────────────────
+% dirname via basename + concat + strip_suffix (no dirname builtin); root-level
+% files ("main.go") yield NO strip_suffix row → the complement clause derives
+% the "" directory via derived-negation (\+ mod_subdir).
+go_module(M, F)      :- node(M, "MODULE"), attr(M, "file", F), ends_with(F, ".go").
+mod_dir(M, D)        :- go_module(M, F), basename(F, B), concat("/", B, SB),
+                        strip_suffix(F, SB, D).
+mod_subdir(M)        :- mod_dir(M, _).
+module_in_dir(D, M)  :- mod_dir(M, D).
+module_in_dir("", M) :- go_module(M, _), \+ mod_subdir(M).
+
+% ── Importer side ────────────────────────────────────────────────────────────
+go_import(I, P) :- node(I, "IMPORT"), attr(I, "file", F), ends_with(F, ".go"),
+                   node_attr(I, "path", P).
+% Exact isStdLib gate (Hs:86-89): the FIRST '/'-segment contains a dot.
+go_import_nonstd(I, P) :- go_import(I, P), first_segment(P, "/", S1),
+                          string_contains(S1, ".").
+
+% '/'-boundary prefixes of each import path (the spec_pfx right-peel idiom).
+imp_pfx(P, P)  :- go_import(_, P).
+imp_pfx(P, D)  :- imp_pfx(P, X), last_segment(X, "/", L),
+                  concat("/", L, Tail), strip_suffix(X, Tail, D).
+
+% Resolved relative package directory per import. The root case binds Rel=""
+% as a BUILTIN OUTPUT (strip_prefix(P, P, Rel) — self-strip of a bound value),
+% NOT as a constant leg: `module_in_dir("", M)` standing alone is the exact
+% E-PLAN-003 shape verdict C1 rejected; a bound Rel makes the final join an
+% equality join (the verdict's prescription).
+imp_rel(I, Rel) :- go_import_nonstd(I, P), imp_pfx(P, MP), go_mod(MP),
+                   concat(MP, "/", MPS), strip_prefix(P, MPS, Rel).
+imp_rel(I, Rel) :- go_import_nonstd(I, P), go_mod(P), strip_prefix(P, P, Rel).
+
+% ── The materialized edge ────────────────────────────────────────────────────
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+go_import_from(I, M) :- imp_rel(I, Rel), module_in_dir(Rel, M).

--- a/packages/rfdb-server/src/derive/stdlib/go_imports_nomod.dl
+++ b/packages/rfdb-server/src/derive/stdlib/go_imports_nomod.dl
@@ -1,0 +1,68 @@
+% go_imports_nomod.dl — the NO-go.mod VARIANT of go_imports: the legacy
+% empty-module-path suffix fallback (GoImportResolution.hs findBySuffix
+% :152-163), selected by the ORCHESTRATOR (precondition P3): a pack cannot
+% test "the GO module-path fact does NOT exist" — a `has_go_mod()`-style
+% global literal shares no variable with the body, the §3 cross-join the
+% planner refuses (and per verdict C2 the filter-connected `ends_with(P, D)`
+% spelling of the suffix match is equally rejected). The orchestrator, which
+% knows whether go.mod resolved, runs this pack ONLY when it did not — the
+% faithful translation of legacy's global `T.null modulePath` branch. BOTH
+% variants are registered (registry order is pinned); selection is a runtime
+% skip in the orchestrator's pack loop (`run_stdlib_rule_packs`).
+%
+% LEGACY ALGORITHM (resolveOneImport :131-135 + findBySuffix :152-163, only
+% when the module path is empty): skip stdlib (isStdLib :86-89), then emit an
+% edge to the first MODULE of the alphabetically-first non-empty directory
+% that is a SUFFIX of the import path (Map.toList order).
+%
+% PLANNER-LEGAL SPELLING (verdict C2): the suffix match must be an EQUALITY
+% join — derive the '/'-boundary SUFFIXES of the import path by LEFT-peel
+% (`first_segment` + strip — the missing capability M1, now shipped; the dual
+% of the spec_pfx right-peel) and join `module_in_dir` on the bound suffix.
+%
+% NUMBERED DELTAS vs the resolver (everything not listed is exact):
+%   DELTA G2-3a (SUPERSET, bounded by #dirs sharing a suffix): legacy picks
+%     the alphabetically-first suffix-matching dir (Map.toList :152-163) and
+%     the first MODULE in it; set semantics derives ALL '/'-boundary suffix
+%     matches, one edge per MODULE in each (the G2-2 multiplicity compounds
+%     here). Every extra edge traces to the documented first-match tie-break.
+%   DELTA G2-3b (REFINED subset, ~0): legacy `T.isSuffixOf` is a RAW string
+%     suffix — directory "auth" matches import path "example.com/pkg/oauth".
+%     The left-peel derives only '/'-BOUNDARY suffixes, dropping that legacy
+%     false-positive class. Diverges only when a local dir is a non-boundary
+%     suffix of an import path (0 expected anywhere real).
+%   DELTA G2-1 (CLOSED): the isStdLib gate is exact via `first_segment`
+%     (see go_imports.dl).
+%   File gate: ends_with(F, ".go") on every base relation (the orchestrator's
+%     Language::Go stream filter, rust_imports DELTA-5 class).
+%
+% MAINTAIN ENVELOPE: negation (\+ mod_subdir) + node_attr ⇒ scratch floor.
+%
+% ORDERING (PRODUCER): produces IMPORTS_FROM — before depends (verdict C4).
+% Registered immediately after go_imports; never runs in the same selection
+% (go.mod either resolved or it did not).
+
+% ── Package-directory kernel (duplicated prelude, js packs precedent) ───────
+go_module(M, F)      :- node(M, "MODULE"), attr(M, "file", F), ends_with(F, ".go").
+mod_dir(M, D)        :- go_module(M, F), basename(F, B), concat("/", B, SB),
+                        strip_suffix(F, SB, D).
+mod_subdir(M)        :- mod_dir(M, _).
+module_in_dir(D, M)  :- mod_dir(M, D).
+module_in_dir("", M) :- go_module(M, _), \+ mod_subdir(M).
+
+% ── Importer side (exact stdlib gate, as go_imports.dl) ─────────────────────
+go_import(I, P) :- node(I, "IMPORT"), attr(I, "file", F), ends_with(F, ".go"),
+                   node_attr(I, "path", P).
+go_import_nonstd(I, P) :- go_import(I, P), first_segment(P, "/", S1),
+                          string_contains(S1, ".").
+
+% '/'-boundary SUFFIXES of each import path (left-peel via first_segment;
+% strictly shrinking ⇒ terminates; the empty suffix is excluded — legacy
+% requires a non-empty dir, findBySuffix :157).
+p_sfx(P, P) :- go_import_nonstd(_, P).
+p_sfx(P, S2) :- p_sfx(P, S), first_segment(S, "/", Seg),
+                concat(Seg, "/", SegS), strip_prefix(S, SegS, S2), neq(S2, "").
+
+% ── The materialized edge ────────────────────────────────────────────────────
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+go_import_suffix(I, M) :- go_import_nonstd(I, P), p_sfx(P, D), module_in_dir(D, M).

--- a/packages/rfdb-server/src/derive/stdlib/go_interfaces.dl
+++ b/packages/rfdb-server/src/derive/stdlib/go_interfaces.dl
@@ -1,0 +1,87 @@
+% go_interfaces.dl — in-engine replacement for the GoInterfaceSatisfaction.hs
+% resolver (packages/go-resolve/src/GoInterfaceSatisfaction.hs): structural
+% duck-typing CLASS → INTERFACE IMPLEMENTS edges by method-set subset
+% (:132-148 — non-empty interface method set ⊆ struct method set; NAME-only
+% matching, pointer/value receivers both match because the method's `receiver`
+% metadata is the bare type name).
+%
+% STRUCTURAL SUBSTITUTE (DELTA G6-1 — REFINED, legacy DEAD on real wire ids;
+% found implementing, missed by both the spec and its verdict): the legacy
+% parent interface comes from parsing the literal `[in:Iface]` semantic-id
+% suffix (extractParent :64-73, `T.breakOn "[in:"`), but the node ids the
+% daemon actually receives are the orchestrator's PERCENT-ENCODED URIs —
+% `…#FUNCTION-%3EGet%5Bin:Store%5D` (live-probed on a real analyze; `[`
+% encodes as `%5B`), so `[in:` never literally occurs and legacy emitted
+% ZERO IMPLEMENTS edges on any real analyzer output (its Spec.hs fixtures
+% pass only because the handcrafted ids are unencoded). The pack joins the
+% structural INTERFACE -CONTAINS-> FUNCTION(kind=interface_method) edge
+% (Declarations.hs:466-472) — the same construct, id-format-independent —
+% restoring the intended semantics (the js_same_file_calls DELTA-3
+% "membership is structural truth" precedent). Differential: expect
+% pack ⊋ legacy with legacy ≈ 0 (proven on the multi-package corpus:
+% legacy=0, pack=1 — the correct MemStore→Store edge; a half-implementing
+% struct correctly excluded).
+%
+% ∀-SUBSET ENCODING: two strata of negation. The CLASS×INTERFACE candidate
+% cross-product is planner-illegal (§3), so candidates are SEEDED through a
+% shared method NAME (`cand`) — sound because implementing a NON-EMPTY
+% interface requires sharing at least one method name (filter-before-
+% generator); the legacy non-empty gate (:144) is implied by the same seed.
+%
+% NUMBERED DELTAS vs the resolver (everything not listed is exact):
+%   DELTA G6-2 (SUPERSET, bounded): legacy StructMethodSet is GLOBAL,
+%     name-keyed (:108-116) — two same-named structs in different packages
+%     MERGE method sets (a legacy false-positive generator), and the
+%     name-keyed StructIndex (:121-126, Map.insert last-wins) gives the edge
+%     to ONE arbitrary same-named CLASS. The pack reproduces the name-keyed
+%     merge (struct_m joins methods by receiver NAME — parity) but emits the
+%     edge for EVERY same-named CLASS node. Bound: #duplicate struct names.
+%     The dir-scoped refinement (methods live in the type's package — a Go
+%     language guarantee) is deferred to the differential.
+%   DELTA G6-3 (verdict C3 — the interface-side name merge, SUPERSET both
+%     ways, bounded): legacy collectIfaceMethods UNIONS method sets across
+%     SAME-NAMED interfaces project-wide (:96-102, insertWith Set.union keyed
+%     by interface NAME) and pairs that union with ONE last-wins interface
+%     node id (:87-93 via Map.intersectionWith). The pack's iface_m is
+%     per-NODE: for duplicate interface names the pack's requirement set is
+%     SMALLER (per-node, not the union) ⇒ structs can satisfy an interface
+%     the legacy merged-set rejected, AND the pack emits an edge per actual
+%     interface node vs legacy's single arbitrary winner. Bound: #duplicate
+%     interface simple names (countable in the differential).
+%   Interface EXTENDS embedding stays un-expanded (legacy Phase-2 limitation
+%     :25-30) — parity. (The analyzer's EXTENDS-by-NAME defect,
+%     Declarations.hs:476-485, is outside this migration.)
+%   File gate: ends_with .go on every base relation (orchestrator stream
+%     filter; CLASS/INTERFACE/FUNCTION are shared vocabulary).
+%   Metadata: legacy edges carry EMPTY metadata (:137-142) — none projected.
+%
+% MAINTAIN ENVELOPE: negation (the subset complement) + node_attr ⇒ scratch
+% floor (accepted).
+%
+% ORDERING: consumes analyzer EDB only; produces IMPLEMENTS (no in-engine
+% consumer today) — position before the negators is conventional, not
+% load-bearing.
+
+% Interface requirement rows: per INTERFACE NODE (DELTA G6-3 — deliberately
+% NOT the legacy name-union).
+iface_m(I, MN) :- node(I, "INTERFACE"), attr(I, "file", IF),
+                  ends_with(IF, ".go"), edge(I, MF, "CONTAINS"),
+                  node(MF, "FUNCTION"),
+                  node_attr(MF, "kind", "interface_method"),
+                  attr(MF, "name", MN).
+
+% Struct method rows: methods join their type by receiver NAME (the legacy
+% global name-keyed merge — DELTA G6-2).
+recv_m(SN, MN)  :- node(MF, "FUNCTION"), attr(MF, "file", MFF),
+                   ends_with(MFF, ".go"), node_attr(MF, "kind", "method"),
+                   node_attr(MF, "receiver", SN), attr(MF, "name", MN).
+struct_m(S, MN) :- node(S, "CLASS"), attr(S, "file", SF),
+                   ends_with(SF, ".go"), attr(S, "name", SN), recv_m(SN, MN).
+
+% Seed candidates through a shared method name; a candidate LACKS the
+% interface iff some required method name is missing from its set.
+cand(S, I)  :- struct_m(S, MN), iface_m(I, MN).
+lacks(S, I) :- cand(S, I), iface_m(I, MN2), \+ struct_m(S, MN2).
+
+@materialize(edge_type = "IMPLEMENTS", mode = "additive")
+go_implements(S, I) :- cand(S, I), \+ lacks(S, I).

--- a/packages/rfdb-server/src/derive/stdlib/go_types.dl
+++ b/packages/rfdb-server/src/derive/stdlib/go_types.dl
@@ -1,0 +1,85 @@
+% go_types.dl — in-engine replacement for the GoTypeResolution.hs resolver
+% (packages/go-resolve/src/GoTypeResolution.hs): VARIABLE → CLASS/INTERFACE
+% TYPE_OF edges (:73-88) and FUNCTION → CLASS/INTERFACE RETURNS edges per
+% comma-separated return type (:95-111). Shared pipeline: recursive `*` /
+% `[]` prefix strip (:47-51), the 21-primitive skip (:27-34), and the global
+% name → node TypeIndex over CLASS + INTERFACE (:60-66).
+%
+% IDIOMS:
+%   * prefix strip = a recursive derived predicate over strictly-shrinking
+%     strings (terminates), one rule per prefix; the clean row is the
+%     fixpoint member with neither prefix (not_starts_with twice — spelled
+%     "[]" per verdict C6; the residual "map[…" / sized-array strings never
+%     match a type_node key, parity for free);
+%   * comma SPLIT = right-peel with `last_segment` (identity-when-no-
+%     separator, builtin.rs) + concat + strip_suffix — no split/3 builtin
+%     needed; return_type is comma-joined with NO spaces (Declarations.hs
+%     :126-128, goTypeToName emits no commas) so the legacy `T.strip` is a
+%     no-op — EXACT;
+%   * the 21 primitives are ground facts (the js_local_refs rt_global
+%     precedent), matching the legacy `primitives` set verbatim (:28-34).
+%
+% NUMBERED DELTAS vs the resolver (everything not listed is exact):
+%   DELTA G7-1 (SUPERSET, bounded by duplicate type names): the TypeIndex is
+%     global last-wins (Map.insert, :60-66 — and a CLASS/INTERFACE name
+%     collision resolves to whichever node folded last); set semantics
+%     derives one edge per same-named type node. Same class as the
+%     go_calls G5-1 / go_interfaces G6-2 tie-breaks.
+%   Qualified types ("pkg.User" — goTypeToName of a selector is the BARE
+%     `sel`, Declarations.hs:641, so these surface as "User" and resolve by
+%     bare name in legacy and pack alike), map/chan/func types (never a
+%     type_node key) — parity for free.
+%   Legacy emits one edge PER comma part including duplicates ("(*User,
+%     *User)") — duplicates collapse under the graph's edge-set semantics for
+%     legacy too, so set semantics is EXACT (spec step 8).
+%   File gate: ends_with .go on every base relation (orchestrator stream
+%     filter; VARIABLE/FUNCTION/CLASS/INTERFACE are shared vocabulary).
+%   Metadata: legacy edges carry EMPTY metadata (:75-79, :97-101) — none
+%     projected.
+%
+% MAINTAIN ENVELOPE: negation (\+ go_primitive) + node_attr ⇒ scratch floor.
+%
+% ORDERING: consumes analyzer EDB only; produces TYPE_OF / RETURNS (no
+% in-engine consumer today) — position not load-bearing.
+
+% ── The 21 Go primitives (verbatim from primitives :28-34) ──────────────────
+go_primitive("int"). go_primitive("int8"). go_primitive("int16").
+go_primitive("int32"). go_primitive("int64"). go_primitive("uint").
+go_primitive("uint8"). go_primitive("uint16"). go_primitive("uint32").
+go_primitive("uint64"). go_primitive("uintptr"). go_primitive("float32").
+go_primitive("float64"). go_primitive("complex64"). go_primitive("complex128").
+go_primitive("string"). go_primitive("bool"). go_primitive("byte").
+go_primitive("rune"). go_primitive("error"). go_primitive("any").
+
+% ── The type index (CLASS + INTERFACE by name, :60-66) ──────────────────────
+type_node(N, Ty) :- node(Ty, "CLASS"), attr(Ty, "file", TF),
+                    ends_with(TF, ".go"), attr(Ty, "name", N).
+type_node(N, Ty) :- node(Ty, "INTERFACE"), attr(Ty, "file", TF),
+                    ends_with(TF, ".go"), attr(Ty, "name", N).
+
+% ── TYPE_OF: VARIABLE `type` metadata → type node (:73-88) ──────────────────
+vt(V, T)  :- node(V, "VARIABLE"), attr(V, "file", F), ends_with(F, ".go"),
+             node_attr(V, "type", T).
+vt(V, T2) :- vt(V, T), strip_prefix(T, "*", T2).
+vt(V, T2) :- vt(V, T), strip_prefix(T, "[]", T2).
+vt_clean(V, T) :- vt(V, T), not_starts_with(T, "*"), not_starts_with(T, "[]"),
+                  neq(T, "").
+
+@materialize(edge_type = "TYPE_OF", mode = "additive")
+go_type_of(V, Ty) :- vt_clean(V, T), \+ go_primitive(T), type_node(T, Ty).
+
+% ── RETURNS: FUNCTION `return_type` comma parts → type node (:95-111) ───────
+% Right-peel: rt holds the comma-joined string and every "drop the last
+% part" prefix; ret0 takes the last part of each — together, every part.
+rt(Fn, R)  :- node(Fn, "FUNCTION"), attr(Fn, "file", F), ends_with(F, ".go"),
+              node_attr(Fn, "return_type", R).
+rt(Fn, R2) :- rt(Fn, R), last_segment(R, ",", L), concat(",", L, CL),
+              strip_suffix(R, CL, R2).
+ret0(Fn, T)  :- rt(Fn, R), last_segment(R, ",", T).
+ret0(Fn, T2) :- ret0(Fn, T), strip_prefix(T, "*", T2).
+ret0(Fn, T2) :- ret0(Fn, T), strip_prefix(T, "[]", T2).
+ret_clean(Fn, T) :- ret0(Fn, T), not_starts_with(T, "*"),
+                    not_starts_with(T, "[]"), neq(T, "").
+
+@materialize(edge_type = "RETURNS", mode = "additive")
+go_returns(Fn, Ty) :- ret_clean(Fn, T), \+ go_primitive(T), type_node(T, Ty).

--- a/packages/rfdb-server/src/derive/stratify.rs
+++ b/packages/rfdb-server/src/derive/stratify.rs
@@ -203,6 +203,7 @@ const BUILTINS: &[&str] = &[
     "strip_prefix",
     "strip_suffix",
     "last_segment",
+    "first_segment",
     "replace_all",
     "path_resolve",
     "edge_attr",


### PR DESCRIPTION
Go joins the derive engine — the last language of this spec round. Headline discovery: percent-encoded wire ids meant legacy IMPLEMENTS/PROPAGATES_CONTEXT never fired on real graphs; the packs restore the intended semantics with corpus proof. CALLS 273≡273 exact on the repo stratum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)