### PR TITLE
Language round integration: java + kotlin + go derive packs, feature-detection HTTP packs, type-inference fix (6 PRs unified)

### DIFF
--- a/_ai/research/lang-spec-go.md
+++ b/_ai/research/lang-spec-go.md
@@ -1,0 +1,620 @@
+# Migration Spec: go-resolve → derive packs (Datalog v2)
+
+Follows the discipline of `_ai/research/resolve-datalog2-migration-specs.json` (js/rust precedent)
+and the synthesis ledger. All evidence from feat/datalog worktree HEAD `9ac0681c` (v0.4.0).
+Self-contained; sections are JSON-able in the precedent's `{spec: {target, purpose, sub_steps[],
+missing_capabilities[], differential_acceptance, expected_speedup_rationale, notes}}` shape.
+
+---
+
+## target
+
+`go-resolve` (binary `go-resolve --daemon`, packages/go-resolve/src/: Main.hs dispatching 5 modules
+via the single orchestrator command `go-all` — Main.hs:72-80 runs imports → calls → interfaces →
+types → context, feeding the CALLS EmitEdge output of step 2 into step 5 via extractCallEdges
+Main.hs:84-87). Driven by orchestrator main.rs:1673-1714 (analyze path) and main.rs:2573-2607
+(re-resolve path): streams ONLY `Language::Go` nodes (`&[config::Language::Go]` filter) to the
+daemon plus a `workspace_packages` wire carrying the go.mod module path
+(config::discover_go_module_path, config.rs:846-865; main.rs:1677-1686 wraps it as a single
+WorkspacePackageWire whose `name` IS the module path — Main.hs:61-63 extractModulePath takes
+`wpName` of the first entry).
+
+## purpose
+
+Go cross-file resolution: materializes
+- **IMPORTS_FROM** (IMPORT → MODULE, same-module only; GoImportResolution.hs)
+- **CALLS** (CALL → FUNCTION, 3 strategies; GoCallResolution.hs)
+- **IMPLEMENTS** (CLASS → INTERFACE, structural duck-typing by method-set subset; GoInterfaceSatisfaction.hs)
+- **TYPE_OF** (VARIABLE → CLASS/INTERFACE; GoTypeResolution.hs:73-88)
+- **RETURNS** (FUNCTION → CLASS/INTERFACE per comma-separated return type; GoTypeResolution.hs:95-111)
+- **PROPAGATES_CONTEXT** (FUNCTION → FUNCTION), **SPAWNS_WITH_CONTEXT** / **DEFERS_WITH_CONTEXT**
+  (CALL → FUNCTION) — context.Context flow; GoContextPropagation.hs.
+
+All legacy edges carry EMPTY metadata (every emitCallsEdge/EmitEdge site: ImportResolution:138-144,
+CallResolution:241-248, InterfaceSatisfaction:137-142, TypeResolution:75-79/97-101) — EXCEPT
+context edges for "possible" targets which carry `unresolved=true` (MetaBool, ContextPropagation:149-152).
+No `resolvedVia` stamps anywhere (unlike js/rust legacy).
+
+Inputs split — GRAPH data: MODULE/IMPORT/CALL/FUNCTION/CLASS/INTERFACE/VARIABLE nodes + their
+metadata. EXTERNAL data: the go.mod module path (wire-only today — never committed to the graph;
+precondition P1 below).
+
+## analyzer vocabulary (what go-analyzer emits that the resolver consumes — verified in source)
+
+Node types (packages/go-analyzer/src/):
+- `MODULE` — one per .go file; name = module-ish name, metadata `package` (Walker.hs:32-44).
+- `IMPORT` — name = import path; metadata `path` (=name), `blank`, `dot` (MetaBool),
+  optional `alias`, and `local_name` (the effective local identifier) (Imports.hs:63-80).
+- `CALL` — name = `recv.Sel` or bare ident (`exprToName`, Calls.hs:74-77); metadata `argCount`,
+  optional `receiver` (= exprToName of selector base — an EXPRESSION name, not a type),
+  `goroutine`/`deferred` (MetaBool, only when true) (Calls.hs:96-129).
+- `FUNCTION` — metadata `kind` ∈ {`function`, `method`, `interface_method`, `closure`},
+  `paramCount`, `returnCount`; functions/methods: optional `return_type` =
+  `T.intercalate "," (map goTypeToName results)` — **comma-joined, NO spaces**
+  (Declarations.hs:126-128 / :197-199; goTypeToName :639-650 never emits a comma);
+  methods additionally `receiver` = bare receiver TYPE name (`grTypeName`, :162,192 —
+  pointer-ness is the separate `pointer_receiver` bool), and
+  `accepts_context`/`possible_context` + `context_param_index`, `returns_error` (:95-109,:166-178).
+- `CLASS` (struct/named type, Declarations.hs:235-252,:318-339), `INTERFACE` (:266-283),
+  `VARIABLE` (metadata `type` = goTypeToName, walkVarSpec :491+).
+
+Edges:
+- `CONTAINS` everywhere (23 sites): MODULE→IMPORT (Imports.hs:83-88), scope→FUNCTION/CLASS/INTERFACE/
+  VARIABLE, **INTERFACE→FUNCTION(kind=interface_method)** (Declarations.hs:466-472), and
+  **scope→CALL** (Calls.hs:132-138). Critically: `Rules/ControlFlow.hs` creates NO scopes
+  (`grep -c withScope ControlFlow.hs` = 0) — only function/method/closure bodies push a scope
+  (Declarations.hs:145-152, Calls.hs FuncLitNode), so a CALL's CONTAINS source is exactly its
+  enclosing FUNCTION (or closure FUNCTION, or the MODULE for top-level initializers).
+  This is the structural substitute for every `[in:Parent]` semantic-id parse in the resolver
+  (same move as js_same_file_calls.dl DELTA 3: "class membership is structural truth").
+- Analyzer also emits CALLS/IMPORTS_FROM **DeferredRef**s (faUnresolvedRefs) — the orchestrator
+  turns unresolved ones into ISSUE diagnostics only (analyzer.rs:580-602), NEVER into CALLS edges.
+  So graph CALLS edges on .go files come exclusively from go-resolve → a pack consuming
+  materialized CALLS (step 9/10) sees exactly the go_calls pack output.
+
+## preconditions (orchestrator, not engine)
+
+- **P1 — GO module-path fact.** The go.mod module path must become a graph fact. Exact precedent
+  exists: WORKSPACE_PACKAGE facts committed at main.rs:2017-2032 for js packs
+  (js_module_imports.dl:157-158 joins `node(W,"WORKSPACE_PACKAGE"), attr(W,"name",N)`).
+  Commit the Go module path the same way (suggest type `WORKSPACE_PACKAGE` with
+  `node_attr(W,"language","go")`, name = module path) from the already-computed
+  `discover_go_module_path` value (main.rs:1677). Zero engine work.
+- **P2 — pack ordering (producer-before-consumer).** `go_calls` produces CALLS that `go_context`
+  consumes via `edge(C,T,"CALLS")` — declared pack order, same as rust_imports.dl's ORDERING
+  note (IMPORTS_FROM before js_cross_file_calls). Legacy did this in-process
+  (Main.hs:78-79 extractCallEdges).
+- **P3 — no-go.mod fallback selection.** Legacy branches globally on empty module path
+  (ImportResolution.hs:131-135 findBySuffix). A pack cannot test "the GO_MODULE fact does not
+  exist" without a zero-arity/global predicate (a `has_go_mod()` literal shares no variable with
+  the body — the §3 cross-join the planner refuses, cf. js_this_method_calls.dl:38-41).
+  Faithful translation: the ORCHESTRATOR (which knows whether go.mod resolved) loads either the
+  main pack or the suffix-fallback variant. Listed under missing capabilities as the engine
+  alternative.
+
+## sub_steps
+
+### 1. package-index kernel (shared; no edges)
+
+- **reads**: MODULE nodes (first-class `file`), GO module-path fact (P1).
+- **writes**: derived relations `mod_dir(M, D)` / `module_in_dir(D, M)` / `pkg_dir(ImportPath, D)`
+  consumed by steps 2-3. Legacy: buildPackageIndex (ImportResolution.hs:57-64 — dir → [moduleIds];
+  CallResolution.hs:118-128 — importPath → dir, with modPath-prefixed, root, and bare-dir keys).
+- **expressible**: yes (fully).
+- **idioms**:
+  - *dirname* (no dirname builtin): `basename` + `concat("/",B,SB)` + `strip_suffix(F,SB,D)`;
+    root-level files ("main.go") yield NO row from strip_suffix → complement clause via
+    derived-negation (`\+` on a derived has-subdir predicate), since there is no
+    `not_string_contains` builtin (only `not_starts_with`, builtin.rs:1268-1273).
+  - *file gate* (DELTA-5 of rust_imports.dl): `ends_with(F, ".go")` on every base relation —
+    MODULE/IMPORT/CALL/FUNCTION/CLASS/INTERFACE/VARIABLE are shared vocabulary across analyzers;
+    the legacy input gate was the orchestrator's Language::Go stream filter (config.rs:751,796).
+- **draft_rules**:
+```datalog
+go_mod(MP)        :- node(W, "WORKSPACE_PACKAGE"), node_attr(W, "language", "go"), attr(W, "name", MP).
+go_module(M, F)   :- node(M, "MODULE"), attr(M, "file", F), ends_with(F, ".go").
+mod_dir(M, D)     :- go_module(M, F), basename(F, B), concat("/", B, SB), strip_suffix(F, SB, D).
+mod_subdir(M)     :- mod_dir(M, _).
+module_in_dir(D, M)  :- mod_dir(M, D).
+module_in_dir("", M) :- go_module(M, _), \+ mod_subdir(M).
+% import-path -> package-dir map (all three legacy key families, CallResolution.hs:118-128)
+pkg_dir(P, D)     :- mod_dir(_, D), go_mod(MP), concat(MP, "/", MPS), concat(MPS, D, P).
+pkg_dir(MP, "")   :- go_mod(MP), module_in_dir("", _).
+pkg_dir(D, D)     :- mod_dir(_, D).
+```
+- **delta**: EXACT (a pure index reformulation).
+
+### 2. go-imports → IMPORTS_FROM (pack `go_imports.dl`)
+
+- **reads**: IMPORT nodes (`node_attr path`), kernel relations, go_mod fact.
+  Legacy: GoImportResolution.resolveOneImport (:116-145) — skip stdlib (isStdLib :87, "no dot in
+  first path segment"), strip module prefix + dropWhile '/' (:123-126), look up dir, emit edge to
+  **first** MODULE in dir (:129); empty-modPath fallback = first dir that is a suffix of the
+  import path, Map order (findBySuffix :152-163). Blank/dot imports resolve normally (:34-35).
+- **writes**: IMPORTS_FROM (IMPORT → MODULE), empty metadata. SHARED vocabulary (js/rust packs
+  also emit it) ⇒ `mode = "additive"`.
+- **expressible**: yes (main arms); fallback arm needs P3.
+- **draft_rules**:
+```datalog
+go_import(I, F, P) :- node(I, "IMPORT"), attr(I, "file", F), ends_with(F, ".go"),
+                      node_attr(I, "path", P).
+
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+go_import_from(I, M) :- go_import(I, _, P), go_mod(MP), concat(MP, "/", MPS),
+                        strip_prefix(P, MPS, Rel), module_in_dir(Rel, M).
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+go_import_from_root(I, M) :- go_import(I, _, P), go_mod(P), module_in_dir("", M).
+
+% fallback VARIANT pack (loaded by orchestrator only when go.mod is absent, P3):
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+go_import_suffix(I, M) :- go_import(I, _, P), string_contains(P, "."),
+                          module_in_dir(D, M), neq(D, ""), ends_with(P, D).
+```
+- **deltas**:
+  - DELTA G2-1 (REFINED — the isStdLib guard is dropped from the same-module arm): redundant
+    there — a stdlib path ("fmt", "net/http") cannot start with `<modPath>/`. Diverges only if
+    the module path itself collides with a stdlib name (pathological). The legacy
+    plain-stripPrefix boundary bug (modPath "…/p" string-prefix-matches "…/project2" then fails
+    the dir lookup, :123-126) is removed by requiring the "/" boundary; net effect on emitted
+    edges: none (legacy resolved those to a miss anyway).
+  - DELTA G2-2 (SUPERSET, bounded by files-per-package): legacy takes the FIRST MODULE id in the
+    target directory (`tid : _`, :129 — fold/insertion order, nondeterministic across runs);
+    set semantics derives one edge per MODULE node (= per .go file) in the package directory.
+    Arguably truer (a Go package IS the directory). Bound: #files in the imported package.
+  - DELTA G2-3 (fallback arm, MIXED): legacy fallback picks the alphabetically-first suffix-matching
+    dir (Map.toList order, :152-163) — the pack derives ALL suffix matches (SUPERSET, bound:
+    #dirs sharing the suffix). The `string_contains(P,".")` stdlib approximation replaces
+    "first segment has a dot": SUBSET for dotless module paths (`module myapp` imports
+    "myapp/util" — no dot anywhere → skipped where legacy's isStdLib ALSO skips it ("myapp" has
+    no dot) — actually EXACT for that case); residual divergence only for paths whose first
+    segment is dotless but a later segment has one ("foo/bar.v2" — legacy skips, pack keeps):
+    SUPERSET gated on a local dir literally suffix-matching such a path, ~0 in practice.
+    Exact fix = `first_segment` builtin (missing capability M1).
+
+### 3. go-calls strategy 1 — package-qualified CALLS (pack `go_calls.dl`)
+
+- **reads**: CALL nodes (`receiver` metadata, dotted `name`), IMPORT nodes in the SAME file
+  (`local_name`+`path`), kernel pkg_dir, FUNCTION nodes kind=function.
+  Legacy: resolveCall :157-174 dispatch (receiver matches an import alias in the caller's file →
+  strategy 1 ONLY, no fallback) + resolvePackageCall :188-210 (isStdLib skip; importPath → dir
+  via pkgIdx with modPath-strip fallback; (dir, callName) lookup; callName = after last ".",
+  extractCallName :54-57).
+- **writes**: CALLS (CALL → FUNCTION), empty metadata, additive (shared vocabulary).
+- **expressible**: yes.
+- **draft_rules**:
+```datalog
+go_call(C, F, N)   :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".go"), attr(C, "name", N).
+call_recv(C, R)    :- go_call(C, _, _), node_attr(C, "receiver", R).
+import_alias(F, L, P) :- node(I, "IMPORT"), attr(I, "file", F), ends_with(F, ".go"),
+                         node_attr(I, "local_name", L), node_attr(I, "path", P).
+fn_dir(T, D)       :- go_fn(T, TF), basename(TF, B), concat("/", B, SB), strip_suffix(TF, SB, D).
+go_fn(T, TF)       :- node(T, "FUNCTION"), attr(T, "file", TF), ends_with(TF, ".go"),
+                      node_attr(T, "kind", "function").
+fn_subdir(T)       :- fn_dir(T, _).
+func_in_dir(D, N, T)  :- go_fn(T, _), fn_dir(T, D), attr(T, "name", N).
+func_in_dir("", N, T) :- go_fn(T, _), \+ fn_subdir(T), attr(T, "name", N).
+% non-stdlib gate (approximation, see DELTA G3-2):
+ok_path(P) :- import_alias(_, _, P), string_contains(P, ".").
+ok_path(P) :- import_alias(_, _, P), go_mod(MP), concat(MP, "/", MPS), strip_prefix(P, MPS, _).
+
+@materialize(edge_type = "CALLS", mode = "additive")
+go_call_s1(C, T) :- call_recv(C, R), go_call(C, F, N), import_alias(F, R, P), ok_path(P),
+                    pkg_dir(P, D), method_suffix(N, MN), func_in_dir(D, MN, T).
+```
+- **deltas**:
+  - DELTA G3-1 (SUPERSET, bounded): FunctionIndex was `Map.fromList` = LAST-wins on duplicate
+    (dir, name) keys (CallResolution.hs:91-100) — duplicates arise from build-tag twins or
+    `_test.go` siblings defining the same name in one directory. Set semantics derives all
+    candidates. Bound: #same-name functions per directory (≈1-2; measure on fixture).
+  - DELTA G3-2 (the isStdLib approximation): exactly DELTA G2-3's classes; additionally the
+    bare-dir pkg_dir keys can let a stdlib-named LOCAL directory ("errors/", "log/") capture a
+    qualified call when no dot guard fires — the `ok_path` guard closes that (a dotless,
+    non-module-prefixed path never passes). Residual: same "foo/bar.v2"-shape SUPERSET as G2-3.
+
+### 4. go-calls strategy 2 — same-package function CALLS
+
+- **reads**: CALL nodes with NO `receiver` metadata; FUNCTION kind=function in the caller's dir.
+  Legacy: resolveSamePackageCall :213-222 — (callerDir, callName) lookup.
+- **expressible**: yes — "no receiver" via stratified negation over a derived predicate
+  (node_attr modes [B,B,F]/[B,B,B], builtin.rs:1176-1180, allow the free-value probe).
+- **draft_rules**:
+```datalog
+has_recv(C)   :- node(C, "CALL"), node_attr(C, "receiver", _).
+call_dir(C, D)   :- go_call(C, F, _), basename(F, B), concat("/", B, SB), strip_suffix(F, SB, D).
+call_subdir(C)   :- call_dir(C, _).
+
+@materialize(edge_type = "CALLS", mode = "additive")
+go_call_s2(C, T) :- go_call(C, F, N), \+ has_recv(C), call_dir(C, D), func_in_dir(D, N, T).
+@materialize(edge_type = "CALLS", mode = "additive")
+go_call_s2r(C, T) :- go_call(C, F, N), \+ has_recv(C), \+ call_subdir(C), func_in_dir("", N, T).
+```
+  (receiver-less names are never dotted — exprToName of a non-selector is the bare ident,
+  Calls.hs:74-77 — so N needs no extractCallName treatment; closures excluded from func_in_dir
+  by the kind="function" gate, matching Spec.hs:141-148.)
+- **deltas**: DELTA G3-1 (last-wins) applies identically. Otherwise EXACT.
+
+### 5. go-calls strategy 3 — same-package method CALLS
+
+- **reads**: CALL nodes whose `receiver` does NOT match any import alias in the same file;
+  FUNCTION kind=method nodes (`receiver` = bare TYPE name, Declarations.hs:162,192).
+  Legacy: resolveMethodCall :227-236 — global (receiverTYPE, method) MethodIndex; the call's
+  receiver is an EXPRESSION name, so this only hits when a variable shares the type's name
+  (the known weakness; fixture Spec.hs:120-127 encodes exactly that shape).
+- **expressible**: yes.
+- **draft_rules**:
+```datalog
+alias_recv(C) :- call_recv(C, R), go_call(C, F, _), import_alias(F, R, _).
+method_in(RT, MN, T) :- node(T, "FUNCTION"), attr(T, "file", TF), ends_with(TF, ".go"),
+                        node_attr(T, "kind", "method"), node_attr(T, "receiver", RT),
+                        attr(T, "name", MN).
+
+@materialize(edge_type = "CALLS", mode = "additive")
+go_call_s3(C, T) :- call_recv(C, R), \+ alias_recv(C), go_call(C, _, N),
+                    method_suffix(N, MN), method_in(R, MN, T).
+```
+- **deltas**:
+  - DELTA G5-1 (SUPERSET, bounded): MethodIndex is GLOBAL last-wins across packages
+    (CallResolution.hs:103-112) — same-named type with same-named method in two packages: legacy
+    picks one arbitrary winner, the pack derives all. A dir-scoped variant (join receiver-type's
+    dir to the call's dir) would REFINE instead — defer to the differential to choose
+    (rust_imports DELTA-1 governed-arm precedent).
+  - NOT attempted (parity): real receiver typing (variable name → VARIABLE → TYPE_OF → methods).
+    That is a Wave-2 REFINEMENT with the rust_receiver_typing.dl precedent, not a parity rule.
+
+### 6. go-interfaces → IMPLEMENTS (pack `go_interfaces.dl`)
+
+- **reads**: INTERFACE nodes + their method FUNCTIONs (kind=interface_method; parent interface
+  extracted by legacy from the `[in:Iface]` semantic-id suffix, GoInterfaceSatisfaction.hs:64-101 —
+  pack substitutes the structural INTERFACE -CONTAINS-> FUNCTION edge, Declarations.hs:466-472);
+  FUNCTION kind=method (`receiver` type name); CLASS nodes by name.
+  Legacy algorithm :132-148: non-empty interface method set ⊆ struct method set → IMPLEMENTS
+  (name-only matching; pointer/value both match — receiver metadata is the bare name).
+- **writes**: IMPLEMENTS (CLASS → INTERFACE), empty metadata. Go-only producer today, but keep
+  additive (vocabulary may be shared later).
+- **expressible**: yes — the ∀-subset via TWO strata of negation; the CLASS×INTERFACE candidate
+  cross-product is planner-illegal (§3 cross-join), so candidates are seeded through a shared
+  method NAME — sound because implementing a non-empty interface requires sharing ≥1 method name
+  (filter-before-generator).
+- **draft_rules**:
+```datalog
+iface_m(I, MN) :- node(I, "INTERFACE"), attr(I, "file", IF), ends_with(IF, ".go"),
+                  edge(I, MF, "CONTAINS"), node(MF, "FUNCTION"),
+                  node_attr(MF, "kind", "interface_method"), attr(MF, "name", MN).
+recv_m(SN, MN) :- node(MF, "FUNCTION"), attr(MF, "file", MFF), ends_with(MFF, ".go"),
+                  node_attr(MF, "kind", "method"), node_attr(MF, "receiver", SN),
+                  attr(MF, "name", MN).
+struct_m(S, MN) :- node(S, "CLASS"), attr(S, "file", SF), ends_with(SF, ".go"),
+                   attr(S, "name", SN), recv_m(SN, MN).
+cand(S, I)  :- struct_m(S, MN), iface_m(I, MN).
+lacks(S, I) :- cand(S, I), iface_m(I, MN2), \+ struct_m(S, MN2).
+
+@materialize(edge_type = "IMPLEMENTS", mode = "additive")
+go_implements(S, I) :- cand(S, I), \+ lacks(S, I).
+```
+- **deltas**:
+  - DELTA G6-1 (structural substitute, EXACT in practice): CONTAINS instead of `[in:Iface]`
+    parsing — the analyzer always emits both for the same construct (Declarations.hs:445-472),
+    so coverage is identical (js_same_file_calls DELTA-3 precedent).
+  - DELTA G6-2 (SUPERSET, bounded): legacy StructIndex AND StructMethodSet are global,
+    name-keyed (:108-126) — two same-named structs in different packages MERGE method sets
+    (a legacy false-positive generator) and only the last-wins CLASS id gets the edge. The pack
+    reproduces the name-keyed merge (parity) but emits the edge for EVERY same-named CLASS.
+    Bound: #duplicate struct names. A dir-scoped struct_m join (methods live in the type's
+    package — a Go language guarantee) is the REFINED variant; recommend measuring both in the
+    differential, expecting refined ⊆ parity with the difference = legacy's own false merges.
+  - Interface EXTENDS embedding stays un-expanded (legacy Phase-2 limitation :25-30) — parity.
+
+### 7. go-types → TYPE_OF (pack `go_types.dl`)
+
+- **reads**: VARIABLE nodes (`type` metadata = goTypeToName), CLASS+INTERFACE nodes by name.
+  Legacy: GoTypeResolution.hs:73-88 — recursive `*`/`[]` prefix strip (:47-51), 22-primitive skip
+  (:27-34), global name → id TypeIndex (last-wins, :60-66).
+- **expressible**: yes — the recursive strip is a recursive derived predicate over shrinking
+  strings (terminates); primitives are 22 ground facts (`ground facts parse`,
+  datalog/parser.rs:265-267 per the js spec's evidence note).
+- **draft_rules**:
+```datalog
+go_primitive("int"). go_primitive("int8"). go_primitive("int16"). go_primitive("int32").
+go_primitive("int64"). go_primitive("uint"). go_primitive("uint8"). go_primitive("uint16").
+go_primitive("uint32"). go_primitive("uint64"). go_primitive("uintptr"). go_primitive("float32").
+go_primitive("float64"). go_primitive("complex64"). go_primitive("complex128").
+go_primitive("string"). go_primitive("bool"). go_primitive("byte"). go_primitive("rune").
+go_primitive("error"). go_primitive("any").
+
+vt(V, T)  :- node(V, "VARIABLE"), attr(V, "file", F), ends_with(F, ".go"),
+             node_attr(V, "type", T).
+vt(V, T2) :- vt(V, T), strip_prefix(T, "*", T2).
+vt(V, T2) :- vt(V, T), strip_prefix(T, "[]", T2).
+vt_clean(V, T) :- vt(V, T), not_starts_with(T, "*"), not_starts_with(T, "["), neq(T, "").
+type_node(N, Ty) :- node(Ty, "CLASS"), attr(Ty, "file", TF), ends_with(TF, ".go"), attr(Ty, "name", N).
+type_node(N, Ty) :- node(Ty, "INTERFACE"), attr(Ty, "file", TF), ends_with(TF, ".go"), attr(Ty, "name", N).
+
+@materialize(edge_type = "TYPE_OF", mode = "additive")
+go_type_of(V, Ty) :- vt_clean(V, T), \+ go_primitive(T), type_node(T, Ty).
+```
+  (`not_starts_with(T,"[")` over-approximates `"[]"` only for map types "map[…" — those never
+  match type_node anyway; spelled `"["` because not_starts_with is FILTER2 and "[]"-exactness
+  needs two literals — use `not_starts_with(T, "[]")` directly; both are [B,B] legal.)
+- **deltas**: DELTA G7-1 (SUPERSET, bounded by duplicate type names): TypeIndex last-wins global —
+  same class as G5-1/G6-2. Qualified types ("pkg.User"), map/chan/func types never resolved in
+  legacy and never resolve here (no type_node key) — parity for free.
+
+### 8. go-types → RETURNS
+
+- **reads**: FUNCTION nodes' `return_type` metadata — comma-joined, NO spaces
+  (Declarations.hs:126-128; goTypeToName emits no commas, so the join is unambiguous).
+  Legacy: :95-111 — splitOn "," + T.strip + same strip/primitive/index pipeline.
+- **expressible**: yes — comma-SPLIT via right-peeling recursion with `last_segment`
+  (identity-when-no-separator semantics, builtin.rs:945-953) + `concat` + `strip_suffix`;
+  no `split` builtin needed:
+- **draft_rules**:
+```datalog
+rt(Fn, R)  :- node(Fn, "FUNCTION"), attr(Fn, "file", F), ends_with(F, ".go"),
+              node_attr(Fn, "return_type", R).
+rt(Fn, R2) :- rt(Fn, R), last_segment(R, ",", L), concat(",", L, CL), strip_suffix(R, CL, R2).
+ret0(Fn, T)  :- rt(Fn, R), last_segment(R, ",", T).
+ret0(Fn, T2) :- ret0(Fn, T), strip_prefix(T, "*", T2).
+ret0(Fn, T2) :- ret0(Fn, T), strip_prefix(T, "[]", T2).
+ret_clean(Fn, T) :- ret0(Fn, T), not_starts_with(T, "*"), not_starts_with(T, "[]"), neq(T, "").
+
+@materialize(edge_type = "RETURNS", mode = "additive")
+go_returns(Fn, Ty) :- ret_clean(Fn, T), \+ go_primitive(T), type_node(T, Ty).
+```
+- **deltas**: G7-1 applies. The legacy `T.strip` is a no-op on this metadata (no spaces emitted) —
+  EXACT. Legacy emits one edge PER comma part including duplicates of the same type
+  (e.g. "(*User, *User)") — list-comprehension duplicates collapse in the graph's edge-set
+  semantics for legacy too, so set semantics is EXACT.
+
+### 9. go-context → PROPAGATES_CONTEXT (pack `go_context.dl`, AFTER go_calls — P2)
+
+- **reads**: materialized CALLS edges (go files only — see analyzer-vocabulary note: Go CALLS come
+  exclusively from the go packs); FUNCTION `accepts_context`/`possible_context` (MetaBool —
+  surfaces as the string "true" via node_attr, the `__exported`/Wave-M contract documented in
+  rust_imports.dl:26-28); the CALL's enclosing FUNCTION.
+  Legacy: GoContextPropagation.hs — contextFns/possibleFns (:79-94), enclosing fn via
+  `[in:parent]` + (dir, bare-name) lookup EXCLUDING interface_method and closure kinds
+  (:101-112, :154-161); emit PROPAGATES_CONTEXT(encFn → target) when target accepts (certainly
+  or possibly) AND caller accepts; `unresolved=true` metadata iff the TARGET is only "possible"
+  (:141-176 — the caller's certainty does not affect metadata, fixture Spec.hs:288-301).
+- **expressible**: yes.
+- **draft_rules**:
+```datalog
+ctx_fn(T)  :- node(T, "FUNCTION"), node_attr(T, "accepts_context", "true").
+poss_fn(T) :- node(T, "FUNCTION"), node_attr(T, "possible_context", "true").
+go_calls_e(C, T) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".go"),
+                    edge(C, T, "CALLS"), node(T, "FUNCTION").
+closure_fn(EF) :- node(EF, "FUNCTION"), node_attr(EF, "kind", "closure").
+iface_fn(EF)   :- node(EF, "FUNCTION"), node_attr(EF, "kind", "interface_method").
+enc_fn(C, EF)  :- go_calls_e(C, _), edge(EF, C, "CONTAINS"), node(EF, "FUNCTION"),
+                  \+ closure_fn(EF), \+ iface_fn(EF).
+caller_ok(C)   :- enc_fn(C, EF), ctx_fn(EF).
+caller_ok(C)   :- enc_fn(C, EF), poss_fn(EF).
+
+@materialize(edge_type = "PROPAGATES_CONTEXT", mode = "additive")
+go_prop(EF, T) :- go_calls_e(C, T), ctx_fn(T), caller_ok(C), enc_fn(C, EF).
+@materialize(edge_type = "PROPAGATES_CONTEXT", mode = "additive", meta(unresolved))
+go_prop_u(EF, T, "true") :- go_calls_e(C, T), poss_fn(T), caller_ok(C), enc_fn(C, EF).
+```
+  (accepts/possible are mutually exclusive per function — the analyzer's contextMeta picks one,
+  Declarations.hs:99-105 — so no `\+ ctx_fn(T)` guard is needed on the possible arm.)
+- **deltas**:
+  - DELTA G9-1 (structural substitute, REFINED): enclosing fn = the literal CONTAINS parent
+    instead of the legacy (dir, parsed-bare-name) lookup, which could hit a DIFFERENT same-named
+    function/method in the directory (its Map is also last-wins, :104-112). Refinement removes
+    a legacy false-positive/false-negative class; bound = #same-bare-name functions per dir.
+    Calls inside closures: legacy finds no enclosing fn (closures excluded from the index AND the
+    `[in:]` name is "<closure>") → caller_ok false; the pack's CONTAINS parent IS the closure
+    node, excluded by `\+ closure_fn` → caller_ok false. EXACT match on that class.
+  - DELTA G9-2 (metadata representation): `unresolved` = string "true" (meta projection) vs
+    legacy MetaBool true — same class as the js packs' resolvedVia-projection delta; consumers
+    reading via node_attr/edge_attr string surface see the identical "true".
+
+### 10. go-context → SPAWNS_WITH_CONTEXT / DEFERS_WITH_CONTEXT
+
+- **reads**: as step 9 + CALL `goroutine`/`deferred` MetaBool flags (Calls.hs:127-128;
+  only stamped when true).
+  Legacy: :177-194 — CALL → target FUNCTION when target accepts (or possibly accepts) context,
+  independent of the caller's own context status.
+- **expressible**: yes.
+- **draft_rules**:
+```datalog
+@materialize(edge_type = "SPAWNS_WITH_CONTEXT", mode = "additive")
+go_spawn(C, T)  :- go_calls_e(C, T), ctx_fn(T), node_attr(C, "goroutine", "true").
+@materialize(edge_type = "SPAWNS_WITH_CONTEXT", mode = "additive", meta(unresolved))
+go_spawn_u(C, T, "true") :- go_calls_e(C, T), poss_fn(T), node_attr(C, "goroutine", "true").
+@materialize(edge_type = "DEFERS_WITH_CONTEXT", mode = "additive")
+go_defer(C, T)  :- go_calls_e(C, T), ctx_fn(T), node_attr(C, "deferred", "true").
+@materialize(edge_type = "DEFERS_WITH_CONTEXT", mode = "additive", meta(unresolved))
+go_defer_u(C, T, "true") :- go_calls_e(C, T), poss_fn(T), node_attr(C, "deferred", "true").
+```
+- **deltas**: G9-2 only. EXACT otherwise (the per-CALL edge has a unique (C,T) key; legacy
+  duplicates collapse identically under edge-set semantics).
+
+## missing_capabilities
+
+1. **`first_segment(S, Sep, Out)`** — the dual of `last_segment` (builtin.rs:945-967), identity
+   when no separator. The ONLY exact spelling of Go's isStdLib test ("first path segment
+   contains a dot", GoImportResolution.hs:87 / GoCallResolution.hs:47-50). Without it the
+   `string_contains(P,".")`-OR-module-prefix approximation leaves the bounded G2-3/G3-2 residue.
+   Low priority: residue ≈ 0 on real repos; becomes a real gap only for dot-less vanity import
+   paths colliding with local directory names.
+2. **Zero-arity (or global-constant) predicates** for "the EXTERNAL fact is absent" tests —
+   the no-go.mod fallback branch (P3). A `has_go_mod()` literal is currently a §3 cross-join
+   the planner refuses. Engine alternative to the recommended orchestrator-side pack selection.
+3. **`not_string_contains(S, Sub)`** — ergonomics only. The root-directory ("file has no '/'")
+   complement is expressible today via derived-negation (`\+ mod_subdir(M)`), which costs one
+   helper predicate per consumer; a negative filter twin of `string_contains` (like
+   `not_starts_with`, builtin.rs:1268-1273) collapses the idiom.
+4. *(precondition, not engine)* **P1 GO module-path fact** — orchestrator commit, precedent
+   main.rs:2017-2032 (WORKSPACE_PACKAGE). Today the module path is wire-only
+   (main.rs:1677-1686), invisible to any pack.
+
+NOT needed (verified against today's kit): `split/3` (the last_segment right-peel recursion covers
+comma-joined return_type exactly, step 8); `dirname` (basename+concat+strip_suffix idiom, step 1);
+`node_attr` (exists since Wave 2, modes builtin.rs:1176-1180 — every metadata read above is legal);
+semantic-id `[in:Parent]` parsing (structural CONTAINS substitutes everywhere — G6-1, G9-1).
+
+## differential_acceptance
+
+**The dogfood graph contains ZERO Go nodes** — probed on a /tmp copy of the 618MB
+`.grafema/graph.rfdb`: `grep -rc '\.go->'` across all segments = 0 matches (semantic ids embed the
+file path, and `.grafema/orchestrator.config.yaml` includes no `*.go` pattern). So the
+differential CANNOT run on dogfood; ground truth is fixture-based:
+
+1. **Unit stratum** — port the 23 Spec.hs cases (packages/go-resolve/test/Spec.hs:50-301) to
+   FixtureStorageView engine tests (the 0.04s discipline): per-strategy call shapes, stdlib/
+   third-party skips, first-MODULE multiplicity, empty-modPath fallback, subset-satisfaction
+   corner cases (missing method, empty interface, pointer receiver), context
+   certain/possible/goroutine/deferred matrix incl. the possible-caller/certain-target metadata
+   case (Spec.hs:288-301).
+2. **Repo stratum** — `packages/go-parser/` is a real 4-file Go module
+   (`module github.com/grafema/go-parser`, package main): analyze it into a /tmp DB twice —
+   legacy go-resolve ON / packs ON with the go resolution phase skipped (skip_resolver("go"),
+   main.rs:1674) — and diff `(src_semantic_id, dst_semantic_id, edge_type)` triples per edge
+   type. Note: single-package module → exercises strategies 2/3, types, context; NOT cross-package
+   imports.
+3. **Corpus stratum** — one small multi-package OSS Go repo (needs go.mod + internal packages +
+   interfaces; e.g. a CLI like spf13/cobra) for the cross-package arms (IMPORTS_FROM, S1 calls,
+   IMPLEMENTS at scale). Partition: edge type IS the sub-step partition for Go (the legacy stamps
+   no resolvedVia) — IMPORTS_FROM↔step2, CALLS↔steps3-5 (sub-partition by pack-rule `_source`
+   hash on the pack side; on the legacy side by receiver/alias shape recomputed offline),
+   IMPLEMENTS↔6, TYPE_OF↔7, RETURNS↔8, PROPAGATES/SPAWNS/DEFERS↔9-10.
+
+Acceptance: per-step EXACT except the enumerated bounded deltas (G2-2/G2-3/G3-1/G5-1/G6-2/G7-1
+SUPERSET classes must each be ≤ the stated bound and every extra edge must trace to a documented
+last-wins/first-match legacy tie-break; G9-1 differences must trace to same-name-in-dir
+ambiguity). Freshness gate before any diff (graph mtime vs HEAD).
+
+## expected_speedup_rationale
+
+Honest: NO measurable wall-clock claim — the dogfood graph has no Go nodes (probe above), and the
+go phase costs ~0 there today. The win is structural: retires the 4th `--daemon` Haskell resolver
+(its msgpack full-node-set streaming round-trip, plugin.rs:679-944) and 886 lines of Haskell
+(go-resolve/src = 5 modules + Main), moving Go to the same pack-runner as js/rust — one engine,
+one differential discipline, one less binary in scripts/build-native.sh and the Hello capability
+matrix. On Go-heavy target repos the js/rust precedent applies (in-engine joins over LSM segments
+vs per-phase IPC; the packs here are negation+node_attr ⇒ scratch floor, maintain-incremental
+refuses them — same accepted stance as every import pack, rust_imports.dl MAINTAIN ENVELOPE note).
+
+## honesty — what is NOT expressible / NOT attempted
+
+- **isStdLib exactly** (first-segment-dot): approximated; residue bounded and enumerated (M1).
+- **The no-go.mod global branch** as in-pack logic: needs orchestrator pack-selection or M2.
+- **Legacy tie-breaks** (first-MODULE-in-dir, Map last-wins in 4 indexes, alphabetical
+  findBySuffix winner): deliberately NOT reproduced — set semantics derives all candidates;
+  every such site is flagged SUPERSET with a bound. Reproducing them would need an ordering
+  primitive the engine doesn't have (and shouldn't — rust_imports DELTA-1 precedent refused it).
+- **MetaBool edge metadata**: `unresolved` rides the meta() projection as string "true" (G9-2).
+- **Module-path discovery, go.mod I/O, binary checks**: stays in the orchestrator (EXTERNAL).
+- **stderr edge-count diagnostics**: no pack analog (rust DELTA-4 class).
+- **Receiver typing for S3 / embedded-interface expansion / signature-aware satisfaction**:
+  legacy doesn't do them; the pack stays at parity. Each is a named Wave-2 refinement
+  (rust_receiver_typing.dl precedent; EXTENDS-closure over the analyzer's embedded-interface
+  edges; paramCount/returnCount as a cheap signature proxy already in metadata).
+- **The analyzer's EXTENDS-by-NAME bug**: walkEmbed emits EXTENDS with geTarget = the embedded
+  interface's NAME, not a node id (Declarations.hs:476-485) — an analyzer defect outside this
+  migration's scope; noted so the differential doesn't misattribute it to the packs.
+
+## notes — evidence base
+
+Resolver semantics: packages/go-resolve/src/{Main.hs:61-87, GoImportResolution.hs:57-163,
+GoCallResolution.hs:47-248, GoInterfaceSatisfaction.hs:64-148, GoTypeResolution.hs:27-122,
+GoContextPropagation.hs:79-194}; tests test/Spec.hs:50-301. Analyzer vocabulary:
+packages/go-analyzer/src/{Rules/Imports.hs:63-88, Rules/Calls.hs:74-138, Rules/Declarations.hs:
+95-199,235-283,318-339,445-485,491+,639-650, Analysis/Walker.hs:32-44, Analysis/Context.hs:81-82};
+ControlFlow.hs has zero withScope sites (no block scopes). Orchestrator: main.rs:1673-1714,
+2573-2607 (go-all dispatch + ws wire), config.rs:846-865 (go.mod discovery), 751/796 (language
+partition), main.rs:2017-2032 (WORKSPACE_PACKAGE commit precedent), analyzer.rs:580-602
+(unresolved→ISSUE only). Engine kit: derive/builtin.rs registry :1188-1374 — node/type/edge/
+incoming/attr/neq/gt/lt/gte/lte/starts_with/not_starts_with/string_contains/method_suffix/
+ends_with/concat/str_lower/basename/strip_quotes/strip_prefix/strip_suffix/last_segment/
+replace_all/path_resolve/edge_attr/node_attr; last_segment identity-no-separator :945-953;
+node_attr modes :1176-1180; attr first-class set {name,file,type,id} :546-554. Pack idioms:
+derive/stdlib/rust_imports.dl (DELTA discipline, bool→"true" surface, additive mode, ORDERING),
+js_module_imports.dl:157-158 (WORKSPACE_PACKAGE join), rust_calls.dl:86-89 (meta() projection),
+js_this_method_calls.dl:38-41 (§3 cross-join refusal). Dogfood probe: cp -R
+.grafema/graph.rfdb /tmp/go-spec-probe.rfdb; grep -rc '\.go->' = 0 (no Go nodes; config includes
+no *.go). Per the Evidence Rule, graph-shape claims here rest on analyzer source + Spec.hs
+fixtures because no live Go graph exists; the differential's repo stratum (packages/go-parser
+analyze) is the mandatory live confirmation before pack implementation.
+
+---
+
+# VERDICT (adversarial review, 2026-06-12, worktree HEAD 9ac0681c)
+
+**VERDICT: REVISE BEFORE IMPLEMENTATION — semantics inventory is accurate and complete, but the headline
+import/call draft rules are planner-illegal as written.** Re-verified in source: dispatch order (alias→S1
+only / receiver-no-alias→S3 / no-receiver→S2, GoCallResolution.hs:157-174), isStdLib first-segment-dot
+(:86-89), plain-stripPrefix + dropWhile '/' + first-MODULE pick + findBySuffix alphabetical-first
+(GoImportResolution.hs:116-163), interface subset algorithm with the non-empty gate
+(GoInterfaceSatisfaction.hs:130-148), context arms incl. SPAWNS/DEFERS sharing edgeMeta and the
+caller-independence of steps 10 (GoContextPropagation.hs:140-194 — `unresolved=true` iff target possible,
+on ALL three edge types, matching the drafted meta rules), return_type `T.intercalate ","`
+(Declarations.hs:126-128), accepts/possible mutual exclusivity (:98-105), goroutine/deferred only-when-true
+(Calls.hs:127-128), INTERFACE→FUNCTION(interface_method) CONTAINS (:466-472), EXTENDS-by-NAME analyzer
+defect (:476-485). Emit-site inventory complete (re-grepped: 3 call sites, 2 type sites, 1 import,
+1 interface, 3 context). The step-8 comma-peel and step-7 prefix-strip recursions are LEGAL — the same
+shipped idiom as js_module_imports.dl:172-179 `spec_pfx`. Corrections:
+
+**C1 (BLOCKING — E-PLAN-003 cross-joins in steps 1, 2, 3).** The §3 cross-join guard polices DERIVED legs
+too (plan.rs:308-318; introduces_tuples = anything that's not a filter/function, :714-717), and the
+ground-atom exemption requires ALL-constant args (plan.rs:1004-1007). Therefore, as drafted:
+- `pkg_dir(P,D) :- mod_dir(_,D), go_mod(MP), …` — go_mod(MP) shares no variable with {D} in any leg order → REJECTED;
+- `pkg_dir(MP,"") :- go_mod(MP), module_in_dir("",_)` — second leg disconnected → REJECTED;
+- `go_import_from(I,M) :- go_import(I,_,P), go_mod(MP), …` — go_mod(MP) disconnected from {I,P} → REJECTED;
+- `go_import_from_root(I,M) :- …, go_mod(P), module_in_dir("",M)` — module_in_dir("",M) has var M, shares
+  nothing → REJECTED (this arm is semantically a cross product: import × root modules);
+- `ok_path(P) :- import_alias(_,_,P), go_mod(MP), …` — same → REJECTED.
+The spec flagged this guard only for the zero-arity `has_go_mod()` (P3) while drafting the identical
+illegal shape in its main arms. LEGAL respelling exists and is the established one: derive the
+'/'-boundary PREFIXES of the import path by right-peel (the spec_pfx idiom), EQUALITY-join `go_mod` on
+the peeled prefix variable, then `strip_prefix(P, MP_slash, RelDir)` and join `module_in_dir(RelDir, M)`
+on the BOUND RelDir — which also covers the root case (RelDir="" is a bound value, not a constant leg).
+Consequence: the step-1 kernel's `pkg_dir` cannot exist as a standalone derived relation (the
+modPath×dirs product is inherently disconnected); consumers (S1 calls, imports) must inline the
+peel-join. This is a kernel redesign, not a tweak.
+
+**C2 (fallback arm harder-blocked than stated).** The no-go.mod fallback rule
+`go_import_suffix(I,M) :- go_import(I,_,P), …, module_in_dir(D,M), …, ends_with(P,D)` is the
+filter-connected spelling the guard exists to reject (the in-file "rust_imports f_anc lesson",
+js_module_imports.dl:168-170) — module_in_dir(D,M) is a disconnected positive leg regardless of which
+pack loads it, so P3's orchestrator-side variant selection does NOT rescue the rule body. An equality-join
+spelling needs the '/'-boundary SUFFIXES of P, which is a left-peel — it requires `first_segment`
+(missing capability M1). So M1 is the blocker for the fallback ARM itself, not merely for isStdLib
+exactness; either build M1 or declare the no-go.mod fallback dropped (bound: only projects without
+go.mod, where legacy's own behavior was the alphabetical-first heuristic).
+
+**C3 (missed delta class — interface-side name merge, step 6).** Legacy
+`collectIfaceMethods` UNIONS method sets across SAME-NAMED interfaces project-wide
+(GoInterfaceSatisfaction.hs:96-102, `Map.insertWith Set.union` keyed by interface NAME) and
+`Map.intersectionWith` pairs that union with ONE last-wins interface node id (:84-88). The pack's
+`iface_m(I, MN)` is per-NODE: for duplicate interface names the pack's requirement set is SMALLER
+(per-node, not the union) ⇒ structs can satisfy an interface the legacy merged-set rejected, AND the
+pack emits an edge per actual interface node vs legacy's single arbitrary winner. This is a separate
+SUPERSET class from G6-2's struct-side merge — declare it (bound = duplicate interface simple names,
+countable) or the differential will misclassify those rows.
+
+**C4 (missed seam — pack ordering beyond P2).** `go_imports` must be registered BEFORE `@stdlib/depends`:
+depends.dl consumes EVERY IMPORTS_FROM edge node-type-agnostically (derive/stdlib/depends.dl:1-6), and the
+go branch feeds `all_imports_from_edges` today (main.rs:1701). `go_calls` (CALLS producer) must precede the
+CALLS negators `method_calls`/`shape_verifier` (shape_verifier.dl:30 negates `edge(C,_,"CALLS")`, no file
+gate). The ordering const is orchestrator main.rs:59-104 STDLIB_RULE_PACKS + rfdb-server stdlib.rs
+STDLIB_PACKS — P2 covers only go_calls→go_context.
+
+**C5 (mechanism misattribution, conclusion stands).** "the orchestrator turns unresolved [DeferredRefs]
+into ISSUE diagnostics only (analyzer.rs:580-602)" — wrong mechanism: FileAnalysis has NO unresolvedRefs
+field (analyzer.rs:41-49; serde drops faUnresolvedRefs exactly as for java/kotlin). The ISSUE nodes are
+generated from POST-RESOLVE graph queries (main.rs:2060-2085: CALLs with no CALLS edge, IMPORT_BINDINGs
+with no IMPORTS_FROM) onto `__grafema_virtual/unresolved-diagnostics`. The load-bearing conclusion ("graph
+CALLS on .go files come exclusively from go-resolve") survives, but the differential must exclude the
+synthetic diagnostics file — pack-coverage deltas change the ISSUE population.
+
+**C6 (minor).** Step 7: rule text uses `not_starts_with(T,"[")` while the note recommends `"[]"` — pick
+one (both parity-safe: neither residue matches a type_node key). The dogfood probe (`grep -rc '\.go->'`
+over binary segments) is weaker evidence than the java/kotlin live-Datalog probes — rerun as a Datalog
+count on the /tmp copy before gating. Negated builtin filters are in fact legal (exec.rs:1912+ per-row
+anti-join; stratify adds no edge for builtins), so M3 `not_string_contains` is even less needed than
+stated — `\+ string_contains(F,"/")` works today (no stdlib precedent; fixture-test first).
+
+Ready for packs: NOT YET — C1/C2 require redrafting the import/call kernels (legal shapes exist and are
+specified above); steps 4-10 are implementable as drafted once the shared func_in_dir/pkg join is respelled.

--- a/_ai/research/lang-spec-java.md
+++ b/_ai/research/lang-spec-java.md
@@ -1,0 +1,566 @@
+# Migration spec: java-resolve → derive packs (Datalog v2)
+
+Date: 2026-06-12. Branch context: worktree at `9ac0681c` (v0.4.0, origin/main-era; `derive/` module layout).
+Discipline: the js/rust precedent in `_ai/research/resolve-datalog2-migration-specs.json` + synthesis-ledger §3/§5.
+All file:line references verified by Read/Grep in this worktree at HEAD.
+
+## 0. Target & purpose
+
+**Target:** `java-resolve` binary (`packages/java-resolve/src/`, 4 modules + Main, 869 LOC total), dispatched
+by the orchestrator as a one-shot full-graph daemon command `("java-all", &[])` over `Language::Java` nodes
+(`packages/grafema-orchestrator/src/main.rs:1566-1595` analyze path, `:2481-2501` reanalyze path; binary
+checked at `:838-839`). `java-all` runs all 4 phases in one pass (`java-resolve/src/Main.hs:64-70`).
+
+**Purpose:** Java cross-file resolution, materializing:
+- `IMPORTS_FROM` (IMPORT→class decl; IMPORT_BINDING→class decl) — `ImportResolution.hs`
+- `RETURNS`, `TYPE_OF`, `EXTENDS`, `IMPLEMENTS`, `THROWS_TYPE` — `TypeResolution.hs`
+- `CALLS`, `INSTANTIATES` — `CallResolution.hs`
+- `ANNOTATION_RESOLVES_TO` — `AnnotationResolution.hs`
+
+All emitted edges carry **EMPTY metadata** (every `mkEdge`/`EmitEdge` site: ImportResolution.hs:85-91,113-130;
+TypeResolution.hs:188-195; CallResolution.hs:132-139; AnnotationResolution.hs:46-53). No virtual nodes are
+minted anywhere in java-resolve — **no `@materialize_node`, no two-pack split needed** (unlike js builtins).
+No external data inputs (no effects-db, no workspace map): graph-in, edges-out. This is the *easiest*
+resolver family migrated so far.
+
+**Out of scope (adjacent):** `jvm-cross-resolve` (`packages/jvm-cross-resolve/src/`, 3 modules) — Java↔Kotlin
+cross-language `IMPORTS_FROM`/`CALLS`/type edges, emitted only when source and target file *languages differ*
+(CrossImportResolution.hs:5,17-18); run separately at main.rs:1793/2680. `kotlin-resolve` is a near-clone of
+java-resolve (own spec). Both deserve their own pack specs; the kernels below (qualified-class index,
+HAS_METHOD membership) are directly reusable.
+
+## 1. Analyzer vocabulary the resolver consumes (java-analyzer, verified)
+
+Node types emitted (`packages/java-analyzer/src/Rules/`):
+`MODULE` (Walker.hs:37-51, metadata `package` when the file has a package decl, else NO key),
+`IMPORT` (Imports.hs:65-81, name = full import path `com.example.Foo`, metadata `path`/`glob`(bool)/`static`(bool)),
+`IMPORT_BINDING` (Imports.hs:96-112, name = leaf `Foo`, metadata `imported_name`/`local_name`/`static` —
+**no `source` key**), `CLASS`/`INTERFACE`/`ENUM`/`RECORD`/`ANNOTATION_TYPE` (Declarations.hs; CLASS metadata
+`extends` single name :114, `implements` comma-joined :118; INTERFACE `extends` comma-joined :169; ENUM/RECORD
+`implements` comma-joined :219,:272), `FUNCTION` (methods :376-391 metadata `kind`="method"/`return_type`/
+`throws` comma-joined; constructors :459-467 `kind`="constructor"; compact ctors :529 `kind`="compact_constructor"),
+`VARIABLE` (fields :740-747 metadata `kind`="field"/`type`; locals/params/catch in Expressions.hs),
+`CALL` (Expressions.hs:103-123 method calls, metadata `method`/`argCount`/`receiver` only-when-nonempty;
+:777-795 `this()`/`super()` with `kind`="constructor_call"/`isThis`(bool); ctor calls named `"new " <> ClassName`
+:1086), `ATTRIBUTE` (Annotations.hs, annotation usages).
+
+Edge types emitted by the analyzer (counted): `CONTAINS` ×43 sites, `HAS_METHOD` (Declarations.hs:402-410
+methods, :477-483 constructors — **NOT compact constructors**: the :534-539 emission for compact ctors is
+CONTAINS-only), `HAS_PROPERTY`, `INNER_CLASS_OF`, plus expression-level edges (CALLS×2 analyzer-side,
+REFERENCES, ASSIGNED_FROM, THROWS, CATCHES, …).
+
+Semantic-id format (`grafema-common/src/Grafema/SemanticId.hs:2`): `file->TYPE->name[in:parent,h:xxx]`.
+- FUNCTION (method/ctor): `parent` = enclosing **class** name (`askNamedParent`, set by `withNamedParent name`
+  at the class walk, Declarations.hs:332-343).
+- CALL: `parent` = enclosing **method** name (`parent = encFn >>= extractName`, Expressions.hs:101,163,226,777;
+  `extractName` takes the *name segment* of the enclosing FUNCTION sid, :1098-1105).
+
+Scope mechanics: members get `CONTAINS` from `scopeId`; class scopes carry the class node id
+(Declarations.hs:332-338), method/ctor scopes carry the FUNCTION node id (:419-428, :542-548 ccScope), lambdas
+carry the lambda FUNCTION id (Expressions.hs:377,424). Blocks do NOT push scopes (no BlockScope construction
+in Rules/). So a CALL's `CONTAINS` source is the enclosing FUNCTION (or class for field initializers, or MODULE
+at top level) — the graph-native parent chain the packs use instead of sid parsing.
+
+**Streaming scope:** the daemon receives ONLY Java-language nodes (`run_resolve(..., &[config::Language::Java], ...)`,
+main.rs:1578). Every pack rule below therefore gates BOTH sides on `ends_with(F, ".java")` — this *is* legacy
+parity, and mandatory because the vocabulary is shared polyglot-wide (ATTRIBUTE also emitted by cpp/kotlin/
+python/swift analyzers; ANNOTATION_TYPE by kotlin; INSTANTIATES by cpp/kotlin/php resolvers — verified by grep).
+
+## 2. Production-dead legacy paths (load-bearing findings)
+
+These three findings change what "parity" means. Each is code-evidence (file:line both sides); the
+differential run must confirm them live (no java graph exists today to live-verify — §8).
+
+**(D1) `resolveBinding` is dead.** ImportResolution.hs:104-107 reads node metadata `source` and returns `[]`
+when absent. The analyzer stamps IMPORT_BINDING with `imported_name`/`local_name`/`static` only
+(Imports.hs:107-111); the intended `source` travels in `DeferredRef.drSource` (Imports.hs:122-135), but the
+orchestrator's `FileAnalysis` struct has **no `unresolvedRefs` field** (analyzer.rs:41-49) — serde drops it.
+⇒ Phase 3 (IMPORT_BINDING→decl) emits ZERO edges in production. The package unit test passes only because it
+fabricates the `source` key (test/Spec.hs:79-91).
+
+**(D2) `asterisk` vs `glob`.** ImportResolution.hs:78 reads metadata `asterisk`; the analyzer stamps `glob`
+(Imports.hs:78). `isAsterisk` is always False — benign: a glob IMPORT is named `com.example.*`, which can never
+match a qualified class name, so the net effect (no edge) is identical. The pack inherits this for free.
+
+**(D3) `resolveSameClassCalls` fires only inside constructors.** It keys the method index by
+`(className, methodName)` where className comes from the FUNCTION sid `[in:Class]` (CallResolution.hs:56-66),
+but looks it up with `extractParentClass(CALL sid)` (:191-194) — which is the enclosing **method** name (§1).
+The lookup matches only when enclosing-method-name == class-name, i.e. inside constructors. Calls in ordinary
+method bodies derive nothing. The unit test masks this by fabricating `[in:Service]` on the CALL sid
+(test/Spec.hs:214-221). Corollary: `resolveSuperThisCalls` (:232-257) **works correctly by the same accident** —
+`super()`/`this()` occur only inside constructors, where `[in:ctorName]` == class name.
+
+## 3. Per-step inventory + draft rules
+
+Builtin kit verified at `packages/rfdb-server/src/derive/builtin.rs` registry (:1188-1372): `node/type/edge/
+incoming/attr` (attr exposes ONLY name/file/type/id — :548-551; "id" is the u128 decimal, NOT the semantic id),
+`neq,gt,lt,gte,lte`, `starts_with,not_starts_with,string_contains,ends_with` [B,B], `method_suffix,str_lower,
+basename,strip_quotes` [B,F|B,B], `concat,strip_prefix,strip_suffix,last_segment,path_resolve` [B,B,F|B,B,B],
+`replace_all` [B,B,B,F|B,B,B,B], `edge_attr/5`, **`node_attr/3`** [B,B,F|B,B,B] point-probe (:1084-1115,
+:1176-1182; JSON string verbatim, number by JSON text, bool as "true"/"false"; missing key = tuple non-match).
+`node_attr` — the js-spec's #1 missing capability — EXISTS; it unblocks every metadata read below.
+Negated builtins are not a thing (`not_starts_with` exists precisely because `\+` applies to derived relations) —
+all "skip" filters below go through derived aux relations.
+
+```json
+[
+  {
+    "step": "S1 qualified-class kernel (buildModuleIndex+buildClassIndex, ImportResolution.hs:41-68)",
+    "reads": "MODULE.metadata.package (node_attr), CLASS/INTERFACE/ENUM/RECORD by (file,name), java gate",
+    "writes": "derived qual_class(QualifiedName, T) — consumed by S2/S3",
+    "expressible": "fully",
+    "deltas": ["last-write-wins Map on duplicate qualified names → set semantics derives ALL candidates (superset, same class as rust DELTA 4)"]
+  },
+  {
+    "step": "S2 IMPORT → class decl IMPORTS_FROM (resolveImport, ImportResolution.hs:75-92)",
+    "reads": "IMPORT.name = full path (first-class), glob exclusion (production-dead D2 — free parity)",
+    "writes": "IMPORTS_FROM IMPORT→{CLASS,INTERFACE,ENUM,RECORD}, empty meta",
+    "expressible": "fully",
+    "deltas": ["S1 superset inherits", "static imports `com.example.Foo.bar` resolve nothing on BOTH sides (full-path lookup fails) — exact parity; an opt-in improvement arm via last_segment exists but is NOT drafted (honesty: superset must be deliberate)"]
+  },
+  {
+    "step": "S3 IMPORT_BINDING → class decl IMPORTS_FROM (resolveBinding, ImportResolution.hs:99-131)",
+    "reads": "legacy: metadata source (NEVER present — D1). pack: IMPORT -CONTAINS-> IMPORT_BINDING + IMPORT.name (Imports.hs:114-120 emits exactly this edge)",
+    "writes": "IMPORTS_FROM IMPORT_BINDING→class decl",
+    "expressible": "fully (graph-native route)",
+    "deltas": ["DECLARED SUPERSET vs production (legacy derives 0); bound = count of java IMPORT_BINDING whose parent IMPORT name ∈ qual_class — measurable pre-flight. This restores the resolver's documented intent (module header :20, unit test :79). Ship decision: include (it is the feature), with the bound recorded"]
+  },
+  {
+    "step": "S4 simple-class kernel (TypeResolution.hs:41-50 / CallResolution.hs:44-52 buildClassIndex by simple name)",
+    "reads": "CLASS/INTERFACE/ENUM/RECORD (file,name), java gate",
+    "writes": "derived jclass_named(N, T) — consumed by S5-S9, S10, S12, S13",
+    "expressible": "fully",
+    "deltas": ["Map last-write-wins on duplicate simple names ACROSS THE PROJECT (e.g. two `Foo` in different packages) → set semantics derives an edge per candidate (superset; bound = names with >1 decl, measurable)"]
+  },
+  {
+    "step": "S5 RETURNS (resolveReturns, TypeResolution.hs:115-126; normalizeType :81-94)",
+    "reads": "FUNCTION.metadata.return_type (node_attr); normalize = strip-all-[] (replace_all), skip 10 primitives (ground facts), skip '?'-wildcards + '<unknown>' (derived-negation aux)",
+    "writes": "RETURNS FUNCTION→class decl",
+    "expressible": "fully",
+    "deltas": ["T.strip trim is not replicated (no trim builtin) — NO-OP: typeToName (Expressions.hs:1108-1114) never emits padded names", "S4 superset inherits"]
+  },
+  {
+    "step": "S6 TYPE_OF (resolveTypeOf, TypeResolution.hs:129-140)",
+    "reads": "VARIABLE.metadata.type (node_attr), same normalize",
+    "writes": "TYPE_OF VARIABLE→class decl",
+    "expressible": "fully",
+    "deltas": ["same as S5"]
+  },
+  {
+    "step": "S7 EXTENDS (resolveExtends, TypeResolution.hs:143-156)",
+    "reads": "CLASS/INTERFACE/ENUM/RECORD metadata.extends — NOTE legacy does NOT split: an interface with `extends A,B` (comma-joined, Declarations.hs:169) is looked up as the literal string 'A,B' and fails",
+    "writes": "EXTENDS decl→class decl",
+    "expressible": "fully (exact parity INCLUDING the no-split miss: a comma-bearing string matches no class name automatically)",
+    "deltas": ["S4 superset inherits", "interface multi-extends: 0 edges on both sides (exact); the FIX needs split/3 (missing capability #1)"]
+  },
+  {
+    "step": "S8 IMPLEMENTS (resolveImplements, TypeResolution.hs:159-171, splitTypes :97-98)",
+    "reads": "CLASS/ENUM metadata.implements, comma-SPLIT then per-element lookup",
+    "writes": "IMPLEMENTS decl→interface decl (one per resolved element)",
+    "expressible": "partially",
+    "deltas": ["single-element values: EXACT", "multi-element values: SUBSET — pack derives 0 of them (no split/3 builtin); bound = java CLASS/ENUM nodes whose implements metadata contains ',' (directly countable via string_contains)"]
+  },
+  {
+    "step": "S9 THROWS_TYPE (resolveThrows, TypeResolution.hs:174-186)",
+    "reads": "FUNCTION.metadata.throws, comma-split per element",
+    "writes": "THROWS_TYPE FUNCTION→class decl",
+    "expressible": "partially",
+    "deltas": ["same split SUBSET as S8 (multi-exception throws clauses); single-exception exact"]
+  },
+  {
+    "step": "S10 constructor calls (resolveConstructorCalls, CallResolution.hs:146-176)",
+    "reads": "CALL name 'new X' (strip_prefix), jclass_named, ctor membership: legacy ctorIdx = FUNCTION kind∈{constructor,compact_constructor} keyed by sid [in:Class] (:70-85) — pack: HAS_METHOD for ctors + RECORD-CONTAINS for compact ctors (HAS_METHOD gap, §1)",
+    "writes": "INSTANTIATES CALL→class decl + CALLS CALL→ctor FUNCTION",
+    "expressible": "fully",
+    "deltas": ["overload pick: legacy takes head of the ctor list (:174-175, arbitrary Map-fold order; the argCount comment is NOT implemented) → pack derives ALL ctors of the class (superset, bound = classes with >1 ctor)", "S4 superset inherits", "local-class ctors: legacy keyed them under the WRONG name when nested in a method (sid parent = method name); pack's edge-based membership is correct (superset/fix, rare)"]
+  },
+  {
+    "step": "S11 same-class method calls (resolveSameClassCalls, CallResolution.hs:182-205) — PRODUCTION-LATENT-BUGGED (D3)",
+    "reads": "CALL with receiver absent/''/'this' (node_attr + derived-negation), NOT ctor-call, NOT super/this; enclosing class: pack = CONTAINS-parent FUNCTION (+ nested-FUNCTION recursion for lambdas) + HAS_METHOD owner; method index = HAS_METHOD + name",
+    "writes": "CALLS CALL→FUNCTION (same class)",
+    "expressible": "fully",
+    "deltas": ["DECLARED SUPERSET: legacy derives only ctor-body calls (D3); pack derives all same-class no-receiver calls — the resolver's documented intent (:12-13) and its unit test (:214). Bound = plain calls in non-ctor methods with a same-class name match; semantically sound (no false-positive vector: the join requires an actual same-class method of that name)", "overload pick head → all-overloads superset", "field-initializer calls (CONTAINS from class node, no FUNCTION parent): legacy no-edge ([in:] absent → extractParentClass Nothing), pack no-edge through encl_fn (FUNCTION-typed parent leg) — parity"]
+  },
+  {
+    "step": "S12 static-style calls (resolveStaticCalls, CallResolution.hs:208-226)",
+    "reads": "CALL.metadata.receiver = a class simple name (node_attr), method via HAS_METHOD+name",
+    "writes": "CALLS CALL→FUNCTION",
+    "expressible": "fully",
+    "deltas": ["all-overloads superset; S4 dup-name superset; otherwise EXACT (receiver matching a non-class identifier derives nothing on both sides — unit test :243-249)"]
+  },
+  {
+    "step": "S13 super()/this() delegating ctor calls (resolveSuperThisCalls, CallResolution.hs:232-257)",
+    "reads": "CALL named 'super'/'this' or isThis=true (node_attr bool surface 'true'); this(): enclosing class ctor; super(): enclosing CLASS metadata.extends → superclass ctor",
+    "writes": "CALLS CALL→ctor FUNCTION",
+    "expressible": "fully",
+    "deltas": ["all-ctors superset vs head-pick; otherwise EXACT (legacy works here — D3 corollary)"]
+  },
+  {
+    "step": "S14 annotation resolution (AnnotationResolution.hs:26-44)",
+    "reads": "ATTRIBUTE.name ↔ ANNOTATION_TYPE.name (both first-class)",
+    "writes": "ANNOTATION_RESOLVES_TO ATTRIBUTE→ANNOTATION_TYPE",
+    "expressible": "fully",
+    "deltas": ["dup-name set-semantics superset; .java gate on BOTH legs is load-bearing (kotlin emits both node types — without the gate the pack would invent java→kotlin edges legacy never saw)"]
+  }
+]
+```
+
+## 4. Draft packs (4 files, canonical order: java_imports → java_types → java_calls → java_annotations)
+
+No inter-pack EDB dependencies (none consumes another's materialized edges), so the order is convention,
+not contract — record it in the STDLIB_PACKS comment anyway (stdlib.rs:303-358 discipline). All `mode =
+"additive"`: every edge type is shared vocabulary and the legacy resolver stays ON during hybrid rollout
+(the rust_trait_resolve.dl precedent). Legacy metadata is empty ⇒ no `meta(...)` columns anywhere; engine
+provenance `_source`/`_generation` is the standing metadata delta (rust DELTA 6).
+
+### 4.1 `java_imports.dl`
+
+```prolog
+% Self-contained name-keyed relations joined on strings (§3 connectivity discipline,
+% rust_trait_resolve.dl ENCODING NOTE — never inline node/attr legs next to a foreign leg).
+jmodule(M, F) :- node(M, "MODULE"), attr(M, "file", F), ends_with(F, ".java").
+jdecl(T, F, N) :- node(T, "CLASS"),     attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "INTERFACE"), attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "ENUM"),      attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "RECORD"),    attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+pkg_of(F, P)  :- jmodule(M, F), node_attr(M, "package", P), neq(P, "").
+has_pkg(F)    :- pkg_of(F, P).
+% qualified name = package "." simple name; default-package files contribute the bare name
+% (ImportResolution.hs:63-66 pkg-or-empty discipline).
+qual_class(Q, T) :- jdecl(T, F, N), pkg_of(F, P), concat(P, ".", P1), concat(P1, N, Q).
+qual_class(N, T) :- jdecl(T, F, N), \+ has_pkg(F).
+
+jimport(I, Q, F) :- node(I, "IMPORT"), attr(I, "file", F), ends_with(F, ".java"), attr(I, "name", Q).
+
+% S2 — IMPORT -> declaration (glob imports fall out naturally: '*'-suffixed names match nothing).
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+import_target(I, T) :- jimport(I, Q, F), qual_class(Q, T).
+
+% S3 — IMPORT_BINDING -> declaration via the parent IMPORT (graph-native source; DECLARED
+% SUPERSET vs the production-dead metadata-source path, §2 D1).
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+binding_target(B, T) :- node(B, "IMPORT_BINDING"), attr(B, "file", F), ends_with(F, ".java"),
+    edge(I, B, "CONTAINS"), jimport(I, Q, F), qual_class(Q, T).
+```
+
+### 4.2 `java_types.dl`
+
+```prolog
+prim("boolean"). prim("byte"). prim("char"). prim("short"). prim("int").
+prim("long"). prim("float"). prim("double"). prim("void"). prim("var").
+
+jdecl(T, F, N) :- node(T, "CLASS"),     attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "INTERFACE"), attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "ENUM"),      attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "RECORD"),    attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jclass_named(N, T) :- jdecl(T, F, N).
+
+% normalizeType (TypeResolution.hs:81-94): strip ALL "[]", reject primitives / '?' / '<unknown>' / "".
+% One raw value per (node,key) ⇒ the per-node bad-flag is a faithful negation surface.
+ret_strip(Fn, N) :- node(Fn, "FUNCTION"), attr(Fn, "file", F), ends_with(F, ".java"),
+    node_attr(Fn, "return_type", Raw), neq(Raw, ""), replace_all(Raw, "[]", "", N), neq(N, "").
+ret_bad(Fn) :- ret_strip(Fn, N), prim(N).
+ret_bad(Fn) :- ret_strip(Fn, N), string_contains(N, "?").
+ret_bad(Fn) :- ret_strip(Fn, "<unknown>").
+@materialize(edge_type = "RETURNS", mode = "additive")
+returns(Fn, T) :- ret_strip(Fn, N), \+ ret_bad(Fn), jclass_named(N, T).
+
+vty_strip(V, N) :- node(V, "VARIABLE"), attr(V, "file", F), ends_with(F, ".java"),
+    node_attr(V, "type", Raw), neq(Raw, ""), replace_all(Raw, "[]", "", N), neq(N, "").
+vty_bad(V) :- vty_strip(V, N), prim(N).
+vty_bad(V) :- vty_strip(V, N), string_contains(N, "?").
+vty_bad(V) :- vty_strip(V, "<unknown>").
+@materialize(edge_type = "TYPE_OF", mode = "additive")
+type_of(V, T) :- vty_strip(V, N), \+ vty_bad(V), jclass_named(N, T).
+
+% EXTENDS — all 4 decl types carry it (TypeResolution.hs:146); comma-joined interface
+% multi-extends matches no class name = the legacy no-split miss, reproduced exactly.
+ext_strip(C, N) :- jdecl(C, F, CN), node_attr(C, "extends", Raw), neq(Raw, ""),
+    replace_all(Raw, "[]", "", N), neq(N, "").
+ext_bad(C) :- ext_strip(C, N), prim(N).
+ext_bad(C) :- ext_strip(C, N), string_contains(N, "?").
+ext_bad(C) :- ext_strip(C, "<unknown>").
+@materialize(edge_type = "EXTENDS", mode = "additive")
+extends(C, T) :- ext_strip(C, N), \+ ext_bad(C), jclass_named(N, T), neq(C, T).
+
+% IMPLEMENTS (CLASS+ENUM only, :163) / THROWS_TYPE — SINGLE-element arm only (split/3 gap):
+% comma-bearing values are excluded explicitly so the subset is the DECLARED one, not an accident.
+impl_one(C, N) :- node(C, "CLASS"), attr(C, "file", F), ends_with(F, ".java"),
+    node_attr(C, "implements", N), neq(N, "").
+impl_one(C, N) :- node(C, "ENUM"),  attr(C, "file", F), ends_with(F, ".java"),
+    node_attr(C, "implements", N), neq(N, "").
+impl_multi(C) :- impl_one(C, N), string_contains(N, ",").
+@materialize(edge_type = "IMPLEMENTS", mode = "additive")
+implements(C, T) :- impl_one(C, N), \+ impl_multi(C), jclass_named(N, T).
+
+throws_one(Fn, N) :- node(Fn, "FUNCTION"), attr(Fn, "file", F), ends_with(F, ".java"),
+    node_attr(Fn, "throws", N), neq(N, "").
+throws_multi(Fn) :- throws_one(Fn, N), string_contains(N, ",").
+@materialize(edge_type = "THROWS_TYPE", mode = "additive")
+throws_type(Fn, T) :- throws_one(Fn, N), \+ throws_multi(Fn), jclass_named(N, T).
+```
+
+### 4.3 `java_calls.dl`
+
+```prolog
+jdecl(T, F, N) :- node(T, "CLASS"),     attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "INTERFACE"), attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "ENUM"),      attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "RECORD"),    attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jclass_named(N, T) :- jdecl(T, F, N).
+
+jcall(C, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".java"), attr(C, "name", N).
+
+% — classification (CallResolution.hs:260-270) —
+ctor_call(C, CN) :- jcall(C, N), strip_prefix(N, "new ", CN), neq(CN, "").
+is_ctor_call(C)  :- ctor_call(C, CN).
+is_ctor_call(C)  :- jcall(C, N), node_attr(C, "kind", "constructor_call").
+this_call(C)  :- jcall(C, "this").
+this_call(C)  :- jcall(C, N), node_attr(C, "isThis", "true").
+super_call(C) :- jcall(C, "super").
+super_this(C) :- this_call(C).
+super_this(C) :- super_call(C).
+has_recv(C) :- jcall(C, N), node_attr(C, "receiver", R), neq(R, ""), neq(R, "this").
+
+% — membership (graph-native replacement of the sid [in:Class] parse) —
+% ctor_of: HAS_METHOD covers methods+constructors (Declarations.hs:402,477); compact
+% constructors get only CONTAINS from the record scope (:534-539) — the second arm.
+ctor_of(Cls, Fn) :- edge(Cls, Fn, "HAS_METHOD"), node_attr(Fn, "kind", "constructor").
+ctor_of(Cls, Fn) :- node(Cls, "RECORD"), edge(Cls, Fn, "CONTAINS"),
+    node_attr(Fn, "kind", "compact_constructor").
+% enclosing class of a CALL: nearest FUNCTION ancestor via CONTAINS, then its HAS_METHOD
+% owner; the recursion lifts lambda/local-fn nesting (lambda FUNCTIONs have no HAS_METHOD).
+encl_fn(C, Fn) :- jcall(C, N), edge(Fn, C, "CONTAINS"), node(Fn, "FUNCTION").
+fn_owner(Fn, Cls) :- edge(Cls, Fn, "HAS_METHOD").
+fn_owner(Fn, Cls) :- edge(Outer, Fn, "CONTAINS"), node(Outer, "FUNCTION"), fn_owner(Outer, Cls).
+encl_class(C, Cls) :- encl_fn(C, Fn), fn_owner(Fn, Cls).
+
+% S10 — constructor calls.
+@materialize(edge_type = "INSTANTIATES", mode = "additive")
+instantiates(C, Cls) :- ctor_call(C, CN), jclass_named(CN, Cls).
+@materialize(edge_type = "CALLS", mode = "additive")
+ctor_calls(C, Fn) :- ctor_call(C, CN), jclass_named(CN, Cls), ctor_of(Cls, Fn).
+
+% S11 — same-class no-receiver calls (DECLARED SUPERSET — fixes §2 D3).
+plain_call(C, N) :- jcall(C, N), \+ is_ctor_call(C), \+ super_this(C), \+ has_recv(C).
+@materialize(edge_type = "CALLS", mode = "additive")
+same_class_calls(C, M) :- plain_call(C, N), encl_class(C, Cls),
+    edge(Cls, M, "HAS_METHOD"), attr(M, "name", N).
+
+% S12 — static-style calls (receiver names a class).
+recv_class(C, N, Cls) :- jcall(C, N), \+ is_ctor_call(C), \+ super_this(C),
+    node_attr(C, "receiver", R), neq(R, ""), neq(R, "this"), jclass_named(R, Cls).
+@materialize(edge_type = "CALLS", mode = "additive")
+static_calls(C, M) :- recv_class(C, N, Cls), edge(Cls, M, "HAS_METHOD"), attr(M, "name", N).
+
+% S13 — this()/super() delegation.
+@materialize(edge_type = "CALLS", mode = "additive")
+this_ctor_calls(C, Fn) :- this_call(C), encl_class(C, Cls), ctor_of(Cls, Fn).
+@materialize(edge_type = "CALLS", mode = "additive")
+super_ctor_calls(C, Fn) :- super_call(C), encl_class(C, Cls),
+    node_attr(Cls, "extends", SN), neq(SN, ""), jclass_named(SN, SCls), ctor_of(SCls, Fn).
+```
+
+### 4.4 `java_annotations.dl`
+
+```prolog
+% .java gates on BOTH legs are load-bearing: kotlin-analyzer emits ATTRIBUTE and
+% ANNOTATION_TYPE too (Rules/Annotations.hs); legacy only ever saw Java-streamed nodes.
+jattr(A, N) :- node(A, "ATTRIBUTE"), attr(A, "file", F), ends_with(F, ".java"),
+    attr(A, "name", N), neq(N, "").
+jann(N, T)  :- node(T, "ANNOTATION_TYPE"), attr(T, "file", F), ends_with(F, ".java"),
+    attr(T, "name", N), neq(N, "").
+@materialize(edge_type = "ANNOTATION_RESOLVES_TO", mode = "additive")
+ann_resolves(A, T) :- jattr(A, N), jann(N, T).
+```
+
+**Maintain envelope (all 4 packs):** `node_attr` legs + stratified negation ⇒ maintain-incremental refuses;
+the scratch floor applies (the standing Wave-2 expectation, rust_trait_resolve.dl MAINTAIN ENVELOPE note).
+`java_annotations` and `java_imports`' S2 arm are negation-light enough to shed it later.
+
+## 5. Predicted delta classes (declared BEFORE diffing, with bounds)
+
+EXACT-MATCH expected: S2 (modulo S1 dup-qual-name extras), S5/S6/S7 single-name types, S8/S9 single-element
+values, S12, S13, S14 (modulo dup-name extras everywhere — bound below).
+
+EXPECTED-SUPERSET (pack ⊇ legacy, each bounded & countable pre-flight):
+1. Set semantics vs Map last-write-wins — bound = decl names (simple or qualified) with >1 decl node;
+   count with `dup(N) :- jclass_named(N,T1), jclass_named(N,T2), neq(T1,T2)`.
+2. All-overloads vs head-pick (S10/S11/S12/S13 CALLS) — bound = (class, name) pairs with >1 FUNCTION.
+3. S3 binding edges — bound = java IMPORT_BINDING count whose parent IMPORT resolves (legacy = 0, §2 D1).
+4. S11 same-class calls outside ctor bodies (legacy = ctor-bodies only, §2 D3) — bound = plain_call rows
+   whose encl_fn is not kind=constructor.
+5. S10 local-class ctor membership fix (rare; classifiable by INNER_CLASS_OF/nesting).
+
+EXPECTED-SUBSET (pack ⊆ legacy, the split/3 debt — must go to zero when split lands):
+6. S8/S9 multi-element implements/throws — bound = nodes whose metadata value `string_contains ","`;
+   single Datalog count each.
+
+Any delta outside classes 1-6 = pack bug or new resolver knowledge → stop, witness (`explain_datalog_fact`
+on pack-extra; legacy stderr counters `java-resolve:`/`java-call-resolve:`… on pack-missing), classify,
+only then proceed.
+
+## 6. Missing capabilities (today's kit, ranked)
+
+1. **`split(S, Sep, Elem)` — multi-row string generator** [B,B,F]: binds Elem once per separator-delimited
+   element. THE only hard blocker in the whole java surface (S8 IMPLEMENTS / S9 THROWS_TYPE multi-element;
+   would also fix S7's interface multi-extends beyond parity). Same need will recur for kotlin-resolve
+   (same comma-joined metadata convention) — worth building once. A peel-from-the-right recursion using
+   `concat(",", Last, Suf), strip_suffix(S, Suf, Rest)` + `last_segment` is technically constructible
+   today but generates fresh string terms in a recursive rule (function-symbol territory the engine's
+   safety discipline does not sanction) — NOT proposed.
+2. (nice-to-have) negated string filters `not_contains`/`not_ends_with` — the derived-negation aux-relation
+   workaround (ret_bad/impl_multi above) is legal but verbose, and every aux relation deepens the negation
+   stratification that blocks maintain-incremental.
+3. (recorded, not needed here) semantic-id surface access from Datalog — `attr(X,"id",V)` yields the u128
+   decimal (builtin.rs:551), not the sid; the `[in:Class]` parses were replaced by HAS_METHOD/CONTAINS
+   edges instead, which is the better design anyway. Languages without membership edges would hit this.
+4. (not engine) **a Java differential corpus**: the dogfood graph has zero java nodes (§7) and
+   `.grafema/config.yaml` include has no `*.java` pattern. Options: (a) add
+   `packages/java-parser/src/main/**/*.java` (3 real files in-repo) to a worktree config — smoke-scale;
+   (b) an external OSS Java repo (e.g. a small Maven project) for real-scale. Either way the acceptance
+   run needs `grafema analyze` with the java analyzer+resolver toolchain built (cabal + the
+   `~/.grafema/bin` staleness trap from the skills list applies).
+
+## 7. Dogfood-graph probe (evidence)
+
+Probe: copied `/Users/vadimr/grafema/.grafema/graph.rfdb` (mtime Jun 11, 618MB) → `/tmp/java-spec-probe.rfdb`,
+own rfdb-server v0.4.0 on `/tmp/java-spec-probe.sock`; loaded 491,535 nodes / 1,037,299 edges. Datalog counts:
+
+```
+q(M,F) :- node(M,"MODULE"), attr(M,"file",F), ends_with(F,".java").   → 0 rows
+… same for IMPORT / CLASS / CALL / FUNCTION java-gated                 → 0 rows each
+string_contains(F,"java-parser")                                       → 0 rows
+ends_with(F,".kt")                                                     → 0 rows
+```
+
+**The dogfood graph contains NO java (or kotlin) nodes.** Root cause is config, not analyzers:
+`.grafema/config.yaml` includes only `*.ts/*.rs/*.hs/*.ex/*.erl`. The repo itself has 3 real .java files
+(`packages/java-parser/src/main/java/com/grafema/parser/{Main,DaemonProtocol,AstSerializer}.java`).
+Consequence: this spec's behavioral claims rest on (a) resolver+analyzer source (file:line cited throughout)
+and (b) the package unit fixtures (`java-resolve/test/Spec.hs`, 323 lines, 18 cases — caveat: two fixtures
+fabricate metadata/sids production never produces, §2 D1/D3). Graph-shape claims (HAS_METHOD coverage,
+CONTAINS chains, metadata keys as stored) MUST be re-verified by live query on the differential corpus DB
+before the acceptance diff is trusted (Evidence Rule: analyzer-source grepping is not graph evidence).
+
+## 8. Differential acceptance
+
+SETUP — two DBs from one checkout containing the chosen java corpus (§6.4): DB_legacy = `analyze` with
+java-resolve ON, java packs OFF; DB_pack = `analyze` with `--skip-resolver java` (the existing
+`skip_resolver("java")` gate, main.rs:1566/2481) + the 4 packs run via the prod pack-runner in §4 order.
+u128 ids are BLAKE3 of sids — comparable across DBs; export `(src_sid, dst_sid, edge_type)` triples regardless.
+
+PARTITION — cleaner than js: legacy stamps NO resolvedVia metadata, but **every edge type except CALLS has
+exactly one producer step**, so slicing is by edge type: IMPORTS_FROM (S2+S3, sub-split by source node type
+IMPORT vs IMPORT_BINDING — S3 expects legacy=∅), RETURNS(S5), TYPE_OF(S6), EXTENDS(S7), IMPLEMENTS(S8),
+THROWS_TYPE(S9), INSTANTIATES(S10), ANNOTATION_RESOLVES_TO(S14). CALLS partitions structurally by source
+CALL node: name starts "new "(S10) / name∈{super,this}∨isThis(S13) / has receiver∉{"",this}(S12) / rest(S11).
+NOTE: the java analyzer itself also emits 2 CALLS edge sites — exclude analyzer-generation edges from both
+sides by diffing only edges absent from a resolver-OFF/pack-OFF baseline DB (3-way diff), or by `_source`
+provenance on the pack side.
+
+PROCEDURE per slice: counts smoke-check → sorted set-diff → witness every diff row (pack-extra:
+`explain_datalog_fact`; pack-missing: legacy stderr totals ImportResolution.hs:148-150 /
+CallResolution.hs:290-293 / TypeResolution.hs:212-218 / AnnotationResolution.hs:63-64 + manual trace).
+Verify both sides before recording (the verify-before-recording lesson). ACCEPTANCE GATE per pack: zero
+deltas outside declared classes 1-6 (§5), each declared class counted against its pre-flight bound,
+a stdlib.rs fixture test per pack (FixtureStorageView units, 0.04s-class), wall-clock recorded.
+
+PREDICTIONS-FIRST headline checks: (P1) legacy IMPORT_BINDING IMPORTS_FROM slice = EXACTLY 0 rows (D1);
+(P2) legacy plain-call CALLS slice contains ONLY calls whose enclosing function is a constructor (D3);
+(P3) glob IMPORTs have no IMPORTS_FROM on either side (D2). If any prediction fails → my §2 reading is
+wrong → STOP and re-derive before shipping packs.
+
+## 9. Expected speedup & why migrate
+
+The java daemon path is the identical IPC shape the js migration killed (full node-set msgpack streaming
+into a Haskell daemon, one-shot `java-all`, per-command commit via `commit_resolve_output`,
+main.rs:1566-1595): the cost is serialization + process lifetime, not resolution math — all 14 steps are
+hash-map lookups. On java corpora of realistic size the packs are small-join workloads far below the
+proven 415k-node baselines (4-20s scratch for the method_calls class). The structural wins dominate:
+one fewer Haskell binary in the toolchain (java-resolve drops out of binaries_to_check :838-839),
+why()-able logic, and the two latent production bugs (D1, D3) become impossible-by-construction instead
+of silently shipping an unresolved java graph. Honesty: per-run wall win is minutes-of-build-and-spawn
+plus the streaming cost, not a 900s→56s headline — the corpus measurement in §8 records the real number.
+
+## 10. Honesty section — NOT expressible / NOT replicated
+
+1. **Multi-element implements/throws** (S8/S9): not expressible without `split/3`. Declared subset, counted.
+2. **Overload selection by argCount**: legacy doesn't implement it either (the CallResolution.hs:172 comment
+   lies; :174-175 takes head). The pack derives all overloads. NEITHER implements real Java overload
+   resolution; if exactly-one-edge semantics is ever required, the binding-table/semiring layer (Gate C §9.3)
+   is the mechanism, not a rule hack.
+3. **Static-import member resolution** (`import static com.example.Foo.bar`): unimplemented in legacy
+   (header comment ImportResolution.hs:17 vs code), unimplemented in the pack. Expressible today via
+   last_segment/strip_suffix if ever wanted — deliberate non-goal to keep parity honest.
+4. **JDK/third-party types**: silently skipped on both sides (no EXTERNAL_MODULE minting for Java).
+   A future java_builtins facts-pack (the js builtins two-pack pattern) is the natural follow-up; the JDK
+   surface is enormous — needs the lang-spec generated-facts route, not hand enumeration.
+5. **Wildcard-import bindings** (`import com.example.*` then bare `Foo` use): glob imports produce no
+   IMPORT_BINDING (Imports.hs:91-93) and no resolution on either side. A real gap in java *analysis*,
+   not a resolver-parity question.
+6. **Generic types**: `typeToName` flattens `List<Foo>` → `List` analyzer-side; type-argument edges don't
+   exist in either world.
+7. **encl_class via CONTAINS recursion** assumes member/expression CONTAINS chains are complete. Code-verified
+   (43 CONTAINS sites + scope discipline §1) but graph-unverified (no java graph) — P-check in §8 before trust.
+8. **kotlin-resolve / jvm-cross-resolve**: out of scope; java packs' .java gates keep them non-interfering.
+   jvm-cross's cross-language edges remain native until its own spec.
+
+---
+
+# VERDICT (adversarial review, 2026-06-12, worktree HEAD 9ac0681c)
+
+**VERDICT: APPROVE WITH CORRECTIONS.** Inventory is complete (all mkEdge/EmitEdge sites in the 4 modules
+covered: ImportResolution.hs:85/113/124, TypeResolution.hs:126/140/156/168/183, CallResolution.hs:157/174-175/
+196/224/246/255, AnnotationResolution.hs:44 — re-grepped). D1/D2/D3 all re-verified against both sides:
+D1 — `FileAnalysis` has no `unresolvedRefs` field (analyzer.rs:41-49 re-read: file/moduleId/nodes/edges/exports
+only) and `resolveBinding`'s ENTIRE body, including the inner bindingName fallback arm at ImportResolution.hs:124
+(which the spec didn't mention — it's inside the `T.null source` gate, so equally dead), emits nothing without
+`source`; analyzer stamps imported_name/local_name/static only (Imports.hs re-read). D2 — analyzer stamps `glob`
+(Imports.hs), resolver reads `asterisk` (ImportResolution.hs:78). D3 — methodIdx keyed by FUNCTION-sid [in:]
+(CallResolution.hs:56-66), probed with CALL-sid [in:] = enclosing-method name (java CALL sid parent =
+`encFn >>= extractName`, Expressions.hs:101-103 re-read). All draft rules re-checked against the registry and
+the planner: every leg's binding pattern has a registered mode (edge [F,B,B] exists for the `edge(I,B,"CONTAINS")`
+/ `edge(Fn,C,"CONTAINS")` spellings — builtin.rs EDGE_MODES), every positive leg is variable-connected
+(E-PLAN-003 clean), constants in derived legs are legal (exec.rs unify_atom handles Term::Const), head-pick
+:174-175 confirmed. Corrections:
+
+**C1 (load-bearing — kills missing-capability #1).** "split/3 is THE only hard blocker" is WRONG. The
+right-peel recursion over shrinking strings is a SANCTIONED, SHIPPED stdlib idiom: `spec_pfx` in
+js_module_imports.dl:172-179 uses exactly `last_segment` + `concat` + `strip_suffix` in a recursive rule, with
+an in-file comment that the fixpoint terminates at segment depth. Comma-split of `implements`/`throws` is the
+same shape (separator "," — analyzer joins with `T.intercalate ","`, Declarations.hs:118/169/219/272/391/467
+re-verified, no spaces; legacy splitTypes' T.strip is a no-op). Therefore **S8 IMPLEMENTS and S9 THROWS_TYPE
+multi-element are fully expressible TODAY**; delta class 6 (SUBSET) is closable in wave 1, and S7's interface
+multi-extends fix is available as a deliberate-superset arm. §6.1's "function-symbol territory the engine's
+safety discipline does not sanction" is contradicted by shipped stdlib. Demote split/3 to ergonomics.
+
+**C2 (engine claim wrong, minor).** "Negated builtins are not a thing" — false. The executor evaluates a
+negated builtin literal as a per-row anti-join (exec.rs:1912-1920 negated path; non-special-cased shapes
+"(attr, filters, …) keep the exact per-row fallback"), and the stratifier creates NO dependency edge for
+base/builtin literals (stratify.rs:215-217, :456 "base relation or builtin — no dependency edge"). So
+`\+ string_contains(N, ",")` / `\+ ends_with(...)` are legal AND stratification-free — the §6.2 rationale
+("every aux relation deepens the negation strata") is inverted: direct negated filters are LIGHTER than the
+ret_bad/impl_multi aux relations drafted. Caveat: zero stdlib packs use the form today (grep: only
+node/edge/derived are negated) — add one FixtureStorageView test before relying on it.
+
+**C3 (missed step — wire/seam).** The java resolve branch ALSO pushes IMPORTS_FROM into
+`all_imports_from_edges` (main.rs:1582-1586; at v0.4.0 consumed only as a count hint to
+run_stdlib_rule_packs :2853), and — the real seam — `@stdlib/depends` consumes EVERY IMPORTS_FROM edge,
+node-type-agnostically via file join (derive/stdlib/depends.dl:1-6). So java IMPORTS_FROM already feed
+MODULE→MODULE DEPENDS_ON today, and §4's "the order is convention, not contract" is wrong at the stdlib
+level: `java_imports` MUST be registered before `depends` in BOTH ordering consts (rfdb-server
+derive/stdlib.rs `STDLIB_PACKS` and orchestrator main.rs:59-104 `STDLIB_RULE_PACKS` — the latter is the
+ordering contract, not "stdlib.rs:303-358"); `java_calls` (a CALLS producer) must precede the CALLS
+negators `method_calls`/`shape_verifier` (shape_verifier.dl:30 negates `edge(C,_,"CALLS")` with NO file
+gate). Also: the unresolved-diagnostics ISSUE generation queries the graph post-resolve for CALLs without
+CALLS / IMPORT_BINDINGs without IMPORTS_FROM (main.rs:2060-2085) — pack-coverage changes (S3, S11) will
+change the ISSUE population on `__grafema_virtual/unresolved-diagnostics`; exclude it from the diff.
+
+**C4 (minor, differential hygiene).** The `<unknown>` skip is dead-letter on BOTH sides: java `typeToName`
+emits `"<type>"` for unhandled types (Expressions.hs:1114), never `"<unknown>"` (that's the resolver's own
+vocabulary, TypeResolution.hs:92). Parity unaffected ("<type>" matches no class name), but the differential
+should not expect the ret_bad("<unknown>") arm to ever fire.
+
+Ready for packs: YES once C1/C3 are folded in (S8/S9 upgraded to full split parity; pack registration order
+pinned). The drafted rules are planner-legal as written.

--- a/_ai/research/lang-spec-kotlin.md
+++ b/_ai/research/lang-spec-kotlin.md
@@ -1,0 +1,552 @@
+# Migration spec: kotlin-resolve → derive packs (.dl)
+
+Authored 2026-06-12 against worktree HEAD `9ac0681c` (chore: release v0.4.0), branch feat/datalog lineage.
+Discipline per `_ai/research/resolve-datalog2-migration-specs.json` (js/rust precedent) and the synthesis
+ledger `_ai/research/resolve-datalog2-migration-synthesis.md` §3 (differential harness) / §5 (per-resolver verdicts).
+All file:line references verified by Read/grep in this worktree at this HEAD.
+
+---
+
+## spec.target
+
+`kotlin-resolve` (binary `kotlin-resolve`, packages/kotlin-resolve/src/ — 4 resolver modules + Main.hs
+dispatch `kotlin-imports` / `kotlin-types` / `kotlin-calls` / `kotlin-annotations` / `kotlin-all`,
+Main.hs:60-70). Driven by the orchestrator at main.rs:1601-1633: single-worker daemon pool, one
+`kotlin-all` command via `plugin::stream_and_resolve_single_worker(&[Language::Kotlin], ...)`
+(plugin.rs:1226-1253) — streams ALL nodes of `RESOLVE_NODE_TYPES` (analyzer.rs:3145-3202) whose `file`
+detects as Kotlin (i.e. `.kt`/`.kts` files only; cross-language nodes are NOT visible to this resolver —
+Java↔Kotlin is the separate `jvm-cross-resolve` at main.rs:1792+, OUT OF SCOPE here and untouched by
+this migration). IMPORTS_FROM edges from the output are additionally collected into
+`all_imports_from_edges` (main.rs:1620-1627) for the orchestrator's MODULE-DEPENDS_ON derivation —
+a pack replacement must keep feeding that seam (the `depends.dl` pack consumes IMPORTS_FROM as EDB,
+so pack ordering kotlin-packs → depends.dl replaces the in-memory collection).
+
+## spec.purpose
+
+Kotlin same-language cross-file resolution, 4 phases (Main.hs:64-70 `kotlin-all` runs all in one pass):
+- **kotlin-imports** (ImportResolution.hs): IMPORTS_FROM edges, IMPORT→class and IMPORT_BINDING→class.
+- **kotlin-types** (TypeResolution.hs): RETURNS, TYPE_OF, EXTENDS, IMPLEMENTS, THROWS_TYPE edges from
+  node metadata type names against a project-wide simple-name class index.
+- **kotlin-calls** (CallResolution.hs): CALLS + INSTANTIATES edges, 5 arms (constructor / same-class /
+  static-companion / super-this / extension).
+- **kotlin-annotations** (AnnotationResolution.hs): ANNOTATION_RESOLVES_TO edges ATTRIBUTE→annotation type.
+
+All emitted edges carry EMPTY metadata (every `mkEdge`/EmitEdge in all 4 modules: geMetadata = Map.empty)
+— no resolvedVia stamps, so parity diffing is by (src_sid, dst_sid, type) triples only.
+
+---
+
+## ANALYZER VOCABULARY (the EDB the packs will see)
+
+What `kotlin-analyzer` (packages/kotlin-analyzer/src/) actually commits. This section is load-bearing:
+several resolver arms read metadata the analyzer NEVER stamps — those arms are dead in production and
+the spec's parity baseline is "zero edges", verified per-arm below.
+
+### Node types emitted (complete list, grep `gnType =` over Rules/ + Analysis/)
+MODULE (Walker.hs:35, metadata `package` when present :44), CLASS (Declarations.hs:95 classes incl.
+interfaces/enums/annotation-classes — `kind` ∈ class|interface|enum|data|sealed|value|annotation|inner;
+:154 object decls `kind=object, singleton=true`; :609 companion `kind=companion`), FUNCTION
+(:207 top-level fn `kind=function`, :366 method `kind=method`, :504 secondary ctor `kind=secondary_constructor`
+name=`<constructor>`, :565 init block `kind=init_block` name=`init`, :730 primary ctor
+`kind=primary_constructor` name=ClassName), VARIABLE (:272/:444 properties `kind=property` (+`type` when
+declared :290/:463), :684 enum entry `kind=enum_entry`, :776/:839 params `kind=parameter`, :804 ctor-val-param
+property, Expressions.hs:659-:766 locals/catch/destructured), TYPE_ALIAS (:319), IMPORT (Imports.hs:58,
+metadata `path`=full dotted name, `glob` Bool, `alias` opt :67-71), IMPORT_BINDING (Imports.hs:92, metadata
+`imported_name`=leaf, `local_name`, `alias` opt :100-104; NO `source` key — the dotted source lives in the
+sid hash bracket and on the containing IMPORT's name), CALL (Expressions.hs:84 `method=true, argCount`,
+`receiver` only when non-empty :96; :137 safe-call adds `safe_call=true`; :192 ObjectCreation
+`kind=constructor_call`, name=ClassName, NO receiver), PROPERTY_ACCESS (:243), REFERENCE (:278), CLOSURE
+(:328), LITERAL (:372), BRANCH, SCOPE, PARAMETER (:798), TYPE_PARAMETER (Types.hs:224), ATTRIBUTE
+(Annotations.hs:122/:177/:214, name=annotation simple name, `kind` classification).
+
+**NEVER emitted by kotlin-analyzer**: INTERFACE, ENUM, OBJECT, ANNOTATION_TYPE node types (everything is
+CLASS + `kind`). The resolver's index arms over those types (ImportResolution.hs:60, CallResolution.hs:55,
+TypeResolution.hs:60, AnnotationResolution.hs:33) are vacuous for the Kotlin-only node stream.
+
+### Edges emitted by the analyzer (already in EDB before resolve)
+CONTAINS (scope→node everywhere; **IMPORT→IMPORT_BINDING** Imports.hs:107-112 — the graph-reachable
+source-path seam, rust_imports.dl precedent), HAS_METHOD (CLASS→method FUNCTION Declarations.hs:401-409,
+CLASS→primary-ctor :752-757, CLASS→secondary-ctor :526-534), HAS_PROPERTY, HAS_ATTRIBUTE
+(decl→ATTRIBUTE Annotations.hs:142-147), COMPANION_OF (:636), DERIVES (enum entry :709), CATCHES,
+THROWS (ErrorFlow.hs:119 — emitted directly in analysis, NOT by the resolver), ITERATES_OVER.
+CALL CONTAINS-source = the enclosing FUNCTION node (method/fn body walks `withScope fnScope` with
+scopeId=fn nodeId, Declarations.hs:417-428; ctor :540-549; init :585-592) or CLOSURE (lambda re-scope,
+Expressions.hs:354 — the ONLY other re-scope; ControlFlow never re-scopes) or module scope (top level).
+
+### Semantic-id shape (SemanticId.hs:21-29)
+`file->TYPE->name[in:Parent,h:Hash]`. Methods: parent = enclosing CLASS name (Declarations.hs:356
+parent=askNamedParent). CALL: parent = enclosing FUNCTION **name** (Expressions.hs:75 `encFn >>= extractName`)
+— NOT the class. Primary ctor: parent=Nothing, h:primary_ctor (:723). This asymmetry kills two resolver
+arms (steps 5, 7 below).
+
+### THE DEFERRED-REF DROP (production-truth keystone)
+The analyzer routes every cross-file intention through `emitDeferred` DeferredRef (Context.hs:84-85):
+EXTENDS/IMPLEMENTS supertypes (Types.hs:166-180), RETURNS/TYPE_OF type refs (:183-201), CALLS
+(Expressions.hs:104-117), IMPORTS_FROM (Imports.hs:117-130), serialized as `unresolvedRefs` in
+FileAnalysis JSON (Types.hs:160-166). **The orchestrator's FileAnalysis struct has NO `unresolvedRefs`
+field (analyzer.rs:41-48) — serde silently drops them.** Consequence: supertype names exist NOWHERE in
+the committed graph (not as metadata, not as edges). Verified by the resolver-side greps below and live
+probe (kt EXTENDS edges = 0; though dogfood has 0 kt nodes at all — see HONESTY).
+
+---
+
+## spec.sub_steps
+
+Format per step: reads / writes / production-truth / expressible / blockers / delta classes / draft rules.
+File gate `kt(F) :- ends_with(F, ".kt"). kt(F) :- ends_with(F, ".kts").` is the cross-language leakage
+guard on every base relation (rust_imports.dl DELTA-5 precedent; CLASS/IMPORT/CALL are shared vocabulary).
+Shared prelude used by several steps:
+
+```prolog
+kt(F) :- ends_with(F, ".kt").
+kt(F) :- ends_with(F, ".kts").
+% class index, simple name (CallResolution.hs:50-58 / TypeResolution.hs:57-65 — CLASS only is live):
+kt_class(N, F, C) :- node(C, "CLASS"), attr(C, "file", F), kt(F), attr(C, "name", N).
+% qualified-name class index (ImportResolution.hs:53-71): package from the file's MODULE node
+kt_module(F, M) :- node(M, "MODULE"), attr(M, "file", F), kt(F).
+kt_pkg(F, P) :- kt_module(F, M), node_attr(M, "package", P).
+has_pkg(F) :- kt_pkg(F, _).
+kt_qclass(Q, F, C) :- kt_class(N, F, C), kt_pkg(F, P), concat(P, ".", PD), concat(PD, N, Q).
+kt_qclass(N, F, C) :- kt_class(N, F, C), \+ has_pkg(F).
+```
+
+### Step 1 — kotlin-imports: IMPORT → class (`resolveImport`, ImportResolution.hs:86-109)
+- **reads**: IMPORT nodes (name = full dotted path, first-class), metadata `asterisk` (Bool) — **analyzer
+  stamps `glob`, not `asterisk` (Imports.hs:69) → isAsterisk is ALWAYS False in production**; glob imports
+  fall through to the qualified lookup and miss (name "com.example.*" is no class key) — accidentally the
+  same skip, so behavior is unchanged. Qualified class index (package + "." + simple name).
+- **writes**: IMPORTS_FROM edge IMPORT→CLASS-node (NB: doc comment says "to MODULE nodes" :17 — the code
+  targets the class node :99-104), empty metadata.
+- **production-truth**: LIVE arm. External imports (stdlib/3rd-party) silently skipped (:109).
+- **expressible**: **fully, today** (node/attr/node_attr/concat/negation).
+- **blockers**: none.
+- **deltas**: D1 SUPERSET — duplicate qualified names across files: Haskell `Map.insert` last-wins
+  (ImportResolution.hs:70) keeps ONE arbitrary winner; set semantics derives all (bound = count of
+  duplicate (package,className) pairs, measurable). D2 EXACT — glob imports: no edge both sides.
+- **draft_rules**:
+```prolog
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+kt_import_class(I, C) :-
+    node(I, "IMPORT"), attr(I, "file", IF), kt(IF), attr(I, "name", Q),
+    kt_qclass(Q, _, C).
+```
+
+### Step 2 — kotlin-imports: IMPORT_BINDING → class (`resolveBinding`, ImportResolution.hs:111-167)
+- **reads**: IMPORT_BINDING (name=localName), metadata `source` — **analyzer never stamps `source`
+  (Imports.hs:100-104 stamps imported_name/local_name/alias only) → the source arm is dead; falls to
+  the importedName-only arm (:124-135)**: leaf name ("Foo") looked up against QUALIFIED keys
+  ("com.example.Foo") → matches only classes in package-less files.
+- **writes**: IMPORTS_FROM edge IMPORT_BINDING→CLASS, empty metadata.
+- **production-truth**: NEAR-DEAD — resolves only into files without a `package` declaration (rare in
+  real Kotlin). The dotted source IS graph-reachable: IMPORT -CONTAINS-> IMPORT_BINDING + IMPORT.name
+  (Imports.hs:107-112), the exact rust_imports.dl Phase-3 pattern.
+- **expressible**: **fully, today** — both the exact-parity arm and the corrected arm.
+- **blockers**: none.
+- **deltas**: D1 (exact-parity arm) EXACT vs legacy. D2 (corrected arm, RECOMMENDED) SUPERSET —
+  resolves every binding whose containing IMPORT's full path names a project class; bound = count of
+  IMPORT_BINDING with a CONTAINS-parent IMPORT resolving in step 1 minus legacy's package-less matches.
+  Aliased imports: localName=alias, but the join is via the IMPORT's path — alias-correct for free
+  (legacy's imported_name arm was alias-correct too, when it matched at all).
+- **draft_rules**:
+```prolog
+% exact-parity arm (replicates the importedName-vs-qualified-keys accident):
+kt_binding_parity(B, C) :-
+    node(B, "IMPORT_BINDING"), attr(B, "file", BF), kt(BF),
+    node_attr(B, "imported_name", N), kt_qclass(N, _, C).
+% corrected arm (the rust precedent — source via the CONTAINS seam; RECOMMENDED, declared superset):
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+kt_binding_import(B, C) :-
+    node(B, "IMPORT_BINDING"), attr(B, "file", BF), kt(BF),
+    incoming(B, I, "CONTAINS"), node(I, "IMPORT"), attr(I, "name", Q),
+    kt_qclass(Q, _, C).
+```
+  (Ship ONE of the two arms — both together double-derive the package-less case; additive mode dedups
+  identical (src,dst,type) but keep the program honest.)
+
+### Step 3 — kotlin-types: RETURNS (`resolveReturns`, TypeResolution.hs:130-141)
+- **reads**: FUNCTION metadata `return_type` — STAMPED (Declarations.hs:229 top-level, :394 methods);
+  normalize = strip `[]` (T.replace), strip trailing `?`, skip 30-entry builtin table (:38-55), skip
+  `<unknown>` and wildcard-containing; simple-name class index (CROSS-FILE, no package check :57-65).
+- **writes**: RETURNS edges FUNCTION→CLASS, empty metadata.
+- **production-truth**: LIVE arm. Generic args already dropped at stamp time (typeToName keeps base name,
+  Expressions.hs:860-862, nullable suffix `?` kept).
+- **expressible**: **fully, today** (node_attr + replace_all + strip_suffix + fact table + negation).
+- **blockers**: none.
+- **deltas**: D1 SUPERSET — duplicate simple class names across files (Map last-wins :64 vs all
+  candidates); bound = count of duplicate kt CLASS simple names. D2 EXACT — builtin/primitive skips
+  (the 30 names become ground facts, generated verbatim from TypeResolution.hs:38-55).
+- **draft_rules**:
+```prolog
+kt_builtin_type("Int"). kt_builtin_type("Long"). % ... ×30, generated from TypeResolution.hs:38-55
+% normalize: strip [] then trailing ? ; two-clause ladder (strip_suffix is a miss when absent)
+ty_norm0(T, R) :- bound_in_context, replace_all(T, "[]", "", R).   % see NOTE below
+ty_base(T, B) :- ty_norm0(T, S), strip_suffix(S, "?", B).
+ty_base(T, S) :- ty_norm0(T, S), \+ ends_with(S, "?").
+ty_ok(B) :- \+ kt_builtin_type(B), \+ string_contains(B, "?"), neq(B, "<unknown>").
+@materialize(edge_type = "RETURNS", mode = "additive")
+kt_returns(Fn, C) :-
+    node(Fn, "FUNCTION"), attr(Fn, "file", F), kt(F),
+    node_attr(Fn, "return_type", T), ty_base(T, B), ty_ok(B),
+    kt_class(B, _, C).
+```
+  NOTE: write `ty_base` inline in each consumer (the helper as shown is unsafe-headed); the inline
+  spelling is the established pack idiom — pseudo-helper shown for readability only.
+- **NOT carried over (recorded, deliberate)**: TypeResolution.hs builds a `_methodIdx` it never uses
+  (:139, leading underscore) — dead code, nothing to migrate.
+
+### Step 4 — kotlin-types: TYPE_OF (`resolveTypeOf`, TypeResolution.hs:143-154)
+- **reads**: VARIABLE metadata `type` — stamped ONLY on properties with declared types
+  (Declarations.hs:290 top-level, :463 member; NOT on parameters/locals/ctor-val-params).
+- **writes**: TYPE_OF edges VARIABLE→CLASS.
+- **production-truth**: LIVE, properties only.
+- **expressible**: **fully, today** — same shape as step 3 with `node_attr(V, "type", T)`.
+- **deltas**: same SUPERSET class as step 3 (duplicate simple names).
+- **draft_rules**: as step 3 with `node(V, "VARIABLE")` + `node_attr(V, "type", T)`,
+  `@materialize(edge_type = "TYPE_OF", mode = "additive")`.
+
+### Step 5 — kotlin-types: EXTENDS + IMPLEMENTS (`resolveExtends`/`resolveImplements`, TypeResolution.hs:156-183)
+- **reads**: CLASS/&c metadata `extends` (single) and `implements` (comma-separated, splitTypes :118).
+- **production-truth**: **DEAD — ZERO edges.** The analyzer NEVER stamps `extends`/`implements` metadata
+  (grep over Rules/*.hs: no such keys; supertypes go ONLY into deferred InheritanceResolve refs,
+  Types.hs:163-180, which the orchestrator drops — analyzer.rs:41-48). Kotlin classes have NO
+  inheritance edges in the production graph at all. This is the kotlin analog of the js superClass
+  story (js_class_inheritance.dl header), except the data is missing entirely rather than metadata-only.
+- **expressible**: rules trivially expressible TODAY (same shape as js_class_inheritance.dl A1), but
+  the EDB lacks the input — **blocked on analyzer-side data, not on the engine**.
+- **blockers**: ANALYZER CHANGE — stamp `extends` / `implements` (comma-joined) metadata on CLASS at
+  emission (Declarations.hs:89-118 has the supertype list in scope at walkDeclaration ClassDecl;
+  Types.hs:40-60 already classifies first-super-vs-interfaces). One-line-class change + version bump.
+- **deltas**: until the stamp lands: pack emits 0, legacy emits 0 — EXACT-zero parity, SHIP THE PACK
+  EMPTY-SAFE. After the stamp: declared SUPERSET vs legacy-zero (entirely new edges; bound = count of
+  kt classes with supertypes).
+- **draft_rules** (active the day the analyzer stamps):
+```prolog
+@materialize(edge_type = "EXTENDS", mode = "additive")
+kt_extends(C, T) :-
+    node(C, "CLASS"), attr(C, "file", F), kt(F),
+    node_attr(C, "extends", SN), ty_base(SN, B), ty_ok(B),
+    kt_class(B, _, T), neq(C, T).
+% implements: comma-split has no builtin — REQUIRES either analyzer stamping ONE name per key
+% (implements_0, implements_1, …) or a split-style builtin; see missing_capabilities #2.
+```
+
+### Step 6 — kotlin-types: THROWS_TYPE (`resolveThrows`, TypeResolution.hs:185-196)
+- **reads**: FUNCTION metadata `throws` (comma-separated).
+- **production-truth**: **DEAD — ZERO edges.** Analyzer never stamps `throws` (Kotlin has no checked
+  exceptions; only `error_exit_count` MetaInt is stamped, Declarations.hs:226). Throw-site edges are the
+  analyzer's own THROWS (ErrorFlow.hs:119), unrelated to this arm.
+- **expressible**: n/a — no input data, and none is coming (language semantics). **DROP, do not port.**
+- **deltas**: EXACT-zero by omission.
+
+### Step 7 — kotlin-calls: constructor calls (`resolveConstructorCalls`, CallResolution.hs:199-238)
+- **reads**: CALL with `kind=constructor_call` metadata (stamped, Expressions.hs:201) or name prefixed
+  `"new "` (never produced by the kotlin analyzer — Java-compat arm, vacuous on the .kt stream);
+  simple-name class index; constructor index.
+- **writes**: INSTANTIATES CALL→CLASS (live) + CALLS CALL→ctor-FUNCTION (see production-truth).
+- **production-truth**: INSTANTIATES arm LIVE. **The CALLS→constructor arm is provably DEAD: the
+  constructor index is ALWAYS EMPTY** (CallResolution.hs:75-95): primary ctors have kind
+  `primary_constructor` ✓ but sid `file->FUNCTION->Foo[h:primary_ctor]` with NO `[in:]` (parent=Nothing,
+  Declarations.hs:723) → extractParentClass=Nothing → skipped; secondary ctors have `[in:Foo]` ✓ but
+  kind `secondary_constructor` (:513) ∉ {"constructor","primary_constructor"} (:91-94) → skipped.
+- **expressible**: **fully, today.** INSTANTIATES = node_attr + name join. The ctor-CALLS arm has a
+  graph-native CORRECTED form (CLASS -HAS_METHOD-> primary-ctor FUNCTION, Declarations.hs:752-757) —
+  exact-parity (zero) needs nothing.
+- **deltas**: D1 SUPERSET — duplicate class simple names (set vs Map last-wins). D2 (only if the
+  corrected ctor arm ships) SUPERSET vs legacy-zero: CALLS to primary+secondary ctors; bound = count of
+  constructor_call CALLs whose class resolves. Recommendation: ship INSTANTIATES at parity in wave 1;
+  ship the ctor-CALLS correction behind the same pack with the delta declared.
+- **draft_rules**:
+```prolog
+ctor_call(C, N, F) :-
+    node(C, "CALL"), attr(C, "file", F), kt(F), attr(C, "name", N),
+    node_attr(C, "kind", "constructor_call").
+@materialize(edge_type = "INSTANTIATES", mode = "additive")
+kt_instantiates(C, Cls) :- ctor_call(C, N, _), kt_class(N, _, Cls).
+% corrected ctor-CALLS arm (declared superset vs legacy-zero):
+@materialize(edge_type = "CALLS", mode = "additive")
+kt_ctor_call(C, Ctor) :-
+    ctor_call(C, N, _), kt_class(N, _, Cls),
+    edge(Cls, Ctor, "HAS_METHOD"), node_attr(Ctor, "kind", "primary_constructor").
+```
+
+### Step 8 — kotlin-calls: same-class method calls (`resolveSameClassCalls`, CallResolution.hs:240-262)
+- **reads**: CALL with no receiver / receiver="this" (`receiver` metadata, stamped only when non-empty,
+  Expressions.hs:96); methodIdx keyed by the FUNCTION sid's `[in:Class]`; the CALL's own `[in:…]`.
+- **production-truth**: **EFFECTIVELY DEAD (coincidence-only).** The CALL sid's `[in:]` is the enclosing
+  FUNCTION's name (Expressions.hs:75), the methodIdx key is the enclosing CLASS name
+  (Declarations.hs:356) — the join `(extractParentClass call, callName)` vs `(className, methodName)`
+  matches only when a class happens to share the enclosing function's name. Cannot be replicated
+  byte-for-byte in a pack anyway: the semantic-id STRING is not on the attr row surface (attr "id"
+  returns the u128, builtin.rs:548-551) — and replicating a name-collision accident has negative value.
+- **expressible**: the CORRECTED semantics is **fully expressible today**, graph-natively: enclosing
+  function via incoming CONTAINS from FUNCTION (Declarations.hs:417-428 — scope source IS the fn node;
+  one recursive hop through CLOSURE for lambda bodies, Expressions.hs:354), enclosing class via
+  HAS_METHOD, member lookup via HAS_METHOD+name. Same substitution the js spec used for `[in:]` parsing.
+- **deltas**: declared SUPERSET vs legacy ~zero (bound: count of receiverless/this CALLs inside methods
+  whose class has a matching member; legacy baseline measurable as the count of (fn-name==class-name)
+  collisions — expected 0 on real code). Overloads: all candidates derived vs legacy head-of-list.
+- **draft_rules**:
+```prolog
+encl_fn(X, Fn) :- incoming(X, Fn, "CONTAINS"), node(Fn, "FUNCTION").
+encl_fn(X, Fn) :- incoming(X, L, "CONTAINS"), node(L, "CLOSURE"), encl_fn(L, Fn).
+encl_class(X, Cls) :- encl_fn(X, Fn), incoming(Fn, Cls, "HAS_METHOD").
+has_recv(C) :- node_attr(C, "receiver", _).
+self_recv(C) :- \+ has_recv(C).
+self_recv(C) :- node_attr(C, "receiver", "this").
+plain_call(C, N, F) :-
+    node(C, "CALL"), attr(C, "file", F), kt(F), attr(C, "name", N),
+    \+ node_attr(C, "kind", "constructor_call"), self_recv(C).
+@materialize(edge_type = "CALLS", mode = "additive")
+kt_same_class_call(C, M) :-
+    plain_call(C, N, _), encl_class(C, Cls),
+    edge(Cls, M, "HAS_METHOD"), attr(M, "name", N).
+```
+
+### Step 9 — kotlin-calls: static/companion calls (`resolveStaticCalls`, CallResolution.hs:264-285)
+- **reads**: CALL `receiver` metadata = a class simple name; classIdx membership gate; methodIdx
+  (receiver, callName).
+- **production-truth**: **LIVE** — the one CALLS arm that actually works: `Foo.create()` with `create`
+  a direct member of class/object/companion `Foo` (receiver name must equal the indexed class's gnName;
+  companion members resolve only under receiver `Companion`, the companion CLASS's own name,
+  Declarations.hs:600-609 — `Foo.create()` for a companion member does NOT match legacy either, since
+  methodIdx keys companion members under "Companion").
+- **expressible**: **fully, today** — methodIdx ≡ HAS_METHOD join (both derive from the same
+  NamedParent context; HAS_METHOD emitted for methods :401-409, primary :752, secondary :526).
+  Divergence: methodIdx also contains FUNCTIONs nested inside method bodies (withNamedParent=method
+  name, Declarations.hs:425) under the method-name key — those fire only if a CLASS shares the method's
+  name AND has no real member of that call name; HAS_METHOD doesn't contain them. SUBSET delta, bound =
+  count of (class-name==method-name) collisions, expected 0.
+- **deltas**: D1 SUBSET as above (≈0). D2 SUPERSET — overloads: all candidates vs head-of-list (:280).
+- **draft_rules**:
+```prolog
+@materialize(edge_type = "CALLS", mode = "additive")
+kt_static_call(C, M) :-
+    node(C, "CALL"), attr(C, "file", F), kt(F), attr(C, "name", N),
+    \+ node_attr(C, "kind", "constructor_call"),
+    node_attr(C, "receiver", R), neq(R, "this"), neq(R, "super"),
+    kt_class(R, _, Cls), edge(Cls, M, "HAS_METHOD"), attr(M, "name", N).
+```
+  (Legacy gate `isSuperOrThisCall` :268 excludes name super/this — see step 10: those nodes don't exist,
+  the receiver-neq guards are belt-and-braces.)
+
+### Step 10 — kotlin-calls: super()/this() delegation (`resolveSuperThisCalls`, CallResolution.hs:287-318)
+- **reads**: CALL named "super"/"this" or `isThis` metadata; ctorIdx; extendsIdx (CLASS `extends` metadata :97-104).
+- **production-truth**: **DEAD, three independent ways**: (a) the parser/analyzer IGNORES constructor
+  delegation (`SecondaryConstructor mods params _delegation _delegArgs`, Declarations.hs:490 — wildcards)
+  → no CALL nodes named super/this exist; (b) `isThis` is never stamped; (c) both ctorIdx (step 7 proof)
+  and extendsIdx (step 5 proof — no `extends` metadata) are always empty.
+- **expressible**: n/a today — no input data. **DROP from wave 1; revisit only after the analyzer emits
+  delegation CALLs + extends metadata** (then it's an easy HAS_METHOD/primary_constructor + extends join).
+- **deltas**: EXACT-zero by omission.
+
+### Step 11 — kotlin-calls: extension function calls (`resolveExtensionCalls`, CallResolution.hs:320-339)
+- **reads**: CALL with `extension=true` + `receiverType` metadata; extension index (FUNCTION
+  extension=true + receiverType, stamped ✓ Declarations.hs:224/228, :385+).
+- **production-truth**: **DEAD** — the analyzer stamps extension/receiverType on FUNCTIONs only, NEVER
+  on CALL nodes (Expressions.hs CALL metadata = method/argCount/receiver/safe_call/kind only). The
+  filter `getMetaBool "extension" node == Just True` on CALLs never passes.
+- **expressible**: rules expressible today, input data missing — **blocked on analyzer stamping CALL-side
+  receiver-type inference** (a static-typing judgment; substantial analyzer work, NOT a quick stamp).
+- **deltas**: EXACT-zero by omission. (The resolver's own unit test :267-295 feeds synthetic CALL
+  metadata the analyzer never produces — tests assert capability, not production behavior.)
+
+### Step 12 — kotlin-annotations (`resolveAnnotations`, AnnotationResolution.hs:28-55)
+- **reads**: ATTRIBUTE nodes (name = annotation simple name, Annotations.hs:112-133); index of
+  ANNOTATION_TYPE nodes (never emitted by kotlin-analyzer → vacuous on the .kt stream) ∪ CLASS with
+  `kind=annotation` (live — Kotlin `annotation class`, Declarations.hs kind taxonomy).
+- **writes**: ANNOTATION_RESOLVES_TO edges ATTRIBUTE→CLASS.
+- **production-truth**: LIVE for project-internal Kotlin annotation classes; external annotations skipped.
+- **expressible**: **fully, today**.
+- **deltas**: D1 SUPERSET — duplicate annotation-class simple names (set vs Map last-wins :36).
+- **draft_rules**:
+```prolog
+@materialize(edge_type = "ANNOTATION_RESOLVES_TO", mode = "additive")
+kt_annotation(A, T) :-
+    node(A, "ATTRIBUTE"), attr(A, "file", F), kt(F), attr(A, "name", N),
+    node(T, "CLASS"), attr(T, "name", N), attr(T, "file", TF), kt(TF),
+    node_attr(T, "kind", "annotation").
+```
+
+### Step 13 — wire/seam obligations (not a resolver step, but part of the migration surface)
+- The orchestrator currently collects kotlin IMPORTS_FROM into `all_imports_from_edges`
+  (main.rs:1620-1627). Pack ordering: kotlin import packs MUST be declared BEFORE `depends.dl` (its
+  IMPORTS_FROM-consuming clauses) — the shape_verifier.dl/rust_imports.dl ordering-contract pattern.
+- `jvm-cross-resolve` (main.rs:1792+) consumes the same node vocabulary natively and stays; the kt()
+  file gate guarantees the packs never collide with its Java-side outputs.
+- Removal of the kotlin resolve invocation = deleting main.rs:1601-1633 + the `kotlin-resolve` binary
+  from the binaries_to_check (main.rs:841-843) once packs are gated in.
+
+---
+
+## spec.missing_capabilities
+
+Ranked. THE HEADLINE: **the v0.4.0 builtin kit (builtin.rs:1188-1373 — node_attr, strip_prefix/suffix,
+path_resolve, replace_all, last_segment, concat, method_suffix, …) is SUFFICIENT for every arm of
+kotlin-resolve that is alive in production.** Every remaining blocker is DATA-side (analyzer emission)
+or a wire convention — none is an engine builtin gap, in sharp contrast to the js spec's era.
+
+1. **ANALYZER: stamp `extends`/`implements` on CLASS nodes** (Declarations.hs walkDeclaration ClassDecl —
+   the supertype list is in scope; Types.hs:40-60 already separates first-super from interfaces).
+   Unblocks step 5 (kotlin inheritance — currently ZERO edges in the entire production graph). The
+   root cause is structural: the orchestrator drops `unresolvedRefs` (analyzer.rs:41-48) and nobody
+   noticed because the resolver's metadata arms silently no-op. Highest value per line of change.
+2. **List-valued metadata convention** for `implements` (and any future comma-joined stamp): either
+   indexed keys (`implements_0…n`, ugly but works with node_attr today) or a `split(S, Sep, Elem)`
+   generator builtin (engine change, mode [B,B,F] multi-row — the only genuinely new engine capability
+   this spec would request, and only for the implements arm).
+3. **ANALYZER: emit delegation CALLs** (`this(...)`/`super(...)` — currently discarded wildcards,
+   Declarations.hs:490) — unblocks step 10.
+4. **ANALYZER: CALL-side receiver-type inference** (`extension`/`receiverType` on CALL) — unblocks
+   step 11 (extension calls). Substantial analysis work; lowest priority.
+5. (Hygiene, not a blocker) the resolver's `asterisk`/`source` reads vs the analyzer's `glob`/`path`
+   stamps — vocabulary drift that the packs simply do not inherit; record in the analyzer's vocabulary
+   doc so future arms don't re-diverge.
+6. NO new string/path builtins, NO node-minting, NO same-run-edge needs: kotlin packs emit edges between
+   existing nodes only, all modes "additive", no @materialize_node anywhere.
+
+## spec.differential_acceptance
+
+SETUP — **the dogfood graph CANNOT gate this migration**: live probe on a /tmp copy of
+`.grafema/graph.rfdb` (491,535 nodes / 1,037,299 edges loaded) returned **0 nodes and 0 edges for every
+kt-file-gated query** (MODULE/CLASS/CALL/IMPORT/IMPORT_BINDING/FUNCTION/ATTRIBUTE/VARIABLE; CALLS/
+IMPORTS_FROM/INSTANTIATES/EXTENDS/RETURNS/TYPE_OF/ANNOTATION_RESOLVES_TO) — the orchestrator config's
+include globs are ts/hs/rs only (`.grafema/orchestrator.config.yaml:2-14`), so the repo's 3 .kt files
+(packages/kotlin-parser/src/main/kotlin/com/grafema/parser/*.kt) were never analyzed.
+
+Gate instead on a FIXTURE PROJECT: (a) minimum viable = the repo's own kotlin-parser .kt sources +
+a synthetic package exercising each live arm (imports w/ and w/o package, aliased import, glob import,
+properties with declared types, constructor calls, companion-receiver calls, annotation classes,
+duplicate simple names for the superset bounds); (b) analyze twice from the same checkout — DB_legacy
+(kotlin resolve ON, packs OFF) vs DB_pack (skip_resolver("kotlin"), packs ON in declared order) — and
+diff per step by (src_sid, dst_sid, type) triples (legacy edges carry empty metadata, so no metadata
+column in the diff key; pack provenance _source/_generation excluded as always).
+
+DECLARED DELTA CLASSES (predictions-first; any delta outside these = stop, witness, classify):
+- EXACT: step 1 (modulo D1), step 2 parity-arm, glob-import skips, builtin-type skips,
+  steps 6/10/11 (zero-by-omission vs zero-by-deadness — assert BOTH sides are literally zero on the
+  fixture: `edge(_,_,"THROWS_TYPE")` count 0 in DB_legacy is itself a required check).
+- SUPERSET, bounded: duplicate-name set-semantics (steps 1/3/4/12 — bound = measured duplicate-key
+  counts on the fixture), overload all-candidates (step 9), corrected arms IF shipped (step 2 corrected,
+  step 7 ctor-CALLS, step 8 same-class — bound each by the candidate-join count, and verify every extra
+  edge with a why()/explain_datalog_fact witness + manual source read).
+- SUBSET, bounded ≈0: step 9 nested-fn methodIdx accident (bound = class-name==method-name collisions).
+ACCEPTANCE per pack: zero unexpected deltas + per-class counted bounds + a stdlib.rs fixture test per
+pack (established pattern) + the step-5/6/10/11 zero-assertions on DB_legacy (they document the dead
+arms as executable evidence).
+
+## spec.expected_speedup_rationale
+
+Honest framing: kotlin volume in known target graphs is currently ZERO (dogfood) to small — this
+migration's value is NOT wall-clock, it is (a) retiring a whole Haskell daemon binary + process pool +
+full-node-set msgpack stream from the per-run path (plugin.rs:1226-1253 collects and ships every
+RESOLVE_NODE_TYPES node of the language per command), (b) making 6 of 12 resolver arms' production
+deadness EXPLICIT and inspectable (why()-able) instead of silently vacuous, and (c) the step-5 analyzer
+stamp turning kotlin inheritance from non-existent to derived. The packs are small pure joins over
+name/file/node_attr probes (the build-once hash-join class — method_calls.dl precedent: 4-20s on a 415k
+graph, and the kt-gated base relations will be orders smaller). Maintain envelope: every pack uses
+node_attr and/or negation ⇒ scratch floor on maintain (same accepted stance as every import pack —
+rust_imports.dl MAINTAIN ENVELOPE note).
+
+## spec.honesty — what is NOT expressible / not known
+
+1. **Byte-exact replication of the `[in:]` sid-parse arms is NOT expressible** (steps 5/7/8: the
+   semantic-id string is not on the attr surface — attr "id" yields the u128, builtin.rs:548-551).
+   Irrelevant for parity (those arms are dead or coincidence-only) but it means the packs CANNOT
+   reproduce the legacy name-collision false positives — pack-vs-legacy diffs on a fixture engineered
+   with such collisions will show legacy-only edges that are BUGS, not coverage.
+2. **`implements` comma-split** is inexpressible today (no split builtin; fact-enumeration impossible
+   for open-ended names) — moot until the analyzer stamps the key at all; the indexed-keys convention
+   (missing_capabilities #2) avoids the engine change entirely.
+3. **Wildcard (glob) import binding-level resolution** ("handled at binding level" per the comment,
+   ImportResolution.hs:14) is handled NOWHERE — glob imports produce an IMPORT node and nothing else
+   in both legacy and pack. Not a regression; recorded as a (pre-existing) coverage gap.
+4. **Ground truth for production behavior is code-derived, not graph-derived**: zero kotlin nodes exist
+   in the dogfood graph (live-probe evidence above), so every dead-arm claim rests on cross-module
+   source analysis (analyzer stamp inventory vs resolver read inventory, file:line cited per step) plus
+   the package's unit suites (kotlin-resolve/test/Spec.hs:59-378 — NB its fixtures hand-feed metadata
+   the analyzer never emits: `source` on bindings :76-89, `extends`/`implements` :134-170, `kind=
+   "constructor"` ctors :232-244, CALL-side `extension`/`receiverType` :267-295 — the tests assert the
+   resolver's CAPABILITY, and are exactly how the vocabulary drift went unnoticed). A fixture-project
+   analyze run (differential SETUP above) is REQUIRED before gating; if it contradicts any dead-arm
+   claim here, the spec must be corrected first (verify-before-recording).
+5. **kotlin-parser is a JVM binary** (packages/kotlin-parser, Kotlin sources) — the analyze phase
+   itself stays untouched by this migration; only the resolve daemon is replaced.
+6. `.kts` script files: detect_language mapping for Kotlin includes them or not — NOT verified in this
+   pass (config.rs detect_language test :1252 checks .kt only). The kt() gate above includes .kts
+   defensively; align it with detect_language before shipping (one-line check).
+
+## appendix: per-arm production-liveness verdict table
+
+| # | arm | legacy production output | pack wave |
+|---|-----|--------------------------|-----------|
+| 1 | IMPORT→class | LIVE | wave 1, EXACT+D1 |
+| 2 | IMPORT_BINDING→class | near-dead (package-less only) | wave 1, corrected (declared superset) |
+| 3 | RETURNS | LIVE | wave 1, EXACT+superset(dup names) |
+| 4 | TYPE_OF | LIVE (properties only) | wave 1, EXACT+superset(dup names) |
+| 5 | EXTENDS/IMPLEMENTS | DEAD (no metadata; deferred refs dropped) | pack ready; blocked on analyzer stamp |
+| 6 | THROWS_TYPE | DEAD (no such Kotlin data) | drop forever |
+| 7 | INSTANTIATES / ctor-CALLS | LIVE / DEAD (ctorIdx provably empty) | wave 1 / corrected optional |
+| 8 | same-class CALLS | dead-coincidence ([in:] fn-vs-class mismatch) | wave 1 corrected (declared superset) |
+| 9 | static/companion CALLS | LIVE | wave 1, EXACT+overload superset |
+| 10 | super()/this() | DEAD (delegation discarded by analyzer) | drop until analyzer emits |
+| 11 | extension CALLS | DEAD (no CALL-side metadata) | drop until analyzer infers |
+| 12 | ANNOTATION_RESOLVES_TO | LIVE (kotlin annotation classes) | wave 1, EXACT+superset(dup names) |
+
+---
+
+# VERDICT (adversarial review, 2026-06-12, worktree HEAD 9ac0681c)
+
+**VERDICT: APPROVE WITH CORRECTIONS (draft-rule respellings required).** Every dead-arm finding re-verified
+in source: ctorIdx provably empty (CallResolution.hs:74-95 re-read — isConstructor accepts only
+"constructor"/"primary_constructor", secondary ctors are kind=secondary_constructor Declarations.hs:513,
+primary ctors have parent=Nothing in the sid Declarations.hs:723 → extractParentClass=Nothing); analyzer
+stamps NO extends/implements metadata (grep over kotlin-analyzer Rules/: zero hits outside a Types.hs:50
+comment); FileAnalysis drops unresolvedRefs (analyzer.rs:41-49 re-read); constructor delegation discarded
+(`_delegation _delegArgs` wildcards, Declarations.hs:490); CALL metadata = method/argCount/receiver/
+safe_call/kind only (Expressions.hs:93-203 re-read — no extension/receiverType); IMPORT→IMPORT_BINDING
+CONTAINS seam exists (Imports.hs re-read); resolveBinding's importedName fallback confirmed (the
+"package-less only" near-dead reading is correct); annotation index = ANNOTATION_TYPE ∪ CLASS kind=annotation
+(AnnotationResolution.hs:25-36). Emit-site inventory complete (re-grepped all mkEdge/EmitEdge: 4 import
+sites, 5 type sites, 7 call sites incl. extension :283, 1 annotation site — all mapped to steps).
+Orchestrator/seam cites verified (main.rs:1602-1633, skip_resolver, plugin streaming). Corrections:
+
+**C1 (draft-rule BUG — the shared prelude is planner-illegal).** `kt(F) :- ends_with(F, ".kt").` is an
+unsafe rule: `ends_with` is a FILTER with the single mode [B,B] (builtin.rs FILTER2_MODES) — it cannot
+generate F, so the rule fails E-PLAN-001/002 and the whole program is rejected. No stdlib pack defines a
+filter-helper relation; the established spelling inlines the gate (`attr(C,"file",F), ends_with(F,".kt")`)
+per base relation — exactly what the java/go sibling specs draft. Every rule using `kt(F)` must be
+respelled (mechanical; the kt()/kts() disjunction becomes two clauses per base relation or one derived
+base relation per node type carrying the file gate inside).
+
+**C2 (draft-rule BUG — step 8).** `has_recv(C) :- node_attr(C, "receiver", _).` is illegal: node_attr has
+NO generator mode — the node id must be bound (builtin.rs NODE_ATTR_MODES [B,B,F]/[B,B,B] only,
+"deliberately NO generator mode"). And `self_recv(C) :- \+ has_recv(C).` is unsafe-headed (C unbound).
+Respell as `has_recv(C) :- node(C,"CALL"), node_attr(C,"receiver",R), neq(R,"this").` and use
+`\+ has_recv(C)` inline in plain_call (the java spec's S11 shape). Same class of fix: step 3's `ty_ok(B)`
+is unsafe-headed too — the NOTE flags only ty_base; flag both, inline all filters in consumers.
+
+**C3 (engine claim wrong — missing_capabilities #2 and honesty #2).** "implements comma-split is
+inexpressible today (no split builtin)" is FALSE as an engine claim: the recursive right-peel over a
+shrinking string (`last_segment` + `concat` + `strip_suffix`) is a shipped stdlib idiom —
+js_module_imports.dl:172-179 `spec_pfx`, with the termination argument in-file. When the analyzer stamps
+comma-joined `implements`, the pack can split it with TODAY'S kit; the indexed-keys convention and the
+split/3 builtin are both unnecessary. (Bonus: negated builtin filters are legal too — exec.rs:1912+ per-row
+anti-join fallback; stratify.rs adds no edge for builtins — so the builtin-table skip can be spelled
+`\+ kt_builtin_type(B), \+ string_contains(B,"?")` without extra strata. No stdlib precedent for the
+negated-filter form yet; add a fixture test first.)
+
+**C4 (honesty #6 resolved).** `.kts` IS mapped to Kotlin: config.rs:749 `"kt" | "kts" => Some(Language::Kotlin)`.
+The kt()+kts() gate is confirmed correct, not "defensive".
+
+**C5 (step 13 mechanism stale, conclusion right).** At v0.4.0 `all_imports_from_edges` is consumed ONLY as
+a count hint to run_stdlib_rule_packs (main.rs:2853 → :573-577 `imports_from_hint`); MODULE→MODULE
+DEPENDS_ON is derived by `@stdlib/depends`, which consumes EVERY IMPORTS_FROM edge node-type-agnostically
+(derive/stdlib/depends.dl:1-6). The ordering obligation is therefore exactly as stated (kotlin import pack
+before `depends` in STDLIB_PACKS/STDLIB_RULE_PACKS), plus one the spec missed: kotlin_calls is a CALLS
+producer and must precede the CALLS negators `method_calls`/`shape_verifier` (shape_verifier.dl:30 negates
+CALLS with no file gate). Also exclude `__grafema_virtual/unresolved-diagnostics` from the differential —
+ISSUE nodes are generated from post-resolve graph queries (main.rs:2060-2085), so corrected-arm coverage
+changes that population.
+
+Ready for packs: YES after the C1/C2 mechanical respellings — the semantics, liveness table, and delta
+classes all survived adversarial re-reading unchanged.

--- a/packages/grafema-orchestrator/src/analyzer.rs
+++ b/packages/grafema-orchestrator/src/analyzer.rs
@@ -841,6 +841,43 @@ pub fn workspace_packages_to_wire(
     nodes
 }
 
+/// The GO module-path fact (precondition P1 of the go pack migration): the
+/// go.mod module path the legacy `go-resolve` daemon consumed over the wire
+/// (`workspace_packages` — main.rs wraps `discover_go_module_path` as a single
+/// WorkspacePackageWire) becomes a graph fact the go packs can join:
+/// `go_mod(MP) :- node(W, "WORKSPACE_PACKAGE"), node_attr(W, "language", "go"),
+/// attr(W, "name", MP)` (go_imports.dl / go_calls.dl).
+///
+/// Shape (the [`workspace_packages_to_wire`] conventions, plus the language
+/// discriminator):
+/// - `name` = the Go module path (e.g. `"github.com/user/project"`);
+/// - `file` = `"go.mod"` (the declaring file — js workspace facts never carry
+///   it, so the js packs' `ws_pkg` arms cannot confuse the fact with an npm
+///   package, and vice versa the go packs key on `language`);
+/// - `metadata.language` = `"go"` — the discriminator the packs join;
+/// - `metadata.package_dir` = the project root.
+///
+/// Semantic id `go.mod->WORKSPACE_PACKAGE-><module path>` (stable across runs;
+/// re-emitted every analyze like the js facts — upsert dedups).
+pub fn go_module_workspace_fact(module_path: &str, root: &str, authority: &str) -> WireNode {
+    let compact_id = format!("go.mod->WORKSPACE_PACKAGE->{module_path}");
+    let node_id = compact_to_uri(&compact_id, authority);
+
+    let mut meta = HashMap::new();
+    meta.insert("language".to_string(), serde_json::json!("go"));
+    meta.insert("package_dir".to_string(), serde_json::json!(root));
+
+    WireNode {
+        id: node_id.clone(),
+        semantic_id: Some(node_id),
+        node_type: Some("WORKSPACE_PACKAGE".to_string()),
+        name: Some(module_path.to_string()),
+        file: Some("go.mod".to_string()),
+        exported: false,
+        metadata: Some(serde_json::to_string(&meta).unwrap()),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Single-file analysis
 // ---------------------------------------------------------------------------
@@ -7513,5 +7550,26 @@ mod tests {
     #[test]
     fn workspace_packages_to_wire_empty_is_empty() {
         assert!(workspace_packages_to_wire(&[], "github.com/o/r").is_empty());
+    }
+
+    /// The GO module-path fact (P1): the go packs join
+    /// `node_attr(W, "language", "go")` × `attr(W, "name", MP)` — the language
+    /// discriminator MUST ride metadata and the module path MUST be the
+    /// first-class name; ids stable across runs (upsert dedups).
+    #[test]
+    fn go_module_workspace_fact_shape_and_stability() {
+        let a = go_module_workspace_fact("github.com/user/project", ".", "github.com/o/r");
+        assert_eq!(a.node_type.as_deref(), Some("WORKSPACE_PACKAGE"));
+        assert_eq!(a.name.as_deref(), Some("github.com/user/project"));
+        assert_eq!(a.file.as_deref(), Some("go.mod"));
+        assert!(!a.exported);
+        let meta: serde_json::Value =
+            serde_json::from_str(a.metadata.as_deref().unwrap()).unwrap();
+        assert_eq!(meta["language"], "go", "the go packs' discriminator key");
+        assert_eq!(meta["package_dir"], ".");
+        let b = go_module_workspace_fact("github.com/user/project", ".", "github.com/o/r");
+        assert_eq!(a.id, b.id, "stable id across runs");
+        assert_eq!(a.semantic_id.as_deref(), Some(a.id.as_str()));
+        assert!(a.id.contains("WORKSPACE_PACKAGE"), "typed id: {}", a.id);
     }
 }

--- a/packages/grafema-orchestrator/src/main.rs
+++ b/packages/grafema-orchestrator/src/main.rs
@@ -48,7 +48,13 @@ use std::path::PathBuf;
 /// js_import_bindings → js_class_inheritance → js_cross_file_calls →
 /// js_property_access_ns → js_property_access_full → js_builtins_nodes →
 /// js_builtins_edges → js_runtime_globals_nodes → js_runtime_globals_edges →
+/// java_imports → java_types → java_calls → java_annotations →
 /// depends → method_calls → shape_verifier → axum_routes.
+/// The Java packs (java-resolve migration): `java_imports` PRODUCES java
+/// IMPORTS_FROM, so it runs strictly before `depends` (which consumes EVERY
+/// IMPORTS_FROM edge node-type-agnostically via the file join);
+/// `java_calls` PRODUCES CALLS, so it runs strictly before the CALLS
+/// negators `method_calls` / `shape_verifier`.
 /// Wave 3c moved depends INTO this list, after every IMPORTS_FROM producer:
 /// with legacy import-resolution gated, the IMPORT-level edges depends
 /// consumes are produced by the packs above it (it ran separately FIRST while
@@ -94,6 +100,13 @@ const STDLIB_RULE_PACKS: &[&str] = &[
     // producer — before method_calls/shape_verifier.
     "@stdlib/js_runtime_globals_nodes",
     "@stdlib/js_runtime_globals_edges",
+    // Java packs (java-resolve migration): java_imports PRODUCES java
+    // IMPORTS_FROM — strictly before depends; java_calls PRODUCES CALLS —
+    // strictly before the negators method_calls / shape_verifier.
+    "@stdlib/java_imports",
+    "@stdlib/java_types",
+    "@stdlib/java_calls",
+    "@stdlib/java_annotations",
     // Wave 3c: depends CONSUMES IMPORTS_FROM (every edge of the shared
     // vocabulary, module- and binding-level). Legacy import-resolution /
     // rust-imports are gated (GRAFEMA_SKIP_RESOLVE_STEPS), so depends must
@@ -535,6 +548,10 @@ fn pack_owned_slice(pack: &str) -> &'static str {
         "@stdlib/js_builtins_edges" => "node-builtin IMPORTS_FROM + CALLS",
         "@stdlib/js_runtime_globals_nodes" => "js runtime-global GLOBAL_DEFINITION nodes",
         "@stdlib/js_runtime_globals_edges" => "js runtime-global CALLS",
+        "@stdlib/java_imports" => "java IMPORTS_FROM (IMPORT + IMPORT_BINDING → declaration)",
+        "@stdlib/java_types" => "java RETURNS/TYPE_OF/EXTENDS/IMPLEMENTS/THROWS_TYPE",
+        "@stdlib/java_calls" => "java INSTANTIATES + CALLS (ctor/same-class/static/super-this)",
+        "@stdlib/java_annotations" => "java ANNOTATION_RESOLVES_TO",
         "@stdlib/depends" => "MODULE→MODULE DEPENDS_ON",
         "@stdlib/method_calls" => "fuzzy method-call CALLS fallback",
         "@stdlib/shape_verifier" => "shape-violation ISSUE diagnostics",

--- a/packages/grafema-orchestrator/src/main.rs
+++ b/packages/grafema-orchestrator/src/main.rs
@@ -94,6 +94,21 @@ const STDLIB_RULE_PACKS: &[&str] = &[
     // producer — before method_calls/shape_verifier.
     "@stdlib/js_runtime_globals_nodes",
     "@stdlib/js_runtime_globals_edges",
+    // Go wave: go_imports / go_imports_nomod PRODUCE IMPORTS_FROM — strictly
+    // before depends (verdict C4). The nomod entry is the orchestrator-selected
+    // VARIANT (P3): a pack cannot test "the go.mod fact is absent" (§3
+    // cross-join), so `run_stdlib_rule_packs` SKIPS it unless go files exist
+    // AND go.mod did not resolve — both names stay registered so the
+    // cross-registry order pin below holds. go_calls PRODUCES CALLS for
+    // go_context (P2 producer-before-consumer) and precedes the CALLS
+    // negators (method_calls / shape_verifier — C4). go_interfaces / go_types
+    // consume analyzer EDB only.
+    "@stdlib/go_imports",
+    "@stdlib/go_imports_nomod",
+    "@stdlib/go_calls",
+    "@stdlib/go_interfaces",
+    "@stdlib/go_types",
+    "@stdlib/go_context",
     // Wave 3c: depends CONSUMES IMPORTS_FROM (every edge of the shared
     // vocabulary, module- and binding-level). Legacy import-resolution /
     // rust-imports are gated (GRAFEMA_SKIP_RESOLVE_STEPS), so depends must
@@ -535,6 +550,12 @@ fn pack_owned_slice(pack: &str) -> &'static str {
         "@stdlib/js_builtins_edges" => "node-builtin IMPORTS_FROM + CALLS",
         "@stdlib/js_runtime_globals_nodes" => "js runtime-global GLOBAL_DEFINITION nodes",
         "@stdlib/js_runtime_globals_edges" => "js runtime-global CALLS",
+        "@stdlib/go_imports" => "go same-module IMPORT→MODULE IMPORTS_FROM",
+        "@stdlib/go_imports_nomod" => "go no-go.mod suffix-fallback IMPORTS_FROM",
+        "@stdlib/go_calls" => "go CALLS (package-qualified / same-package / method)",
+        "@stdlib/go_interfaces" => "go structural IMPLEMENTS (duck typing)",
+        "@stdlib/go_types" => "go TYPE_OF + RETURNS",
+        "@stdlib/go_context" => "go PROPAGATES/SPAWNS/DEFERS context flow",
         "@stdlib/depends" => "MODULE→MODULE DEPENDS_ON",
         "@stdlib/method_calls" => "fuzzy method-call CALLS fallback",
         "@stdlib/shape_verifier" => "shape-violation ISSUE diagnostics",
@@ -570,13 +591,29 @@ fn pack_failure_summary(failures: &[(String, String)]) -> String {
 /// later packs depend on earlier ones only through committed edges, so a failed
 /// producer degrades but does not invalidate them), then the phase FAILS with
 /// [`pack_failure_summary`] naming every failed pack and its owned slice.
+///
+/// PACK-VARIANT SELECTION (go P3): `go_nomod_fallback` is the ONE runtime
+/// selection condition — `@stdlib/go_imports_nomod` (the legacy
+/// empty-module-path suffix fallback, GoImportResolution.hs findBySuffix) runs
+/// ONLY when go files exist and go.mod did NOT resolve. The condition lives
+/// here because a pack cannot test "the go.mod fact is absent" (a global
+/// has-fact literal is the §3 cross-join the planner refuses — and per the
+/// spec verdict C2 a filter-connected suffix spelling is equally rejected);
+/// the orchestrator, which discovered go.mod, owns the branch — the faithful
+/// translation of legacy's `T.null modulePath` global. The main `go_imports`
+/// pack always runs: without the P1 fact its module-prefix arms derive
+/// nothing (fixture-proven), so the two variants never both fire.
 async fn run_stdlib_rule_packs(
     rfdb: &mut rfdb::RfdbClient,
     prof: Option<&profiler::Profiler>,
     imports_from_hint: usize,
+    go_nomod_fallback: bool,
 ) -> Result<()> {
     let mut failed_packs: Vec<(String, String)> = Vec::new();
     for pack in STDLIB_RULE_PACKS {
+        if *pack == "@stdlib/go_imports_nomod" && !go_nomod_fallback {
+            continue;
+        }
         let pack_start = std::time::Instant::now();
         match rfdb.materialize_datalog(pack).await {
             Ok(pack_edges) => {
@@ -2032,13 +2069,45 @@ async fn main() -> Result<()> {
                 tracing::info!(count = n_ws, "WORKSPACE_PACKAGE facts committed");
             }
 
+            // 8n-go. Commit the GO module-path fact (go pack precondition P1):
+            // the go.mod module path the legacy daemon consumed over the wire
+            // (main.rs go_ws_packages above) becomes a WORKSPACE_PACKAGE node
+            // with metadata language="go" that go_imports.dl / go_calls.dl
+            // join. Must land BEFORE the pack phase below. The P3 variant
+            // selection (no-go.mod suffix fallback) keys off the same
+            // discovery — see `run_stdlib_rule_packs`.
+            let go_module_path_for_packs = if go_files.is_empty() {
+                None
+            } else {
+                config::discover_go_module_path(&cfg.root)
+            };
+            let go_nomod_fallback = !go_files.is_empty() && go_module_path_for_packs.is_none();
+            if let Some(ref go_mp) = go_module_path_for_packs {
+                let mut go_fact = analyzer::go_module_workspace_fact(
+                    go_mp,
+                    &cfg.root.display().to_string(),
+                    &authority,
+                );
+                gc::stamp_node_metadata(&mut go_fact.metadata, generation, "workspace-packages");
+                rfdb.commit_batch(&[], &[go_fact], &[], true)
+                    .await
+                    .context("Failed to commit GO module-path fact")?;
+                tracing::info!(module_path = %go_mp, "GO module-path WORKSPACE_PACKAGE fact committed");
+            }
+
             // 9. Rule-pack phase. The server's capability was asserted at
             // connect time (fail-fast above), so this phase ALWAYS runs — see
             // `run_stdlib_rule_packs` for the ordering contract and the Wave-6
             // failure policy (any failed pack fails the run at end of phase).
             let depends_on_start = std::time::Instant::now();
             profile!("depends_on_start", "imports_from_edges" => all_imports_from_edges.len());
-            run_stdlib_rule_packs(&mut rfdb, prof.as_ref(), all_imports_from_edges.len()).await?;
+            run_stdlib_rule_packs(
+                &mut rfdb,
+                prof.as_ref(),
+                all_imports_from_edges.len(),
+                go_nomod_fallback,
+            )
+            .await?;
             let depends_on_ms = depends_on_start.elapsed().as_millis() as u64;
 
             // 10. Generate unresolved diagnostics — AFTER the pack phase (Wave 3c):
@@ -2850,7 +2919,19 @@ async fn main() -> Result<()> {
             // too — and BEFORE the unresolved diagnostics below, whose negation
             // queries would otherwise flag every pack-resolved node.
             let depends_on_start = std::time::Instant::now();
-            run_stdlib_rule_packs(&mut rfdb, None, all_imports_from_edges.len()).await?;
+            // P3 selection in the resolve-only pass: the graph already holds
+            // (or lacks) the P1 fact from the prior analyze; re-discover
+            // go.mod for the variant condition (cheap file read). Go presence
+            // comes from the detected-language scan above.
+            let go_nomod_fallback = detected_langs.contains(&config::Language::Go)
+                && config::discover_go_module_path(&cfg.root).is_none();
+            run_stdlib_rule_packs(
+                &mut rfdb,
+                None,
+                all_imports_from_edges.len(),
+                go_nomod_fallback,
+            )
+            .await?;
             let depends_on_ms = depends_on_start.elapsed().as_millis() as u64;
 
             // Unresolved diagnostics
@@ -3354,10 +3435,14 @@ mod tests {
     ) -> std::path::PathBuf {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+        // pid + a per-process counter: two tests binding in the same instant
+        // collided on a nanos-only name (macOS clock granularity).
+        static SOCK_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         let dir = std::env::temp_dir();
         let sock = dir.join(format!(
-            "grafema-fake-rfdb-{}-{}.sock",
+            "grafema-fake-rfdb-{}-{}-{}.sock",
             std::process::id(),
+            SOCK_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
@@ -3466,7 +3551,7 @@ mod tests {
             vec!["@stdlib/js_local_refs".to_string(), "@stdlib/axum_routes".to_string()],
         );
         let mut client = rfdb::RfdbClient::connect(&sock).await.expect("connect fake server");
-        let err = run_stdlib_rule_packs(&mut client, None, 0)
+        let err = run_stdlib_rule_packs(&mut client, None, 0, false)
             .await
             .expect_err("a failed pack must fail the phase");
         let msg = format!("{err:#}");
@@ -3479,9 +3564,47 @@ mod tests {
         // All packs green → Ok.
         let sock2 = spawn_fake_rfdb_server(features, vec![]);
         let mut client2 = rfdb::RfdbClient::connect(&sock2).await.expect("connect fake server");
-        run_stdlib_rule_packs(&mut client2, None, 0)
+        run_stdlib_rule_packs(&mut client2, None, 0, false)
             .await
             .expect("green pack phase passes");
+        let _ = std::fs::remove_file(&sock2);
+    }
+
+    /// Go P3 — the pack-VARIANT selection, end-to-end through the production
+    /// pack loop: `@stdlib/go_imports_nomod` (the no-go.mod suffix fallback)
+    /// runs ONLY when `go_nomod_fallback` is true. Proven via the fake-server
+    /// failure mechanism: the variant is FORCED to fail, so its presence in
+    /// the run is observable — skipped (Ok) when go.mod resolved, run (Err
+    /// naming it) when it did not.
+    #[tokio::test]
+    async fn go_imports_nomod_variant_is_selected_by_the_go_nomod_flag() {
+        let features = vec!["datalogDerive".to_string()];
+
+        // go.mod resolved (or no go files) → the variant must be SKIPPED:
+        // even though the fake server would fail it, the phase is green.
+        let sock = spawn_fake_rfdb_server(
+            features.clone(),
+            vec!["@stdlib/go_imports_nomod".to_string()],
+        );
+        let mut client = rfdb::RfdbClient::connect(&sock).await.expect("connect fake server");
+        run_stdlib_rule_packs(&mut client, None, 0, false)
+            .await
+            .expect("variant skipped when go.mod resolved — phase green");
+        let _ = std::fs::remove_file(&sock);
+
+        // go files present + no go.mod → the variant RUNS (and here fails,
+        // proving it was selected and that its owned slice is named).
+        let sock2 = spawn_fake_rfdb_server(
+            features,
+            vec!["@stdlib/go_imports_nomod".to_string()],
+        );
+        let mut client2 = rfdb::RfdbClient::connect(&sock2).await.expect("connect fake server");
+        let err = run_stdlib_rule_packs(&mut client2, None, 0, true)
+            .await
+            .expect_err("variant selected without go.mod — forced failure surfaces");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("@stdlib/go_imports_nomod"), "variant named: {msg}");
+        assert!(msg.contains("suffix-fallback"), "owned slice named: {msg}");
         let _ = std::fs::remove_file(&sock2);
     }
 

--- a/packages/grafema-orchestrator/src/main.rs
+++ b/packages/grafema-orchestrator/src/main.rs
@@ -1989,7 +1989,9 @@ async fn main() -> Result<()> {
                     }
                 };
 
-                let plugin_results = plugin::run_plugins_dag(
+                // A plugin failure aborts the analyze run (loud-failure policy,
+                // same as derive-pack failures) — but shut the pool down first.
+                let dag_result = plugin::run_plugins_dag(
                     &user_plugins,
                     &mut rfdb,
                     &socket_path,
@@ -1997,17 +1999,13 @@ async fn main() -> Result<()> {
                     generation,
                     resolve_pool.as_ref(),
                 )
-                .await?;
+                .await;
 
                 if let Some(pool) = resolve_pool {
                     pool.shutdown().await;
                 }
 
-                for pr in &plugin_results {
-                    if let Some(ref err) = pr.error {
-                        tracing::error!(plugin = %pr.plugin_name, "{err}");
-                    }
-                }
+                dag_result?;
             }
 
             let resolve_ms = resolve_timer.elapsed().as_millis() as u64;
@@ -2823,7 +2821,9 @@ async fn main() -> Result<()> {
                     }
                 };
 
-                let plugin_results = plugin::run_plugins_dag(
+                // A plugin failure aborts the analyze run (loud-failure policy,
+                // same as derive-pack failures) — but shut the pool down first.
+                let dag_result = plugin::run_plugins_dag(
                     &user_plugins,
                     &mut rfdb,
                     &socket_path,
@@ -2831,17 +2831,13 @@ async fn main() -> Result<()> {
                     generation,
                     resolve_pool.as_ref(),
                 )
-                .await?;
+                .await;
 
                 if let Some(pool) = resolve_pool {
                     pool.shutdown().await;
                 }
 
-                for pr in &plugin_results {
-                    if let Some(ref err) = pr.error {
-                        tracing::error!(plugin = %pr.plugin_name, "{err}");
-                    }
-                }
+                dag_result?;
             }
 
             // Rule-pack phase (Wave 6): the packs are the only producer of the

--- a/packages/grafema-orchestrator/src/main.rs
+++ b/packages/grafema-orchestrator/src/main.rs
@@ -48,7 +48,8 @@ use std::path::PathBuf;
 /// js_import_bindings → js_class_inheritance → js_cross_file_calls →
 /// js_property_access_ns → js_property_access_full → js_builtins_nodes →
 /// js_builtins_edges → js_runtime_globals_nodes → js_runtime_globals_edges →
-/// depends → method_calls → shape_verifier → axum_routes.
+/// depends → method_calls → shape_verifier → axum_routes →
+/// js_http_routes_nodes → js_http_routes_edges.
 /// Wave 3c moved depends INTO this list, after every IMPORTS_FROM producer:
 /// with legacy import-resolution gated, the IMPORT-level edges depends
 /// consumes are produced by the packs above it (it ran separately FIRST while
@@ -105,6 +106,12 @@ const STDLIB_RULE_PACKS: &[&str] = &[
     "@stdlib/method_calls",
     "@stdlib/shape_verifier",
     "@stdlib/axum_routes",
+    // Wave 14 feature-detection vertical: the nodes pack MINTS the
+    // anchorCall-pinned http:route endpoints the edges pack joins as
+    // committed EDB (strict nodes→edges order — the js_builtins two-pack
+    // split); both consume analyzer EDB only.
+    "@stdlib/js_http_routes_nodes",
+    "@stdlib/js_http_routes_edges",
 ];
 
 
@@ -539,6 +546,8 @@ fn pack_owned_slice(pack: &str) -> &'static str {
         "@stdlib/method_calls" => "fuzzy method-call CALLS fallback",
         "@stdlib/shape_verifier" => "shape-violation ISSUE diagnostics",
         "@stdlib/axum_routes" => "axum ROUTES_TO",
+        "@stdlib/js_http_routes_nodes" => "js http:route nodes + ROUTES_TO (express/fastify/koa/hono)",
+        "@stdlib/js_http_routes_edges" => "js http:route EXPOSES + HANDLES",
         _ => "(unregistered pack)",
     }
 }

--- a/packages/grafema-orchestrator/src/main.rs
+++ b/packages/grafema-orchestrator/src/main.rs
@@ -48,7 +48,7 @@ use std::path::PathBuf;
 /// js_import_bindings → js_class_inheritance → js_cross_file_calls →
 /// js_property_access_ns → js_property_access_full → js_builtins_nodes →
 /// js_builtins_edges → js_runtime_globals_nodes → js_runtime_globals_edges →
-/// depends → method_calls → shape_verifier → axum_routes.
+/// kotlin_inheritance → depends → method_calls → shape_verifier → axum_routes.
 /// Wave 3c moved depends INTO this list, after every IMPORTS_FROM producer:
 /// with legacy import-resolution gated, the IMPORT-level edges depends
 /// consumes are produced by the packs above it (it ran separately FIRST while
@@ -94,6 +94,11 @@ const STDLIB_RULE_PACKS: &[&str] = &[
     // producer — before method_calls/shape_verifier.
     "@stdlib/js_runtime_globals_nodes",
     "@stdlib/js_runtime_globals_edges",
+    // Kotlin wave: kotlin_inheritance PRODUCES EXTENDS (for shape_verifier's
+    // EXTENDS-closed member lookup) + IMPLEMENTS from the kotlin-analyzer's
+    // CLASS metadata stamps — consumes analyzer EDB only, precedes the
+    // negators below.
+    "@stdlib/kotlin_inheritance",
     // Wave 3c: depends CONSUMES IMPORTS_FROM (every edge of the shared
     // vocabulary, module- and binding-level). Legacy import-resolution /
     // rust-imports are gated (GRAFEMA_SKIP_RESOLVE_STEPS), so depends must
@@ -535,6 +540,7 @@ fn pack_owned_slice(pack: &str) -> &'static str {
         "@stdlib/js_builtins_edges" => "node-builtin IMPORTS_FROM + CALLS",
         "@stdlib/js_runtime_globals_nodes" => "js runtime-global GLOBAL_DEFINITION nodes",
         "@stdlib/js_runtime_globals_edges" => "js runtime-global CALLS",
+        "@stdlib/kotlin_inheritance" => "kotlin EXTENDS + IMPLEMENTS",
         "@stdlib/depends" => "MODULE→MODULE DEPENDS_ON",
         "@stdlib/method_calls" => "fuzzy method-call CALLS fallback",
         "@stdlib/shape_verifier" => "shape-violation ISSUE diagnostics",
@@ -3354,10 +3360,17 @@ mod tests {
     ) -> std::path::PathBuf {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+        // Process-wide sequence number: two tests starting concurrently can
+        // draw the SAME SystemTime nanos, and the remove_file→bind pair below
+        // is then a TOCTOU race (observed: `bind fake socket: AlreadyExists`
+        // flakes). The counter makes the name unique within the process.
+        static FAKE_SOCK_SEQ: std::sync::atomic::AtomicU64 =
+            std::sync::atomic::AtomicU64::new(0);
         let dir = std::env::temp_dir();
         let sock = dir.join(format!(
-            "grafema-fake-rfdb-{}-{}.sock",
+            "grafema-fake-rfdb-{}-{}-{}.sock",
             std::process::id(),
+            FAKE_SOCK_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()

--- a/packages/grafema-orchestrator/src/main.rs
+++ b/packages/grafema-orchestrator/src/main.rs
@@ -3350,14 +3350,16 @@ mod tests {
     ) -> std::path::PathBuf {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+        // Unique per call: pid + a process-wide counter. A timestamp alone is
+        // NOT unique — concurrent tests can land in the same SystemTime tick,
+        // collide on the socket name, and the second bind panics (flaky
+        // EADDRINUSE in pack_failure_fails_the_run_with_a_loud_summary).
+        static SOCK_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         let dir = std::env::temp_dir();
         let sock = dir.join(format!(
             "grafema-fake-rfdb-{}-{}.sock",
             std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
+            SOCK_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
         ));
         let _ = std::fs::remove_file(&sock);
         let listener = std::os::unix::net::UnixListener::bind(&sock).expect("bind fake socket");

--- a/packages/grafema-orchestrator/src/plugin.rs
+++ b/packages/grafema-orchestrator/src/plugin.rs
@@ -1841,6 +1841,98 @@ mod tests {
         assert!(err.contains("timed out"), "{err}");
     }
 
+    /// Minimal fake RFDB server: answers every incoming frame with a
+    /// Hello-shaped MessagePack response — just enough for
+    /// `RfdbClient::connect` to complete its handshake. Batch plugins never
+    /// touch the client afterwards, so nothing else is needed.
+    fn spawn_fake_hello_server(listener: tokio::net::UnixListener) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    return;
+                };
+                tokio::spawn(async move {
+                    // protocolVersion must match rfdb::PROTOCOL_VERSION (3).
+                    let reply = rmp_serde::to_vec_named(&serde_json::json!({
+                        "requestId": "r0",
+                        "ok": true,
+                        "protocolVersion": 3,
+                        "serverVersion": "fake-rfdb",
+                        "features": [],
+                    }))
+                    .expect("encode fake hello reply");
+                    loop {
+                        let mut len_buf = [0u8; 4];
+                        if stream.read_exact(&mut len_buf).await.is_err() {
+                            return;
+                        }
+                        let len = u32::from_be_bytes(len_buf) as usize;
+                        let mut payload = vec![0u8; len];
+                        if stream.read_exact(&mut payload).await.is_err() {
+                            return;
+                        }
+                        let frame_len = (reply.len() as u32).to_be_bytes();
+                        if stream.write_all(&frame_len).await.is_err() {
+                            return;
+                        }
+                        if stream.write_all(&reply).await.is_err() {
+                            return;
+                        }
+                    }
+                });
+            }
+        });
+    }
+
+    /// Helper: a batch-mode plugin running an arbitrary command.
+    fn make_batch_plugin(name: &str, command: String, deps: &[&str]) -> PluginConfig {
+        PluginConfig {
+            name: name.to_string(),
+            command,
+            query: None,
+            depends_on: deps.iter().map(|s| s.to_string()).collect(),
+            mode: PluginMode::Batch,
+            timeout_secs: None,
+        }
+    }
+
+    /// Gate PLACEMENT test: the three `check_plugin_result` unit tests above
+    /// would keep passing even if the gate call were deleted from the DAG
+    /// loop. This exercises the real `run_plugins_dag`: in the chain
+    /// A → B(fails) → C, the run must return Err naming B, and B's dependent
+    /// C must never execute against the half-populated graph.
+    #[tokio::test]
+    async fn run_plugins_dag_failing_plugin_aborts_and_skips_dependents() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sock = dir.path().join("fake-rfdb.sock");
+        let listener = tokio::net::UnixListener::bind(&sock).expect("bind fake rfdb socket");
+        spawn_fake_hello_server(listener);
+
+        let mut rfdb = RfdbClient::connect(&sock)
+            .await
+            .expect("handshake with fake hello server");
+
+        // C touches a sentinel file iff it actually runs.
+        let sentinel = dir.path().join("c-ran");
+        let plugins = vec![
+            make_batch_plugin("A", "true".to_string(), &[]),
+            make_batch_plugin("B", "false".to_string(), &["A"]),
+            make_batch_plugin("C", format!("touch {}", sentinel.display()), &["B"]),
+        ];
+
+        let err = run_plugins_dag(&plugins, &mut rfdb, &sock, "testdb", 1, None)
+            .await
+            .expect_err("a failing plugin must abort the DAG");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("Plugin 'B' failed"), "{msg}");
+        assert!(msg.contains("exit status"), "{msg}");
+        assert!(
+            !sentinel.exists(),
+            "dependent plugin C ran even though its dependency B failed"
+        );
+    }
+
     // -- resolve_progress telemetry (REG-1138 defect 2) --
 
     /// The `resolve_progress` event carries the phase + progress counters under

--- a/packages/grafema-orchestrator/src/plugin.rs
+++ b/packages/grafema-orchestrator/src/plugin.rs
@@ -1305,6 +1305,19 @@ pub async fn stream_and_resolve_single_worker(
 // Full DAG execution
 // ---------------------------------------------------------------------------
 
+/// Convert a finished plugin result into a hard error if the plugin failed.
+///
+/// Wave 6 made derive-pack failures fail the analyze run, but plugin failures
+/// were still log-and-continue — a plugin exiting non-zero (or timing out)
+/// silently shipped a graph missing whole edge families (e.g. type-inference
+/// is the sole INSTANCE_OF producer). A failed plugin now aborts the run.
+pub fn check_plugin_result(result: &PluginRunResult) -> Result<()> {
+    if let Some(ref err) = result.error {
+        bail!("Plugin '{}' failed: {}", result.plugin_name, err);
+    }
+    Ok(())
+}
+
 /// Execute the full plugin DAG: build levels, run each level sequentially.
 ///
 /// Within each level, plugins are run sequentially because `RfdbClient` requires
@@ -1316,6 +1329,11 @@ pub async fn stream_and_resolve_single_worker(
 ///
 /// For streaming plugins: output is validated, metadata-stamped, and committed.
 /// Results for all plugins are collected and returned.
+///
+/// A plugin failure (non-zero exit, timeout, invalid output, commit failure)
+/// aborts the DAG with an error via [`check_plugin_result`] — dependents of a
+/// failed plugin never run against a half-populated graph, and the analyze
+/// run fails loudly instead of logging and continuing.
 pub async fn run_plugins_dag(
     plugins: &[PluginConfig],
     rfdb: &mut RfdbClient,
@@ -1350,6 +1368,7 @@ pub async fn run_plugins_dag(
                 );
             }
 
+            check_plugin_result(&result)?;
             results.push(result);
         }
     }
@@ -1774,6 +1793,52 @@ mod tests {
         acc.record(&[ck_node("a")], &[]);
         acc.record(&[ck_node("b")], &[]);
         assert!(acc.take_if_due().is_some(), "counter reset after empty checkpoint");
+    }
+
+    // -- loud-failure policy: plugin failures abort the analyze run --
+
+    /// Helper: build a PluginRunResult with an optional error.
+    fn make_result(name: &str, error: Option<&str>) -> PluginRunResult {
+        PluginRunResult {
+            plugin_name: name.to_string(),
+            nodes_emitted: 0,
+            edges_emitted: 0,
+            duration: Duration::from_millis(1),
+            error: error.map(|s| s.to_string()),
+        }
+    }
+
+    /// A successful plugin result passes the gate.
+    #[test]
+    fn check_plugin_result_ok_passes() {
+        let result = make_result("type-inference", None);
+        assert!(check_plugin_result(&result).is_ok());
+    }
+
+    /// A plugin that exited non-zero fails the run, naming the plugin and
+    /// carrying the underlying error (run_plugins_dag calls this per result,
+    /// so the `?` aborts the DAG → the analyze run fails loudly).
+    #[test]
+    fn check_plugin_result_exit_failure_aborts() {
+        let result = make_result(
+            "type-inference",
+            Some("Batch plugin 'type-inference' exited with status: exit status: 1"),
+        );
+        let err = check_plugin_result(&result).unwrap_err().to_string();
+        assert!(err.contains("Plugin 'type-inference' failed"), "{err}");
+        assert!(err.contains("exit status: 1"), "{err}");
+    }
+
+    /// A timed-out plugin is a failure too — same gate, same abort.
+    #[test]
+    fn check_plugin_result_timeout_aborts() {
+        let result = make_result(
+            "shape-tracker",
+            Some("Plugin 'shape-tracker' timed out after 600s"),
+        );
+        let err = check_plugin_result(&result).unwrap_err().to_string();
+        assert!(err.contains("Plugin 'shape-tracker' failed"), "{err}");
+        assert!(err.contains("timed out"), "{err}");
     }
 
     // -- resolve_progress telemetry (REG-1138 defect 2) --

--- a/packages/kotlin-analyzer/src/KotlinAST.hs
+++ b/packages/kotlin-analyzer/src/KotlinAST.hs
@@ -26,7 +26,9 @@ module KotlinAST
   ) where
 
 import Data.Text (Text)
-import Data.Aeson (FromJSON(..), withObject, (.:), (.:?), (.!=))
+import qualified Data.Text as T
+import Data.Aeson (FromJSON(..), Value(..), withObject, (.:), (.:?), (.!=))
+import qualified Data.Aeson.KeyMap as KM
 import Data.Aeson.Types (Parser)
 
 -- Position & Span
@@ -66,17 +68,35 @@ data KotlinDecl
       , kdTypeParams       :: ![KotlinTypeParam]
       , kdPrimaryConstructor :: !(Maybe KotlinPrimaryConstructor)
       , kdSuperTypes       :: ![KotlinType]
+        -- ^ Decoded from the "superTypes" key — the live kotlin-parser never
+        -- emits that key for classes (it emits "extends"/"implements",
+        -- KotlinAstSerializer.kt:99-123), so this list is empty on real
+        -- parser output; kept for the deferred-ref path and old fixtures.
+      , kdExtendsNames     :: ![Text]
+        -- ^ Supertype names from the parser's "extends" entries
+        -- (KtSuperTypeCallEntry — the constructor-call '()' suffix marks the
+        -- class supertype). Scope-qualified when the parser provides "scope".
+      , kdImplementsNames  :: ![Text]
+        -- ^ Supertype names from the parser's "implements" entries (bare
+        -- KtSuperTypeEntry / delegated KtDelegatedSuperTypeEntry — interfaces,
+        -- plus the no-primary-constructor class supertype ambiguity; see
+        -- Rules.Declarations.inheritanceMeta).
       , kdMembers          :: ![KotlinMember]
       , kdAnnotations      :: ![KotlinAnnotation]
       , kdSpan             :: !Span
       }
   | ObjectDecl
-      { kdName        :: !Text
-      , kdModifiers   :: ![Text]
-      , kdSuperTypes  :: ![KotlinType]
-      , kdMembers     :: ![KotlinMember]
-      , kdAnnotations :: ![KotlinAnnotation]
-      , kdSpan        :: !Span
+      { kdName            :: !Text
+      , kdModifiers       :: ![Text]
+      , kdSuperTypes      :: ![KotlinType]
+      , kdExtendsNames    :: ![Text]
+        -- ^ Constructor-call entries of the parser's mixed "supertypes" array
+        -- (KotlinAstSerializer.kt:148-171).
+      , kdImplementsNames :: ![Text]
+        -- ^ Bare/delegated entries of the same array.
+      , kdMembers         :: ![KotlinMember]
+      , kdAnnotations     :: ![KotlinAnnotation]
+      , kdSpan            :: !Span
       }
   | FunDecl
       { kdName         :: !Text
@@ -495,23 +515,39 @@ instance FromJSON KotlinDecl where
   parseJSON = withObject "KotlinDecl" $ \v -> do
     ty <- v .: "type" :: Parser Text
     case ty of
-      "ClassDecl" -> ClassDecl
-        <$> v .:  "name"
-        <*> v .:? "kind" .!= "class"
-        <*> v .:? "modifiers" .!= []
-        <*> v .:? "typeParameters" .!= []
-        <*> v .:? "primaryConstructor"
-        <*> v .:? "superTypes" .!= []
-        <*> v .:? "members" .!= []
-        <*> v .:? "annotations" .!= []
-        <*> v .:  "span"
-      "ObjectDecl" -> ObjectDecl
-        <$> v .:  "name"
-        <*> v .:? "modifiers" .!= []
-        <*> v .:? "superTypes" .!= []
-        <*> v .:? "members" .!= []
-        <*> v .:? "annotations" .!= []
-        <*> v .:  "span"
+      "ClassDecl" -> do
+        -- The live parser splits the supertype list into "extends"
+        -- (constructor-call entries) and "implements" (bare/delegated);
+        -- see parseSuperTypeEntry.
+        extEntries  <- v .:? "extends"    .!= []
+        implEntries <- v .:? "implements" .!= []
+        ClassDecl
+          <$> v .:  "name"
+          <*> v .:? "kind" .!= "class"
+          <*> v .:? "modifiers" .!= []
+          <*> v .:? "typeParameters" .!= []
+          <*> v .:? "primaryConstructor"
+          <*> v .:? "superTypes" .!= []
+          <*> pure (superTypeEntryNames extEntries)
+          <*> pure (superTypeEntryNames implEntries)
+          <*> v .:? "members" .!= []
+          <*> v .:? "annotations" .!= []
+          <*> v .:  "span"
+      "ObjectDecl" -> do
+        -- The live parser emits ONE mixed "supertypes" array for objects;
+        -- constructor-call entries (wrapped, with "args") are the class
+        -- supertype, the rest are interfaces.
+        entries <- v .:? "supertypes" .!= []
+        let pairs = map parseSuperTypeEntry entries
+        ObjectDecl
+          <$> v .:  "name"
+          <*> v .:? "modifiers" .!= []
+          <*> v .:? "superTypes" .!= []
+          <*> pure [ n | (True,  n) <- pairs, not (T.null n) ]
+          <*> pure [ n | (False, n) <- pairs, not (T.null n) ]
+          <*> v .:? "members" .!= []
+          <*> v .:? "annotations" .!= []
+          <*> v .:  "span"
       "FunDecl" -> FunDecl
         <$> v .:  "name"
         <*> v .:? "modifiers" .!= []
@@ -542,6 +578,58 @@ instance FromJSON KotlinDecl where
         <*> v .:  "span"
       _ -> DeclUnknown
         <$> v .: "span"
+
+-- Supertype-list entry decoding (the live kotlin-parser vocabulary).
+--
+-- serializeClass (KotlinAstSerializer.kt:99-123) emits
+--   "extends"    = [{type: <typeref>, args, span}]            (KtSuperTypeCallEntry)
+--   "implements" = [<typeref> | {type: <typeref>, delegate, span}]
+--                                  (KtSuperTypeEntry / KtDelegatedSuperTypeEntry)
+-- and serializeObject (:148-171) one mixed "supertypes" array of the same two
+-- shapes. The typeref itself is {"type":"ClassType","name":N,"scope":Q?,...}.
+-- Both helpers are total: malformed entries yield "" and are dropped upstream.
+
+-- | One supertype-list entry → (isConstructorCall, supertype name).
+-- A wrapped entry holds the typeref under "type" (an Object, vs the String
+-- discriminator of a direct typeref); "args" marks the constructor-call form.
+parseSuperTypeEntry :: Value -> (Bool, Text)
+parseSuperTypeEntry (Object v) =
+  case KM.lookup "type" v of
+    Just inner@(Object _) -> (KM.member "args" v, superTypeRefName inner)
+    _                     -> (False, superTypeRefName (Object v))
+parseSuperTypeEntry _ = (False, "")
+
+-- | All non-empty names of a supertype-entry list (classification dropped —
+-- the ClassDecl keys are pre-classified by the parser).
+superTypeEntryNames :: [Value] -> [Text]
+superTypeEntryNames = filter (not . T.null) . map (snd . parseSuperTypeEntry)
+
+-- | The name of a supertype reference, scope-qualified when the parser
+-- provides "scope" ("java.util" + "AbstractList" → "java.util.AbstractList").
+-- Type arguments are NOT part of the name (generics stripped). Accepts the
+-- live parser tag "ClassType" and the analyzer-internal/test tag "SimpleType";
+-- nullable wrappers unwrap; anything else (function types, star projections,
+-- unknowns) yields "".
+superTypeRefName :: Value -> Text
+superTypeRefName (Object v) =
+  case KM.lookup "type" v of
+    Just (String "ClassType")  -> qualifiedName
+    Just (String "SimpleType") -> qualifiedName
+    Just (String "NullableType") ->
+      case KM.lookup "inner" v of
+        Just inner -> superTypeRefName inner
+        Nothing    -> ""
+    _ -> ""
+  where
+    qualifiedName =
+      let n = case KM.lookup "name" v of
+                Just (String t) -> t
+                _               -> ""
+          mScope = case KM.lookup "scope" v of
+                     Just (String s) -> Just s
+                     _               -> Nothing
+      in if T.null n then "" else maybe n (\s -> s <> "." <> n) mScope
+superTypeRefName _ = ""
 
 instance FromJSON KotlinMember where
   parseJSON = withObject "KotlinMember" $ \v -> do

--- a/packages/kotlin-analyzer/src/Rules/Annotations.hs
+++ b/packages/kotlin-analyzer/src/Rules/Annotations.hs
@@ -35,14 +35,14 @@ import Grafema.SemanticId (semanticId, contentHash)
 
 walkDeclAnnotations :: KotlinDecl -> Analyzer ()
 
-walkDeclAnnotations (ClassDecl name _kind _mods _tps _ctor _supers members annots sp) = do
+walkDeclAnnotations (ClassDecl name _kind _mods _tps _ctor _supers _exts _impls members annots sp) = do
   file   <- askFile
   parent <- askNamedParent
   let itemId = semanticId file "CLASS" name parent Nothing
   mapM_ (walkAnnotation file itemId sp) annots
   mapM_ (walkMemberAnnotations file) members
 
-walkDeclAnnotations (ObjectDecl name _mods _supers members annots sp) = do
+walkDeclAnnotations (ObjectDecl name _mods _supers _exts _impls members annots sp) = do
   file   <- askFile
   parent <- askNamedParent
   let itemId = semanticId file "CLASS" name parent Nothing

--- a/packages/kotlin-analyzer/src/Rules/Declarations.hs
+++ b/packages/kotlin-analyzer/src/Rules/Declarations.hs
@@ -73,13 +73,35 @@ visibilityText mods
 isExportable :: [Text] -> Bool
 isExportable mods = not (isPrivate mods)
 
+-- | Supertype metadata stamps on CLASS nodes — the analyzer-side unblock for
+-- kotlin inheritance edges (the deferred InheritanceResolve refs are dropped
+-- by the orchestrator, so these names must live on the node itself):
+--   "extends"          = the single class supertype (the parser's
+--                        constructor-call entry; first wins if the parser
+--                        ever yields several — invalid Kotlin),
+--   "implements_0..n"  = indexed interface supertypes (the list-valued
+--                        metadata convention: node_attr-addressable today,
+--                        no split builtin needed).
+-- Kotlin nuance: a class with NO primary constructor may extend a class via a
+-- bare supertype entry (`class X : Base { constructor() : super() }`) — the
+-- parser classifies bare entries as "implements", so such a superclass lands
+-- in implements_N; the consuming kotlin_inheritance.dl pack re-classifies by
+-- the resolved declaration's own `kind` (interface → IMPLEMENTS, else
+-- EXTENDS). Names arrive pre-filtered non-empty from the KotlinAST decoder.
+-- Consumed by the kotlin_inheritance.dl stdlib pack.
+inheritanceMeta :: [Text] -> [Text] -> [(Text, MetaValue)]
+inheritanceMeta extNames implNames =
+  [ ("extends", MetaText e) | e <- take 1 extNames ]
+  ++ [ ("implements_" <> T.pack (show i), MetaText n)
+     | (i, n) <- zip [0 :: Int ..] implNames ]
+
 -- Top-level declaration walker
 
 -- | Walk a single top-level or nested declaration.
 walkDeclaration :: KotlinDecl -> Analyzer ()
 
 -- Class declaration (class, data, sealed, enum, inner, value, annotation)
-walkDeclaration (ClassDecl name kind mods _typeParams mPrimaryCtor _supers members _annots sp) = do
+walkDeclaration (ClassDecl name kind mods _typeParams mPrimaryCtor _supers extNames implNames members _annots sp) = do
   file     <- askFile
   scopeId  <- askScopeId
   parent   <- askNamedParent
@@ -110,6 +132,7 @@ walkDeclaration (ClassDecl name kind mods _typeParams mPrimaryCtor _supers membe
         , ("inner",      MetaBool (kind == "inner" || "inner" `elem` mods))
         , ("value",      MetaBool (kind == "value"))
         ]
+        ++ inheritanceMeta extNames implNames
     }
 
   emitEdge GraphEdge
@@ -138,7 +161,7 @@ walkDeclaration (ClassDecl name kind mods _typeParams mPrimaryCtor _supers membe
       mapM_ walkMember members
 
 -- Object declaration
-walkDeclaration (ObjectDecl name mods _supers members _annots sp) = do
+walkDeclaration (ObjectDecl name mods _supers extNames implNames members _annots sp) = do
   file     <- askFile
   scopeId  <- askScopeId
   parent   <- askNamedParent
@@ -159,11 +182,12 @@ walkDeclaration (ObjectDecl name mods _supers members _annots sp) = do
     , gnEndLine   = posLine (spanEnd sp)
     , gnEndColumn = posCol  (spanEnd sp)
     , gnExported  = objExported
-    , gnMetadata  = Map.fromList
+    , gnMetadata  = Map.fromList $
         [ ("kind",       MetaText "object")
         , ("visibility", MetaText (visibilityText mods))
         , ("singleton",  MetaBool True)
         ]
+        ++ inheritanceMeta extNames implNames
     }
 
   emitEdge GraphEdge
@@ -860,8 +884,8 @@ walkParam fnId param = do
 -- Helpers
 
 declName' :: KotlinDecl -> Text
-declName' (ClassDecl n _ _ _ _ _ _ _ _)       = n
-declName' (ObjectDecl n _ _ _ _ _)            = n
+declName' (ClassDecl n _ _ _ _ _ _ _ _ _ _)   = n
+declName' (ObjectDecl n _ _ _ _ _ _ _)        = n
 declName' (FunDecl n _ _ _ _ _ _ _ _)         = n
 declName' (PropertyDecl n _ _ _ _ _ _ _ _ _)  = n
 declName' (TypeAliasDecl n _ _ _ _ _)         = n

--- a/packages/kotlin-analyzer/src/Rules/Exports.hs
+++ b/packages/kotlin-analyzer/src/Rules/Exports.hs
@@ -33,7 +33,7 @@ isPrivate mods = "private" `elem` mods
 walkDeclExports :: KotlinDecl -> Analyzer ()
 
 -- Public class (default) -> NamedExport + walk members
-walkDeclExports (ClassDecl name _kind mods _tps _ctor _supers members _annots _sp)
+walkDeclExports (ClassDecl name _kind mods _tps _ctor _supers _exts _impls members _annots _sp)
   | not (isPrivate mods) = do
     file   <- askFile
     _parent <- askNamedParent
@@ -46,7 +46,7 @@ walkDeclExports (ClassDecl name _kind mods _tps _ctor _supers members _annots _s
       }
     mapM_ (walkMemberExports file name) members
 
-walkDeclExports (ObjectDecl name mods _supers members _annots _sp)
+walkDeclExports (ObjectDecl name mods _supers _exts _impls members _annots _sp)
   | not (isPrivate mods) = do
     file   <- askFile
     _parent <- askNamedParent

--- a/packages/kotlin-analyzer/src/Rules/Types.hs
+++ b/packages/kotlin-analyzer/src/Rules/Types.hs
@@ -40,7 +40,7 @@ import Grafema.SemanticId (semanticId, contentHash)
 walkDeclTypeRefs :: KotlinDecl -> Analyzer ()
 
 -- Class: superTypes + type params + member types
-walkDeclTypeRefs (ClassDecl name _kind _mods typeParams _mCtor supers members _annots sp) = do
+walkDeclTypeRefs (ClassDecl name _kind _mods typeParams _mCtor supers _exts _impls members _annots sp) = do
   file   <- askFile
   parent <- askNamedParent
   let nodeId = semanticId file "CLASS" name parent Nothing
@@ -58,7 +58,7 @@ walkDeclTypeRefs (ClassDecl name _kind _mods typeParams _mCtor supers members _a
   mapM_ (walkMemberTypeRefs file nodeId) members
 
 -- Object: superTypes + member types
-walkDeclTypeRefs (ObjectDecl name _mods supers members _annots sp) = do
+walkDeclTypeRefs (ObjectDecl name _mods supers _exts _impls members _annots sp) = do
   file   <- askFile
   parent <- askNamedParent
   let nodeId = semanticId file "CLASS" name parent Nothing

--- a/packages/kotlin-analyzer/test/Spec.hs
+++ b/packages/kotlin-analyzer/test/Spec.hs
@@ -101,7 +101,7 @@ emptyBlock = BlockStmt [] (mkSpan 3 0 3 2)
 
 mkClassDecl :: Text -> Text -> [Text] -> [KotlinType] -> [KotlinMember] -> KotlinDecl
 mkClassDecl name kind mods supers members = ClassDecl
-  name kind mods [] Nothing supers members [] (mkSpan 1 0 10 1)
+  name kind mods [] Nothing supers [] [] members [] (mkSpan 1 0 10 1)
 
 mkFunDecl :: Text -> [Text] -> [KotlinParam] -> Maybe KotlinType -> Maybe KotlinStmt -> KotlinDecl
 mkFunDecl name mods params retType body = FunDecl
@@ -209,11 +209,88 @@ main = hspec $ do
           containsEdges = findEdgesByType "CONTAINS" fa
       length containsEdges `shouldSatisfy` (> 0)
 
+  -- Declarations: Inheritance metadata stamps (the kotlin_inheritance.dl EDB).
+  -- JSON fixtures use the LIVE kotlin-parser vocabulary (KotlinAstSerializer.kt):
+  -- ClassDecl carries "extends" (wrapped constructor-call entries) and
+  -- "implements" (bare/delegated typerefs); ObjectDecl one mixed "supertypes"
+  -- array; typerefs are tagged "ClassType" with optional "scope"/"typeArgs".
+
+  describe "Declarations.InheritanceMeta" $ do
+    let sp = "{\"start\": {\"line\": 1, \"col\": 0}, \"end\": {\"line\": 1, \"col\": 10}}"
+        ref name = "{\"type\": \"ClassType\", \"name\": \"" ++ name ++ "\", \"span\": " ++ sp ++ "}"
+        callEntry name = "{\"type\": " ++ ref name ++ ", \"args\": [], \"span\": " ++ sp ++ "}"
+        delegEntry name = "{\"type\": " ++ ref name ++ ", \"delegate\": {\"type\": \"NameExpr\", \"name\": \"g\", \"span\": " ++ sp ++ "}, \"span\": " ++ sp ++ "}"
+        classJson name extra =
+          "{\"declarations\": [{\"type\": \"ClassDecl\", \"name\": \"" ++ name
+            ++ "\", \"kind\": \"class\"" ++ extra ++ ", \"span\": " ++ sp ++ "}]}"
+        analyzed json = case parseKotlinFile json of
+          Left err -> error ("Parse failed: " ++ err)
+          Right file -> analyzeText file
+        classNode name fa = case find (\n -> gnType n == "CLASS" && gnName n == name) (faNodes fa) of
+          Nothing -> error ("No CLASS node " ++ show name)
+          Just node -> node
+
+    it "stamps extends for a constructor-call supertype" $ do
+      let fa = analyzed (classJson "Simple" (", \"extends\": [" ++ callEntry "Base" ++ "]"))
+          node = classNode "Simple" fa
+      getMetaText "extends" node `shouldBe` Just "Base"
+      getMetaText "implements_0" node `shouldBe` Nothing
+
+    it "stamps indexed implements for interface supertypes" $ do
+      let fa = analyzed (classJson "Impl" (", \"implements\": [" ++ ref "Greeter" ++ ", " ++ ref "Closer" ++ "]"))
+          node = classNode "Impl" fa
+      getMetaText "extends" node `shouldBe` Nothing
+      getMetaText "implements_0" node `shouldBe` Just "Greeter"
+      getMetaText "implements_1" node `shouldBe` Just "Closer"
+      getMetaText "implements_2" node `shouldBe` Nothing
+
+    it "stamps combined extends + implements" $ do
+      let fa = analyzed (classJson "Multi"
+                 (", \"extends\": [" ++ callEntry "Base" ++ "], \"implements\": ["
+                   ++ ref "Greeter" ++ ", " ++ ref "Closer" ++ "]"))
+          node = classNode "Multi" fa
+      getMetaText "extends" node `shouldBe` Just "Base"
+      getMetaText "implements_0" node `shouldBe` Just "Greeter"
+      getMetaText "implements_1" node `shouldBe` Just "Closer"
+
+    it "strips generic type args and keeps the scope qualifier" $ do
+      -- class GenericSuper : java.util.AbstractList<String>(), Comparable<Simple>
+      let absList = "{\"type\": \"ClassType\", \"name\": \"AbstractList\", \"scope\": \"java.util\", \"typeArgs\": [{\"type\": " ++ ref "String" ++ ", \"span\": " ++ sp ++ "}], \"span\": " ++ sp ++ "}"
+          cmp = "{\"type\": \"ClassType\", \"name\": \"Comparable\", \"typeArgs\": [{\"type\": " ++ ref "Simple" ++ ", \"span\": " ++ sp ++ "}], \"span\": " ++ sp ++ "}"
+          fa = analyzed (classJson "GenericSuper"
+                 (", \"extends\": [{\"type\": " ++ absList ++ ", \"args\": [], \"span\": " ++ sp ++ "}], \"implements\": [" ++ cmp ++ "]"))
+          node = classNode "GenericSuper" fa
+      getMetaText "extends" node `shouldBe` Just "java.util.AbstractList"
+      getMetaText "implements_0" node `shouldBe` Just "Comparable"
+
+    it "stamps nothing for a class without supertypes" $ do
+      let fa = analyzed (classJson "NoSupers" "")
+          node = classNode "NoSupers" fa
+      getMetaText "extends" node `shouldBe` Nothing
+      getMetaText "implements_0" node `shouldBe` Nothing
+
+    it "classifies a delegated supertype entry as implements" $ do
+      -- class Delegated(g: Greeter) : Greeter by g
+      let fa = analyzed (classJson "Delegated" (", \"implements\": [" ++ delegEntry "Greeter" ++ "]"))
+          node = classNode "Delegated" fa
+      getMetaText "extends" node `shouldBe` Nothing
+      getMetaText "implements_0" node `shouldBe` Just "Greeter"
+
+    it "partitions an object's mixed supertypes array by the constructor-call marker" $ do
+      -- object Singleton : Base(9), Greeter
+      let json = "{\"declarations\": [{\"type\": \"ObjectDecl\", \"name\": \"Singleton\", \"supertypes\": ["
+                   ++ callEntry "Base" ++ ", " ++ ref "Greeter" ++ "], \"span\": " ++ sp ++ "}]}"
+          fa = analyzed json
+          node = classNode "Singleton" fa
+      getMetaText "kind" node `shouldBe` Just "object"
+      getMetaText "extends" node `shouldBe` Just "Base"
+      getMetaText "implements_0" node `shouldBe` Just "Greeter"
+
   -- Declarations: Object
 
   describe "Declarations.Object" $ do
     it "emits CLASS node with kind=object and singleton=true" $ do
-      let obj = ObjectDecl "AppConfig" [] [] [] [] (mkSpan 1 0 5 1)
+      let obj = ObjectDecl "AppConfig" [] [] [] [] [] [] (mkSpan 1 0 5 1)
           fa = analyzeText (KotlinFile Nothing [] [obj])
       case findNodeByType "CLASS" fa of
         Nothing -> expectationFailure "No CLASS node"
@@ -343,7 +420,7 @@ main = hspec $ do
 
     it "emits TYPE_PARAMETER nodes with variance" $ do
       let tp = KotlinTypeParam "T" (Just "out") [] False (mkSpan 1 10 1 15)
-          cls = ClassDecl "Box" "class" [] [tp] Nothing [] [] [] (mkSpan 1 0 5 1)
+          cls = ClassDecl "Box" "class" [] [tp] Nothing [] [] [] [] [] (mkSpan 1 0 5 1)
           fa = analyzeText (KotlinFile Nothing [] [cls])
           tpNodes = findNodesByType "TYPE_PARAMETER" fa
       length tpNodes `shouldBe` 1
@@ -357,7 +434,7 @@ main = hspec $ do
   describe "Annotations" $ do
     it "emits ATTRIBUTE node for marker annotation" $ do
       let ann = MarkerAnnotation "Deprecated" Nothing (mkSpan 2 2 2 13)
-          cls = ClassDecl "Old" "class" [] [] Nothing [] [] [ann] (mkSpan 3 0 5 1)
+          cls = ClassDecl "Old" "class" [] [] Nothing [] [] [] [] [ann] (mkSpan 3 0 5 1)
           fa = analyzeText (KotlinFile Nothing [] [cls])
           attrs = findNodesByType "ATTRIBUTE" fa
       case find (\n -> gnName n == "Deprecated") attrs of
@@ -366,7 +443,7 @@ main = hspec $ do
 
     it "emits HAS_ATTRIBUTE edge" $ do
       let ann = MarkerAnnotation "Deprecated" Nothing (mkSpan 2 2 2 13)
-          cls = ClassDecl "Old" "class" [] [] Nothing [] [] [ann] (mkSpan 3 0 5 1)
+          cls = ClassDecl "Old" "class" [] [] Nothing [] [] [] [] [ann] (mkSpan 3 0 5 1)
           fa = analyzeText (KotlinFile Nothing [] [cls])
           hasAttrEdges = findEdgesByType "HAS_ATTRIBUTE" fa
       length hasAttrEdges `shouldBe` 1

--- a/packages/kotlin-resolve/src/TypeResolution.hs
+++ b/packages/kotlin-resolve/src/TypeResolution.hs
@@ -4,13 +4,23 @@
 -- Resolves type references from node metadata to produce typed edges:
 --   - RETURNS edges: function -> return type class
 --   - TYPE_OF edges: variable -> type class
---   - EXTENDS edges: class -> superclass
---   - IMPLEMENTS edges: class -> interface
 --   - THROWS_TYPE edges: function -> exception class
 --
 -- Uses class index to find targets within the project.
 -- External types (stdlib, third-party), primitives, and Kotlin built-in
 -- types are silently skipped.
+--
+-- EXTENDS / IMPLEMENTS are owned by the kotlin_inheritance.dl stdlib pack
+-- (rfdb-server derive/stdlib/kotlin_inheritance.dl), which resolves the
+-- analyzer's `extends` / `implements_0..n` CLASS stamps with file/directory
+-- scoping and an ambiguity discipline. The resolveExtends/resolveImplements
+-- arms that used to live here were retired in the same wave that introduced
+-- those stamps: they had been dead (the analyzer never stamped `extends` /
+-- `implements` before, so their production output was provably ZERO), and the
+-- new `extends` stamp would have woken resolveExtends into a second EXTENDS
+-- producer routed through the UNSCOPED project-wide last-wins simple-name
+-- index below — silent wrong cross-package edges the pack deliberately
+-- refuses.
 module TypeResolution (run, resolveAll) where
 
 import Grafema.Types (GraphNode(..), GraphEdge(..), MetaValue(..))
@@ -150,37 +160,6 @@ resolveTypeOf classIdx = concatMap go
                 Nothing      -> []
                 Just classId -> [mkEdge (gnId node) classId "TYPE_OF"]
 
--- | Resolve EXTENDS edges: CLASS nodes with extends metadata.
-resolveExtends :: ClassIndex -> [GraphNode] -> [PluginCommand]
-resolveExtends classIdx = concatMap go
-  where
-    classTypes = Set.fromList ["CLASS", "INTERFACE", "ENUM", "OBJECT"]
-
-    go node
-      | not (Set.member (gnType node) classTypes) = []
-      | otherwise =
-          case getMetaText "extends" node of
-            Nothing -> []
-            Just extendsName ->
-              case lookupType classIdx extendsName of
-                Nothing      -> []
-                Just classId -> [mkEdge (gnId node) classId "EXTENDS"]
-
--- | Resolve IMPLEMENTS edges: CLASS nodes with implements metadata (comma-separated).
-resolveImplements :: ClassIndex -> [GraphNode] -> [PluginCommand]
-resolveImplements classIdx = concatMap go
-  where
-    go node
-      | gnType node /= "CLASS" && gnType node /= "ENUM" = []
-      | otherwise =
-          case getMetaText "implements" node of
-            Nothing -> []
-            Just implStr ->
-              [ mkEdge (gnId node) ifaceId "IMPLEMENTS"
-              | typeName <- splitTypes implStr
-              , Just ifaceId <- [lookupType classIdx typeName]
-              ]
-
 -- | Resolve THROWS_TYPE edges: FUNCTION nodes with throws metadata (comma-separated).
 resolveThrows :: ClassIndex -> [GraphNode] -> [PluginCommand]
 resolveThrows classIdx = concatMap go
@@ -213,19 +192,14 @@ resolveAll nodes = do
 
   let returnsEdges    = resolveReturns classIdx nodes
       typeOfEdges     = resolveTypeOf classIdx nodes
-      extendsEdges    = resolveExtends classIdx nodes
-      implementsEdges = resolveImplements classIdx nodes
       throwsEdges     = resolveThrows classIdx nodes
 
-      allEdges = returnsEdges ++ typeOfEdges ++ extendsEdges
-              ++ implementsEdges ++ throwsEdges
+      allEdges = returnsEdges ++ typeOfEdges ++ throwsEdges
 
   hPutStrLn stderr $
     "kotlin-type-resolve: " ++ show (length allEdges) ++ " type edges"
     ++ " (RETURNS=" ++ show (length returnsEdges)
     ++ ", TYPE_OF=" ++ show (length typeOfEdges)
-    ++ ", EXTENDS=" ++ show (length extendsEdges)
-    ++ ", IMPLEMENTS=" ++ show (length implementsEdges)
     ++ ", THROWS_TYPE=" ++ show (length throwsEdges) ++ ")"
 
   return allEdges

--- a/packages/kotlin-resolve/test/Spec.hs
+++ b/packages/kotlin-resolve/test/Spec.hs
@@ -131,7 +131,13 @@ main = hspec $ do
 
   describe "TypeResolution" $ do
 
-    it "resolves EXTENDS metadata to CLASS node" $ do
+    -- EXTENDS / IMPLEMENTS are owned by the kotlin_inheritance.dl stdlib
+    -- pack; the retired resolveExtends/resolveImplements arms must NOT come
+    -- back — the analyzer now stamps `extends` on CLASS nodes, and a revived
+    -- arm would be a second, unscoped EXTENDS producer (last-wins
+    -- simple-name index, no ambiguity discipline). These are regression
+    -- guards: the stamps that wake the pack must leave this plugin silent.
+    it "does NOT resolve the analyzer's extends stamp (pack-owned)" $ do
       let child = mkNodeMeta
             "f1->CLASS->Child" "CLASS" "Child" "f1.kt"
             [("extends", MetaText "Parent")]
@@ -139,34 +145,22 @@ main = hspec $ do
             "f2->CLASS->Parent" "CLASS" "Parent" "f2.kt"
           nodes = [child, parent]
       cmds <- TypeResolution.resolveAll nodes
-      let extends = findEdgesOfType "EXTENDS" cmds
-      length extends `shouldBe` 1
-      geSource (head extends) `shouldBe` "f1->CLASS->Child"
-      geTarget (head extends) `shouldBe` "f2->CLASS->Parent"
+      countEdgeType "EXTENDS" cmds `shouldBe` 0
 
-    it "resolves IMPLEMENTS metadata to INTERFACE node" $ do
+    it "does NOT resolve implements metadata (pack-owned)" $ do
       let cls = mkNodeMeta
             "f1->CLASS->Impl" "CLASS" "Impl" "f1.kt"
-            [("implements", MetaText "Serializable")]
-          iface = mkNode
-            "f2->INTERFACE->Serializable" "INTERFACE" "Serializable" "f2.kt"
-          nodes = [cls, iface]
-      cmds <- TypeResolution.resolveAll nodes
-      let impls = findEdgesOfType "IMPLEMENTS" cmds
-      length impls `shouldBe` 1
-      geTarget (head impls) `shouldBe` "f2->INTERFACE->Serializable"
-
-    it "resolves multiple implements" $ do
-      let cls = mkNodeMeta
-            "f1->CLASS->Impl" "CLASS" "Impl" "f1.kt"
-            [("implements", MetaText "Serializable,Comparable")]
+            [ ("implements", MetaText "Serializable")
+            , ("implements_0", MetaText "Comparable")
+            ]
           iface1 = mkNode
             "f2->INTERFACE->Serializable" "INTERFACE" "Serializable" "f2.kt"
           iface2 = mkNode
             "f3->INTERFACE->Comparable" "INTERFACE" "Comparable" "f3.kt"
           nodes = [cls, iface1, iface2]
       cmds <- TypeResolution.resolveAll nodes
-      countEdgeType "IMPLEMENTS" cmds `shouldBe` 2
+      countEdgeType "IMPLEMENTS" cmds `shouldBe` 0
+      countEdgeType "EXTENDS" cmds `shouldBe` 0
 
     it "resolves return_type metadata to RETURNS edge" $ do
       let fn = mkNodeMeta
@@ -376,11 +370,14 @@ main = hspec $ do
   describe "Edge integrity" $ do
 
     it "never produces edges with empty source or target" $ do
-      let cls = mkNodeMeta
-            "f1->CLASS->Foo" "CLASS" "Foo" "f1.kt"
-            [("extends", MetaText "Bar")]
-          nodes = [cls]
+      let fn = mkNodeMeta
+            "f1->FUNCTION->make[in:Foo,h:x]" "FUNCTION" "make" "f1.kt"
+            [("return_type", MetaText "Bar")]
+          cls = mkNode
+            "f2->CLASS->Bar" "CLASS" "Bar" "f2.kt"
+          nodes = [fn, cls]
       cmds <- TypeResolution.resolveAll nodes
+      countEdgeType "RETURNS" cmds `shouldBe` 1
       let badEdges = [ e | EmitEdge e <- cmds
                          , geSource e == "" || geTarget e == "" ]
       badEdges `shouldBe` []

--- a/packages/rfdb-server/src/datalog/parser.rs
+++ b/packages/rfdb-server/src/datalog/parser.rs
@@ -106,18 +106,37 @@ impl<'a> Parser<'a> {
         Ok(self.input[start..self.pos].to_string())
     }
 
+    /// Parse a double-quoted string literal.
+    ///
+    /// Escape handling is LENIENT (Wave 14): a backslash followed by `"` or
+    /// `\` is an escape sequence producing that character (so a literal
+    /// double-quote CAN appear inside a string — required by quote-stripping
+    /// rules over JS string literals, whose graph `name` keeps the raw source
+    /// quoting). A backslash followed by anything else stays a literal
+    /// backslash — pre-escape strings like `"C:\Users"` keep their meaning
+    /// (only `\"` / `\\` sequences, previously impossible to express in the
+    /// first case and degenerate in the second, change interpretation).
     fn parse_string(&mut self) -> Result<String, ParseError> {
         self.skip_whitespace();
         self.expect("\"")?;
 
         let start = self.pos;
+        let mut value = String::new();
         while self.pos < self.input.len() {
             let c = self.input[self.pos..].chars().next().unwrap();
             if c == '"' {
-                let value = self.input[start..self.pos].to_string();
                 self.pos += 1; // consume closing quote
                 return Ok(value);
             }
+            if c == '\\' {
+                let next = self.input[self.pos + 1..].chars().next();
+                if matches!(next, Some('"') | Some('\\')) {
+                    value.push(next.unwrap());
+                    self.pos += 1 + next.unwrap().len_utf8();
+                    continue;
+                }
+            }
+            value.push(c);
             self.pos += c.len_utf8();
         }
 
@@ -359,4 +378,39 @@ pub fn parse_query(input: &str) -> Result<Vec<Literal>, ParseError> {
         ));
     }
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn const_of(t: &Term) -> &str {
+        match t {
+            Term::Const(s) => s,
+            other => panic!("expected Const, got {other:?}"),
+        }
+    }
+
+    /// Wave 14 — lenient escape sequences in string literals: `\"` and `\\`
+    /// decode to the bare character; any other backslash stays literal
+    /// (pre-escape behavior for strings like "C:\Users" is preserved).
+    #[test]
+    fn string_literal_escapes_are_lenient() {
+        let a = parse_atom(r#"p("a\"b")"#).expect("escaped quote parses");
+        assert_eq!(const_of(&a.args()[0]), "a\"b");
+
+        let a = parse_atom(r#"p("a\\b")"#).expect("escaped backslash parses");
+        assert_eq!(const_of(&a.args()[0]), "a\\b");
+
+        // Lone backslash before a non-escapable char stays literal.
+        let a = parse_atom(r#"p("C:\Users")"#).expect("non-escape backslash parses");
+        assert_eq!(const_of(&a.args()[0]), "C:\\Users");
+
+        // A bare double-quote literal — the quote-strip use case.
+        let a = parse_atom(r#"sw(X, "\"")"#).expect("single dquote literal parses");
+        assert_eq!(const_of(&a.args()[1]), "\"");
+
+        // Unterminated string (escape eats the closer) still errors.
+        assert!(parse_atom(r#"p("abc\")"#).is_err());
+    }
 }

--- a/packages/rfdb-server/src/derive/builtin.rs
+++ b/packages/rfdb-server/src/derive/builtin.rs
@@ -966,6 +966,32 @@ fn eval_last_segment(_v: &dyn StorageView, out: &mut Batch, spec: &ArgSpec) -> B
     Ok(())
 }
 
+/// `first_segment(S, Sep, Seg)` — the substring before the FIRST occurrence of the bound
+/// separator `Sep` (`first_segment("github.com/user/proj", "/", X)` → `"github.com"`);
+/// identity when `S` contains no `Sep` (the dual of `last_segment`'s no-separator stance —
+/// a one-segment path IS its own first segment). NO row when the produced segment is
+/// empty — a leading separator (`"/a"`), or the degenerate empty `Sep` (which "matches"
+/// at the very start): an empty segment names nothing (the `last_segment` discipline).
+/// Built for the Go packs: the EXACT spelling of Go's `isStdLib` test ("first path
+/// segment contains a dot", GoImportResolution.hs:86-89) and the left-peel that derives
+/// the '/'-boundary SUFFIXES of an import path (the no-go.mod fallback arm — the
+/// right-peel `last_segment` idiom mirrored). Free arg2 binds; bound arg2
+/// equality-filters.
+fn eval_first_segment(_v: &dyn StorageView, out: &mut Batch, spec: &ArgSpec) -> BuiltinResult<()> {
+    let (Some(s), Some(sep)) = (bound_str(&spec.args[0]), bound_str(&spec.args[1])) else {
+        return Ok(());
+    };
+    let produced = match s.find(sep.as_str()) {
+        Some(i) => &s[..i],
+        None => s.as_str(),
+    };
+    if produced.is_empty() {
+        return Ok(());
+    }
+    bind_or_check(out, spec, 2, produced);
+    Ok(())
+}
+
 /// `replace_all(S, From, To, Out)` — `Out` is `S` with EVERY occurrence of `From`
 /// replaced by `To`, non-overlapping left-to-right (`replace_all("foo/bar", "/", "::",
 /// X)` → `"foo::bar"`; the file-path → Rust-module-path separator rewrite,
@@ -1153,9 +1179,9 @@ const METHOD_SUFFIX_MODES: &[Mode] = &[Mode { args: &[B, F] }, Mode { args: &[B,
 /// the same discipline as [`METHOD_SUFFIX_MODES`].
 const STR_FN2_MODES: &[Mode] = &[Mode { args: &[B, F] }, Mode { args: &[B, B] }];
 
-/// `concat/3`/`strip_prefix/3`/`strip_suffix/3`/`last_segment/3`/`path_resolve/3`
-/// modes: both inputs bound; the output (last position) is free (bind) or bound
-/// (equality check).
+/// `concat/3`/`strip_prefix/3`/`strip_suffix/3`/`last_segment/3`/`first_segment/3`/
+/// `path_resolve/3` modes: both inputs bound; the output (last position) is free (bind)
+/// or bound (equality check).
 const CONCAT_MODES: &[Mode] = &[Mode { args: &[B, B, F] }, Mode { args: &[B, B, B] }];
 
 /// `replace_all/4` modes: the three inputs (subject, pattern, replacement) bound; the
@@ -1342,6 +1368,13 @@ pub fn registry() -> Vec<BuiltinDef> {
             eval: eval_last_segment,
         },
         BuiltinDef {
+            name: "first_segment",
+            arity: 3,
+            modes: CONCAT_MODES,
+            kind: BuiltinKind::Function,
+            eval: eval_first_segment,
+        },
+        BuiltinDef {
             name: "replace_all",
             arity: 4,
             modes: REPLACE_ALL_MODES,
@@ -1486,6 +1519,7 @@ mod tests {
             "strip_prefix",
             "strip_suffix",
             "last_segment",
+            "first_segment",
             "replace_all",
             "path_resolve",
             "edge_attr",
@@ -2455,6 +2489,61 @@ mod tests {
         let err = def.check_mode(&spec).unwrap_err();
         assert_eq!(err.code.as_str(), "E-PLAN-001");
         assert!(err.required_bindings.contains(&0), "must name the free input");
+    }
+
+    // ── first_segment ──────────────────────────────────────────────
+
+    #[test]
+    fn first_segment_before_first_separator_identity_and_empty_skip() {
+        // [B, B, F] — the Go isStdLib shape: the first '/'-segment of an import path.
+        let path = ArgSpec::new(vec![
+            ArgValue::Bound(s("github.com/user/proj")),
+            ArgValue::Bound(s("/")),
+            ArgValue::Free { slot: 0 },
+        ]);
+        let out = run("first_segment", path);
+        assert_eq!(out.rows.len(), 1);
+        assert_eq!(out.rows[0][0], s("github.com"));
+
+        // No separator occurrence → identity ("fmt" IS its own first segment).
+        let flat = ArgSpec::new(vec![
+            ArgValue::Bound(s("fmt")),
+            ArgValue::Bound(s("/")),
+            ArgValue::Free { slot: 0 },
+        ]);
+        let out = run("first_segment", flat);
+        assert_eq!(out.rows.len(), 1);
+        assert_eq!(out.rows[0][0], s("fmt"));
+
+        // Leading separator → empty segment → NO row.
+        let leading = ArgSpec::new(vec![
+            ArgValue::Bound(s("/abs/path")),
+            ArgValue::Bound(s("/")),
+            ArgValue::Free { slot: 0 },
+        ]);
+        assert_eq!(run("first_segment", leading).rows.len(), 0);
+
+        // Empty separator "matches" at the very start → empty segment → NO row.
+        let empty_sep = ArgSpec::new(vec![
+            ArgValue::Bound(s("Bar")),
+            ArgValue::Bound(s("")),
+            ArgValue::Free { slot: 0 },
+        ]);
+        assert_eq!(run("first_segment", empty_sep).rows.len(), 0);
+
+        // [B, B, B] — equality check: pass and non-match.
+        let hit = ArgSpec::new(vec![
+            ArgValue::Bound(s("a/b/c")),
+            ArgValue::Bound(s("/")),
+            ArgValue::Bound(s("a")),
+        ]);
+        assert_eq!(run("first_segment", hit).rows.len(), 1);
+        let miss = ArgSpec::new(vec![
+            ArgValue::Bound(s("a/b/c")),
+            ArgValue::Bound(s("/")),
+            ArgValue::Bound(s("b")),
+        ]);
+        assert_eq!(run("first_segment", miss).rows.len(), 0);
     }
 
     // ── last_segment ───────────────────────────────────────────────

--- a/packages/rfdb-server/src/derive/differential.rs
+++ b/packages/rfdb-server/src/derive/differential.rs
@@ -3039,3 +3039,226 @@ fn w8_cancel_overhead_pack_probe_times() {
     }
     eprintln!("=== W8 probe times: printed ===\n");
 }
+
+// ── Java packs: shadow differential against a java-corpus graph copy ───────
+
+/// Shadow differential for the four java packs (`java_imports` / `java_types`
+/// / `java_calls` / `java_annotations`) against the LEGACY `java-resolve`
+/// slices committed in a java-corpus graph (lang-spec-java.md §8 — the wave3b
+/// harness pattern). The dogfood graph has ZERO java nodes (spec §7, config
+/// gap), so this is the CHECKED-IN acceptance procedure for the corpus run.
+///
+/// SETUP (spec §8): build the corpus DB with `grafema analyze` over a java
+/// codebase with the legacy resolver ON and the java packs OFF — legacy edges
+/// then carry `_source = "java-resolution"` (the `commit_resolve_output`
+/// stamp, orchestrator main.rs:1604), which is how the legacy slice is cut
+/// (pack-written edges carry a rule-hash `_source`; analyzer-emitted CALLS
+/// carry no java-resolution stamp — the 3-way-diff concern resolves to the
+/// stamp). Copy it to the dataset path; NEVER point this at the live store.
+///
+/// Dataset: `GRAFEMA_JAVA_DIFF_DB` (default `/tmp/wave-java.rfdb`, a
+/// caller-made copy). The store is copied again into a tempdir so a
+/// concurrently-running server on the copy cannot contend.
+///
+/// PREDICTIONS, declared BEFORE the diff (spec §8, verified D1/D2/D3):
+/// - P1: the legacy IMPORT_BINDING → decl IMPORTS_FROM slice is EXACTLY 0
+///   (D1 — `resolveBinding` reads metadata `source` that never exists).
+/// - P2: legacy plain-call CALLS rows occur ONLY inside constructors (D3 —
+///   the [in:] probe matches only where method name == class name).
+/// - P3: glob IMPORTs have no IMPORTS_FROM on EITHER side (D2).
+/// If any prediction fails, the spec §2 reading is wrong — STOP, re-derive.
+///
+/// DELTA classes that absorb PACK-EXTRA rows (spec §5; witness each row with
+/// `explain_datalog_fact` before accepting): 1 dup-name set semantics,
+/// 2 all-overloads/all-ctors vs head-pick, 3 binding edges (the P1 declared
+/// superset, bounded below), 4 non-ctor same-class calls (the D3 fix),
+/// 5 local-class ctor membership. Class 6 (multi-element implements/throws
+/// SUBSET) is CLOSED by the right-peel split (verdict C1) — the pack must
+/// never MISS a legacy row, with ONE carve-out: an EXTENDS self-loop
+/// (java_types DELTA 2, `neq(C,T)`).
+///
+///   GRAFEMA_JAVA_DIFF_DB=/tmp/wave-java.rfdb \
+///   cargo test --release --lib java_packs_shadow_differential -- --ignored --nocapture
+#[test]
+#[ignore = "manual real-data shadow differential; needs a java-corpus graph copy"]
+fn java_packs_shadow_differential() {
+    use crate::derive::evaluate_with_materialize;
+
+    let dataset = std::env::var("GRAFEMA_JAVA_DIFF_DB")
+        .unwrap_or_else(|_| "/tmp/wave-java.rfdb".to_string());
+    let dataset = PathBuf::from(dataset);
+    if !dataset.join("db_config.json").exists() {
+        panic!(
+            "dataset not found at {} — build a java-corpus graph first (legacy resolver ON, \
+             packs OFF) and copy it: cp -R <corpus>/.grafema/graph.rfdb /tmp/wave-java.rfdb",
+            dataset.display()
+        );
+    }
+
+    let tmp = tempfile::tempdir().expect("temp");
+    let work = tmp.path().join("graph.rfdb");
+    copy_dir_all(&dataset, &work).expect("copy dataset");
+    let _ = std::fs::remove_file(work.join("LOCK"));
+    let manifest = ManifestStore::open(&work).expect("manifest");
+    let store = MultiShardStore::open(&work, &manifest).expect("store");
+    let store = Arc::new(store);
+    let view = LsmStorageView::capture(store.clone(), &manifest);
+
+    let snap = store.snapshot(&manifest);
+    let all_nodes = store.find_nodes_at(&snap, None, None);
+    let mut nbt: std::collections::HashMap<String, u64> = std::collections::HashMap::new();
+    for n in &all_nodes {
+        *nbt.entry(n.node_type.clone()).or_insert(0) += 1;
+    }
+    let stats = Stats {
+        total_nodes: all_nodes.len() as u64,
+        total_edges: store.iter_all_edges_at(&snap).len() as u64,
+        nodes_by_type: nbt,
+    };
+    eprintln!(
+        "\n=== java packs shadow differential (nodes={}, edges={}) ===",
+        stats.total_nodes, stats.total_edges
+    );
+
+    let pairs = |eval: &crate::derive::exec::Evaluation, pred: &str| -> BTreeSet<(u128, u128)> {
+        eval.facts(pred)
+            .iter()
+            .filter_map(|r| Some((r.first()?.as_id()?, r.get(1)?.as_id()?)))
+            .collect()
+    };
+
+    // ── The LEGACY slices: committed edges stamped by commit_resolve_output.
+    //    Every edge type except CALLS has exactly one producer step (spec §8);
+    //    CALLS partitions structurally by the source CALL node. ──
+    let legacy_src = r#"
+        leg_if_imp(I, T) :- node(I, "IMPORT"), attr(I, "file", F), ends_with(F, ".java"),
+            edge(I, T, "IMPORTS_FROM"), edge_attr(I, T, "IMPORTS_FROM", "_source", "java-resolution").
+        leg_if_bind(B, T) :- node(B, "IMPORT_BINDING"), attr(B, "file", F), ends_with(F, ".java"),
+            edge(B, T, "IMPORTS_FROM"), edge_attr(B, T, "IMPORTS_FROM", "_source", "java-resolution").
+        leg_returns(S, D) :- edge(S, D, "RETURNS"), edge_attr(S, D, "RETURNS", "_source", "java-resolution").
+        leg_type_of(S, D) :- edge(S, D, "TYPE_OF"), edge_attr(S, D, "TYPE_OF", "_source", "java-resolution").
+        leg_extends(S, D) :- edge(S, D, "EXTENDS"), edge_attr(S, D, "EXTENDS", "_source", "java-resolution").
+        leg_implements(S, D) :- edge(S, D, "IMPLEMENTS"), edge_attr(S, D, "IMPLEMENTS", "_source", "java-resolution").
+        leg_throws(S, D) :- edge(S, D, "THROWS_TYPE"), edge_attr(S, D, "THROWS_TYPE", "_source", "java-resolution").
+        leg_inst(S, D) :- edge(S, D, "INSTANTIATES"), edge_attr(S, D, "INSTANTIATES", "_source", "java-resolution").
+        leg_ann(S, D) :- edge(S, D, "ANNOTATION_RESOLVES_TO"),
+            edge_attr(S, D, "ANNOTATION_RESOLVES_TO", "_source", "java-resolution").
+
+        leg_calls(C, M) :- edge(C, M, "CALLS"), edge_attr(C, M, "CALLS", "_source", "java-resolution").
+        is_new(C) :- leg_calls(C, M), attr(C, "name", N), starts_with(N, "new ").
+        is_st(C) :- leg_calls(C, M), attr(C, "name", "super").
+        is_st(C) :- leg_calls(C, M), attr(C, "name", "this").
+        has_rv(C) :- leg_calls(C, M), node_attr(C, "receiver", R), neq(R, ""), neq(R, "this").
+        leg_calls_ctor(C, M) :- leg_calls(C, M), is_new(C).
+        leg_calls_st(C, M) :- leg_calls(C, M), is_st(C).
+        leg_calls_static(C, M) :- leg_calls(C, M), has_rv(C), \+ is_new(C), \+ is_st(C).
+        leg_calls_plain(C, M) :- leg_calls(C, M), \+ is_new(C), \+ is_st(C), \+ has_rv(C).
+
+        % P2 probe: a legacy plain-call row whose enclosing FUNCTION is NOT a
+        % constructor falsifies the D3 reading.
+        plain_encl(C, Fn) :- leg_calls_plain(C, M), edge(Fn, C, "CONTAINS"), node(Fn, "FUNCTION").
+        ctor_encl(C) :- plain_encl(C, Fn), node_attr(Fn, "kind", "constructor").
+        p2_violation(C) :- plain_encl(C, Fn), \+ ctor_encl(C).
+
+        % P3 probe: glob imports with a resolved edge, either producer.
+        glob_imp(I) :- node(I, "IMPORT"), attr(I, "file", F), ends_with(F, ".java"),
+            attr(I, "name", N), ends_with(N, ".*").
+        p3_violation(I, T) :- glob_imp(I), edge(I, T, "IMPORTS_FROM").
+    "#;
+    let legacy_eval = evaluate(&view, legacy_src, stats.clone(), EvalLimits::none(), EventLog::discard())
+        .expect("legacy slice eval");
+
+    // PREDICTIONS first (spec §8: a failed prediction = wrong premise, STOP).
+    let leg_bind = pairs(&legacy_eval, "leg_if_bind");
+    assert!(
+        leg_bind.is_empty(),
+        "P1 FALSIFIED: legacy IMPORT_BINDING IMPORTS_FROM slice has {} rows (expected \
+         EXACTLY 0 — D1 says resolveBinding is production-dead); re-derive spec §2 before \
+         trusting any other slice",
+        leg_bind.len()
+    );
+    let p2 = legacy_eval.facts("p2_violation").len();
+    assert_eq!(
+        p2, 0,
+        "P2 FALSIFIED: {p2} legacy plain-call CALLS rows outside constructor bodies — \
+         D3 reading wrong, STOP"
+    );
+    let p3 = legacy_eval.facts("p3_violation").len();
+    assert_eq!(p3, 0, "P3 FALSIFIED: {p3} glob IMPORTs carry IMPORTS_FROM edges");
+
+    // ── The PACKS, evaluated read-only over the same pinned view. ──
+    let run = |name: &str| -> crate::derive::exec::Evaluation {
+        let src = crate::derive::stdlib::stdlib_pack(name).expect("registered pack");
+        let (eval, _s, _n) =
+            evaluate_with_materialize(&view, src, stats.clone(), EvalLimits::none(), EventLog::discard())
+                .unwrap_or_else(|e| panic!("{name} evaluates on the real graph: {e}"));
+        eval
+    };
+    let ev_imp = run("java_imports");
+    let ev_typ = run("java_types");
+    let ev_cal = run("java_calls");
+    let ev_ann = run("java_annotations");
+
+    // Non-vacuity floors: the packs genuinely saw a JAVA graph (a corpus copy
+    // with zero java nodes would pass every 0 ≡ 0 slice on a broken pack).
+    let count = |eval: &crate::derive::exec::Evaluation, pred: &str| eval.facts(pred).len();
+    eprintln!(
+        "intermediates: jdecl={} qual_class={} jimport={} jbinding={} jcall={} jattr={} jann={}",
+        count(&ev_imp, "jdecl"), count(&ev_imp, "qual_class"), count(&ev_imp, "jimport"),
+        count(&ev_imp, "jbinding"), count(&ev_cal, "jcall"), count(&ev_ann, "jattr"),
+        count(&ev_ann, "jann"),
+    );
+    assert!(count(&ev_imp, "jdecl") > 0, "non-vacuity: java declarations present");
+    assert!(count(&ev_imp, "jimport") > 0, "non-vacuity: java imports present");
+    assert!(count(&ev_cal, "jcall") > 0, "non-vacuity: java calls present");
+
+    // ── Per-slice diff: NO pack-missing rows (class 6 is closed); pack-extra
+    //    rows are reported for witnessing against delta classes 1-5. ──
+    let mut pack_calls_st = pairs(&ev_cal, "this_ctor_calls");
+    pack_calls_st.extend(pairs(&ev_cal, "super_ctor_calls"));
+    let slices: Vec<(&str, BTreeSet<(u128, u128)>, BTreeSet<(u128, u128)>, bool)> = vec![
+        // (slice, legacy, pack, self-loop-misses-allowed)
+        ("IMPORTS_FROM/import", pairs(&legacy_eval, "leg_if_imp"), pairs(&ev_imp, "import_target"), false),
+        ("IMPORTS_FROM/binding", leg_bind, pairs(&ev_imp, "binding_target"), false),
+        ("RETURNS", pairs(&legacy_eval, "leg_returns"), pairs(&ev_typ, "returns"), false),
+        ("TYPE_OF", pairs(&legacy_eval, "leg_type_of"), pairs(&ev_typ, "type_of"), false),
+        ("EXTENDS", pairs(&legacy_eval, "leg_extends"), pairs(&ev_typ, "extends"), true),
+        ("IMPLEMENTS", pairs(&legacy_eval, "leg_implements"), pairs(&ev_typ, "implements"), false),
+        ("THROWS_TYPE", pairs(&legacy_eval, "leg_throws"), pairs(&ev_typ, "throws_type"), false),
+        ("INSTANTIATES", pairs(&legacy_eval, "leg_inst"), pairs(&ev_cal, "instantiates"), false),
+        ("CALLS/ctor", pairs(&legacy_eval, "leg_calls_ctor"), pairs(&ev_cal, "ctor_calls"), false),
+        ("CALLS/plain", pairs(&legacy_eval, "leg_calls_plain"), pairs(&ev_cal, "same_class_calls"), false),
+        ("CALLS/static", pairs(&legacy_eval, "leg_calls_static"), pairs(&ev_cal, "static_calls"), false),
+        ("CALLS/super-this", pairs(&legacy_eval, "leg_calls_st"), pack_calls_st, false),
+        ("ANNOTATION_RESOLVES_TO", pairs(&legacy_eval, "leg_ann"), pairs(&ev_ann, "ann_resolves"), false),
+    ];
+    let mut bad_misses = 0usize;
+    for (name, legacy, pack, self_loop_ok) in &slices {
+        let missing: Vec<_> = legacy.difference(pack).collect();
+        let extra: Vec<_> = pack.difference(legacy).collect();
+        eprintln!(
+            "{name}: legacy={} pack={} missing={} extra={}",
+            legacy.len(), pack.len(), missing.len(), extra.len()
+        );
+        for (s, d) in missing.iter().take(20) {
+            let carved = *self_loop_ok && s == d;
+            if !carved {
+                bad_misses += 1;
+            }
+            eprintln!(
+                "  MISSING ({s}, {d}){} — pack must not lose a legacy row; witness via \
+                 the legacy stderr counters",
+                if carved { " [EXTENDS self-loop carve-out]" } else { "" }
+            );
+        }
+        for (s, d) in extra.iter().take(20) {
+            eprintln!("  EXTRA ({s}, {d}) — classify against delta classes 1-5 (explain_datalog_fact)");
+        }
+    }
+    assert_eq!(
+        bad_misses, 0,
+        "pack-missing rows outside the EXTENDS self-loop carve-out — class 6 is closed \
+         (verdict C1), so any miss is a pack bug"
+    );
+    eprintln!("=== java packs shadow differential: slices printed; witness extras before accepting ===\n");
+}

--- a/packages/rfdb-server/src/derive/differential.rs
+++ b/packages/rfdb-server/src/derive/differential.rs
@@ -3039,3 +3039,205 @@ fn w8_cancel_overhead_pack_probe_times() {
     }
     eprintln!("=== W8 probe times: printed ===\n");
 }
+
+// ── Go wave: pack-vs-legacy differential on a real analyzed Go module ──────
+
+/// The Go packs' REPO-STRATUM differential (the spec's mandatory live
+/// confirmation — the dogfood graph has ZERO Go nodes, so this runs against a
+/// caller-built analyze of a real Go module, canonically `packages/go-parser`,
+/// a 4-file single-package module).
+///
+/// Dataset: `GRAFEMA_GO_DIFF_DB` (default `/tmp/go-diff.rfdb`) — a DB produced
+/// by `grafema-orchestrator analyze` over a Go module with the LEGACY
+/// go-resolve daemon ON, copied here (NEVER the live store). Provenance
+/// discrimination (re-run-safety, the wave3c precedent): legacy edges are
+/// stamped `_source = "go-resolution"` by the orchestrator's gc stamp at
+/// commit time (or carry no stamp on pre-stamp graphs); pack-written edges
+/// carry a rule-hash `_source` and are excluded from the legacy slice. The
+/// `.go`-file gate on the src node also excludes the synthetic
+/// unresolved-diagnostics nodes (verdict C5).
+///
+/// PREDICTIONS, declared BEFORE the diff (the §3 harness discipline):
+/// - legacy-only rows = 0 on EVERY edge type (the packs cover everything
+///   legacy resolved; every divergence class is pack-⊇-legacy);
+/// - pack-only rows classify into the numbered SUPERSET deltas (G2-2 / G3-1 /
+///   G5-1 / G6-2 / G6-3 / G7-1) — printed with names for classification;
+/// - PROPAGATES_CONTEXT: legacy = 0 EXACTLY (DELTA G9-3 — the wire node ids
+///   are percent-encoded URIs, so the legacy `[in:` parse never matches; and
+///   even unencoded, the parsed name keeps the ",h:xxxx" hash); the pack
+///   derives the intended edges (corpus-proven: legacy=0, pack=5);
+/// - IMPLEMENTS: legacy ≈ 0 on post-URI graphs (DELTA G6-1 — the same
+///   `[in:` parse class is dead under percent-encoding; corpus-proven:
+///   legacy=0, pack=1 correct edge) — reported, not hard-asserted (an
+///   unencoded-id-era graph could legitimately carry legacy rows);
+/// - SPAWNS/DEFERS: exact (caller-independent, unaffected by G9-3).
+///
+///   GRAFEMA_GO_DIFF_DB=/tmp/go-diff.rfdb \
+///   cargo test --release --lib go_packs_differential_against_real_go_module -- --ignored --nocapture
+#[test]
+#[ignore = "manual real-data differential; needs an analyzed Go-module DB — run with --ignored"]
+fn go_packs_differential_against_real_go_module() {
+    use crate::derive::stdlib::{
+        GO_CALLS_DL, GO_CONTEXT_DL, GO_IMPORTS_DL, GO_IMPORTS_NOMOD_DL, GO_INTERFACES_DL,
+        GO_TYPES_DL,
+    };
+    use std::collections::HashMap;
+
+    let dataset = std::env::var("GRAFEMA_GO_DIFF_DB")
+        .unwrap_or_else(|_| "/tmp/go-diff.rfdb".to_string());
+    let dataset = PathBuf::from(dataset);
+    if !dataset.join("db_config.json").exists() {
+        panic!(
+            "dataset not found at {} — analyze a Go module first (legacy go-resolve ON), \
+             e.g. grafema-orchestrator analyze over packages/go-parser into a /tmp DB, \
+             then point GRAFEMA_GO_DIFF_DB at the copied graph dir",
+            dataset.display()
+        );
+    }
+
+    let tmp = tempfile::tempdir().expect("temp");
+    let work = tmp.path().join("graph.rfdb");
+    copy_dir_all(&dataset, &work).expect("copy dataset");
+    let _ = std::fs::remove_file(work.join("LOCK"));
+    let manifest = ManifestStore::open(&work).expect("manifest");
+    let store = MultiShardStore::open(&work, &manifest).expect("store");
+    let store = Arc::new(store);
+    let view = LsmStorageView::capture(store.clone(), &manifest);
+
+    let snap = store.snapshot(&manifest);
+    let all_nodes = store.find_nodes_at(&snap, None, None);
+    let mut nodes_by_type: HashMap<String, u64> = HashMap::new();
+    for n in &all_nodes {
+        *nodes_by_type.entry(n.node_type.clone()).or_insert(0) += 1;
+    }
+    let stats = Stats {
+        total_nodes: all_nodes.len() as u64,
+        total_edges: store.iter_all_edges_at(&snap).len() as u64,
+        nodes_by_type: nodes_by_type.clone(),
+    };
+
+    // id → (name, file, type) for row classification + the .go src gate.
+    let mut info: HashMap<u128, (String, String, String)> = HashMap::new();
+    for n in &all_nodes {
+        info.insert(n.id, (n.name.clone(), n.file.clone(), n.node_type.clone()));
+    }
+    let is_go_src = |id: &u128| info.get(id).map(|(_, f, _)| f.ends_with(".go")).unwrap_or(false);
+
+    // The P1 fact decides the variant (the orchestrator's P3 selection mirrored).
+    let has_go_mod_fact = all_nodes.iter().any(|n| {
+        n.node_type == "WORKSPACE_PACKAGE"
+            && view
+                .node_metadata(n.id)
+                .map(|m| m.contains("\"language\":\"go\""))
+                .unwrap_or(false)
+    });
+    eprintln!(
+        "\n=== go packs differential (nodes={}, edges={}, go.mod fact={}) ===",
+        stats.total_nodes, stats.total_edges, has_go_mod_fact
+    );
+
+    // ── LEGACY slices: committed edges per type, src in a .go file,
+    //    provenance ∈ {go-resolution, unstamped} (NOT pack rule-hashes). ──
+    let legacy_slice = |edge_type: &str| -> BTreeSet<(u128, u128)> {
+        store
+            .iter_all_edges_at(&snap)
+            .into_iter()
+            .filter(|e| e.edge_type == edge_type && is_go_src(&e.src))
+            .filter(|e| match view.edge_metadata(e.src, e.dst, edge_type) {
+                None => true,
+                Some(blob) => match serde_json::from_str::<serde_json::Value>(&blob) {
+                    Ok(v) => match v.get("_source").and_then(|s| s.as_str()) {
+                        None => true,
+                        Some(src) => src == "go-resolution",
+                    },
+                    Err(_) => true,
+                },
+            })
+            .map(|e| (e.src, e.dst))
+            .collect()
+    };
+
+    // ── PACK slices: head facts of the go packs over the same view. ──
+    let pack_facts = |src: &str, preds: &[&str]| -> BTreeSet<(u128, u128)> {
+        let eval = evaluate(
+            &view,
+            src,
+            stats.clone(),
+            crate::datalog::EvalLimits::none(),
+            EventLog::discard(),
+        )
+        .unwrap_or_else(|e| panic!("go pack evaluates: {e}"));
+        let mut out = BTreeSet::new();
+        for p in preds {
+            for r in eval.facts(p) {
+                out.insert((r[0].as_id().expect("src"), r[1].as_id().expect("dst")));
+            }
+        }
+        out
+    };
+
+    let mut pack_imports = pack_facts(GO_IMPORTS_DL, &["go_import_from"]);
+    if !has_go_mod_fact {
+        pack_imports.extend(pack_facts(GO_IMPORTS_NOMOD_DL, &["go_import_suffix"]));
+    }
+    let pack_calls = pack_facts(GO_CALLS_DL, &["go_call_s1", "go_call_s2", "go_call_s3"]);
+    let pack_impls = pack_facts(GO_INTERFACES_DL, &["go_implements"]);
+    let pack_typeof = pack_facts(GO_TYPES_DL, &["go_type_of"]);
+    let pack_returns = pack_facts(GO_TYPES_DL, &["go_returns"]);
+    let pack_prop = pack_facts(GO_CONTEXT_DL, &["go_prop", "go_prop_u"]);
+    let pack_spawn = pack_facts(GO_CONTEXT_DL, &["go_spawn", "go_spawn_u"]);
+    let pack_defer = pack_facts(GO_CONTEXT_DL, &["go_defer", "go_defer_u"]);
+
+    let name_of = |id: &u128| {
+        info.get(id)
+            .map(|(n, f, t)| format!("{t} {n} ({f})"))
+            .unwrap_or_else(|| format!("{id}"))
+    };
+    let mut hard_failures: Vec<String> = Vec::new();
+    let mut diff = |label: &str, pack: &BTreeSet<(u128, u128)>, legacy: &BTreeSet<(u128, u128)>, legacy_must_be_empty: bool| {
+        let both = pack.intersection(legacy).count();
+        let pack_only: Vec<_> = pack.difference(legacy).collect();
+        let legacy_only: Vec<_> = legacy.difference(pack).collect();
+        eprintln!(
+            "{label:<22} pack={:<5} legacy={:<5} both={both:<5} pack_only={:<4} legacy_only={}",
+            pack.len(),
+            legacy.len(),
+            pack_only.len(),
+            legacy_only.len()
+        );
+        for (s, d) in pack_only.iter().take(20) {
+            eprintln!("  PACK-ONLY  {} -> {}  (classify against the numbered SUPERSET deltas)", name_of(s), name_of(d));
+        }
+        for (s, d) in legacy_only.iter().take(20) {
+            eprintln!("  LEGACY-ONLY {} -> {}", name_of(s), name_of(d));
+        }
+        if !legacy_only.is_empty() {
+            hard_failures.push(format!(
+                "{label}: {} legacy-only rows — the pack must cover everything legacy resolved",
+                legacy_only.len()
+            ));
+        }
+        if legacy_must_be_empty && !legacy.is_empty() {
+            hard_failures.push(format!(
+                "{label}: predicted legacy = 0 (DELTA G9-3) but found {}",
+                legacy.len()
+            ));
+        }
+    };
+
+    diff("IMPORTS_FROM", &pack_imports, &legacy_slice("IMPORTS_FROM"), false);
+    diff("CALLS", &pack_calls, &legacy_slice("CALLS"), false);
+    diff("IMPLEMENTS", &pack_impls, &legacy_slice("IMPLEMENTS"), false);
+    diff("TYPE_OF", &pack_typeof, &legacy_slice("TYPE_OF"), false);
+    diff("RETURNS", &pack_returns, &legacy_slice("RETURNS"), false);
+    diff("PROPAGATES_CONTEXT", &pack_prop, &legacy_slice("PROPAGATES_CONTEXT"), true);
+    diff("SPAWNS_WITH_CONTEXT", &pack_spawn, &legacy_slice("SPAWNS_WITH_CONTEXT"), false);
+    diff("DEFERS_WITH_CONTEXT", &pack_defer, &legacy_slice("DEFERS_WITH_CONTEXT"), false);
+
+    assert!(
+        hard_failures.is_empty(),
+        "go differential predictions violated:\n{}",
+        hard_failures.join("\n")
+    );
+    eprintln!("=== go packs differential: predictions hold (pack ⊇ legacy everywhere; legacy PROPAGATES = 0) ===\n");
+}

--- a/packages/rfdb-server/src/derive/parser_ext.rs
+++ b/packages/rfdb-server/src/derive/parser_ext.rs
@@ -430,6 +430,16 @@ impl<'a> Framer<'a> {
         while self.pos < self.bytes.len() {
             let c = self.bytes[self.pos];
             if in_string {
+                // Lenient escapes (Wave 14, mirrors datalog::parser::parse_string):
+                // a backslash followed by `"` or `\` is consumed as one unit so an
+                // escaped quote never terminates the string scan.
+                if c == b'\\'
+                    && self.pos + 1 < self.bytes.len()
+                    && matches!(self.bytes[self.pos + 1], b'"' | b'\\')
+                {
+                    self.pos += 2;
+                    continue;
+                }
                 if c == b'"' {
                     in_string = false;
                 }
@@ -946,6 +956,19 @@ mod tests {
         assert!(item.lattice_payload.is_none());
         assert_eq!(item.rule.body().len(), 2);
         assert!(item.rule.body()[1].is_negative());
+    }
+
+    /// Wave 14 — the clause scanner honors `\"` escapes inside string literals
+    /// (mirrors `datalog::parser::parse_string`): a rule carrying a literal
+    /// double-quote (the quote-strip idiom over raw JS source literals) is ONE
+    /// clause, and its terminating `.` is found.
+    #[test]
+    fn clause_scan_skips_escaped_quotes_in_strings() {
+        let src = r#"q(X, P) :- raw(X, R), strip_prefix(R, "\"", T), strip_suffix(T, "\"", P)."#;
+        let prog = parse_ext_program(src).expect("escaped-quote clause parses");
+        assert_eq!(prog.items.len(), 1);
+        assert_eq!(head_pred(&prog.items[0]), "q");
+        assert_eq!(prog.items[0].rule.body().len(), 3);
     }
 
     #[test]

--- a/packages/rfdb-server/src/derive/plan.rs
+++ b/packages/rfdb-server/src/derive/plan.rs
@@ -635,7 +635,8 @@ fn positive_can_place_and_provides(
         // genuinely underivable stays unplaceable here (E-PLAN-002 unsafe rule) instead of
         // reaching eval and tripping a confusing E-PLAN-001.
         "concat" | "str_lower" | "basename" | "strip_quotes" | "strip_prefix" | "strip_suffix"
-        | "last_segment" | "replace_all" | "path_resolve" | "edge_attr" | "node_attr" => {
+        | "last_segment" | "first_segment" | "replace_all" | "path_resolve" | "edge_attr"
+        | "node_attr" => {
             if args.is_empty() {
                 return (true, HashSet::new());
             }
@@ -699,6 +700,7 @@ fn is_filter_or_function(pred: &str) -> bool {
             | "strip_prefix"
             | "strip_suffix"
             | "last_segment"
+            | "first_segment"
             | "replace_all"
             | "path_resolve"
             | "edge_attr"

--- a/packages/rfdb-server/src/derive/plan.rs
+++ b/packages/rfdb-server/src/derive/plan.rs
@@ -635,7 +635,8 @@ fn positive_can_place_and_provides(
         // genuinely underivable stays unplaceable here (E-PLAN-002 unsafe rule) instead of
         // reaching eval and tripping a confusing E-PLAN-001.
         "concat" | "str_lower" | "basename" | "strip_quotes" | "strip_prefix" | "strip_suffix"
-        | "last_segment" | "replace_all" | "path_resolve" | "edge_attr" | "node_attr" => {
+        | "method_suffix" | "last_segment" | "replace_all" | "path_resolve" | "edge_attr"
+        | "node_attr" => {
             if args.is_empty() {
                 return (true, HashSet::new());
             }
@@ -698,6 +699,7 @@ fn is_filter_or_function(pred: &str) -> bool {
             | "strip_quotes"
             | "strip_prefix"
             | "strip_suffix"
+            | "method_suffix"
             | "last_segment"
             | "replace_all"
             | "path_resolve"

--- a/packages/rfdb-server/src/derive/stdlib.rs
+++ b/packages/rfdb-server/src/derive/stdlib.rs
@@ -300,6 +300,40 @@ pub const JS_RUNTIME_GLOBALS_EDGES_DL: &str = concat!(
 /// (the rank ladder) ⇒ scratch-only under maintain.
 pub const JS_MODULE_IMPORTS_DL: &str = include_str!("stdlib/js_module_imports.dl");
 
+// ── Java packs (the java-resolve migration, lang-spec-java.md) ─────────────
+
+/// Java import resolution — replaces `ImportResolution.hs` of `java-resolve`:
+/// IMPORT → declaration `IMPORTS_FROM` (qualified-name kernel) plus the
+/// IMPORT_BINDING arm via the graph-native IMPORT-CONTAINS-binding edge (a
+/// DECLARED SUPERSET: the legacy metadata-`source` path was production-dead,
+/// spec §2 D1). PRODUCER of java `IMPORTS_FROM` — must precede `depends`
+/// (verdict C3: depends consumes EVERY IMPORTS_FROM edge node-type-
+/// agnostically). node_attr + negation ⇒ scratch-only under maintain.
+pub const JAVA_IMPORTS_DL: &str = include_str!("stdlib/java_imports.dl");
+
+/// Java type-position resolution — replaces `TypeResolution.hs`: RETURNS /
+/// TYPE_OF / EXTENDS / IMPLEMENTS / THROWS_TYPE against the simple-name class
+/// kernel. Multi-element `implements`/`throws` are comma-split via the
+/// right-peel recursion (verdict C1 — full parity, delta class 6 closed);
+/// EXTENDS keeps the legacy no-split miss exactly. node_attr + negation ⇒
+/// scratch-only under maintain.
+pub const JAVA_TYPES_DL: &str = include_str!("stdlib/java_types.dl");
+
+/// Java call resolution — replaces `CallResolution.hs`: INSTANTIATES + ctor
+/// CALLS, same-class no-receiver CALLS (a DECLARED SUPERSET — the legacy sid
+/// probe fired only inside constructors, spec §2 D3), static-style CALLS and
+/// super()/this() delegation, all on graph-native HAS_METHOD/CONTAINS
+/// membership instead of sid parses. PRODUCER of `CALLS` — must precede the
+/// CALLS negators `method_calls`/`shape_verifier` (verdict C3). node_attr +
+/// negation ⇒ scratch-only under maintain.
+pub const JAVA_CALLS_DL: &str = include_str!("stdlib/java_calls.dl");
+
+/// Java annotation resolution — replaces `AnnotationResolution.hs`:
+/// ANNOTATION_RESOLVES_TO from ATTRIBUTE usages to same-named
+/// ANNOTATION_TYPE declarations, .java-gated on BOTH legs (kotlin emits both
+/// node types). No node_attr, no negation — maintain-eligible.
+pub const JAVA_ANNOTATIONS_DL: &str = include_str!("stdlib/java_annotations.dl");
+
 /// The named stdlib rule packs, addressable on the wire as `"@stdlib/<name>"`
 /// (`MaterializeDatalog` and the other empty-source-defaulting dispatchers), listed
 /// in CANONICAL RUN ORDER. The order is a CONTRACT, not cosmetics — producers run
@@ -342,12 +376,21 @@ pub const JS_MODULE_IMPORTS_DL: &str = include_str!("stdlib/js_module_imports.dl
 ///   IMPORT→MODULE `IMPORTS_FROM` seam and `RE_EXPORTS` (the star seam) that
 ///   `js_import_bindings` (`b_mod`/`resolved_at`/`star_src`) and the Wave-1b
 ///   hybrid packs read as committed EDB, so it runs strictly before them.
+/// - the Java packs (the java-resolve migration, canonical intra-family
+///   order java_imports → java_types → java_calls → java_annotations):
+///   `java_imports` PRODUCES java `IMPORTS_FROM`, so it precedes `depends`
+///   (verdict C3 — depends consumes EVERY IMPORTS_FROM edge node-type-
+///   agnostically via the file join); `java_calls` PRODUCES `CALLS`, so it
+///   precedes the CALLS negators `method_calls`/`shape_verifier`
+///   (shape_verifier negates `edge(C,_,"CALLS")` with NO file gate). The
+///   packs have no inter-pack EDB seams among themselves.
 /// - `depends` (Wave 3c position) CONSUMES IMPORTS_FROM — every edge of the
 ///   shared vocabulary, module- and binding-level — so with legacy
 ///   import-resolution GATED (GRAFEMA_SKIP_RESOLVE_STEPS) it runs after ALL
 ///   in-engine IMPORTS_FROM producers: `rust_imports`, `js_module_imports`,
-///   `js_import_bindings`, `js_builtins_edges`. (It ran first while the
-///   legacy resolver pre-committed those edges at analysis time.)
+///   `js_import_bindings`, `js_builtins_edges`, `java_imports`. (It ran
+///   first while the legacy resolver pre-committed those edges at analysis
+///   time.)
 /// An orchestrator running the packs sequentially must preserve this order:
 /// js_local_refs → js_same_file_calls → js_this_method_calls →
 /// rust_calls → rust_cross_methods_ctor → rust_trait_resolve →
@@ -355,7 +398,8 @@ pub const JS_MODULE_IMPORTS_DL: &str = include_str!("stdlib/js_module_imports.dl
 /// js_import_bindings → js_class_inheritance →
 /// js_cross_file_calls → js_property_access_ns → js_property_access_full →
 /// js_builtins_nodes → js_builtins_edges → js_runtime_globals_nodes →
-/// js_runtime_globals_edges → depends → method_calls → shape_verifier →
+/// js_runtime_globals_edges → java_imports → java_types → java_calls →
+/// java_annotations → depends → method_calls → shape_verifier →
 /// axum_routes.
 pub const STDLIB_PACKS: &[(&str, &str)] = &[
     ("js_local_refs", JS_LOCAL_REFS_DL),
@@ -400,6 +444,14 @@ pub const STDLIB_PACKS: &[(&str, &str)] = &[
     // (shape_verifier).
     ("js_runtime_globals_nodes", JS_RUNTIME_GLOBALS_NODES_DL),
     ("js_runtime_globals_edges", JS_RUNTIME_GLOBALS_EDGES_DL),
+    // Java packs (java-resolve migration): java_imports PRODUCES java
+    // IMPORTS_FROM — strictly before depends (verdict C3); java_calls
+    // PRODUCES CALLS — strictly before the negators method_calls /
+    // shape_verifier. No inter-pack seams among the four.
+    ("java_imports", JAVA_IMPORTS_DL),
+    ("java_types", JAVA_TYPES_DL),
+    ("java_calls", JAVA_CALLS_DL),
+    ("java_annotations", JAVA_ANNOTATIONS_DL),
     // Wave 3c: depends CONSUMES IMPORTS_FROM (every edge, module- and
     // binding-level) — with legacy import-resolution gated it must run after
     // ALL in-engine IMPORTS_FROM producers (rust_imports, js_module_imports,
@@ -1268,6 +1320,10 @@ mod tests {
                 "js_builtins_edges",
                 "js_runtime_globals_nodes",
                 "js_runtime_globals_edges",
+                "java_imports",
+                "java_types",
+                "java_calls",
+                "java_annotations",
                 "depends",
                 "method_calls",
                 "shape_verifier",
@@ -1284,6 +1340,8 @@ mod tests {
              packs (js_import_bindings PRODUCES the IMPORTS_FROM seam, so it \
              precedes js_class_inheritance and the js hybrid consumers; \
              js_class_inheritance produces EXTENDS for shape_verifier) → \
+             java packs (java_imports PRODUCES java IMPORTS_FROM — before \
+             depends; java_calls PRODUCES CALLS — before the negators) → \
              depends (Wave 3c: AFTER every IMPORTS_FROM producer — legacy \
              import-resolution is gated, so the in-engine producers feed it) → \
              method_calls → shape_verifier → axum_routes (producers strictly \
@@ -4292,6 +4350,16 @@ mod tests {
             // Wave 3c: orchestrator-committed workspace facts (one per
             // discovered package + alias virtual packages; dogfood ~30).
             ("WORKSPACE_PACKAGE", 30),
+            // Java packs: the dogfood graph has ZERO java nodes (config gap,
+            // lang-spec-java.md §7), so an unknown type would estimate 0 and
+            // make the gate VACUOUS for the java-only vocabulary. Model a
+            // mid-size java corpus folded into this graph (the shared types —
+            // CALL/FUNCTION/VARIABLE/CLASS/IMPORT/… — already carry
+            // dogfood-scale counts above, which is the harsher test).
+            ("ENUM", 200),
+            ("RECORD", 100),
+            ("ANNOTATION_TYPE", 80),
+            ("ATTRIBUTE", 15_000),
         ] {
             nodes_by_type.insert(ty.to_string(), n);
         }
@@ -4319,6 +4387,530 @@ mod tests {
             "packs must plan under dogfood-scale stats (E-PLAN-003 is a \
              production rejection, not a perf hint):\n{}",
             failed.join("\n")
+        );
+    }
+
+    // ── Java packs (java-resolve migration, lang-spec-java.md) ─────────────
+
+    /// VERDICT C2 pin (lang-spec-java.md): a NEGATED BUILTIN literal is a
+    /// legal per-row anti-join — the executor's negated path keeps the exact
+    /// per-row fallback for non-special-cased shapes (exec.rs), and the
+    /// stratifier creates NO dependency edge for base/builtin literals
+    /// (stratify.rs "base relation or builtin — no dependency edge"), so
+    /// `\+ string_contains(...)` is stratification-free. No stdlib pack used
+    /// the form before the java packs; this fixture pins the semantics
+    /// java_types.dl's normalizeType filters rely on, BEFORE relying on it
+    /// (the verdict's explicit precondition).
+    #[test]
+    fn negated_builtin_literal_is_a_per_row_anti_join() {
+        let mut v = FixtureStorageView::new(1);
+        named_node(&mut v, "c_plain", "Alpha", "CLASS", "a.java");
+        named_node(&mut v, "c_comma", "Alpha,Beta", "CLASS", "b.java");
+
+        let eval = evaluate(
+            &v,
+            r#"cand(X, N) :- node(X, "CLASS"), attr(X, "name", N).
+               kept(X) :- cand(X, N), \+ string_contains(N, ",")."#,
+            Stats::default(),
+            EvalLimits::none(),
+            EventLog::discard(),
+        )
+        .expect("negated-builtin program evaluates");
+
+        let kept: BTreeSet<u128> = eval
+            .facts("kept")
+            .iter()
+            .filter_map(|r| r[0].as_id())
+            .collect();
+        assert_eq!(
+            kept,
+            BTreeSet::from([id_of("c_plain")]),
+            "\\+ string_contains must drop exactly the comma-bearing row"
+        );
+    }
+
+    /// Shared collector: the (src, dst) id pairs of one derived predicate.
+    fn id_pairs(eval: &crate::derive::exec::Evaluation, pred: &str) -> BTreeSet<(u128, u128)> {
+        eval.facts(pred)
+            .iter()
+            .filter_map(|r| Some((r.first()?.as_id()?, r.get(1)?.as_id()?)))
+            .collect()
+    }
+
+    /// java_imports.dl — every arm of the S1/S2/S3 surface on one fixture:
+    /// - S2 happy path: IMPORT "com.lib.Foo" → the packaged CLASS Foo;
+    /// - DELTA 1 pin (spec §5 class 1): a SECOND "com.lib.Foo" declaration —
+    ///   set semantics derives an edge per candidate (legacy Map kept one);
+    /// - DELTA 2 pin (spec §5 class 3, the D1 fix): the IMPORT_BINDING — with
+    ///   NO `source` metadata, exactly as the analyzer stamps it — resolves
+    ///   via the parent-IMPORT CONTAINS edge; legacy production derived ZERO
+    ///   here (resolveBinding read a key that never exists);
+    /// - default-package arm: a declaration in a package-less file is keyed
+    ///   by its BARE name;
+    /// - P3 parity pin: a glob IMPORT ("com.lib.*") derives nothing;
+    /// - static-member parity pin: "com.lib.Foo.bar" derives nothing;
+    /// - dead-arm zero: a binding whose parent IMPORT resolves nothing
+    ///   derives nothing;
+    /// - .java gate: a same-qualified kotlin declaration never matches.
+    #[test]
+    fn java_imports_pack_resolves_imports_and_bindings() {
+        let mut v = FixtureStorageView::new(1);
+        // Declaration side: com.lib.Foo (packaged), twice (DELTA 1).
+        named_node(&mut v, "m_lib", "lib", "MODULE", "com/lib/Foo.java");
+        v.put_node_metadata(id_of("m_lib"), r#"{"package":"com.lib"}"#);
+        named_node(&mut v, "c_foo", "Foo", "CLASS", "com/lib/Foo.java");
+        named_node(&mut v, "m_lib2", "lib2", "MODULE", "com/lib2/Foo.java");
+        v.put_node_metadata(id_of("m_lib2"), r#"{"package":"com.lib"}"#);
+        named_node(&mut v, "c_foo2", "Foo", "CLASS", "com/lib2/Foo.java");
+        // .java gate: kotlin twin of the same qualified name.
+        named_node(&mut v, "m_kt", "ktlib", "MODULE", "com/lib/Foo.kt");
+        v.put_node_metadata(id_of("m_kt"), r#"{"package":"com.lib"}"#);
+        named_node(&mut v, "c_kt", "Foo", "CLASS", "com/lib/Foo.kt");
+        // Default-package declaration (MODULE has NO package key —
+        // Walker.hs:37-51 omits it entirely).
+        named_node(&mut v, "m_def", "def", "MODULE", "Def.java");
+        named_node(&mut v, "c_bare", "Bare", "CLASS", "Def.java");
+
+        // Importing side.
+        named_node(&mut v, "i1", "com.lib.Foo", "IMPORT", "app/App.java");
+        named_node(&mut v, "b1", "Foo", "IMPORT_BINDING", "app/App.java");
+        v.put_node_metadata(
+            id_of("b1"),
+            r#"{"imported_name":"Foo","local_name":"Foo","static":false}"#,
+        );
+        edge(&mut v, "i1", "b1", "CONTAINS");
+        named_node(&mut v, "i2", "com.lib.*", "IMPORT", "app/App.java");
+        named_node(&mut v, "i3", "com.lib.Foo.bar", "IMPORT", "app/App.java");
+        named_node(&mut v, "i4", "Bare", "IMPORT", "app/App.java");
+        named_node(&mut v, "i5", "com.none.Nope", "IMPORT", "app/App.java");
+        named_node(&mut v, "b5", "Nope", "IMPORT_BINDING", "app/App.java");
+        edge(&mut v, "i5", "b5", "CONTAINS");
+
+        let (eval, specs, _node_specs) = evaluate_with_materialize(
+            &v,
+            JAVA_IMPORTS_DL,
+            Stats::default(),
+            EvalLimits::none(),
+            EventLog::discard(),
+        )
+        .expect("java_imports.dl evaluates");
+
+        assert_eq!(
+            id_pairs(&eval, "import_target"),
+            BTreeSet::from([
+                (id_of("i1"), id_of("c_foo")),
+                (id_of("i1"), id_of("c_foo2")),
+                (id_of("i4"), id_of("c_bare")),
+            ]),
+            "S2: qualified + default-package imports resolve; glob/static/unknown derive nothing"
+        );
+        assert_eq!(
+            id_pairs(&eval, "binding_target"),
+            BTreeSet::from([
+                (id_of("b1"), id_of("c_foo")),
+                (id_of("b1"), id_of("c_foo2")),
+            ]),
+            "S3 (DELTA 2): bindings resolve via the parent IMPORT, source-metadata-free; \
+             the unresolvable-parent binding derives nothing"
+        );
+        assert!(
+            specs
+                .iter()
+                .all(|s| s.edge_type == "IMPORTS_FROM" && s.additive && s.meta.is_empty()),
+            "both heads are additive empty-meta IMPORTS_FROM; got {:?}",
+            specs.iter().map(|s| (&s.predicate, &s.edge_type)).collect::<Vec<_>>()
+        );
+        assert_eq!(specs.len(), 2, "exactly the S2 + S3 heads materialize");
+    }
+
+    /// java_types.dl — every arm of S5-S9 on one fixture:
+    /// - RETURNS: plain name resolves; "Alpha[]" strips; "int" (primitive),
+    ///   "?" (wildcard) and "<unknown>" (C4 dead-letter vocabulary) derive
+    ///   nothing; the .kt twin is gated out;
+    /// - TYPE_OF: interface type resolves; "boolean[]" strips to a primitive
+    ///   and derives nothing;
+    /// - EXTENDS: single name resolves; the interface multi-extends
+    ///   "Alpha,Beta" derives NOTHING (the legacy no-split miss, reproduced
+    ///   exactly — spec §3 S7); the dup-named self-extend derives only the
+    ///   OTHER candidate (DELTA 2's neq(C,T));
+    /// - IMPLEMENTS (VERDICT C1, delta class 6 CLOSED): single element,
+    ///   3-element right-peel split (recursion depth 2), ENUM arm; the
+    ///   RECORD's implements is NOT read (legacy reads CLASS+ENUM only,
+    ///   TypeResolution.hs:163 — parity dead-arm zero);
+    /// - THROWS_TYPE (C1): single + 2-element split.
+    #[test]
+    fn java_types_pack_resolves_type_positions_with_split() {
+        let mut v = FixtureStorageView::new(1);
+        named_node(&mut v, "c_a", "Alpha", "CLASS", "a.java");
+        named_node(&mut v, "i_b", "Beta", "INTERFACE", "b.java");
+        named_node(&mut v, "i_g", "Gamma", "INTERFACE", "g.java");
+        named_node(&mut v, "i_z", "Zeta", "INTERFACE", "z.java");
+        named_node(&mut v, "c_io", "IOExc", "CLASS", "io.java");
+        named_node(&mut v, "c_sql", "SqlExc", "CLASS", "sql.java");
+
+        // S5 RETURNS.
+        named_node(&mut v, "f1", "mk", "FUNCTION", "m.java");
+        v.put_node_metadata(id_of("f1"), r#"{"kind":"method","return_type":"Alpha"}"#);
+        named_node(&mut v, "f2", "count", "FUNCTION", "m.java");
+        v.put_node_metadata(id_of("f2"), r#"{"kind":"method","return_type":"int"}"#);
+        named_node(&mut v, "f3", "arr", "FUNCTION", "m.java");
+        v.put_node_metadata(id_of("f3"), r#"{"kind":"method","return_type":"Alpha[]"}"#);
+        named_node(&mut v, "f4", "wild", "FUNCTION", "m.java");
+        v.put_node_metadata(id_of("f4"), r#"{"kind":"method","return_type":"?"}"#);
+        named_node(&mut v, "f5", "unk", "FUNCTION", "m.java");
+        v.put_node_metadata(id_of("f5"), r#"{"kind":"method","return_type":"<unknown>"}"#);
+        named_node(&mut v, "f_kt", "mk", "FUNCTION", "m.kt");
+        v.put_node_metadata(id_of("f_kt"), r#"{"kind":"method","return_type":"Alpha"}"#);
+
+        // S6 TYPE_OF.
+        named_node(&mut v, "v1", "b", "VARIABLE", "m.java");
+        v.put_node_metadata(id_of("v1"), r#"{"kind":"field","type":"Beta"}"#);
+        named_node(&mut v, "v2", "flags", "VARIABLE", "m.java");
+        v.put_node_metadata(id_of("v2"), r#"{"kind":"field","type":"boolean[]"}"#);
+
+        // S7 EXTENDS.
+        named_node(&mut v, "c_sub", "Sub", "CLASS", "sub.java");
+        v.put_node_metadata(id_of("c_sub"), r#"{"extends":"Alpha"}"#);
+        named_node(&mut v, "i_multi", "Both", "INTERFACE", "im.java");
+        v.put_node_metadata(id_of("i_multi"), r#"{"extends":"Alpha,Beta"}"#);
+        named_node(&mut v, "c_x", "X", "CLASS", "x.java");
+        v.put_node_metadata(id_of("c_x"), r#"{"extends":"X"}"#);
+        named_node(&mut v, "c_x2", "X", "CLASS", "x2.java");
+
+        // S8 IMPLEMENTS.
+        named_node(&mut v, "c_one", "One", "CLASS", "one.java");
+        v.put_node_metadata(id_of("c_one"), r#"{"implements":"Beta"}"#);
+        named_node(&mut v, "c_multi", "Multi", "CLASS", "multi.java");
+        v.put_node_metadata(id_of("c_multi"), r#"{"implements":"Beta,Gamma,Zeta"}"#);
+        named_node(&mut v, "e_en", "En", "ENUM", "en.java");
+        v.put_node_metadata(id_of("e_en"), r#"{"implements":"Beta"}"#);
+        named_node(&mut v, "r_rec", "Rec", "RECORD", "rec.java");
+        v.put_node_metadata(id_of("r_rec"), r#"{"implements":"Beta"}"#);
+
+        // S9 THROWS_TYPE.
+        named_node(&mut v, "f7", "one", "FUNCTION", "t.java");
+        v.put_node_metadata(id_of("f7"), r#"{"kind":"method","throws":"IOExc"}"#);
+        named_node(&mut v, "f8", "two", "FUNCTION", "t.java");
+        v.put_node_metadata(id_of("f8"), r#"{"kind":"method","throws":"IOExc,SqlExc"}"#);
+
+        let (eval, specs, _node_specs) = evaluate_with_materialize(
+            &v,
+            JAVA_TYPES_DL,
+            Stats::default(),
+            EvalLimits::none(),
+            EventLog::discard(),
+        )
+        .expect("java_types.dl evaluates");
+
+        assert_eq!(
+            id_pairs(&eval, "returns"),
+            BTreeSet::from([(id_of("f1"), id_of("c_a")), (id_of("f3"), id_of("c_a"))]),
+            "RETURNS: plain + []-stripped resolve; primitive/wildcard/<unknown>/.kt derive nothing"
+        );
+        assert_eq!(
+            id_pairs(&eval, "type_of"),
+            BTreeSet::from([(id_of("v1"), id_of("i_b"))]),
+            "TYPE_OF: interface type resolves; boolean[] strips to a primitive and is rejected"
+        );
+        assert_eq!(
+            id_pairs(&eval, "extends"),
+            BTreeSet::from([(id_of("c_sub"), id_of("c_a")), (id_of("c_x"), id_of("c_x2"))]),
+            "EXTENDS: single name resolves; comma-joined multi-extends misses (legacy parity); \
+             neq(C,T) keeps the dup-name self-loop out (DELTA 2)"
+        );
+        assert_eq!(
+            id_pairs(&eval, "implements"),
+            BTreeSet::from([
+                (id_of("c_one"), id_of("i_b")),
+                (id_of("c_multi"), id_of("i_b")),
+                (id_of("c_multi"), id_of("i_g")),
+                (id_of("c_multi"), id_of("i_z")),
+                (id_of("e_en"), id_of("i_b")),
+            ]),
+            "IMPLEMENTS: C1 right-peel splits all 3 elements; ENUM arm works; \
+             RECORD implements is not read (legacy parity dead-arm)"
+        );
+        assert_eq!(
+            id_pairs(&eval, "throws_type"),
+            BTreeSet::from([
+                (id_of("f7"), id_of("c_io")),
+                (id_of("f8"), id_of("c_io")),
+                (id_of("f8"), id_of("c_sql")),
+            ]),
+            "THROWS_TYPE: C1 right-peel splits the 2-element throws clause"
+        );
+        let expect: std::collections::BTreeMap<&str, &str> = [
+            ("returns", "RETURNS"),
+            ("type_of", "TYPE_OF"),
+            ("extends", "EXTENDS"),
+            ("implements", "IMPLEMENTS"),
+            ("throws_type", "THROWS_TYPE"),
+        ]
+        .into_iter()
+        .collect();
+        let got: std::collections::BTreeMap<&str, &str> = specs
+            .iter()
+            .map(|s| (s.predicate.as_str(), s.edge_type.as_str()))
+            .collect();
+        assert_eq!(got, expect, "all 5 type heads materialize");
+        assert!(
+            specs.iter().all(|s| s.additive && s.meta.is_empty()),
+            "every head additive with empty meta (legacy metadata was empty)"
+        );
+    }
+
+    /// java_calls.dl — every arm of S10-S13 on one fixture:
+    /// - S10: "new Service" → INSTANTIATES + CALLS to BOTH ctors (DELTA 2,
+    ///   all-ctors vs legacy head-pick); a RECORD's compact constructor is
+    ///   reached through the CONTAINS arm (it has NO HAS_METHOD —
+    ///   Declarations.hs:534-539); "new Missing" derives nothing;
+    /// - S11 (DELTA 3, the D3 fix): a receiverless call inside an ORDINARY
+    ///   method body resolves to the same-class method — the declared
+    ///   superset (legacy fired only where [in:] == class name); receiver
+    ///   "this" counts as plain; lambdas are CLOSURE nodes (Expressions.hs:
+    ///   352-355, :399-404 — NOT FUNCTION), and the jbody/fn_owner recursion
+    ///   lifts a CLOSURE-nested call, a CLOSURE-in-CLOSURE-nested call, and
+    ///   the ctor-expression-lambda LEGACY-PARITY arm (LambdaExpr pushes no
+    ///   withEnclosingFn, Expressions.hs:343-386, so legacy resolves via the
+    ///   leaked [in:ctorName] — the pack must not lose that row); a
+    ///   foreign-receiver call, a field-initializer call, and a call in a
+    ///   field-initializer LAMBDA (the CLOSURE's CONTAINS parent is the
+    ///   CLASS — fn_owner chain stops) derive nothing;
+    /// - S12: a class-named receiver resolves to that class's method; the
+    ///   non-class receiver derives nothing (Hs test :243-249 parity);
+    /// - S13: this() → all same-class ctors; super() → the superclass ctor
+    ///   via the extends metadata;
+    /// - .java gate: a kotlin "new Service" call derives nothing.
+    #[test]
+    fn java_calls_pack_resolves_call_families() {
+        let mut v = FixtureStorageView::new(1);
+        // class Service extends Base, with 2 ctors + 2 methods.
+        named_node(&mut v, "c_svc", "Service", "CLASS", "svc.java");
+        v.put_node_metadata(id_of("c_svc"), r#"{"extends":"Base"}"#);
+        named_node(&mut v, "m_ctor", "Service", "FUNCTION", "svc.java");
+        v.put_node_metadata(id_of("m_ctor"), r#"{"kind":"constructor"}"#);
+        edge(&mut v, "c_svc", "m_ctor", "HAS_METHOD");
+        named_node(&mut v, "m_ctor2", "Service", "FUNCTION", "svc.java");
+        v.put_node_metadata(id_of("m_ctor2"), r#"{"kind":"constructor"}"#);
+        edge(&mut v, "c_svc", "m_ctor2", "HAS_METHOD");
+        named_node(&mut v, "m_helper", "helper", "FUNCTION", "svc.java");
+        v.put_node_metadata(id_of("m_helper"), r#"{"kind":"method"}"#);
+        edge(&mut v, "c_svc", "m_helper", "HAS_METHOD");
+        named_node(&mut v, "m_run", "run", "FUNCTION", "svc.java");
+        v.put_node_metadata(id_of("m_run"), r#"{"kind":"method"}"#);
+        edge(&mut v, "c_svc", "m_run", "HAS_METHOD");
+        // class Base (the super() target).
+        named_node(&mut v, "c_base", "Base", "CLASS", "base.java");
+        named_node(&mut v, "m_bctor", "Base", "FUNCTION", "base.java");
+        v.put_node_metadata(id_of("m_bctor"), r#"{"kind":"constructor"}"#);
+        edge(&mut v, "c_base", "m_bctor", "HAS_METHOD");
+        // class Util (the static-receiver target).
+        named_node(&mut v, "c_util", "Util", "CLASS", "util.java");
+        named_node(&mut v, "m_stat", "format", "FUNCTION", "util.java");
+        v.put_node_metadata(id_of("m_stat"), r#"{"kind":"method"}"#);
+        edge(&mut v, "c_util", "m_stat", "HAS_METHOD");
+        // record Pt with a compact constructor (CONTAINS-only, NO HAS_METHOD).
+        named_node(&mut v, "r_pt", "Pt", "RECORD", "pt.java");
+        named_node(&mut v, "m_cc", "Pt", "FUNCTION", "pt.java");
+        v.put_node_metadata(id_of("m_cc"), r#"{"kind":"compact_constructor"}"#);
+        edge(&mut v, "r_pt", "m_cc", "CONTAINS");
+
+        // S10: constructor calls.
+        named_node(&mut v, "c_new", "new Service", "CALL", "app.java");
+        edge(&mut v, "m_run", "c_new", "CONTAINS");
+        named_node(&mut v, "c_newpt", "new Pt", "CALL", "app.java");
+        edge(&mut v, "m_run", "c_newpt", "CONTAINS");
+        named_node(&mut v, "c_newmiss", "new Missing", "CALL", "app.java");
+        edge(&mut v, "m_run", "c_newmiss", "CONTAINS");
+        named_node(&mut v, "c_kt", "new Service", "CALL", "app.kt");
+
+        // S11: same-class plain calls.
+        named_node(&mut v, "c_plain", "helper", "CALL", "svc.java");
+        v.put_node_metadata(id_of("c_plain"), r#"{"method":true,"argCount":0}"#);
+        edge(&mut v, "m_run", "c_plain", "CONTAINS");
+        named_node(&mut v, "c_this_recv", "helper", "CALL", "svc.java");
+        v.put_node_metadata(id_of("c_this_recv"), r#"{"method":true,"argCount":0,"receiver":"this"}"#);
+        edge(&mut v, "m_run", "c_this_recv", "CONTAINS");
+        named_node(&mut v, "c_recv", "helper", "CALL", "svc.java");
+        v.put_node_metadata(id_of("c_recv"), r#"{"method":true,"argCount":0,"receiver":"other"}"#);
+        edge(&mut v, "m_run", "c_recv", "CONTAINS");
+        // Field-initializer call: CONTAINS parent is the CLASS node.
+        named_node(&mut v, "c_field", "helper", "CALL", "svc.java");
+        v.put_node_metadata(id_of("c_field"), r#"{"method":true,"argCount":0}"#);
+        edge(&mut v, "c_svc", "c_field", "CONTAINS");
+        // Lambda-nested call: lambdas are CLOSURE nodes (no HAS_METHOD);
+        // fn_owner lifts through the CLOSURE to the method's class.
+        named_node(&mut v, "f_lambda", "<lambda>", "CLOSURE", "svc.java");
+        edge(&mut v, "m_run", "f_lambda", "CONTAINS");
+        named_node(&mut v, "c_inlam", "helper", "CALL", "svc.java");
+        v.put_node_metadata(id_of("c_inlam"), r#"{"method":true,"argCount":0}"#);
+        edge(&mut v, "f_lambda", "c_inlam", "CONTAINS");
+        // Nested lambda (CLOSURE inside CLOSURE): pins the CLOSURE→CLOSURE
+        // hop of the fn_owner recursion.
+        named_node(&mut v, "f_nested", "<lambda>", "CLOSURE", "svc.java");
+        edge(&mut v, "f_lambda", "f_nested", "CONTAINS");
+        named_node(&mut v, "c_innested", "helper", "CALL", "svc.java");
+        v.put_node_metadata(id_of("c_innested"), r#"{"method":true,"argCount":0}"#);
+        edge(&mut v, "f_nested", "c_innested", "CONTAINS");
+        // Expression-body lambda inside a CONSTRUCTOR — the LEGACY-PARITY
+        // arm: LambdaExpr pushes no withEnclosingFn, so legacy emits this
+        // edge via the leaked [in:Service] sid; the pack must too.
+        named_node(&mut v, "f_lamctor", "<lambda>", "CLOSURE", "svc.java");
+        edge(&mut v, "m_ctor", "f_lamctor", "CONTAINS");
+        named_node(&mut v, "c_inlamctor", "helper", "CALL", "svc.java");
+        v.put_node_metadata(id_of("c_inlamctor"), r#"{"method":true,"argCount":0}"#);
+        edge(&mut v, "f_lamctor", "c_inlamctor", "CONTAINS");
+        // Lambda in a FIELD INITIALIZER: the CLOSURE's CONTAINS parent is
+        // the CLASS — the fn_owner chain stops, nothing derives (legacy:
+        // nothing on both lambda kinds).
+        named_node(&mut v, "f_lamfield", "<lambda>", "CLOSURE", "svc.java");
+        edge(&mut v, "c_svc", "f_lamfield", "CONTAINS");
+        named_node(&mut v, "c_inlamfield", "helper", "CALL", "svc.java");
+        v.put_node_metadata(id_of("c_inlamfield"), r#"{"method":true,"argCount":0}"#);
+        edge(&mut v, "f_lamfield", "c_inlamfield", "CONTAINS");
+
+        // S12: static-style call.
+        named_node(&mut v, "c_static", "format", "CALL", "svc.java");
+        v.put_node_metadata(id_of("c_static"), r#"{"method":true,"argCount":1,"receiver":"Util"}"#);
+        edge(&mut v, "m_run", "c_static", "CONTAINS");
+
+        // S13: this() / super() inside the first ctor.
+        named_node(&mut v, "c_thisc", "this", "CALL", "svc.java");
+        v.put_node_metadata(
+            id_of("c_thisc"),
+            r#"{"kind":"constructor_call","method":false,"argCount":0,"isThis":true}"#,
+        );
+        edge(&mut v, "m_ctor", "c_thisc", "CONTAINS");
+        named_node(&mut v, "c_superc", "super", "CALL", "svc.java");
+        v.put_node_metadata(
+            id_of("c_superc"),
+            r#"{"kind":"constructor_call","method":false,"argCount":0,"isThis":false}"#,
+        );
+        edge(&mut v, "m_ctor", "c_superc", "CONTAINS");
+
+        let (eval, specs, _node_specs) = evaluate_with_materialize(
+            &v,
+            JAVA_CALLS_DL,
+            Stats::default(),
+            EvalLimits::none(),
+            EventLog::discard(),
+        )
+        .expect("java_calls.dl evaluates");
+
+        assert_eq!(
+            id_pairs(&eval, "instantiates"),
+            BTreeSet::from([(id_of("c_new"), id_of("c_svc")), (id_of("c_newpt"), id_of("r_pt"))]),
+            "INSTANTIATES: class + record; unknown class and the .kt call derive nothing"
+        );
+        assert_eq!(
+            id_pairs(&eval, "ctor_calls"),
+            BTreeSet::from([
+                (id_of("c_new"), id_of("m_ctor")),
+                (id_of("c_new"), id_of("m_ctor2")),
+                (id_of("c_newpt"), id_of("m_cc")),
+            ]),
+            "ctor CALLS: ALL ctors (DELTA 2) + the compact ctor via the CONTAINS arm"
+        );
+        assert_eq!(
+            id_pairs(&eval, "same_class_calls"),
+            BTreeSet::from([
+                (id_of("c_plain"), id_of("m_helper")),
+                (id_of("c_this_recv"), id_of("m_helper")),
+                (id_of("c_inlam"), id_of("m_helper")),
+                (id_of("c_innested"), id_of("m_helper")),
+                (id_of("c_inlamctor"), id_of("m_helper")),
+            ]),
+            "same-class CALLS (DELTA 3): ordinary-method-body + this-receiver + CLOSURE-lifted \
+             (single, nested, and the ctor-expression-lambda LEGACY-PARITY arm) resolve; \
+             foreign receiver, field-initializer, and field-initializer-lambda derive nothing"
+        );
+        assert_eq!(
+            id_pairs(&eval, "static_calls"),
+            BTreeSet::from([(id_of("c_static"), id_of("m_stat"))]),
+            "static-style CALLS: class-named receiver only"
+        );
+        assert_eq!(
+            id_pairs(&eval, "this_ctor_calls"),
+            BTreeSet::from([
+                (id_of("c_thisc"), id_of("m_ctor")),
+                (id_of("c_thisc"), id_of("m_ctor2")),
+            ]),
+            "this() delegation: all same-class ctors (DELTA 2)"
+        );
+        assert_eq!(
+            id_pairs(&eval, "super_ctor_calls"),
+            BTreeSet::from([(id_of("c_superc"), id_of("m_bctor"))]),
+            "super() delegation: the superclass ctor via extends metadata"
+        );
+        let calls_heads: BTreeSet<&str> = specs
+            .iter()
+            .filter(|s| s.edge_type == "CALLS")
+            .map(|s| s.predicate.as_str())
+            .collect();
+        assert_eq!(
+            calls_heads,
+            BTreeSet::from([
+                "ctor_calls",
+                "same_class_calls",
+                "static_calls",
+                "this_ctor_calls",
+                "super_ctor_calls"
+            ]),
+            "the 5 CALLS producers materialize"
+        );
+        assert!(
+            specs.iter().any(|s| s.edge_type == "INSTANTIATES" && s.predicate == "instantiates"),
+            "INSTANTIATES materializes"
+        );
+        assert!(
+            specs.iter().all(|s| s.additive && s.meta.is_empty()),
+            "every head additive with empty meta"
+        );
+    }
+
+    /// java_annotations.dl — the S14 surface:
+    /// - happy path: ATTRIBUTE "Marker" → ANNOTATION_TYPE Marker;
+    /// - DELTA 1 pin: a duplicate same-named ANNOTATION_TYPE — an edge per
+    ///   candidate (legacy Map kept one);
+    /// - .java gates BOTH ways (load-bearing — kotlin emits both node
+    ///   types): a .kt ATTRIBUTE never resolves, and a .kt ANNOTATION_TYPE
+    ///   is never a target;
+    /// - unknown annotation name derives nothing.
+    #[test]
+    fn java_annotations_pack_resolves_attributes() {
+        let mut v = FixtureStorageView::new(1);
+        named_node(&mut v, "an_1", "Marker", "ANNOTATION_TYPE", "marker.java");
+        named_node(&mut v, "an_2", "Marker", "ANNOTATION_TYPE", "marker2.java");
+        named_node(&mut v, "an_kt", "KMark", "ANNOTATION_TYPE", "mark.kt");
+        named_node(&mut v, "at_1", "Marker", "ATTRIBUTE", "app.java");
+        named_node(&mut v, "at_kt", "Marker", "ATTRIBUTE", "app.kt");
+        named_node(&mut v, "at_k2", "KMark", "ATTRIBUTE", "app.java");
+        named_node(&mut v, "at_none", "NoSuch", "ATTRIBUTE", "app.java");
+
+        let (eval, specs, _node_specs) = evaluate_with_materialize(
+            &v,
+            JAVA_ANNOTATIONS_DL,
+            Stats::default(),
+            EvalLimits::none(),
+            EventLog::discard(),
+        )
+        .expect("java_annotations.dl evaluates");
+
+        assert_eq!(
+            id_pairs(&eval, "ann_resolves"),
+            BTreeSet::from([
+                (id_of("at_1"), id_of("an_1")),
+                (id_of("at_1"), id_of("an_2")),
+            ]),
+            "ANNOTATION_RESOLVES_TO: both same-named candidates (DELTA 1); the .kt \
+             attribute, the .kt-declared target and the unknown name derive nothing"
+        );
+        assert_eq!(specs.len(), 1, "one head");
+        assert!(
+            specs[0].edge_type == "ANNOTATION_RESOLVES_TO"
+                && specs[0].additive
+                && specs[0].meta.is_empty(),
+            "additive empty-meta ANNOTATION_RESOLVES_TO"
         );
     }
 

--- a/packages/rfdb-server/src/derive/stdlib.rs
+++ b/packages/rfdb-server/src/derive/stdlib.rs
@@ -72,6 +72,61 @@ pub const SHAPE_VERIFIER_DL: &str = include_str!("stdlib/shape_verifier.dl");
 /// head is exclusive (provenance-scoped, safe on the shared `http:route` type).
 pub const AXUM_ROUTES_DL: &str = include_str!("stdlib/axum_routes.dl");
 
+/// The bundled Go same-module import-resolution pack — the in-engine
+/// replacement for the import slice of the `go-resolve` daemon
+/// (`GoImportResolution.hs`): IMPORT → MODULE `IMPORTS_FROM`, driven by the
+/// GO module-path WORKSPACE_PACKAGE fact (orchestrator precondition P1).
+/// The exact `isStdLib` gate rides the `first_segment` builtin; the
+/// module-prefix arm is the C1-legal prefix-peel equality join. `IMPORTS_FROM`
+/// is SHARED vocabulary ⇒ additive. Deltas numbered in the `.dl` header
+/// (G2-2 first-MODULE multiplicity is the only live one).
+pub const GO_IMPORTS_DL: &str = include_str!("stdlib/go_imports.dl");
+
+/// The NO-go.mod VARIANT of [`GO_IMPORTS_DL`] — the legacy empty-module-path
+/// suffix fallback (`findBySuffix`), '/'-boundary suffixes by `first_segment`
+/// left-peel. A pack cannot test "the go.mod fact is absent" (the §3
+/// cross-join), so the ORCHESTRATOR selects the variant: this pack runs ONLY
+/// when go.mod did not resolve (run_stdlib_rule_packs' selection condition);
+/// both variants stay registered so the cross-registry order pin holds.
+pub const GO_IMPORTS_NOMOD_DL: &str = include_str!("stdlib/go_imports_nomod.dl");
+
+/// The bundled Go call-resolution pack — the in-engine replacement for the
+/// `GoCallResolution.hs` slice of `go-resolve`: the three legacy strategies
+/// (package-qualified via same-file import alias + the C1-legal peel-join
+/// package index; same-package receiverless; same-package method by global
+/// (receiver, name) index), exclusive dispatch on the CALL's `receiver`
+/// metadata. `CALLS` additive, NO meta (legacy stamps none). Bounded
+/// last-wins SUPERSET deltas numbered in the `.dl` header.
+pub const GO_CALLS_DL: &str = include_str!("stdlib/go_calls.dl");
+
+/// The bundled Go interface-satisfaction pack — the in-engine replacement for
+/// the `GoInterfaceSatisfaction.hs` slice of `go-resolve`: structural
+/// duck-typing CLASS → INTERFACE `IMPLEMENTS` by method-name subset, the
+/// ∀-subset spelled as two strata of negation seeded through a shared method
+/// name (the planner-legal substitute for the CLASS×INTERFACE product).
+/// Structural INTERFACE-CONTAINS-FUNCTION membership replaces the legacy
+/// `[in:Iface]` semantic-id parse — which is DEAD on real (percent-encoded)
+/// wire ids, so the pack RESTORES interface satisfaction (`.dl` DELTA G6-1).
+/// Additive; G6-2/G6-3 (struct- and interface-side name merges) numbered in
+/// the `.dl` header.
+pub const GO_INTERFACES_DL: &str = include_str!("stdlib/go_interfaces.dl");
+
+/// The bundled Go type-resolution pack — the in-engine replacement for the
+/// `GoTypeResolution.hs` slice of `go-resolve`: VARIABLE → type `TYPE_OF` and
+/// FUNCTION → type `RETURNS` (comma-peeled `return_type`, recursive `*`/`[]`
+/// strip, 21 primitive ground facts). Both heads additive, no meta.
+pub const GO_TYPES_DL: &str = include_str!("stdlib/go_types.dl");
+
+/// The bundled Go context-propagation pack — the in-engine replacement for
+/// the `GoContextPropagation.hs` slice of `go-resolve`:
+/// `PROPAGATES_CONTEXT` (enclosing fn → target) plus `SPAWNS_WITH_CONTEXT` /
+/// `DEFERS_WITH_CONTEXT` (call → target), `unresolved="true"` meta iff the
+/// TARGET is only possibly-context. CONSUMES committed CALLS on .go files —
+/// MUST run after [`GO_CALLS_DL`] (precondition P2). The CONTAINS-parent
+/// enclosing-fn join REFINES a legacy defect (the `[in:parent,h:xxxx]` parse
+/// never matched a real function name — `.dl` DELTA G9-3).
+pub const GO_CONTEXT_DL: &str = include_str!("stdlib/go_context.dl");
+
 /// The bundled JS/TS local-reference resolution pack — the in-engine replacement
 /// for the `JsLocalRefs.hs` resolver (the #1 edge producer per the perf memory:
 /// REFERENCE → same-file declaration `READS_FROM` over 8 declaration types,
@@ -348,6 +403,12 @@ pub const JS_MODULE_IMPORTS_DL: &str = include_str!("stdlib/js_module_imports.dl
 ///   in-engine IMPORTS_FROM producers: `rust_imports`, `js_module_imports`,
 ///   `js_import_bindings`, `js_builtins_edges`. (It ran first while the
 ///   legacy resolver pre-committed those edges at analysis time.)
+/// - the Go wave packs: `go_imports` / `go_imports_nomod` PRODUCE
+///   IMPORTS_FROM (before `depends`, verdict C4); `go_calls` PRODUCES CALLS
+///   for `go_context` (the P2 producer-before-consumer seam) and precedes the
+///   CALLS negators (`method_calls` / `shape_verifier`); the nomod VARIANT is
+///   selected by the orchestrator at runtime (P3 — only when go.mod is
+///   absent), but stays in BOTH registries so the order pin holds.
 /// An orchestrator running the packs sequentially must preserve this order:
 /// js_local_refs → js_same_file_calls → js_this_method_calls →
 /// rust_calls → rust_cross_methods_ctor → rust_trait_resolve →
@@ -355,8 +416,9 @@ pub const JS_MODULE_IMPORTS_DL: &str = include_str!("stdlib/js_module_imports.dl
 /// js_import_bindings → js_class_inheritance →
 /// js_cross_file_calls → js_property_access_ns → js_property_access_full →
 /// js_builtins_nodes → js_builtins_edges → js_runtime_globals_nodes →
-/// js_runtime_globals_edges → depends → method_calls → shape_verifier →
-/// axum_routes.
+/// js_runtime_globals_edges → go_imports → go_imports_nomod → go_calls →
+/// go_interfaces → go_types → go_context → depends → method_calls →
+/// shape_verifier → axum_routes.
 pub const STDLIB_PACKS: &[(&str, &str)] = &[
     ("js_local_refs", JS_LOCAL_REFS_DL),
     ("js_same_file_calls", JS_SAME_FILE_CALLS_DL),
@@ -400,6 +462,18 @@ pub const STDLIB_PACKS: &[(&str, &str)] = &[
     // (shape_verifier).
     ("js_runtime_globals_nodes", JS_RUNTIME_GLOBALS_NODES_DL),
     ("js_runtime_globals_edges", JS_RUNTIME_GLOBALS_EDGES_DL),
+    // Go wave: go_imports / go_imports_nomod PRODUCE IMPORTS_FROM — strictly
+    // before depends (verdict C4); the nomod VARIANT is orchestrator-selected
+    // (P3: runs only when go.mod is absent — both registered, runtime skip).
+    // go_calls PRODUCES CALLS — strictly before its consumer go_context (P2)
+    // and before the CALLS negators method_calls / shape_verifier (C4).
+    // go_interfaces / go_types consume analyzer EDB only.
+    ("go_imports", GO_IMPORTS_DL),
+    ("go_imports_nomod", GO_IMPORTS_NOMOD_DL),
+    ("go_calls", GO_CALLS_DL),
+    ("go_interfaces", GO_INTERFACES_DL),
+    ("go_types", GO_TYPES_DL),
+    ("go_context", GO_CONTEXT_DL),
     // Wave 3c: depends CONSUMES IMPORTS_FROM (every edge, module- and
     // binding-level) — with legacy import-resolution gated it must run after
     // ALL in-engine IMPORTS_FROM producers (rust_imports, js_module_imports,
@@ -1268,6 +1342,12 @@ mod tests {
                 "js_builtins_edges",
                 "js_runtime_globals_nodes",
                 "js_runtime_globals_edges",
+                "go_imports",
+                "go_imports_nomod",
+                "go_calls",
+                "go_interfaces",
+                "go_types",
+                "go_context",
                 "depends",
                 "method_calls",
                 "shape_verifier",
@@ -4322,4 +4402,533 @@ mod tests {
         );
     }
 
+    // ── Go wave: fixture tests per arm (ports of go-resolve/test/Spec.hs:50-301
+    //    plus the numbered-delta predictions — predictions FIRST, in the assert
+    //    messages). The dogfood graph has ZERO Go nodes (spec probe + the
+    //    Datalog re-probe), so these fixtures + the GRAFEMA_GO_DIFF_DB repo
+    //    harness in differential.rs ARE the differential ground truth. ──────
+
+    /// The GO module-path WORKSPACE_PACKAGE fact (orchestrator P1 shape).
+    fn go_mod_fact(v: &mut FixtureStorageView, module_path: &str) {
+        let sid = format!("go.mod->WORKSPACE_PACKAGE->{module_path}");
+        named_node(v, &sid, module_path, "WORKSPACE_PACKAGE", "go.mod");
+        v.put_node_metadata(id_of(&sid), r#"{"language":"go"}"#);
+    }
+
+    fn derived_pairs(v: &FixtureStorageView, src: &str, pred: &str) -> BTreeSet<(u128, u128)> {
+        let eval = evaluate(v, src, Stats::default(), EvalLimits::none(), EventLog::discard())
+            .unwrap_or_else(|e| panic!("pack evaluates: {e}"));
+        eval.facts(pred)
+            .into_iter()
+            .map(|r| {
+                (
+                    r[0].as_id().expect("src id"),
+                    r[1].as_id().expect("dst id"),
+                )
+            })
+            .collect()
+    }
+
+    /// go_imports — Spec.hs:52-92 ported: same-module hit, stdlib skip,
+    /// third-party skip, the root-package arm, the per-MODULE multiplicity
+    /// (DELTA G2-2), the exact-isStdLib dot-less-module-path skip (DELTA G2-1
+    /// CLOSED), the plain-stripPrefix boundary bug removal, and pack inertness
+    /// without the P1 fact.
+    #[test]
+    fn go_imports_same_module_arms_on_fixture() {
+        let mut v = FixtureStorageView::new(1);
+        go_mod_fact(&mut v, "github.com/user/project");
+        // Target package with TWO files (DELTA G2-2) + a root-level module.
+        node(&mut v, "mod_auth1", "MODULE", "pkg/auth/auth.go");
+        node(&mut v, "mod_auth2", "MODULE", "pkg/auth/token.go");
+        node(&mut v, "mod_root", "MODULE", "main.go");
+        // Importers (all metadata `path`, the analyzer contract Imports.hs:73-79).
+        named_node(&mut v, "imp_auth", "github.com/user/project/pkg/auth", "IMPORT", "cmd/main.go");
+        v.put_node_metadata(id_of("imp_auth"), r#"{"path":"github.com/user/project/pkg/auth"}"#);
+        named_node(&mut v, "imp_fmt", "fmt", "IMPORT", "cmd/main.go");
+        v.put_node_metadata(id_of("imp_fmt"), r#"{"path":"fmt"}"#);
+        named_node(&mut v, "imp_3p", "github.com/sirupsen/logrus", "IMPORT", "cmd/main.go");
+        v.put_node_metadata(id_of("imp_3p"), r#"{"path":"github.com/sirupsen/logrus"}"#);
+        named_node(&mut v, "imp_root", "github.com/user/project", "IMPORT", "cmd/main.go");
+        v.put_node_metadata(id_of("imp_root"), r#"{"path":"github.com/user/project"}"#);
+        // The legacy plain-stripPrefix boundary bug shape: module path is a
+        // non-'/'-boundary string prefix — must NOT resolve (legacy missed too).
+        node(&mut v, "mod_p2", "MODULE", "roject2/x/x.go");
+        named_node(&mut v, "imp_p2", "github.com/user/project2/x", "IMPORT", "cmd/main.go");
+        v.put_node_metadata(id_of("imp_p2"), r#"{"path":"github.com/user/project2/x"}"#);
+        // A non-go IMPORT with a go-looking path must be gated out (DELTA-5 file gate).
+        named_node(&mut v, "imp_js", "github.com/user/project/pkg/auth", "IMPORT", "app.ts");
+        v.put_node_metadata(id_of("imp_js"), r#"{"path":"github.com/user/project/pkg/auth"}"#);
+
+        let pairs = derived_pairs(&v, GO_IMPORTS_DL, "go_import_from");
+        assert_eq!(
+            pairs,
+            BTreeSet::from([
+                // PREDICTION DELTA G2-2: one edge per MODULE in the package dir
+                // (legacy: first module only).
+                (id_of("imp_auth"), id_of("mod_auth1")),
+                (id_of("imp_auth"), id_of("mod_auth2")),
+                // Root-package arm: P == module path → the "" directory.
+                (id_of("imp_root"), id_of("mod_root")),
+            ]),
+            "stdlib/third-party/boundary-bug/non-go importers derive nothing; \
+             same-module derives per-MODULE (G2-2); root import hits main.go"
+        );
+
+        // Dot-less module path (G2-1 CLOSED): legacy isStdLib skips
+        // "myapp/util" BEFORE prefix-stripping — the exact first_segment gate
+        // reproduces the skip.
+        let mut v2 = FixtureStorageView::new(1);
+        go_mod_fact(&mut v2, "myapp");
+        node(&mut v2, "mod_util", "MODULE", "util/u.go");
+        named_node(&mut v2, "imp_util", "myapp/util", "IMPORT", "main.go");
+        v2.put_node_metadata(id_of("imp_util"), r#"{"path":"myapp/util"}"#);
+        assert!(
+            derived_pairs(&v2, GO_IMPORTS_DL, "go_import_from").is_empty(),
+            "dot-less module path: legacy isStdLib skips it — exact gate, no edge (G2-1 closed)"
+        );
+
+        // No P1 fact ⇒ the module-prefix arms are inert (the nomod VARIANT
+        // owns that world — orchestrator-selected, P3).
+        let mut v3 = FixtureStorageView::new(1);
+        node(&mut v3, "mod_a", "MODULE", "pkg/auth/auth.go");
+        named_node(&mut v3, "imp_a", "example.com/pkg/auth", "IMPORT", "main.go");
+        v3.put_node_metadata(id_of("imp_a"), r#"{"path":"example.com/pkg/auth"}"#);
+        assert!(
+            derived_pairs(&v3, GO_IMPORTS_DL, "go_import_from").is_empty(),
+            "without the go.mod fact the main pack derives nothing"
+        );
+    }
+
+    /// go_imports_nomod — Spec.hs:80-85 ported (empty-modPath suffix fallback)
+    /// plus the G2-3a all-matches SUPERSET and the G2-3b '/'-boundary
+    /// refinement predictions.
+    #[test]
+    fn go_imports_nomod_suffix_fallback_on_fixture() {
+        let mut v = FixtureStorageView::new(1);
+        node(&mut v, "mod_auth", "MODULE", "pkg/auth/auth.go");
+        named_node(&mut v, "imp_auth", "example.com/pkg/auth", "IMPORT", "main.go");
+        v.put_node_metadata(id_of("imp_auth"), r#"{"path":"example.com/pkg/auth"}"#);
+        // G2-3b: dir "auth" is a RAW suffix of ".../oauth" (legacy false
+        // positive) but NOT a '/'-boundary suffix — pack must NOT match.
+        named_node(&mut v, "imp_oauth", "example.com/pkg/oauth", "IMPORT", "main.go");
+        v.put_node_metadata(id_of("imp_oauth"), r#"{"path":"example.com/pkg/oauth"}"#);
+        node(&mut v, "mod_rawauth", "MODULE", "auth/a.go");
+        // stdlib skip applies in the fallback too ("fmt" — even with a local
+        // dir literally named fmt).
+        named_node(&mut v, "imp_fmt", "fmt", "IMPORT", "main.go");
+        v.put_node_metadata(id_of("imp_fmt"), r#"{"path":"fmt"}"#);
+        node(&mut v, "mod_fmt", "MODULE", "fmt/f.go");
+        // G2-3a: two dirs share the boundary suffix → ALL matches derived.
+        node(&mut v, "mod_u1", "MODULE", "a/util/u.go");
+        node(&mut v, "mod_u2", "MODULE", "util/u.go");
+        named_node(&mut v, "imp_util", "example.com/a/util", "IMPORT", "main.go");
+        v.put_node_metadata(id_of("imp_util"), r#"{"path":"example.com/a/util"}"#);
+
+        let pairs = derived_pairs(&v, GO_IMPORTS_NOMOD_DL, "go_import_suffix");
+        assert_eq!(
+            pairs,
+            BTreeSet::from([
+                // "pkg/auth" and "auth" are both '/'-boundary suffixes of the
+                // auth import — but only pkg/auth/... has modules at "pkg/auth";
+                // "auth/a.go"'s dir IS "auth", also a boundary suffix → both.
+                (id_of("imp_auth"), id_of("mod_auth")),
+                (id_of("imp_auth"), id_of("mod_rawauth")),
+                // PREDICTION G2-3a: all suffix matches (legacy: alphabetical first).
+                (id_of("imp_util"), id_of("mod_u1")),
+                (id_of("imp_util"), id_of("mod_u2")),
+            ]),
+            "boundary-suffix matches only (G2-3b drops the …/oauth raw-suffix \
+             false positive); stdlib skipped; all matches derived (G2-3a)"
+        );
+    }
+
+    /// go_calls — Spec.hs:98-146 ported: the three strategies, the EXCLUSIVE
+    /// dispatch, the stdlib skip on S1, closure/interface_method exclusion,
+    /// the cross-package S2 miss, and the G3-1 duplicate-(dir,name) SUPERSET.
+    #[test]
+    fn go_calls_three_strategies_and_dispatch_on_fixture() {
+        let mut v = FixtureStorageView::new(1);
+        go_mod_fact(&mut v, "github.com/user/project");
+
+        // S1: package-qualified via same-file import alias.
+        node(&mut v, "mod_utils", "MODULE", "pkg/utils/utils.go");
+        named_node(&mut v, "fn_do", "DoStuff", "FUNCTION", "pkg/utils/utils.go");
+        v.put_node_metadata(id_of("fn_do"), r#"{"kind":"function"}"#);
+        named_node(&mut v, "imp_utils", "github.com/user/project/pkg/utils", "IMPORT", "cmd/main.go");
+        v.put_node_metadata(
+            id_of("imp_utils"),
+            r#"{"path":"github.com/user/project/pkg/utils","local_name":"utils"}"#,
+        );
+        named_node(&mut v, "call_do", "utils.DoStuff", "CALL", "cmd/main.go");
+        v.put_node_metadata(id_of("call_do"), r#"{"receiver":"utils"}"#);
+
+        // S1 stdlib skip: alias to "fmt" — even with a same-name local function.
+        named_node(&mut v, "imp_fmt", "fmt", "IMPORT", "cmd/main.go");
+        v.put_node_metadata(id_of("imp_fmt"), r#"{"path":"fmt","local_name":"fmt"}"#);
+        named_node(&mut v, "call_println", "fmt.Println", "CALL", "cmd/main.go");
+        v.put_node_metadata(id_of("call_println"), r#"{"receiver":"fmt"}"#);
+        named_node(&mut v, "fn_println", "Println", "FUNCTION", "fmt/print.go");
+        v.put_node_metadata(id_of("fn_println"), r#"{"kind":"function"}"#);
+
+        // Dispatch exclusivity: receiver matches an alias whose path is
+        // stdlib AND a method index entry exists for (receiver, name) —
+        // legacy dispatches S1 ONLY (alias match), which skips; S3 must NOT
+        // fire (Hs:163-174).
+        named_node(&mut v, "m_trap", "Println", "FUNCTION", "pkg/trap.go");
+        v.put_node_metadata(id_of("m_trap"), r#"{"kind":"method","receiver":"fmt"}"#);
+
+        // S2: same-package receiverless call (sub-dir AND root-dir shapes).
+        named_node(&mut v, "fn_helper", "helper", "FUNCTION", "pkg/util.go");
+        v.put_node_metadata(id_of("fn_helper"), r#"{"kind":"function"}"#);
+        named_node(&mut v, "call_helper", "helper", "CALL", "pkg/main.go");
+        named_node(&mut v, "fn_rootfn", "rootFn", "FUNCTION", "tool.go");
+        v.put_node_metadata(id_of("fn_rootfn"), r#"{"kind":"function"}"#);
+        named_node(&mut v, "call_rootfn", "rootFn", "CALL", "main.go");
+        // Cross-package S2 miss (Spec.hs:134-139).
+        named_node(&mut v, "call_cross", "helper", "CALL", "cmd/main.go");
+        // Closure exclusion (Spec.hs:141-146): kind=closure never indexed.
+        named_node(&mut v, "fn_clo", "<closure>", "FUNCTION", "pkg/main.go");
+        v.put_node_metadata(id_of("fn_clo"), r#"{"kind":"closure"}"#);
+        named_node(&mut v, "call_clo", "<closure>", "CALL", "pkg/main.go");
+        // G3-1: duplicate (dir, name) — a _test.go sibling defines helper too.
+        named_node(&mut v, "fn_helper2", "helper", "FUNCTION", "pkg/util_test.go");
+        v.put_node_metadata(id_of("fn_helper2"), r#"{"kind":"function"}"#);
+
+        // S3: method call where a variable shares the type's name (Spec.hs:120-127).
+        named_node(&mut v, "m_start", "Start", "FUNCTION", "pkg/server.go");
+        v.put_node_metadata(id_of("m_start"), r#"{"kind":"method","receiver":"Server"}"#);
+        named_node(&mut v, "call_start", "s.Start", "CALL", "pkg/main.go");
+        v.put_node_metadata(id_of("call_start"), r#"{"receiver":"Server"}"#);
+        // Unknown receiver (Spec.hs:128-132): no edge.
+        named_node(&mut v, "call_unk", "x.Unknown", "CALL", "pkg/main.go");
+        v.put_node_metadata(id_of("call_unk"), r#"{"receiver":"x"}"#);
+
+        let eval = evaluate(&v, GO_CALLS_DL, Stats::default(), EvalLimits::none(), EventLog::discard())
+            .expect("go_calls.dl evaluates");
+        let mut pairs: BTreeSet<(u128, u128)> = BTreeSet::new();
+        for pred in ["go_call_s1", "go_call_s2", "go_call_s3"] {
+            for r in eval.facts(pred) {
+                pairs.insert((r[0].as_id().unwrap(), r[1].as_id().unwrap()));
+            }
+        }
+        assert_eq!(
+            pairs,
+            BTreeSet::from([
+                (id_of("call_do"), id_of("fn_do")),
+                // PREDICTION G3-1: both same-(dir,name) functions derived
+                // (legacy last-wins picked one).
+                (id_of("call_helper"), id_of("fn_helper")),
+                (id_of("call_helper"), id_of("fn_helper2")),
+                (id_of("call_rootfn"), id_of("fn_rootfn")),
+                (id_of("call_start"), id_of("m_start")),
+            ]),
+            "S1 alias hit; S1 stdlib skip; S1-only dispatch (no S3 fallback for \
+             alias receivers); S2 same-dir + root-dir; S2 cross-package miss; \
+             closure excluded; S3 type-named receiver; unknown receiver miss"
+        );
+    }
+
+    /// go_interfaces — Spec.hs:152-210 ported: subset hit, missing-method
+    /// miss, empty-interface miss, multi-struct fan-out, pointer receiver;
+    /// plus the G6-2 (struct-side) and G6-3 (interface-side, verdict C3)
+    /// name-merge predictions.
+    #[test]
+    fn go_interfaces_subset_satisfaction_on_fixture() {
+        let mut v = FixtureStorageView::new(1);
+        // Reader{Read} ⊆ MyReader{Read} → IMPLEMENTS.
+        node(&mut v, "iface_reader", "INTERFACE", "io.go");
+        named_node(&mut v, "im_read", "Read", "FUNCTION", "io.go");
+        v.put_node_metadata(id_of("im_read"), r#"{"kind":"interface_method"}"#);
+        edge(&mut v, "iface_reader", "im_read", "CONTAINS");
+        named_node(&mut v, "cls_myreader", "MyReader", "CLASS", "reader.go");
+        named_node(&mut v, "sm_read", "Read", "FUNCTION", "reader.go");
+        v.put_node_metadata(id_of("sm_read"), r#"{"kind":"method","receiver":"MyReader","pointer_receiver":true}"#);
+        // ReadWriter{Read,Write} ⊄ MyReader{Read} → no edge (missing Write).
+        node(&mut v, "iface_rw", "INTERFACE", "io.go");
+        named_node(&mut v, "im_read2", "Read", "FUNCTION", "io.go");
+        v.put_node_metadata(id_of("im_read2"), r#"{"kind":"interface_method"}"#);
+        named_node(&mut v, "im_write", "Write", "FUNCTION", "io.go");
+        v.put_node_metadata(id_of("im_write"), r#"{"kind":"interface_method"}"#);
+        edge(&mut v, "iface_rw", "im_read2", "CONTAINS");
+        edge(&mut v, "iface_rw", "im_write", "CONTAINS");
+        // Empty interface → never satisfied (the non-empty gate via cand seeding).
+        node(&mut v, "iface_empty", "INTERFACE", "types.go");
+        named_node(&mut v, "cls_any", "Anything", "CLASS", "impl.go");
+        // Second struct also implementing Reader (multi-struct fan-out).
+        named_node(&mut v, "cls_fr", "FileReader", "CLASS", "file.go");
+        named_node(&mut v, "sm_fread", "Read", "FUNCTION", "file.go");
+        v.put_node_metadata(id_of("sm_fread"), r#"{"kind":"method","receiver":"FileReader"}"#);
+
+        let pairs = derived_pairs(&v, GO_INTERFACES_DL, "go_implements");
+        assert_eq!(
+            pairs,
+            BTreeSet::from([
+                (id_of("cls_myreader"), id_of("iface_reader")),
+                (id_of("cls_fr"), id_of("iface_reader")),
+            ]),
+            "subset hit (pointer receiver matches by bare name); missing-method \
+             and empty-interface miss; one edge per implementing struct"
+        );
+
+        // PREDICTION G6-3 (verdict C3): duplicate interface NAMES — legacy
+        // unions their method sets ({Read} ∪ {Close} = {Read,Close}, rejecting
+        // a Read-only struct) and the per-NODE pack accepts the {Read} node.
+        let mut v2 = FixtureStorageView::new(1);
+        named_node(&mut v2, "if_a", "Reader", "INTERFACE", "a.go");
+        named_node(&mut v2, "ifm_a", "Read", "FUNCTION", "a.go");
+        v2.put_node_metadata(id_of("ifm_a"), r#"{"kind":"interface_method"}"#);
+        edge(&mut v2, "if_a", "ifm_a", "CONTAINS");
+        named_node(&mut v2, "if_b", "Reader", "INTERFACE", "b.go");
+        named_node(&mut v2, "ifm_b", "Close", "FUNCTION", "b.go");
+        v2.put_node_metadata(id_of("ifm_b"), r#"{"kind":"interface_method"}"#);
+        edge(&mut v2, "if_b", "ifm_b", "CONTAINS");
+        named_node(&mut v2, "cls_r", "R", "CLASS", "r.go");
+        named_node(&mut v2, "rm", "Read", "FUNCTION", "r.go");
+        v2.put_node_metadata(id_of("rm"), r#"{"kind":"method","receiver":"R"}"#);
+        // PREDICTION G6-2: a same-named CLASS twin also receives the edge.
+        named_node(&mut v2, "cls_r2", "R", "CLASS", "r2.go");
+        let pairs2 = derived_pairs(&v2, GO_INTERFACES_DL, "go_implements");
+        assert_eq!(
+            pairs2,
+            BTreeSet::from([
+                (id_of("cls_r"), id_of("if_a")),
+                (id_of("cls_r2"), id_of("if_a")),
+            ]),
+            "G6-3: per-NODE requirement sets (legacy's name-union rejected this); \
+             G6-2: every same-named CLASS gets the edge (legacy last-wins one)"
+        );
+    }
+
+    /// go_types — TYPE_OF + RETURNS: recursive prefix strip, primitive skip,
+    /// comma-peel of return_type, map/chan non-resolution, INTERFACE targets,
+    /// and the G7-1 duplicate-type-name SUPERSET.
+    #[test]
+    fn go_types_type_of_and_returns_on_fixture() {
+        let mut v = FixtureStorageView::new(1);
+        named_node(&mut v, "cls_user", "User", "CLASS", "user.go");
+        named_node(&mut v, "if_store", "Store", "INTERFACE", "store.go");
+        // *User → User; []byte → primitive skip; []*User → User;
+        // map[string]User → no type_node key; int → primitive skip.
+        named_node(&mut v, "var_ptr", "u", "VARIABLE", "main.go");
+        v.put_node_metadata(id_of("var_ptr"), r#"{"type":"*User"}"#);
+        named_node(&mut v, "var_bytes", "b", "VARIABLE", "main.go");
+        v.put_node_metadata(id_of("var_bytes"), r#"{"type":"[]byte"}"#);
+        named_node(&mut v, "var_slice", "us", "VARIABLE", "main.go");
+        v.put_node_metadata(id_of("var_slice"), r#"{"type":"[]*User"}"#);
+        named_node(&mut v, "var_map", "m", "VARIABLE", "main.go");
+        v.put_node_metadata(id_of("var_map"), r#"{"type":"map[string]User"}"#);
+        named_node(&mut v, "var_int", "n", "VARIABLE", "main.go");
+        v.put_node_metadata(id_of("var_int"), r#"{"type":"int"}"#);
+        named_node(&mut v, "var_iface", "s", "VARIABLE", "main.go");
+        v.put_node_metadata(id_of("var_iface"), r#"{"type":"Store"}"#);
+
+        let pairs = derived_pairs(&v, GO_TYPES_DL, "go_type_of");
+        assert_eq!(
+            pairs,
+            BTreeSet::from([
+                (id_of("var_ptr"), id_of("cls_user")),
+                (id_of("var_slice"), id_of("cls_user")),
+                (id_of("var_iface"), id_of("if_store")),
+            ]),
+            "*/[] strip recursion; primitives and map types never resolve; \
+             INTERFACE is a type target"
+        );
+
+        // RETURNS: "*User,error" → User only (error is a primitive);
+        // "User,Store" → both; single "Config" → identity (no comma).
+        named_node(&mut v, "fn_a", "loadUser", "FUNCTION", "main.go");
+        v.put_node_metadata(id_of("fn_a"), r#"{"kind":"function","return_type":"*User,error"}"#);
+        named_node(&mut v, "fn_b", "both", "FUNCTION", "main.go");
+        v.put_node_metadata(id_of("fn_b"), r#"{"kind":"function","return_type":"User,Store"}"#);
+        named_node(&mut v, "cls_cfg", "Config", "CLASS", "cfg.go");
+        named_node(&mut v, "fn_c", "cfg", "FUNCTION", "main.go");
+        v.put_node_metadata(id_of("fn_c"), r#"{"kind":"function","return_type":"Config"}"#);
+        // G7-1: a duplicate type name — both nodes derived (legacy last-wins).
+        named_node(&mut v, "cls_cfg2", "Config", "CLASS", "cfg2.go");
+
+        let pairs = derived_pairs(&v, GO_TYPES_DL, "go_returns");
+        assert_eq!(
+            pairs,
+            BTreeSet::from([
+                (id_of("fn_a"), id_of("cls_user")),
+                (id_of("fn_b"), id_of("cls_user")),
+                (id_of("fn_b"), id_of("if_store")),
+                (id_of("fn_c"), id_of("cls_cfg")),
+                // PREDICTION G7-1: duplicate type names fan out.
+                (id_of("fn_c"), id_of("cls_cfg2")),
+            ]),
+            "comma-peel splits return_type exactly; error primitive skipped; \
+             duplicate type names fan out (G7-1)"
+        );
+    }
+
+    /// go_context — Spec.hs:216-302 ported onto the structural CONTAINS seam:
+    /// the certain/possible target × caller matrix, goroutine/deferred arms,
+    /// the unresolved meta column, closure- and module-contained calls
+    /// (G9-1/G9-3 — the pack derives what legacy INTENDED; on real analyzer
+    /// ids legacy's caller lookup never matched, see the .dl header).
+    #[test]
+    fn go_context_propagation_matrix_on_fixture() {
+        let mut v = FixtureStorageView::new(1);
+        // fnA (accepts) contains callB → fnB (accepts): PROPAGATES, no meta.
+        named_node(&mut v, "fn_a", "A", "FUNCTION", "pkg/handler.go");
+        v.put_node_metadata(id_of("fn_a"), r#"{"kind":"function","accepts_context":true}"#);
+        named_node(&mut v, "fn_b", "B", "FUNCTION", "pkg/service.go");
+        v.put_node_metadata(id_of("fn_b"), r#"{"kind":"function","accepts_context":true}"#);
+        named_node(&mut v, "call_b", "B", "CALL", "pkg/handler.go");
+        edge(&mut v, "fn_a", "call_b", "CONTAINS");
+        edge(&mut v, "call_b", "fn_b", "CALLS");
+        // goroutine: SPAWNS + PROPAGATES (Spec.hs:231-243).
+        named_node(&mut v, "fn_worker", "worker", "FUNCTION", "pkg/main.go");
+        v.put_node_metadata(id_of("fn_worker"), r#"{"kind":"function","accepts_context":true}"#);
+        named_node(&mut v, "call_w", "worker", "CALL", "pkg/main.go");
+        v.put_node_metadata(id_of("call_w"), r#"{"goroutine":true}"#);
+        edge(&mut v, "fn_a2", "call_w", "CONTAINS");
+        named_node(&mut v, "fn_a2", "main", "FUNCTION", "pkg/main.go");
+        v.put_node_metadata(id_of("fn_a2"), r#"{"kind":"function","accepts_context":true}"#);
+        edge(&mut v, "call_w", "fn_worker", "CALLS");
+        // deferred: DEFERS + PROPAGATES (Spec.hs:257-269).
+        named_node(&mut v, "fn_cleanup", "cleanup", "FUNCTION", "pkg/api.go");
+        v.put_node_metadata(id_of("fn_cleanup"), r#"{"kind":"function","accepts_context":true}"#);
+        named_node(&mut v, "call_d", "cleanup", "CALL", "pkg/api.go");
+        v.put_node_metadata(id_of("call_d"), r#"{"deferred":true}"#);
+        edge(&mut v, "fn_a", "call_d", "CONTAINS");
+        edge(&mut v, "call_d", "fn_cleanup", "CALLS");
+        // No-context target: nothing (Spec.hs:245-255).
+        named_node(&mut v, "fn_c", "C", "FUNCTION", "pkg/util.go");
+        v.put_node_metadata(id_of("fn_c"), r#"{"kind":"function"}"#);
+        named_node(&mut v, "call_c", "C", "CALL", "pkg/handler.go");
+        edge(&mut v, "fn_a", "call_c", "CONTAINS");
+        edge(&mut v, "call_c", "fn_c", "CALLS");
+        // possible → possible: meta unresolved="true" (Spec.hs:271-286).
+        named_node(&mut v, "fn_pa", "PA", "FUNCTION", "pkg/p.go");
+        v.put_node_metadata(id_of("fn_pa"), r#"{"kind":"function","possible_context":true}"#);
+        named_node(&mut v, "fn_pb", "PB", "FUNCTION", "pkg/p.go");
+        v.put_node_metadata(id_of("fn_pb"), r#"{"kind":"function","possible_context":true}"#);
+        named_node(&mut v, "call_pb", "PB", "CALL", "pkg/p.go");
+        edge(&mut v, "fn_pa", "call_pb", "CONTAINS");
+        edge(&mut v, "call_pb", "fn_pb", "CALLS");
+        // possible caller → CERTAIN target: plain edge, NO meta (Spec.hs:288-301).
+        named_node(&mut v, "call_b2", "B", "CALL", "pkg/p.go");
+        edge(&mut v, "fn_pa", "call_b2", "CONTAINS");
+        edge(&mut v, "call_b2", "fn_b", "CALLS");
+        // Call inside a CLOSURE: no PROPAGATES (caller excluded) but SPAWNS
+        // still fires (caller-independent).
+        named_node(&mut v, "fn_clo", "<closure>", "FUNCTION", "pkg/z.go");
+        v.put_node_metadata(id_of("fn_clo"), r#"{"kind":"closure"}"#);
+        named_node(&mut v, "call_z", "B", "CALL", "pkg/z.go");
+        v.put_node_metadata(id_of("call_z"), r#"{"goroutine":true}"#);
+        edge(&mut v, "fn_clo", "call_z", "CONTAINS");
+        edge(&mut v, "call_z", "fn_b", "CALLS");
+        // Top-level call (CONTAINS from MODULE): no PROPAGATES.
+        node(&mut v, "mod_top", "MODULE", "pkg/t.go");
+        named_node(&mut v, "call_t", "B", "CALL", "pkg/t.go");
+        edge(&mut v, "mod_top", "call_t", "CONTAINS");
+        edge(&mut v, "call_t", "fn_b", "CALLS");
+
+        let eval = evaluate(&v, GO_CONTEXT_DL, Stats::default(), EvalLimits::none(), EventLog::discard())
+            .expect("go_context.dl evaluates");
+        let prop: BTreeSet<(u128, u128)> = eval
+            .facts("go_prop")
+            .into_iter()
+            .map(|r| (r[0].as_id().unwrap(), r[1].as_id().unwrap()))
+            .collect();
+        assert_eq!(
+            prop,
+            BTreeSet::from([
+                (id_of("fn_a"), id_of("fn_b")),
+                (id_of("fn_a2"), id_of("fn_worker")),
+                (id_of("fn_a"), id_of("fn_cleanup")),
+                // Possible caller + certain target rides the PLAIN head.
+                (id_of("fn_pa"), id_of("fn_b")),
+            ]),
+            "certain-target PROPAGATES: enclosing fn via CONTAINS; closure- and \
+             module-contained calls excluded; no-context target inert"
+        );
+        let prop_u: BTreeSet<(u128, u128, String)> = eval
+            .facts("go_prop_u")
+            .into_iter()
+            .map(|r| (r[0].as_id().unwrap(), r[1].as_id().unwrap(), r[2].as_str()))
+            .collect();
+        assert_eq!(
+            prop_u,
+            BTreeSet::from([(id_of("fn_pa"), id_of("fn_pb"), "true".to_string())]),
+            "possible-target edges carry unresolved=\"true\" (G9-2 projection); \
+             the certain-target row must NOT appear here (Spec.hs:288-301)"
+        );
+        let spawns: BTreeSet<(u128, u128)> = eval
+            .facts("go_spawn")
+            .into_iter()
+            .map(|r| (r[0].as_id().unwrap(), r[1].as_id().unwrap()))
+            .collect();
+        assert_eq!(
+            spawns,
+            BTreeSet::from([
+                (id_of("call_w"), id_of("fn_worker")),
+                // Caller-independent: the closure-contained goroutine still spawns.
+                (id_of("call_z"), id_of("fn_b")),
+            ]),
+            "SPAWNS is caller-independent (legacy :177-185)"
+        );
+        let defers: BTreeSet<(u128, u128)> = eval
+            .facts("go_defer")
+            .into_iter()
+            .map(|r| (r[0].as_id().unwrap(), r[1].as_id().unwrap()))
+            .collect();
+        assert_eq!(
+            defers,
+            BTreeSet::from([(id_of("call_d"), id_of("fn_cleanup"))]),
+            "DEFERS for deferred calls with certain-context targets"
+        );
+    }
+
+    /// Every go pack declares its @materialize heads with the expected edge
+    /// types and ADDITIVE mode (shared vocabulary — never tombstone), and the
+    /// unresolved meta column rides only the *_u context heads.
+    #[test]
+    fn go_packs_declare_additive_materialization() {
+        let mut v = FixtureStorageView::new(1);
+        node(&mut v, "m", "MODULE", "a.go");
+        for (src, expected) in [
+            (GO_IMPORTS_DL, vec!["IMPORTS_FROM"]),
+            (GO_IMPORTS_NOMOD_DL, vec!["IMPORTS_FROM"]),
+            (GO_CALLS_DL, vec!["CALLS", "CALLS", "CALLS"]),
+            (GO_INTERFACES_DL, vec!["IMPLEMENTS"]),
+            (GO_TYPES_DL, vec!["TYPE_OF", "RETURNS"]),
+            (
+                GO_CONTEXT_DL,
+                vec![
+                    "PROPAGATES_CONTEXT",
+                    "PROPAGATES_CONTEXT",
+                    "SPAWNS_WITH_CONTEXT",
+                    "SPAWNS_WITH_CONTEXT",
+                    "DEFERS_WITH_CONTEXT",
+                    "DEFERS_WITH_CONTEXT",
+                ],
+            ),
+        ] {
+            let (_eval, specs, node_specs) = evaluate_with_materialize(
+                &v,
+                src,
+                Stats::default(),
+                EvalLimits::none(),
+                EventLog::discard(),
+            )
+            .expect("go pack evaluates with materialize");
+            let mut types: Vec<&str> = specs.iter().map(|s| s.edge_type.as_str()).collect();
+            let mut want = expected.clone();
+            types.sort_unstable();
+            want.sort_unstable();
+            assert_eq!(types, want, "edge-type heads of a go pack");
+            assert!(
+                specs.iter().all(|s| s.additive),
+                "every go head is additive (shared vocabulary)"
+            );
+            assert!(
+                node_specs.is_empty(),
+                "go packs materialize edges only, no nodes"
+            );
+        }
+    }
 }

--- a/packages/rfdb-server/src/derive/stdlib.rs
+++ b/packages/rfdb-server/src/derive/stdlib.rs
@@ -300,6 +300,38 @@ pub const JS_RUNTIME_GLOBALS_EDGES_DL: &str = concat!(
 /// (the rank ladder) ⇒ scratch-only under maintain.
 pub const JS_MODULE_IMPORTS_DL: &str = include_str!("stdlib/js_module_imports.dl");
 
+/// Node half of the JS HTTP-route feature vertical (Wave 14, REG-1115 slice):
+/// `http:route` minting (sid `<file>::http:route::<name>::<callIdDecimal>`)
+/// + ROUTES_TO for Express/Fastify/Koa(+routers)/Hono registrations — the
+/// derive-pack REPLACEMENT for libraryCallbackEnricher.ts's HTTP slice (the
+/// 6 framework entries were retired from its LIBRARY_NODE_TYPE map in this
+/// wave; the enricher keeps only cli:command/mcp:tool/vscode:command —
+/// running both would mint duplicate http:route nodes with byte-different
+/// ids), driven by the effects-db callable registry as generated
+/// ground facts (effects_callable_facts.dl, prepended at compile time;
+/// regenerate via scripts/generate-effects-callable-facts.mjs). Receiver
+/// resolution = RECEIVER_CALL chain origin + IMPORT_BINDING `source` +
+/// CONSTANT/VARIABLE initializer hops (incl. factory calls — delta 2).
+/// Negation + minting ⇒ scratch-only under maintain.
+pub const JS_HTTP_ROUTES_NODES_DL: &str = concat!(
+    include_str!("stdlib/effects_callable_facts.dl"),
+    "\n",
+    include_str!("stdlib/js_http_routes_nodes.dl"),
+);
+
+/// Edge half of the JS HTTP-route vertical (Wave 14): EXPOSES
+/// (CALL → http:route) + HANDLES (http:route → callback), endpoints pinned by
+/// the exact `node_attr(R,"anchorCall") ⋈ attr(C,"id")` join — other
+/// producers' http:route nodes (axum_routes, the legacy enricher) are never
+/// joined. MUST run after `js_http_routes_nodes` (committed-EDB endpoint
+/// join — the js_builtins two-pack split). Both heads additive (EXPOSES /
+/// HANDLES are shared enricher vocabulary).
+pub const JS_HTTP_ROUTES_EDGES_DL: &str = concat!(
+    include_str!("stdlib/effects_callable_facts.dl"),
+    "\n",
+    include_str!("stdlib/js_http_routes_edges.dl"),
+);
+
 /// The named stdlib rule packs, addressable on the wire as `"@stdlib/<name>"`
 /// (`MaterializeDatalog` and the other empty-source-defaulting dispatchers), listed
 /// in CANONICAL RUN ORDER. The order is a CONTRACT, not cosmetics — producers run
@@ -356,7 +388,11 @@ pub const JS_MODULE_IMPORTS_DL: &str = include_str!("stdlib/js_module_imports.dl
 /// js_cross_file_calls → js_property_access_ns → js_property_access_full →
 /// js_builtins_nodes → js_builtins_edges → js_runtime_globals_nodes →
 /// js_runtime_globals_edges → depends → method_calls → shape_verifier →
-/// axum_routes.
+/// axum_routes → js_http_routes_nodes → js_http_routes_edges.
+/// - the Wave-14 feature-detection pair: `js_http_routes_nodes` MINTS the
+///   anchorCall-pinned http:route endpoints that `js_http_routes_edges` joins
+///   as committed EDB (strict nodes→edges order, the js_builtins split);
+///   both consume analyzer EDB only.
 pub const STDLIB_PACKS: &[(&str, &str)] = &[
     ("js_local_refs", JS_LOCAL_REFS_DL),
     ("js_same_file_calls", JS_SAME_FILE_CALLS_DL),
@@ -409,6 +445,13 @@ pub const STDLIB_PACKS: &[(&str, &str)] = &[
     ("method_calls", METHOD_CALLS_DL),
     ("shape_verifier", SHAPE_VERIFIER_DL),
     ("axum_routes", AXUM_ROUTES_DL),
+    // Wave 14 feature-detection vertical: js_http_routes_nodes MINTS the
+    // http:route endpoints (anchorCall-pinned) that js_http_routes_edges
+    // joins as committed EDB (strict nodes→edges order — the js_builtins
+    // two-pack split). Both consume analyzer EDB only and produce nothing any
+    // earlier pack reads, so they sit at the registry tail with axum_routes.
+    ("js_http_routes_nodes", JS_HTTP_ROUTES_NODES_DL),
+    ("js_http_routes_edges", JS_HTTP_ROUTES_EDGES_DL),
 ];
 
 /// Look up a bundled pack by its wire name (the `<name>` in `"@stdlib/<name>"`).
@@ -1272,6 +1315,8 @@ mod tests {
                 "method_calls",
                 "shape_verifier",
                 "axum_routes",
+                "js_http_routes_nodes",
+                "js_http_routes_edges",
             ],
             "canonical run order: Wave-1 resolver packs → Wave-1b packs \
              (rust_cross_methods_ctor after rust_calls — the CALLS EDB seam; the \
@@ -1286,8 +1331,10 @@ mod tests {
              js_class_inheritance produces EXTENDS for shape_verifier) → \
              depends (Wave 3c: AFTER every IMPORTS_FROM producer — legacy \
              import-resolution is gated, so the in-engine producers feed it) → \
-             method_calls → shape_verifier → axum_routes (producers strictly \
-             before consumers)"
+             method_calls → shape_verifier → axum_routes → \
+             js_http_routes_nodes → js_http_routes_edges (Wave 14: the nodes \
+             pack mints the anchorCall-pinned http:route endpoints the edges \
+             pack joins as committed EDB) (producers strictly before consumers)"
         );
         assert_eq!(stdlib_pack("depends"), Some(DEPENDS_DL));
         assert_eq!(stdlib_pack("js_local_refs"), Some(JS_LOCAL_REFS_DL));
@@ -1325,6 +1372,14 @@ mod tests {
         assert_eq!(stdlib_pack("method_calls"), Some(METHOD_CALLS_DL));
         assert_eq!(stdlib_pack("shape_verifier"), Some(SHAPE_VERIFIER_DL));
         assert_eq!(stdlib_pack("axum_routes"), Some(AXUM_ROUTES_DL));
+        assert_eq!(
+            stdlib_pack("js_http_routes_nodes"),
+            Some(JS_HTTP_ROUTES_NODES_DL)
+        );
+        assert_eq!(
+            stdlib_pack("js_http_routes_edges"),
+            Some(JS_HTTP_ROUTES_EDGES_DL)
+        );
         assert_eq!(stdlib_pack("nope"), None, "unknown pack name resolves to None");
     }
 
@@ -3644,6 +3699,305 @@ mod tests {
         assert_eq!(spec.meta, vec!["resolvedVia".to_string(), "globalCategory".to_string()]);
     }
 
+    /// Realistic small-corpus stats for the Wave-14 fixture tests: the
+    /// empty-graph `Stats::default()` (total_nodes = 0) degenerates every
+    /// keyed probe into a DERIVED relation to its FULL cardinality
+    /// (`k / total_nodes.max(1)` = k), so the deep ecb-fact join chain
+    /// multiplies past the E-PLAN-003 guard on estimates alone. Production
+    /// always plans with store-derived stats; the dogfood-scale plan gate
+    /// below covers these packs at full scale.
+    fn w14_stats() -> Stats {
+        let mut nodes_by_type = std::collections::HashMap::new();
+        for (ty, n) in [
+            ("CALL", 70_000u64),
+            ("LITERAL", 40_000),
+            ("VARIABLE", 15_500),
+            ("FUNCTION", 10_221),
+            ("CONSTANT", 6_700),
+            ("IMPORT_BINDING", 5_781),
+            ("http:route", 50),
+        ] {
+            nodes_by_type.insert(ty.to_string(), n);
+        }
+        Stats {
+            total_nodes: 500_000,
+            total_edges: 1_000_000,
+            nodes_by_type,
+        }
+    }
+
+    /// Wave 14 — js_http_routes_nodes framework arms, each pinned on the
+    /// live-verified analyzer shapes (IMPORT_BINDING metadata.source, CALL
+    /// metadata.kind="new", RECEIVER_CALL chains, PASSES_ARGUMENT
+    /// metadata.index, LITERAL name = raw quoted source text):
+    /// - express FACTORY initializer (delta 2): `const app = express();
+    ///   app.get('/users', handler)` — single-quote strip;
+    /// - hono NEW initializer + chained second registration (deltas 1, 9):
+    ///   `const app2 = new Hono(); app2.post("/items", h).put('/things', h2)`
+    ///   — double-quote strip (the Wave-14 parser escape) and the chained
+    ///   call's OWN path;
+    /// - @koa/router SUBPATH import + `del` verb: `import Router from
+    ///   '@koa/router/lib/router.js'; const router = new Router();
+    ///   router.del('/old', h3)` → DELETE;
+    /// - fastify `register` (callback at index 0, NO route path): minted as
+    ///   "<unnamed-http-route>", no ROUTES_TO (non-verb method);
+    /// - negatives: `.get` with an unresolvable receiver (map.get), a
+    ///   receiver imported from a NON-registry lib (lodash), and a verb call
+    ///   missing its callback argument (delta 8) all derive nothing.
+    #[test]
+    fn js_http_routes_nodes_framework_arms() {
+        let idx0 = r#"{"index":0}"#;
+        let idx1 = r#"{"index":1}"#;
+        let mut v = FixtureStorageView::new(1);
+
+        // a. express factory: import + const app = express() + app.get('/users', h).
+        named_node(&mut v, "b_express", "express", "IMPORT_BINDING", "app.ts");
+        v.put_node_metadata(id_of("b_express"), r#"{"source":"express"}"#);
+        named_node(&mut v, "k_app", "app", "CONSTANT", "app.ts");
+        named_node(&mut v, "c_factory", "express", "CALL", "app.ts");
+        edge(&mut v, "k_app", "c_factory", "ASSIGNED_FROM");
+        named_node(&mut v, "c_get", "app.get", "CALL", "app.ts");
+        named_node(&mut v, "p_users", "'/users'", "LITERAL", "app.ts");
+        named_node(&mut v, "h_users", "<arrow>", "FUNCTION", "app.ts");
+        edge_meta(&mut v, "c_get", "p_users", "PASSES_ARGUMENT", idx0);
+        edge_meta(&mut v, "c_get", "h_users", "PASSES_ARGUMENT", idx1);
+
+        // b. hono new + chain: const app2 = new Hono();
+        //    app2.post("/items", h).put('/things', h2).
+        named_node(&mut v, "b_hono", "Hono", "IMPORT_BINDING", "hono.ts");
+        v.put_node_metadata(id_of("b_hono"), r#"{"source":"hono"}"#);
+        named_node(&mut v, "k_app2", "app2", "CONSTANT", "hono.ts");
+        named_node(&mut v, "c_hono_new", "Hono", "CALL", "hono.ts");
+        v.put_node_metadata(id_of("c_hono_new"), r#"{"kind":"new"}"#);
+        edge(&mut v, "k_app2", "c_hono_new", "ASSIGNED_FROM");
+        named_node(&mut v, "c_post", "app2.post", "CALL", "hono.ts");
+        named_node(&mut v, "p_items", "\"/items\"", "LITERAL", "hono.ts");
+        named_node(&mut v, "h_items", "h", "FUNCTION", "hono.ts");
+        edge_meta(&mut v, "c_post", "p_items", "PASSES_ARGUMENT", idx0);
+        edge_meta(&mut v, "c_post", "h_items", "PASSES_ARGUMENT", idx1);
+        named_node(&mut v, "c_put", "<obj>.put", "CALL", "hono.ts");
+        edge(&mut v, "c_put", "c_post", "RECEIVER_CALL");
+        named_node(&mut v, "p_things", "'/things'", "LITERAL", "hono.ts");
+        named_node(&mut v, "h_things", "h2", "FUNCTION", "hono.ts");
+        edge_meta(&mut v, "c_put", "p_things", "PASSES_ARGUMENT", idx0);
+        edge_meta(&mut v, "c_put", "h_things", "PASSES_ARGUMENT", idx1);
+
+        // b2. hono `on` — data-driven NON-(0,1) indexes: app2.on(['GET'], '/x', h4)
+        //     (ROUTE_PATH at index 1, ENTRY_POINT_CALLBACK at index 2; "on" is
+        //     not a verb so the node minted carries no ROUTES_TO).
+        let idx2 = r#"{"index":2}"#;
+        named_node(&mut v, "c_on", "app2.on", "CALL", "hono.ts");
+        named_node(&mut v, "p_methods", "<array>", "LITERAL", "hono.ts");
+        named_node(&mut v, "p_x", "'/x'", "LITERAL", "hono.ts");
+        named_node(&mut v, "h_x", "h4", "FUNCTION", "hono.ts");
+        edge_meta(&mut v, "c_on", "p_methods", "PASSES_ARGUMENT", idx0);
+        edge_meta(&mut v, "c_on", "p_x", "PASSES_ARGUMENT", idx1);
+        edge_meta(&mut v, "c_on", "h_x", "PASSES_ARGUMENT", idx2);
+
+        // c. @koa/router subpath import + new Router() + router.del('/old', h3).
+        named_node(&mut v, "b_router", "Router", "IMPORT_BINDING", "koa.ts");
+        v.put_node_metadata(id_of("b_router"), r#"{"source":"@koa/router/lib/router.js"}"#);
+        named_node(&mut v, "k_router", "router", "CONSTANT", "koa.ts");
+        named_node(&mut v, "c_router_new", "Router", "CALL", "koa.ts");
+        v.put_node_metadata(id_of("c_router_new"), r#"{"kind":"new"}"#);
+        edge(&mut v, "k_router", "c_router_new", "ASSIGNED_FROM");
+        named_node(&mut v, "c_del", "router.del", "CALL", "koa.ts");
+        named_node(&mut v, "p_old", "'/old'", "LITERAL", "koa.ts");
+        named_node(&mut v, "h_old", "h3", "FUNCTION", "koa.ts");
+        edge_meta(&mut v, "c_del", "p_old", "PASSES_ARGUMENT", idx0);
+        edge_meta(&mut v, "c_del", "h_old", "PASSES_ARGUMENT", idx1);
+
+        // d. fastify register: const srv = fastify(); srv.register(plugin) —
+        //    callback at index 0, no ROUTE_PATH role.
+        named_node(&mut v, "b_fastify", "fastify", "IMPORT_BINDING", "f.ts");
+        v.put_node_metadata(id_of("b_fastify"), r#"{"source":"fastify"}"#);
+        named_node(&mut v, "k_srv", "srv", "CONSTANT", "f.ts");
+        named_node(&mut v, "c_ffactory", "fastify", "CALL", "f.ts");
+        edge(&mut v, "k_srv", "c_ffactory", "ASSIGNED_FROM");
+        named_node(&mut v, "c_register", "srv.register", "CALL", "f.ts");
+        named_node(&mut v, "h_plugin", "plugin", "FUNCTION", "f.ts");
+        edge_meta(&mut v, "c_register", "h_plugin", "PASSES_ARGUMENT", idx0);
+
+        // e. negatives.
+        named_node(&mut v, "c_map", "map.get", "CALL", "app.ts"); // no binding
+        edge_meta(&mut v, "c_map", "p_users", "PASSES_ARGUMENT", idx0);
+        edge_meta(&mut v, "c_map", "h_users", "PASSES_ARGUMENT", idx1);
+        named_node(&mut v, "b_other", "other", "IMPORT_BINDING", "app.ts");
+        v.put_node_metadata(id_of("b_other"), r#"{"source":"lodash"}"#);
+        named_node(&mut v, "c_other", "other.get", "CALL", "app.ts"); // non-registry lib
+        edge_meta(&mut v, "c_other", "p_users", "PASSES_ARGUMENT", idx0);
+        edge_meta(&mut v, "c_other", "h_users", "PASSES_ARGUMENT", idx1);
+        named_node(&mut v, "c_nocb", "app.options", "CALL", "app.ts"); // delta 8: no idx-1 arg
+        edge_meta(&mut v, "c_nocb", "p_users", "PASSES_ARGUMENT", idx0);
+
+        let (eval, specs, node_specs) = evaluate_with_materialize(
+            &v,
+            JS_HTTP_ROUTES_NODES_DL,
+            w14_stats(),
+            EvalLimits::none(),
+            EventLog::discard(),
+        )
+        .expect("js_http_routes_nodes.dl evaluates");
+
+        // ROUTES_TO: verb methods with a path; register is non-verb ⇒ absent.
+        let routes: BTreeSet<(u128, u128, String, String)> = eval
+            .facts("http_routes_to")
+            .into_iter()
+            .map(|r| {
+                (
+                    r[0].as_id().expect("src id"),
+                    r[1].as_id().expect("dst id"),
+                    r[2].as_str(),
+                    r[3].as_str(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            routes,
+            BTreeSet::from([
+                (id_of("c_get"), id_of("h_users"), "GET".to_string(), "/users".to_string()),
+                (id_of("c_post"), id_of("h_items"), "POST".to_string(), "/items".to_string()),
+                (id_of("c_put"), id_of("h_things"), "PUT".to_string(), "/things".to_string()),
+                (id_of("c_del"), id_of("h_old"), "DELETE".to_string(), "/old".to_string()),
+            ]),
+            "factory/new/chained/subpath arms route with stripped paths and \
+             mapped verbs; register (non-verb) and all negatives derive none"
+        );
+
+        // The minted nodes: sid <file>::http:route::<name>::<callIdDecimal>.
+        let minted: BTreeSet<(String, String, String, String, String)> = eval
+            .facts("http_route_js")
+            .into_iter()
+            .map(|r| (r[0].as_str(), r[1].as_str(), r[2].as_str(), r[3].as_str(), r[4].as_str()))
+            .collect();
+        let rn = |file: &str, name: &str, lib: &str, m: &str, call: &str| {
+            (
+                format!("{file}::http:route::{name}::{}", id_of(call)),
+                name.to_string(),
+                file.to_string(),
+                lib.to_string(),
+                m.to_string(),
+            )
+        };
+        assert_eq!(
+            minted,
+            BTreeSet::from([
+                rn("app.ts", "/users", "express", "get", "c_get"),
+                rn("hono.ts", "/items", "hono", "post", "c_post"),
+                rn("hono.ts", "/things", "hono", "put", "c_put"),
+                rn("koa.ts", "/old", "@koa/router", "del", "c_del"),
+                rn("f.ts", "<unnamed-http-route>", "fastify", "register", "c_register"),
+                rn("hono.ts", "/x", "hono", "on", "c_on"),
+            ]),
+            "one node per resolved registration call (chained .put names its \
+             OWN path — delta 9; pathless register is unnamed); negatives mint \
+             nothing"
+        );
+
+        // Specs: additive ROUTES_TO; provenance-scoped exclusive http:route node.
+        let rt = specs
+            .iter()
+            .find(|s| s.edge_type == "ROUTES_TO")
+            .expect("ROUTES_TO spec");
+        assert!(rt.additive, "ROUTES_TO is shared vocabulary — additive");
+        assert_eq!(rt.meta, vec!["method".to_string(), "path".to_string()]);
+        assert_eq!(node_specs.len(), 1, "exactly one node-materialized head");
+        let ns = &node_specs[0];
+        assert_eq!(ns.predicate, "http_route_js");
+        assert_eq!(ns.node_type, "http:route");
+        assert!(!ns.additive, "exclusive (provenance-scoped) node ownership");
+        assert_eq!(
+            ns.meta,
+            vec!["library".to_string(), "method".to_string(), "anchorCall".to_string()]
+        );
+    }
+
+    /// Wave 14 — js_http_routes_edges joins the COMMITTED http:route
+    /// endpoints by the exact anchorCall pin and reproduces the enricher's
+    /// edge vocabulary: EXPOSES (CALL → http:route) + HANDLES
+    /// (http:route → callback). Decoy http:route nodes — axum-style (no
+    /// anchorCall), enricher-style (anchorCall = wire semantic-id string),
+    /// and an anchorCall pointing at an UNRELATED call — are never joined.
+    #[test]
+    fn js_http_routes_edges_joins_minted_endpoints() {
+        let idx0 = r#"{"index":0}"#;
+        let idx1 = r#"{"index":1}"#;
+        let mut v = FixtureStorageView::new(1);
+
+        // The resolvable registration: const app = express(); app.get('/users', h).
+        named_node(&mut v, "b_express", "express", "IMPORT_BINDING", "app.ts");
+        v.put_node_metadata(id_of("b_express"), r#"{"source":"express"}"#);
+        named_node(&mut v, "k_app", "app", "CONSTANT", "app.ts");
+        named_node(&mut v, "c_factory", "express", "CALL", "app.ts");
+        edge(&mut v, "k_app", "c_factory", "ASSIGNED_FROM");
+        named_node(&mut v, "c_get", "app.get", "CALL", "app.ts");
+        named_node(&mut v, "p_users", "'/users'", "LITERAL", "app.ts");
+        named_node(&mut v, "h_users", "<arrow>", "FUNCTION", "app.ts");
+        edge_meta(&mut v, "c_get", "p_users", "PASSES_ARGUMENT", idx0);
+        edge_meta(&mut v, "c_get", "h_users", "PASSES_ARGUMENT", idx1);
+
+        // The COMMITTED node minted by js_http_routes_nodes (anchorCall pin).
+        let route_sid = format!("app.ts::http:route::/users::{}", id_of("c_get"));
+        named_node(&mut v, &route_sid, "/users", "http:route", "app.ts");
+        v.put_node_metadata(
+            id_of(&route_sid),
+            &format!(r#"{{"anchorCall":"{}","library":"express","method":"get"}}"#, id_of("c_get")),
+        );
+
+        // Decoys: axum-style (no anchorCall), enricher-style (wire-sid
+        // anchorCall), and an anchorCall anchored on a DIFFERENT call.
+        named_node(&mut v, "http:route::GET::/users", "/users", "http:route", "src/main.rs");
+        v.put_node_metadata(
+            id_of("http:route::GET::/users"),
+            r#"{"method":"GET","path":"/users"}"#,
+        );
+        named_node(&mut v, "app.ts::http:route::/users::wire", "/users", "http:route", "app.ts");
+        v.put_node_metadata(
+            id_of("app.ts::http:route::/users::wire"),
+            r#"{"anchorCall":"app.ts->CALL->app.get[0]","library":"express"}"#,
+        );
+        named_node(&mut v, "decoy_other_anchor", "/users", "http:route", "app.ts");
+        v.put_node_metadata(
+            id_of("decoy_other_anchor"),
+            &format!(r#"{{"anchorCall":"{}"}}"#, id_of("c_factory")),
+        );
+
+        let (eval, specs, _node_specs) = evaluate_with_materialize(
+            &v,
+            JS_HTTP_ROUTES_EDGES_DL,
+            w14_stats(),
+            EvalLimits::none(),
+            EventLog::discard(),
+        )
+        .expect("js_http_routes_edges.dl evaluates");
+
+        let pairs = |pred: &str| -> BTreeSet<(u128, u128)> {
+            eval.facts(pred)
+                .into_iter()
+                .map(|r| (r[0].as_id().expect("src id"), r[1].as_id().expect("dst id")))
+                .collect()
+        };
+        assert_eq!(
+            pairs("http_exposes"),
+            BTreeSet::from([(id_of("c_get"), id_of(&route_sid))]),
+            "EXPOSES joins exactly the anchorCall-pinned node — no decoy joins"
+        );
+        assert_eq!(
+            pairs("http_handles"),
+            BTreeSet::from([(id_of(&route_sid), id_of("h_users"))]),
+            "HANDLES: pinned node → the callback-index argument target"
+        );
+
+        for ty in ["EXPOSES", "HANDLES"] {
+            let s = specs
+                .iter()
+                .find(|s| s.edge_type == ty)
+                .unwrap_or_else(|| panic!("{ty} spec present"));
+            assert!(s.additive, "{ty} is shared enricher vocabulary — additive");
+            assert!(s.meta.is_empty(), "{ty} carries no meta columns");
+        }
+    }
+
     /// Wave 2b — js_cross_file_calls namespace arm through the visible() chain:
     /// `import * as barrel from './top'; barrel.deepFn()` where top.ts star
     /// re-exports mid.ts which directly exports deepFn — the member resolves to
@@ -4292,6 +4646,8 @@ mod tests {
             // Wave 3c: orchestrator-committed workspace facts (one per
             // discovered package + alias virtual packages; dogfood ~30).
             ("WORKSPACE_PACKAGE", 30),
+            // Wave 14: axum_routes + js_http_routes minted routes (dogfood 8).
+            ("http:route", 8),
         ] {
             nodes_by_type.insert(ty.to_string(), n);
         }

--- a/packages/rfdb-server/src/derive/stdlib.rs
+++ b/packages/rfdb-server/src/derive/stdlib.rs
@@ -283,6 +283,25 @@ pub const JS_RUNTIME_GLOBALS_EDGES_DL: &str = concat!(
     include_str!("stdlib/js_runtime_globals_edges.dl"),
 );
 
+/// The Kotlin inheritance pack — EXTENDS (class supertype) + IMPLEMENTS
+/// (interface supertypes) from the kotlin-analyzer's CLASS metadata stamps
+/// (`extends` single key + `implements_0..n` indexed keys — the list-valued
+/// metadata convention). Closes the lang-spec-kotlin step-5 gap: kotlin
+/// classes had ZERO inheritance edges in production (the analyzer's deferred
+/// InheritanceResolve refs are dropped by the orchestrator, and the legacy
+/// kotlin-resolve metadata arms read keys the analyzer never stamped) — every
+/// edge is a declared superset vs legacy-zero. Resolution scope: same-file +
+/// same-package-by-directory arms only (cross-file via imports = next wave,
+/// SUBSET delta). Bare class supertypes of no-primary-constructor classes
+/// (the Kotlin syntactic ambiguity) are re-classified by the resolved
+/// declaration's `kind` (interface → IMPLEMENTS, else EXTENDS recovery arms).
+/// Both edge types are pre-registered SHARED vocabulary
+/// (`packages/types/src/edges.ts`) ⇒ `mode = "additive"` on all heads,
+/// `resolvedVia = "kotlin-inheritance"` meta. PRODUCER of EXTENDS — must run
+/// before shape_verifier (its EXTENDS-closed member lookup); consumes
+/// analyzer EDB only. node_attr ⇒ scratch floor under maintain.
+pub const KOTLIN_INHERITANCE_DL: &str = include_str!("stdlib/kotlin_inheritance.dl");
+
 /// The JS module-path kernel pack (Wave 3b, path/string-kit-unblocked): the
 /// in-engine replacement for the module-level arms of `ImportResolution.hs` —
 /// IMPORT → MODULE `IMPORTS_FROM` (`resolveModuleImports`) and star re-export
@@ -400,6 +419,10 @@ pub const STDLIB_PACKS: &[(&str, &str)] = &[
     // (shape_verifier).
     ("js_runtime_globals_nodes", JS_RUNTIME_GLOBALS_NODES_DL),
     ("js_runtime_globals_edges", JS_RUNTIME_GLOBALS_EDGES_DL),
+    // Kotlin wave: kotlin_inheritance PRODUCES EXTENDS for shape_verifier's
+    // EXTENDS-closed member lookup — strictly before the negators; consumes
+    // analyzer EDB only (CLASS metadata stamps), so no run-after seam.
+    ("kotlin_inheritance", KOTLIN_INHERITANCE_DL),
     // Wave 3c: depends CONSUMES IMPORTS_FROM (every edge, module- and
     // binding-level) — with legacy import-resolution gated it must run after
     // ALL in-engine IMPORTS_FROM producers (rust_imports, js_module_imports,
@@ -1268,6 +1291,7 @@ mod tests {
                 "js_builtins_edges",
                 "js_runtime_globals_nodes",
                 "js_runtime_globals_edges",
+                "kotlin_inheritance",
                 "depends",
                 "method_calls",
                 "shape_verifier",
@@ -2528,6 +2552,207 @@ mod tests {
         assert!(triples(&eval, "ext_chain").is_empty());
         assert!(triples(&eval, "ext_builtin_import").is_empty());
         assert!(triples(&eval, "ext_builtin_global").is_empty());
+    }
+
+    /// The bundled kotlin_inheritance pack derives EXTENDS/IMPLEMENTS from the
+    /// kotlin-analyzer's CLASS metadata stamps (`extends` + `implements_0..n`,
+    /// the EXACT shapes the analyzer emits — verified e2e against the live
+    /// kotlin-parser → analyzer pipeline, see the `.dl` header):
+    /// - same-file extends / implements (`kt_ext_file` / `kt_impl_file`);
+    /// - same-directory fall-through arms (`kt_ext_dir` / `kt_impl_dir`) —
+    ///   fire only with NO same-file candidate;
+    /// - the DELTA-2 recovery arms (`kt_ext_rec_*`): an implements_N stamp
+    ///   resolving to a NON-interface (the bare no-primary-ctor class
+    ///   supertype) derives EXTENDS;
+    /// - the DELTA-8 sealed refusal: `sealed interface` serializes
+    ///   kind="sealed" (parser cascade checks isSealed before isInterface),
+    ///   so a bare entry naming a sealed declaration derives NOTHING from the
+    ///   recovery arms (was: silent wrong EXTENDS toward an interface), while
+    ///   a ctor-call `: SealedClass()` (the `extends` stamp) still derives
+    ///   EXTENDS — kt_ext_file/dir carry no kind guard;
+    /// - the \+ ambig discipline (same-file and same-dir duplicate names skip);
+    /// - negatives: self-edge refusal, out-of-directory scope (SUBSET DELTA 1),
+    ///   the .kt/.kts file gate.
+    #[test]
+    fn kotlin_inheritance_arms_on_analyzer_stamp_shapes() {
+        let mut v = FixtureStorageView::new(1);
+        let dir_a = "src/main/kotlin/com/ex"; // shared directory ("package")
+
+        // a.kt: Greeter (interface), Base, Simple : Base(),
+        //       Multi : Base(), Greeter, Closer (Closer lives in b.kt),
+        //       object Singleton : Base(), Greeter
+        let a = format!("{dir_a}/a.kt");
+        named_node(&mut v, "kt_greeter", "Greeter", "CLASS", &a);
+        v.put_node_metadata(id_of("kt_greeter"), r#"{"kind":"interface"}"#);
+        named_node(&mut v, "kt_base", "Base", "CLASS", &a);
+        v.put_node_metadata(id_of("kt_base"), r#"{"kind":"class"}"#);
+        named_node(&mut v, "kt_simple", "Simple", "CLASS", &a);
+        v.put_node_metadata(id_of("kt_simple"), r#"{"kind":"class","extends":"Base"}"#);
+        named_node(&mut v, "kt_multi", "Multi", "CLASS", &a);
+        v.put_node_metadata(
+            id_of("kt_multi"),
+            r#"{"kind":"class","extends":"Base","implements_0":"Greeter","implements_1":"Closer"}"#,
+        );
+        named_node(&mut v, "kt_singleton", "Singleton", "CLASS", &a);
+        v.put_node_metadata(
+            id_of("kt_singleton"),
+            r#"{"kind":"object","singleton":true,"extends":"Base","implements_0":"Greeter"}"#,
+        );
+
+        // b.kt (same directory): Closer (interface), Helper,
+        //       NoCtorDerived : Base   (bare entry → implements_0, Base is a
+        //                               CLASS in a.kt → EXTENDS recovery, dir arm)
+        //       NoCtor2 : Helper       (bare entry, same-file non-interface →
+        //                               EXTENDS recovery, file arm)
+        //       DirExt : Simple()      (extends, candidate only in a.kt → dir arm)
+        let b = format!("{dir_a}/b.kt");
+        named_node(&mut v, "kt_closer", "Closer", "CLASS", &b);
+        v.put_node_metadata(id_of("kt_closer"), r#"{"kind":"interface"}"#);
+        named_node(&mut v, "kt_helper", "Helper", "CLASS", &b);
+        v.put_node_metadata(id_of("kt_helper"), r#"{"kind":"class"}"#);
+        named_node(&mut v, "kt_noctor", "NoCtorDerived", "CLASS", &b);
+        v.put_node_metadata(id_of("kt_noctor"), r#"{"kind":"class","implements_0":"Base"}"#);
+        named_node(&mut v, "kt_noctor2", "NoCtor2", "CLASS", &b);
+        v.put_node_metadata(id_of("kt_noctor2"), r#"{"kind":"class","implements_0":"Helper"}"#);
+        named_node(&mut v, "kt_dirext", "DirExt", "CLASS", &b);
+        v.put_node_metadata(id_of("kt_dirext"), r#"{"kind":"class","extends":"Simple"}"#);
+
+        // Ambiguity (DELTA 3): c.kt has TWO classes "Dup" — Twin : Dup() skips
+        // (same-file ambig; the dir arm is suppressed by the same-file
+        // candidates). "DD" exists once in a.kt and once in b.kt — DDX : DD()
+        // in c.kt has no same-file candidate and the DIR index is ambiguous.
+        let c = format!("{dir_a}/c.kt");
+        named_node(&mut v, "kt_dup1", "Dup", "CLASS", &c);
+        named_node(&mut v, "kt_dup2", "Dup", "CLASS", &c);
+        named_node(&mut v, "kt_twin", "Twin", "CLASS", &c);
+        v.put_node_metadata(id_of("kt_twin"), r#"{"kind":"class","extends":"Dup"}"#);
+        named_node(&mut v, "kt_dd_a", "DD", "CLASS", &a);
+        named_node(&mut v, "kt_dd_b", "DD", "CLASS", &b);
+        named_node(&mut v, "kt_ddx", "DDX", "CLASS", &c);
+        v.put_node_metadata(id_of("kt_ddx"), r#"{"kind":"class","extends":"DD"}"#);
+
+        // Self-edge refusal: Selfy : Selfy — the only candidate is itself.
+        named_node(&mut v, "kt_selfy", "Selfy", "CLASS", &c);
+        v.put_node_metadata(id_of("kt_selfy"), r#"{"kind":"class","extends":"Selfy"}"#);
+
+        // DELTA 8 — sealed targets. `sealed interface Event` and
+        // `sealed class State` BOTH serialize kind="sealed" (the parser's
+        // isSealed-before-isInterface cascade): bare entries naming them are
+        // unclassifiable and the recovery arms refuse them.
+        // a.kt: Event (sealed interface), State (sealed class),
+        //       Click : Event   (bare → implements_0, sealed target, SAME
+        //                        file → kt_ext_rec_file must NOT fire)
+        named_node(&mut v, "kt_event", "Event", "CLASS", &a);
+        v.put_node_metadata(id_of("kt_event"), r#"{"kind":"sealed","sealed":true}"#);
+        named_node(&mut v, "kt_state", "State", "CLASS", &a);
+        v.put_node_metadata(id_of("kt_state"), r#"{"kind":"sealed","sealed":true}"#);
+        named_node(&mut v, "kt_click", "Click", "CLASS", &a);
+        v.put_node_metadata(id_of("kt_click"), r#"{"kind":"class","implements_0":"Event"}"#);
+        // b.kt: Render : Event   (bare, sealed target in a.kt → the DIR
+        //                         recovery arm must NOT fire either)
+        //       Loading : State() (ctor-call → `extends` stamp; sealed CLASS
+        //                          target still derives EXTENDS via the dir
+        //                          arm — DELTA 8 does not touch kt_ext_*)
+        named_node(&mut v, "kt_render", "Render", "CLASS", &b);
+        v.put_node_metadata(id_of("kt_render"), r#"{"kind":"class","implements_0":"Event"}"#);
+        named_node(&mut v, "kt_loading", "Loading", "CLASS", &b);
+        v.put_node_metadata(id_of("kt_loading"), r#"{"kind":"class","extends":"State"}"#);
+
+        // Scope bound (SUBSET DELTA 1): Far : Base() in another directory —
+        // Base is out of scope, no edge.
+        named_node(&mut v, "kt_far", "Far", "CLASS", "other/pkg/far.kt");
+        v.put_node_metadata(id_of("kt_far"), r#"{"kind":"class","extends":"Base"}"#);
+
+        // File gate: the same stamp shape in a .rs file derives nothing.
+        named_node(&mut v, "rs_base", "RsBase", "CLASS", "src/x.rs");
+        named_node(&mut v, "rs_child", "RsChild", "CLASS", "src/x.rs");
+        v.put_node_metadata(id_of("rs_child"), r#"{"kind":"class","extends":"RsBase"}"#);
+
+        let (eval, specs, _node_specs) = evaluate_with_materialize(
+            &v,
+            KOTLIN_INHERITANCE_DL,
+            Stats::default(),
+            EvalLimits::none(),
+            EventLog::discard(),
+        )
+        .expect("kotlin_inheritance.dl evaluates");
+
+        let via = |pairs: &[(&str, &str)]| -> BTreeSet<(u128, u128, String)> {
+            pairs
+                .iter()
+                .map(|(s, t)| (id_of(s), id_of(t), "kotlin-inheritance".to_string()))
+                .collect()
+        };
+        assert_eq!(
+            triples(&eval, "kt_ext_file"),
+            via(&[
+                ("kt_simple", "kt_base"),
+                ("kt_multi", "kt_base"),
+                ("kt_singleton", "kt_base"),
+            ]),
+            "same-file extends; Twin (ambig Dup), Selfy (self-edge), Far \
+             (out of scope) and the .rs shape derive nothing"
+        );
+        assert_eq!(
+            triples(&eval, "kt_ext_dir"),
+            via(&[("kt_dirext", "kt_simple"), ("kt_loading", "kt_state")]),
+            "directory fall-through extends; the ctor-call `extends` stamp \
+             reaches a SEALED CLASS target (DELTA 8 guards only the recovery \
+             arms); DDX skips (dir-ambiguous DD), same-file candidates \
+             suppress the arm everywhere else"
+        );
+        assert_eq!(
+            triples(&eval, "kt_impl_file"),
+            via(&[("kt_multi", "kt_greeter"), ("kt_singleton", "kt_greeter")]),
+            "same-file implements_N resolving to kind=interface"
+        );
+        assert_eq!(
+            triples(&eval, "kt_impl_dir"),
+            via(&[("kt_multi", "kt_closer")]),
+            "directory fall-through implements (Closer lives in b.kt)"
+        );
+        assert_eq!(
+            triples(&eval, "kt_ext_rec_file"),
+            via(&[("kt_noctor2", "kt_helper")]),
+            "DELTA 2 recovery, same file: bare class supertype stamped as \
+             implements_0 re-classified to EXTENDS by the target's kind; \
+             Click : Event (sealed target, same file) derives NOTHING — \
+             DELTA 8 refuses kind=sealed in the recovery arms"
+        );
+        assert_eq!(
+            triples(&eval, "kt_ext_rec_dir"),
+            via(&[("kt_noctor", "kt_base")]),
+            "DELTA 2 recovery, directory fall-through; Render : Event \
+             (sealed target in a.kt) derives NOTHING — DELTA 8 dir arm"
+        );
+        // DELTA 8 cross-check: the sealed-interface bare entries derive no
+        // IMPLEMENTS either (kind=sealed ≠ kind=interface), so Click/Render
+        // carry ZERO inheritance edges — a documented gap, not a wrong edge.
+        for rel in ["kt_impl_file", "kt_impl_dir", "kt_ext_file"] {
+            assert!(
+                !triples(&eval, rel)
+                    .iter()
+                    .any(|(s, _, _)| *s == id_of("kt_click") || *s == id_of("kt_render")),
+                "{rel} must not derive for the sealed-interface implementors"
+            );
+        }
+
+        // Heads: 4 EXTENDS + 2 IMPLEMENTS, all additive (shared vocabulary),
+        // resolvedVia projected on all.
+        let ext: Vec<_> = specs.iter().filter(|s| s.edge_type == "EXTENDS").collect();
+        assert_eq!(ext.len(), 4, "EXTENDS heads: file + dir + 2 recovery arms");
+        let imp: Vec<_> = specs.iter().filter(|s| s.edge_type == "IMPLEMENTS").collect();
+        assert_eq!(imp.len(), 2, "IMPLEMENTS heads: file + dir arms");
+        assert!(
+            specs.iter().all(|s| s.additive),
+            "EXTENDS/IMPLEMENTS are shared vocabulary — additive is mandatory"
+        );
+        assert!(
+            specs
+                .iter()
+                .all(|s| s.meta == vec!["resolvedVia".to_string()]),
+            "resolvedVia is projected on all heads"
+        );
     }
 
     /// The bundled js_import_bindings pack (Wave 2, node_attr) resolves the

--- a/packages/rfdb-server/src/derive/stdlib/effects_callable_facts.dl
+++ b/packages/rfdb-server/src/derive/stdlib/effects_callable_facts.dl
@@ -1,0 +1,501 @@
+% ── GENERATED ground facts — DO NOT EDIT BY HAND ──────────────────────────
+% Source: effects-db/{runtimes,packages}/*.yaml — the structured-entry
+% callable registry (args[N].role / returns.type / channel) that
+% libraryCallbackEnricher consumes via EffectsLookup.getEntry.
+% Generator: scripts/generate-effects-callable-facts.mjs (Wave 14); re-run
+% it and replace this file when the registry changes.
+% 180 entries (152 arg roles, 65 returns, 91 channel rows).
+%
+% ecb_method(Lib, Full, Bare): one per role-or-channel-carrying entry;
+%   Lib = top-level YAML key VERBATIM, Bare = fn key after the last dot.
+% ecb_arg(Lib, Full, Idx, Role): role-annotated argument positions.
+% ecb_returns(Lib, Full, Type): declared returns.type of those entries.
+% ecb_channel(Lib, Full, Key, Spec): channel metadata rows (e.g. url -> arg[0]).
+ecb_method("@koa/router", "Router.all", "all").
+ecb_method("@koa/router", "Router.del", "del").
+ecb_method("@koa/router", "Router.delete", "delete").
+ecb_method("@koa/router", "Router.get", "get").
+ecb_method("@koa/router", "Router.head", "head").
+ecb_method("@koa/router", "Router.options", "options").
+ecb_method("@koa/router", "Router.param", "param").
+ecb_method("@koa/router", "Router.patch", "patch").
+ecb_method("@koa/router", "Router.post", "post").
+ecb_method("@koa/router", "Router.put", "put").
+ecb_method("@koa/router", "Router.use", "use").
+ecb_method("@modelcontextprotocol/sdk", "Server.setRequestHandler", "setRequestHandler").
+ecb_method("commander", "Command.action", "action").
+ecb_method("commander", "Command.addCommand", "addCommand").
+ecb_method("commander", "Command.command", "command").
+ecb_method("ecma:web", "fetch", "fetch").
+ecb_method("express", "Application.all", "all").
+ecb_method("express", "Application.delete", "delete").
+ecb_method("express", "Application.get", "get").
+ecb_method("express", "Application.head", "head").
+ecb_method("express", "Application.options", "options").
+ecb_method("express", "Application.patch", "patch").
+ecb_method("express", "Application.post", "post").
+ecb_method("express", "Application.put", "put").
+ecb_method("express", "Application.use", "use").
+ecb_method("express", "Router.all", "all").
+ecb_method("express", "Router.delete", "delete").
+ecb_method("express", "Router.get", "get").
+ecb_method("express", "Router.head", "head").
+ecb_method("express", "Router.options", "options").
+ecb_method("express", "Router.patch", "patch").
+ecb_method("express", "Router.post", "post").
+ecb_method("express", "Router.put", "put").
+ecb_method("express", "Router.use", "use").
+ecb_method("fastify", "FastifyInstance.addHook", "addHook").
+ecb_method("fastify", "FastifyInstance.all", "all").
+ecb_method("fastify", "FastifyInstance.delete", "delete").
+ecb_method("fastify", "FastifyInstance.get", "get").
+ecb_method("fastify", "FastifyInstance.head", "head").
+ecb_method("fastify", "FastifyInstance.options", "options").
+ecb_method("fastify", "FastifyInstance.patch", "patch").
+ecb_method("fastify", "FastifyInstance.post", "post").
+ecb_method("fastify", "FastifyInstance.put", "put").
+ecb_method("fastify", "FastifyInstance.register", "register").
+ecb_method("fastify", "FastifyInstance.setErrorHandler", "setErrorHandler").
+ecb_method("fastify", "FastifyInstance.setNotFoundHandler", "setNotFoundHandler").
+ecb_method("hono", "Hono.all", "all").
+ecb_method("hono", "Hono.delete", "delete").
+ecb_method("hono", "Hono.get", "get").
+ecb_method("hono", "Hono.notFound", "notFound").
+ecb_method("hono", "Hono.on", "on").
+ecb_method("hono", "Hono.onError", "onError").
+ecb_method("hono", "Hono.options", "options").
+ecb_method("hono", "Hono.patch", "patch").
+ecb_method("hono", "Hono.post", "post").
+ecb_method("hono", "Hono.put", "put").
+ecb_method("hono", "Hono.route", "route").
+ecb_method("hono", "Hono.use", "use").
+ecb_method("koa", "Koa.on", "on").
+ecb_method("koa", "Koa.use", "use").
+ecb_method("koa-router", "Router.all", "all").
+ecb_method("koa-router", "Router.del", "del").
+ecb_method("koa-router", "Router.delete", "delete").
+ecb_method("koa-router", "Router.get", "get").
+ecb_method("koa-router", "Router.head", "head").
+ecb_method("koa-router", "Router.options", "options").
+ecb_method("koa-router", "Router.param", "param").
+ecb_method("koa-router", "Router.patch", "patch").
+ecb_method("koa-router", "Router.post", "post").
+ecb_method("koa-router", "Router.put", "put").
+ecb_method("koa-router", "Router.use", "use").
+ecb_method("node:child_process", "exec", "exec").
+ecb_method("node:child_process", "execFile", "execFile").
+ecb_method("node:child_process", "execFileSync", "execFileSync").
+ecb_method("node:child_process", "execSync", "execSync").
+ecb_method("node:child_process", "fork", "fork").
+ecb_method("node:child_process", "spawn", "spawn").
+ecb_method("node:child_process", "spawnSync", "spawnSync").
+ecb_method("node:http", "get", "get").
+ecb_method("node:http", "request", "request").
+ecb_method("node:https", "request", "request").
+ecb_method("node:net", "Socket.connect", "connect").
+ecb_method("node:net", "connect", "connect").
+ecb_method("node:net", "createConnection", "createConnection").
+ecb_method("python:aiohttp", "ClientSession.delete", "delete").
+ecb_method("python:aiohttp", "ClientSession.get", "get").
+ecb_method("python:aiohttp", "ClientSession.head", "head").
+ecb_method("python:aiohttp", "ClientSession.patch", "patch").
+ecb_method("python:aiohttp", "ClientSession.post", "post").
+ecb_method("python:aiohttp", "ClientSession.put", "put").
+ecb_method("python:aiohttp", "ClientSession.request", "request").
+ecb_method("python:aiohttp", "ClientSession.ws_connect", "ws_connect").
+ecb_method("python:aiohttp", "request", "request").
+ecb_method("python:asyncio", "create_subprocess_exec", "create_subprocess_exec").
+ecb_method("python:asyncio", "create_subprocess_shell", "create_subprocess_shell").
+ecb_method("python:asyncio", "open_connection", "open_connection").
+ecb_method("python:asyncio", "open_unix_connection", "open_unix_connection").
+ecb_method("python:asyncio", "start_server", "start_server").
+ecb_method("python:asyncio", "start_unix_server", "start_unix_server").
+ecb_method("python:httpx", "AsyncClient.delete", "delete").
+ecb_method("python:httpx", "AsyncClient.get", "get").
+ecb_method("python:httpx", "AsyncClient.patch", "patch").
+ecb_method("python:httpx", "AsyncClient.post", "post").
+ecb_method("python:httpx", "AsyncClient.put", "put").
+ecb_method("python:httpx", "AsyncClient.request", "request").
+ecb_method("python:httpx", "Client.delete", "delete").
+ecb_method("python:httpx", "Client.get", "get").
+ecb_method("python:httpx", "Client.head", "head").
+ecb_method("python:httpx", "Client.patch", "patch").
+ecb_method("python:httpx", "Client.post", "post").
+ecb_method("python:httpx", "Client.put", "put").
+ecb_method("python:httpx", "Client.request", "request").
+ecb_method("python:httpx", "delete", "delete").
+ecb_method("python:httpx", "get", "get").
+ecb_method("python:httpx", "head", "head").
+ecb_method("python:httpx", "options", "options").
+ecb_method("python:httpx", "patch", "patch").
+ecb_method("python:httpx", "post", "post").
+ecb_method("python:httpx", "put", "put").
+ecb_method("python:httpx", "request", "request").
+ecb_method("python:httpx", "stream", "stream").
+ecb_method("python:os", "execl", "execl").
+ecb_method("python:os", "execle", "execle").
+ecb_method("python:os", "execlp", "execlp").
+ecb_method("python:os", "execlpe", "execlpe").
+ecb_method("python:os", "execv", "execv").
+ecb_method("python:os", "execve", "execve").
+ecb_method("python:os", "execvp", "execvp").
+ecb_method("python:os", "execvpe", "execvpe").
+ecb_method("python:os", "popen", "popen").
+ecb_method("python:os", "system", "system").
+ecb_method("python:paramiko", "SSHClient.connect", "connect").
+ecb_method("python:requests", "Session.delete", "delete").
+ecb_method("python:requests", "Session.get", "get").
+ecb_method("python:requests", "Session.head", "head").
+ecb_method("python:requests", "Session.patch", "patch").
+ecb_method("python:requests", "Session.post", "post").
+ecb_method("python:requests", "Session.put", "put").
+ecb_method("python:requests", "Session.request", "request").
+ecb_method("python:requests", "delete", "delete").
+ecb_method("python:requests", "get", "get").
+ecb_method("python:requests", "head", "head").
+ecb_method("python:requests", "options", "options").
+ecb_method("python:requests", "patch", "patch").
+ecb_method("python:requests", "post", "post").
+ecb_method("python:requests", "put", "put").
+ecb_method("python:requests", "request", "request").
+ecb_method("python:socket", "create_connection", "create_connection").
+ecb_method("python:socket", "create_server", "create_server").
+ecb_method("python:socket", "socket.bind", "bind").
+ecb_method("python:socket", "socket.connect", "connect").
+ecb_method("python:subprocess", "Popen", "Popen").
+ecb_method("python:subprocess", "call", "call").
+ecb_method("python:subprocess", "check_call", "check_call").
+ecb_method("python:subprocess", "check_output", "check_output").
+ecb_method("python:subprocess", "getoutput", "getoutput").
+ecb_method("python:subprocess", "getstatusoutput", "getstatusoutput").
+ecb_method("python:subprocess", "run", "run").
+ecb_method("python:urllib.request", "urlopen", "urlopen").
+ecb_method("vscode", "commands.registerCommand", "registerCommand").
+ecb_method("vscode", "commands.registerTextEditorCommand", "registerTextEditorCommand").
+ecb_method("vscode", "languages.registerCodeActionsProvider", "registerCodeActionsProvider").
+ecb_method("vscode", "languages.registerCodeLensProvider", "registerCodeLensProvider").
+ecb_method("vscode", "languages.registerCompletionItemProvider", "registerCompletionItemProvider").
+ecb_method("vscode", "languages.registerDefinitionProvider", "registerDefinitionProvider").
+ecb_method("vscode", "languages.registerDocumentFormattingEditProvider", "registerDocumentFormattingEditProvider").
+ecb_method("vscode", "languages.registerDocumentSymbolProvider", "registerDocumentSymbolProvider").
+ecb_method("vscode", "languages.registerHoverProvider", "registerHoverProvider").
+ecb_method("vscode", "languages.registerReferenceProvider", "registerReferenceProvider").
+ecb_method("vscode", "window.registerCustomEditorProvider", "registerCustomEditorProvider").
+ecb_method("vscode", "window.registerFileDecorationProvider", "registerFileDecorationProvider").
+ecb_method("vscode", "window.registerTreeDataProvider", "registerTreeDataProvider").
+ecb_method("vscode", "window.registerUriHandler", "registerUriHandler").
+ecb_method("vscode", "window.registerWebviewPanelSerializer", "registerWebviewPanelSerializer").
+ecb_method("vscode", "window.registerWebviewViewProvider", "registerWebviewViewProvider").
+ecb_method("vscode", "workspace.onDidChangeConfiguration", "onDidChangeConfiguration").
+ecb_method("vscode", "workspace.onDidChangeTextDocument", "onDidChangeTextDocument").
+ecb_method("vscode", "workspace.onDidCloseTextDocument", "onDidCloseTextDocument").
+ecb_method("vscode", "workspace.onDidOpenTextDocument", "onDidOpenTextDocument").
+ecb_method("vscode", "workspace.onDidSaveTextDocument", "onDidSaveTextDocument").
+ecb_arg("@koa/router", "Router.all", "0", "ROUTE_PATH").
+ecb_arg("@koa/router", "Router.all", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@koa/router", "Router.del", "0", "ROUTE_PATH").
+ecb_arg("@koa/router", "Router.del", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@koa/router", "Router.delete", "0", "ROUTE_PATH").
+ecb_arg("@koa/router", "Router.delete", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@koa/router", "Router.get", "0", "ROUTE_PATH").
+ecb_arg("@koa/router", "Router.get", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@koa/router", "Router.head", "0", "ROUTE_PATH").
+ecb_arg("@koa/router", "Router.head", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@koa/router", "Router.options", "0", "ROUTE_PATH").
+ecb_arg("@koa/router", "Router.options", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@koa/router", "Router.param", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@koa/router", "Router.patch", "0", "ROUTE_PATH").
+ecb_arg("@koa/router", "Router.patch", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@koa/router", "Router.post", "0", "ROUTE_PATH").
+ecb_arg("@koa/router", "Router.post", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@koa/router", "Router.put", "0", "ROUTE_PATH").
+ecb_arg("@koa/router", "Router.put", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@koa/router", "Router.use", "0", "MOUNTPOINT").
+ecb_arg("@koa/router", "Router.use", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("@modelcontextprotocol/sdk", "Server.setRequestHandler", "0", "TOOL_SCHEMA").
+ecb_arg("@modelcontextprotocol/sdk", "Server.setRequestHandler", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("commander", "Command.action", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("commander", "Command.addCommand", "0", "COMMAND_NAME").
+ecb_arg("commander", "Command.command", "0", "COMMAND_NAME").
+ecb_arg("express", "Application.all", "0", "ROUTE_PATH").
+ecb_arg("express", "Application.all", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Application.delete", "0", "ROUTE_PATH").
+ecb_arg("express", "Application.delete", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Application.get", "0", "ROUTE_PATH").
+ecb_arg("express", "Application.get", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Application.head", "0", "ROUTE_PATH").
+ecb_arg("express", "Application.head", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Application.options", "0", "ROUTE_PATH").
+ecb_arg("express", "Application.options", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Application.patch", "0", "ROUTE_PATH").
+ecb_arg("express", "Application.patch", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Application.post", "0", "ROUTE_PATH").
+ecb_arg("express", "Application.post", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Application.put", "0", "ROUTE_PATH").
+ecb_arg("express", "Application.put", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Application.use", "0", "MOUNTPOINT").
+ecb_arg("express", "Application.use", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Router.all", "0", "ROUTE_PATH").
+ecb_arg("express", "Router.all", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Router.delete", "0", "ROUTE_PATH").
+ecb_arg("express", "Router.delete", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Router.get", "0", "ROUTE_PATH").
+ecb_arg("express", "Router.get", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Router.head", "0", "ROUTE_PATH").
+ecb_arg("express", "Router.head", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Router.options", "0", "ROUTE_PATH").
+ecb_arg("express", "Router.options", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Router.patch", "0", "ROUTE_PATH").
+ecb_arg("express", "Router.patch", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Router.post", "0", "ROUTE_PATH").
+ecb_arg("express", "Router.post", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Router.put", "0", "ROUTE_PATH").
+ecb_arg("express", "Router.put", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("express", "Router.use", "0", "MOUNTPOINT").
+ecb_arg("express", "Router.use", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.addHook", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.all", "0", "ROUTE_PATH").
+ecb_arg("fastify", "FastifyInstance.all", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.delete", "0", "ROUTE_PATH").
+ecb_arg("fastify", "FastifyInstance.delete", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.get", "0", "ROUTE_PATH").
+ecb_arg("fastify", "FastifyInstance.get", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.head", "0", "ROUTE_PATH").
+ecb_arg("fastify", "FastifyInstance.head", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.options", "0", "ROUTE_PATH").
+ecb_arg("fastify", "FastifyInstance.options", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.patch", "0", "ROUTE_PATH").
+ecb_arg("fastify", "FastifyInstance.patch", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.post", "0", "ROUTE_PATH").
+ecb_arg("fastify", "FastifyInstance.post", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.put", "0", "ROUTE_PATH").
+ecb_arg("fastify", "FastifyInstance.put", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.register", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.setErrorHandler", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("fastify", "FastifyInstance.setNotFoundHandler", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.all", "0", "ROUTE_PATH").
+ecb_arg("hono", "Hono.all", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.delete", "0", "ROUTE_PATH").
+ecb_arg("hono", "Hono.delete", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.get", "0", "ROUTE_PATH").
+ecb_arg("hono", "Hono.get", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.notFound", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.on", "1", "ROUTE_PATH").
+ecb_arg("hono", "Hono.on", "2", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.onError", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.options", "0", "ROUTE_PATH").
+ecb_arg("hono", "Hono.options", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.patch", "0", "ROUTE_PATH").
+ecb_arg("hono", "Hono.patch", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.post", "0", "ROUTE_PATH").
+ecb_arg("hono", "Hono.post", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.put", "0", "ROUTE_PATH").
+ecb_arg("hono", "Hono.put", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("hono", "Hono.route", "0", "MOUNTPOINT").
+ecb_arg("hono", "Hono.use", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa", "Koa.on", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa", "Koa.use", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.all", "0", "ROUTE_PATH").
+ecb_arg("koa-router", "Router.all", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.del", "0", "ROUTE_PATH").
+ecb_arg("koa-router", "Router.del", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.delete", "0", "ROUTE_PATH").
+ecb_arg("koa-router", "Router.delete", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.get", "0", "ROUTE_PATH").
+ecb_arg("koa-router", "Router.get", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.head", "0", "ROUTE_PATH").
+ecb_arg("koa-router", "Router.head", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.options", "0", "ROUTE_PATH").
+ecb_arg("koa-router", "Router.options", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.param", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.patch", "0", "ROUTE_PATH").
+ecb_arg("koa-router", "Router.patch", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.post", "0", "ROUTE_PATH").
+ecb_arg("koa-router", "Router.post", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.put", "0", "ROUTE_PATH").
+ecb_arg("koa-router", "Router.put", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("koa-router", "Router.use", "0", "MOUNTPOINT").
+ecb_arg("koa-router", "Router.use", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "commands.registerCommand", "0", "COMMAND_NAME").
+ecb_arg("vscode", "commands.registerCommand", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "commands.registerTextEditorCommand", "0", "COMMAND_NAME").
+ecb_arg("vscode", "commands.registerTextEditorCommand", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "languages.registerCodeActionsProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "languages.registerCodeLensProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "languages.registerCompletionItemProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "languages.registerDefinitionProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "languages.registerDocumentFormattingEditProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "languages.registerDocumentSymbolProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "languages.registerHoverProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "languages.registerReferenceProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "window.registerCustomEditorProvider", "0", "COMMAND_NAME").
+ecb_arg("vscode", "window.registerCustomEditorProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "window.registerFileDecorationProvider", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "window.registerTreeDataProvider", "0", "COMMAND_NAME").
+ecb_arg("vscode", "window.registerTreeDataProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "window.registerUriHandler", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "window.registerWebviewPanelSerializer", "0", "COMMAND_NAME").
+ecb_arg("vscode", "window.registerWebviewPanelSerializer", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "window.registerWebviewViewProvider", "0", "COMMAND_NAME").
+ecb_arg("vscode", "window.registerWebviewViewProvider", "1", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "workspace.onDidChangeConfiguration", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "workspace.onDidChangeTextDocument", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "workspace.onDidCloseTextDocument", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "workspace.onDidOpenTextDocument", "0", "ENTRY_POINT_CALLBACK").
+ecb_arg("vscode", "workspace.onDidSaveTextDocument", "0", "ENTRY_POINT_CALLBACK").
+ecb_returns("@koa/router", "Router.all", "Router").
+ecb_returns("@koa/router", "Router.del", "Router").
+ecb_returns("@koa/router", "Router.delete", "Router").
+ecb_returns("@koa/router", "Router.get", "Router").
+ecb_returns("@koa/router", "Router.head", "Router").
+ecb_returns("@koa/router", "Router.options", "Router").
+ecb_returns("@koa/router", "Router.param", "Router").
+ecb_returns("@koa/router", "Router.patch", "Router").
+ecb_returns("@koa/router", "Router.post", "Router").
+ecb_returns("@koa/router", "Router.put", "Router").
+ecb_returns("@koa/router", "Router.use", "Router").
+ecb_returns("commander", "Command.action", "Command").
+ecb_returns("commander", "Command.addCommand", "Command").
+ecb_returns("commander", "Command.command", "Command").
+ecb_returns("express", "Application.all", "Application").
+ecb_returns("express", "Application.delete", "Application").
+ecb_returns("express", "Application.get", "Application").
+ecb_returns("express", "Application.head", "Application").
+ecb_returns("express", "Application.options", "Application").
+ecb_returns("express", "Application.patch", "Application").
+ecb_returns("express", "Application.post", "Application").
+ecb_returns("express", "Application.put", "Application").
+ecb_returns("express", "Application.use", "Application").
+ecb_returns("express", "Router.all", "Router").
+ecb_returns("express", "Router.delete", "Router").
+ecb_returns("express", "Router.get", "Router").
+ecb_returns("express", "Router.head", "Router").
+ecb_returns("express", "Router.options", "Router").
+ecb_returns("express", "Router.patch", "Router").
+ecb_returns("express", "Router.post", "Router").
+ecb_returns("express", "Router.put", "Router").
+ecb_returns("express", "Router.use", "Router").
+ecb_returns("fastify", "FastifyInstance.all", "FastifyInstance").
+ecb_returns("fastify", "FastifyInstance.delete", "FastifyInstance").
+ecb_returns("fastify", "FastifyInstance.get", "FastifyInstance").
+ecb_returns("fastify", "FastifyInstance.head", "FastifyInstance").
+ecb_returns("fastify", "FastifyInstance.options", "FastifyInstance").
+ecb_returns("fastify", "FastifyInstance.patch", "FastifyInstance").
+ecb_returns("fastify", "FastifyInstance.post", "FastifyInstance").
+ecb_returns("fastify", "FastifyInstance.put", "FastifyInstance").
+ecb_returns("fastify", "FastifyInstance.register", "FastifyInstance").
+ecb_returns("hono", "Hono.all", "Hono").
+ecb_returns("hono", "Hono.delete", "Hono").
+ecb_returns("hono", "Hono.get", "Hono").
+ecb_returns("hono", "Hono.notFound", "Hono").
+ecb_returns("hono", "Hono.on", "Hono").
+ecb_returns("hono", "Hono.onError", "Hono").
+ecb_returns("hono", "Hono.options", "Hono").
+ecb_returns("hono", "Hono.patch", "Hono").
+ecb_returns("hono", "Hono.post", "Hono").
+ecb_returns("hono", "Hono.put", "Hono").
+ecb_returns("hono", "Hono.route", "Hono").
+ecb_returns("hono", "Hono.use", "Hono").
+ecb_returns("koa", "Koa.use", "Koa").
+ecb_returns("koa-router", "Router.all", "Router").
+ecb_returns("koa-router", "Router.del", "Router").
+ecb_returns("koa-router", "Router.delete", "Router").
+ecb_returns("koa-router", "Router.get", "Router").
+ecb_returns("koa-router", "Router.head", "Router").
+ecb_returns("koa-router", "Router.options", "Router").
+ecb_returns("koa-router", "Router.param", "Router").
+ecb_returns("koa-router", "Router.patch", "Router").
+ecb_returns("koa-router", "Router.post", "Router").
+ecb_returns("koa-router", "Router.put", "Router").
+ecb_returns("koa-router", "Router.use", "Router").
+ecb_channel("ecma:web", "fetch", "url", "arg[0]").
+ecb_channel("node:child_process", "exec", "binary", "arg[0]").
+ecb_channel("node:child_process", "execFile", "binary", "arg[0]").
+ecb_channel("node:child_process", "execFileSync", "binary", "arg[0]").
+ecb_channel("node:child_process", "execSync", "binary", "arg[0]").
+ecb_channel("node:child_process", "fork", "binary", "arg[0]").
+ecb_channel("node:child_process", "spawn", "binary", "arg[0]").
+ecb_channel("node:child_process", "spawnSync", "binary", "arg[0]").
+ecb_channel("node:http", "get", "url", "arg[0]").
+ecb_channel("node:http", "request", "url", "arg[0]").
+ecb_channel("node:https", "request", "url", "arg[0]").
+ecb_channel("node:net", "Socket.connect", "path", "arg[0]").
+ecb_channel("node:net", "connect", "path", "arg[0]").
+ecb_channel("node:net", "createConnection", "path", "arg[0]").
+ecb_channel("python:aiohttp", "ClientSession.delete", "url", "arg[0]").
+ecb_channel("python:aiohttp", "ClientSession.get", "url", "arg[0]").
+ecb_channel("python:aiohttp", "ClientSession.head", "url", "arg[0]").
+ecb_channel("python:aiohttp", "ClientSession.patch", "url", "arg[0]").
+ecb_channel("python:aiohttp", "ClientSession.post", "url", "arg[0]").
+ecb_channel("python:aiohttp", "ClientSession.put", "url", "arg[0]").
+ecb_channel("python:aiohttp", "ClientSession.request", "url", "arg[1]").
+ecb_channel("python:aiohttp", "ClientSession.ws_connect", "url", "arg[0]").
+ecb_channel("python:aiohttp", "request", "url", "arg[1]").
+ecb_channel("python:asyncio", "create_subprocess_exec", "binary", "arg[0]").
+ecb_channel("python:asyncio", "create_subprocess_shell", "binary", "arg[0]").
+ecb_channel("python:asyncio", "open_connection", "host", "arg[0]").
+ecb_channel("python:asyncio", "open_connection", "port", "arg[1]").
+ecb_channel("python:asyncio", "open_unix_connection", "path", "arg[0]").
+ecb_channel("python:asyncio", "start_server", "host", "arg[1]").
+ecb_channel("python:asyncio", "start_server", "port", "arg[2]").
+ecb_channel("python:asyncio", "start_unix_server", "path", "arg[1]").
+ecb_channel("python:httpx", "AsyncClient.delete", "url", "arg[0]").
+ecb_channel("python:httpx", "AsyncClient.get", "url", "arg[0]").
+ecb_channel("python:httpx", "AsyncClient.patch", "url", "arg[0]").
+ecb_channel("python:httpx", "AsyncClient.post", "url", "arg[0]").
+ecb_channel("python:httpx", "AsyncClient.put", "url", "arg[0]").
+ecb_channel("python:httpx", "AsyncClient.request", "url", "arg[1]").
+ecb_channel("python:httpx", "Client.delete", "url", "arg[0]").
+ecb_channel("python:httpx", "Client.get", "url", "arg[0]").
+ecb_channel("python:httpx", "Client.head", "url", "arg[0]").
+ecb_channel("python:httpx", "Client.patch", "url", "arg[0]").
+ecb_channel("python:httpx", "Client.post", "url", "arg[0]").
+ecb_channel("python:httpx", "Client.put", "url", "arg[0]").
+ecb_channel("python:httpx", "Client.request", "url", "arg[1]").
+ecb_channel("python:httpx", "delete", "url", "arg[0]").
+ecb_channel("python:httpx", "get", "url", "arg[0]").
+ecb_channel("python:httpx", "head", "url", "arg[0]").
+ecb_channel("python:httpx", "options", "url", "arg[0]").
+ecb_channel("python:httpx", "patch", "url", "arg[0]").
+ecb_channel("python:httpx", "post", "url", "arg[0]").
+ecb_channel("python:httpx", "put", "url", "arg[0]").
+ecb_channel("python:httpx", "request", "url", "arg[1]").
+ecb_channel("python:httpx", "stream", "url", "arg[1]").
+ecb_channel("python:os", "execl", "binary", "arg[0]").
+ecb_channel("python:os", "execle", "binary", "arg[0]").
+ecb_channel("python:os", "execlp", "binary", "arg[0]").
+ecb_channel("python:os", "execlpe", "binary", "arg[0]").
+ecb_channel("python:os", "execv", "binary", "arg[0]").
+ecb_channel("python:os", "execve", "binary", "arg[0]").
+ecb_channel("python:os", "execvp", "binary", "arg[0]").
+ecb_channel("python:os", "execvpe", "binary", "arg[0]").
+ecb_channel("python:os", "popen", "binary", "arg[0]").
+ecb_channel("python:os", "system", "binary", "arg[0]").
+ecb_channel("python:paramiko", "SSHClient.connect", "host", "arg[0]").
+ecb_channel("python:requests", "Session.delete", "url", "arg[0]").
+ecb_channel("python:requests", "Session.get", "url", "arg[0]").
+ecb_channel("python:requests", "Session.head", "url", "arg[0]").
+ecb_channel("python:requests", "Session.patch", "url", "arg[0]").
+ecb_channel("python:requests", "Session.post", "url", "arg[0]").
+ecb_channel("python:requests", "Session.put", "url", "arg[0]").
+ecb_channel("python:requests", "Session.request", "url", "arg[1]").
+ecb_channel("python:requests", "delete", "url", "arg[0]").
+ecb_channel("python:requests", "get", "url", "arg[0]").
+ecb_channel("python:requests", "head", "url", "arg[0]").
+ecb_channel("python:requests", "options", "url", "arg[0]").
+ecb_channel("python:requests", "patch", "url", "arg[0]").
+ecb_channel("python:requests", "post", "url", "arg[0]").
+ecb_channel("python:requests", "put", "url", "arg[0]").
+ecb_channel("python:requests", "request", "url", "arg[1]").
+ecb_channel("python:socket", "create_connection", "addr", "arg[0]").
+ecb_channel("python:socket", "create_server", "addr", "arg[0]").
+ecb_channel("python:socket", "socket.bind", "addr", "arg[0]").
+ecb_channel("python:socket", "socket.connect", "addr", "arg[0]").
+ecb_channel("python:subprocess", "Popen", "binary", "arg[0]").
+ecb_channel("python:subprocess", "call", "binary", "arg[0]").
+ecb_channel("python:subprocess", "check_call", "binary", "arg[0]").
+ecb_channel("python:subprocess", "check_output", "binary", "arg[0]").
+ecb_channel("python:subprocess", "getoutput", "binary", "arg[0]").
+ecb_channel("python:subprocess", "getstatusoutput", "binary", "arg[0]").
+ecb_channel("python:subprocess", "run", "binary", "arg[0]").
+ecb_channel("python:urllib.request", "urlopen", "url", "arg[0]").

--- a/packages/rfdb-server/src/derive/stdlib/go_calls.dl
+++ b/packages/rfdb-server/src/derive/stdlib/go_calls.dl
@@ -1,0 +1,136 @@
+% go_calls.dl — in-engine replacement for the GoCallResolution.hs resolver
+% (packages/go-resolve/src/GoCallResolution.hs): CALL → FUNCTION CALLS edges,
+% three strategies dispatched on the CALL's `receiver` metadata against the
+% SAME-FILE import aliases (resolveCall :157-174 — the dispatch is exclusive:
+% alias-receiver → strategy 1 ONLY, non-alias receiver → strategy 3 ONLY,
+% no receiver → strategy 2 ONLY; a strategy that misses has NO fallback):
+%
+%   S1 package-qualified (`utils.DoStuff()` where `utils` is an import's
+%      local_name): import path → package dir (PackageIndex :118-128, three
+%      key families: modPath<>"/"<>dir, modPath→"", bare dir→dir; plus the
+%      modPath-strip fallback :197-201) → (dir, callName) FunctionIndex.
+%   S2 same-package (`helper()`, no receiver): (callerDir, callName) lookup
+%      (:213-222).
+%   S3 same-package method (`s.Method()`, receiver not an alias): GLOBAL
+%      (receiverNAME, method) MethodIndex (:227-236) — only hits when a
+%      variable shares its TYPE's name (the known legacy weakness; receiver
+%      typing is the named Wave-2 refinement, NOT attempted — parity).
+%
+% callName = after the last '.' (extractCallName :54-57) — `method_suffix`
+% for the dotted S1/S3 names; S2 names are never dotted (a receiver-less
+% CALL's name is the bare ident or "<expr>", go-analyzer Calls.hs:74-77).
+%
+% PLANNER-LEGAL SPELLING (verdict C1): the import-path → dir map cannot be a
+% standalone `pkg_dir` relation (the modPath×dirs product is disconnected).
+% Consumers inline the peel-join: '/'-boundary prefixes of the alias's import
+% path (spec_pfx right-peel) equality-join `go_mod`, then the bound RelDir
+% joins `func_in_dir`. The legacy "dir must hold MODULEs" key condition is
+% IMPLIED here: a FUNCTION in dir d ⇒ its .go file is in d ⇒ that file's
+% MODULE is in d (the analyzer emits one MODULE per file, Walker.hs:32-44) —
+% so the func_in_dir join subsumes the PackageIndex membership test, exactly.
+%
+% NUMBERED DELTAS vs the resolver (everything not listed is exact):
+%   DELTA G3-1 (SUPERSET, bounded): FunctionIndex is Map.fromList = LAST-wins
+%     on duplicate (dir, name) keys (:91-100) — build-tag twins / _test.go
+%     siblings defining one name in one directory. Set semantics derives all
+%     candidates. Bound: #same-name functions per directory (≈1-2).
+%   DELTA G3-2 (CLOSED, was an approximation in the spec): the isStdLib gate
+%     on S1 import paths (:193) is EXACT via `first_segment` (M1 shipped) —
+%     first '/'-segment contains a dot. No "foo/bar.v2" residue, and no
+%     stdlib-named local dir ("errors/", "log/") can capture a qualified call.
+%   DELTA G3-3 (SUPERSET, pathological-only): legacy PackageIndex is ONE map —
+%     when P == modPath AND a directory literally named P exists, fromList
+%     order makes the bare key win (dir = P, not ""); the pack derives both
+%     arms. Requires a directory literally named like a module path (0 real).
+%   DELTA G3-4 (SUPERSET, compile-error-only): the per-file ImportAliasIndex
+%     is Map.fromList = last-wins on duplicate local_name in ONE file — a Go
+%     compile error except for `_`/`.` names, which can never appear as a
+%     call receiver. Set semantics derives per alias row. Bound 0 on code
+%     that compiles.
+%   DELTA G5-1 (SUPERSET, bounded): the S3 MethodIndex is GLOBAL last-wins
+%     across packages (:103-112) — same-named type with same-named method in
+%     two packages: legacy picks one arbitrary winner, the pack derives all.
+%     Bound: #duplicate (receiver-type-name, method) pairs. The dir-scoped
+%     REFINEMENT is deliberately deferred to the differential (rust_imports
+%     DELTA-1 governed-arm precedent).
+%   File gate: ends_with .go on every base relation (orchestrator stream
+%     filter; CALL/FUNCTION/IMPORT/MODULE are shared vocabulary).
+%   Metadata: legacy CALLS edges carry EMPTY metadata (emitCallsEdge
+%     :241-248) and stamp NO resolvedVia — no meta projected, exact parity.
+%
+% MAINTAIN ENVELOPE: negation (dispatch guards) + node_attr ⇒ scratch floor.
+%
+% ORDERING (PRODUCER): produces CALLS — must run BEFORE go_context (which
+% consumes committed CALLS on .go files — precondition P2; legacy did this
+% in-process, Main.hs:78-79 extractCallEdges) and BEFORE the CALLS negators
+% method_calls / shape_verifier (verdict C4: shape_verifier.dl negates
+% `edge(C, _, "CALLS")` with no file gate).
+
+% ── Shared sources ───────────────────────────────────────────────────────────
+go_call(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".go"),
+                    attr(C, "name", N).
+call_recv(C, R)  :- go_call(C, _, _), node_attr(C, "receiver", R).
+has_recv(C)      :- go_call(C, _, _), node_attr(C, "receiver", _).
+import_alias(F, L, P) :- node(I, "IMPORT"), attr(I, "file", F),
+                         ends_with(F, ".go"), node_attr(I, "local_name", L),
+                         node_attr(I, "path", P).
+
+% (dir, name) → FUNCTION kind=function (buildFunctionIndex :91-100; closures
+% and interface_methods excluded by the kind gate — Spec.hs:141-148).
+go_fn(T)             :- node(T, "FUNCTION"), attr(T, "file", TF),
+                        ends_with(TF, ".go"), node_attr(T, "kind", "function").
+fn_dir(T, D)         :- go_fn(T), attr(T, "file", TF), basename(TF, B),
+                        concat("/", B, SB), strip_suffix(TF, SB, D).
+fn_subdir(T)         :- fn_dir(T, _).
+func_in_dir(D, N, T) :- fn_dir(T, D), attr(T, "name", N).
+func_in_dir("", N, T) :- go_fn(T), \+ fn_subdir(T), attr(T, "name", N).
+
+go_mod(MP) :- node(W, "WORKSPACE_PACKAGE"), node_attr(W, "language", "go"),
+              attr(W, "name", MP).
+
+% ── Strategy 1: package-qualified calls ──────────────────────────────────────
+% Receiver matches a same-file import alias (the dispatch test :165).
+s1_path(C, P) :- call_recv(C, R), go_call(C, F, _), import_alias(F, R, P).
+% Exact isStdLib gate (:193, via first_segment — DELTA G3-2 closed).
+s1_ok(C, P)   :- s1_path(C, P), first_segment(P, "/", S1), string_contains(S1, ".").
+
+% '/'-boundary prefixes of S1 import paths (the spec_pfx right-peel).
+s1_pfx(P, P) :- s1_ok(_, P).
+s1_pfx(P, D) :- s1_pfx(P, X), last_segment(X, "/", L),
+                concat("/", L, Tail), strip_suffix(X, Tail, D).
+
+% Import path → target package dir, all three legacy key families
+% (buildPackageIndex :118-128 + the strip fallback :197-201), Rel/"" bound
+% as builtin outputs (the C1 discipline — see go_imports.dl):
+%   (a) modPath-prefixed → relative dir;
+%   (b) P == modPath     → root dir "";
+%   (c) bare dir key     → P itself names a local package directory.
+s1_dir(P, Rel) :- s1_pfx(P, MP), go_mod(MP), concat(MP, "/", MPS),
+                  strip_prefix(P, MPS, Rel).
+s1_dir(P, Rel) :- s1_ok(_, P), go_mod(P), strip_prefix(P, P, Rel).
+s1_dir(P, P)   :- s1_ok(_, P).
+
+@materialize(edge_type = "CALLS", mode = "additive")
+go_call_s1(C, T) :- s1_ok(C, P), s1_dir(P, D), go_call(C, _, N),
+                    method_suffix(N, MN), func_in_dir(D, MN, T).
+
+% ── Strategy 2: same-package function calls (no receiver) ───────────────────
+call_dir(C, D)  :- go_call(C, F, _), basename(F, B), concat("/", B, SB),
+                   strip_suffix(F, SB, D).
+call_subdir(C)  :- call_dir(C, _).
+
+@materialize(edge_type = "CALLS", mode = "additive")
+go_call_s2(C, T) :- go_call(C, _, N), \+ has_recv(C), call_dir(C, D),
+                    func_in_dir(D, N, T).
+go_call_s2(C, T) :- go_call(C, _, N), \+ has_recv(C), \+ call_subdir(C),
+                    func_in_dir("", N, T).
+
+% ── Strategy 3: same-package method calls (receiver is not an alias) ────────
+alias_recv(C) :- call_recv(C, R), go_call(C, F, _), import_alias(F, R, _).
+method_in(RT, MN, T) :- node(T, "FUNCTION"), attr(T, "file", TF),
+                        ends_with(TF, ".go"), node_attr(T, "kind", "method"),
+                        node_attr(T, "receiver", RT), attr(T, "name", MN).
+
+@materialize(edge_type = "CALLS", mode = "additive")
+go_call_s3(C, T) :- call_recv(C, R), \+ alias_recv(C), go_call(C, _, N),
+                    method_suffix(N, MN), method_in(R, MN, T).

--- a/packages/rfdb-server/src/derive/stdlib/go_context.dl
+++ b/packages/rfdb-server/src/derive/stdlib/go_context.dl
@@ -1,0 +1,103 @@
+% go_context.dl — in-engine replacement for the GoContextPropagation.hs
+% resolver (packages/go-resolve/src/GoContextPropagation.hs): context.Context
+% flow over resolved CALLS edges.
+%
+%   PROPAGATES_CONTEXT (enclosing FUNCTION → target FUNCTION, :167-176):
+%     target accepts context (certainly or possibly) AND the call's enclosing
+%     function accepts context (certainly or possibly).
+%   SPAWNS_WITH_CONTEXT / DEFERS_WITH_CONTEXT (CALL → target FUNCTION,
+%     :177-194): target accepts (certainly or possibly) and the CALL carries
+%     the goroutine / deferred flag — INDEPENDENT of the caller's own context
+%     status.
+%   Edge metadata (:148-152): `unresolved = true` iff the TARGET is only
+%     "possible" — on ALL three edge types; the caller's certainty never
+%     affects metadata (fixture Spec.hs:288-301). accepts_context /
+%     possible_context are mutually exclusive per function (the analyzer's
+%     contextMeta picks one, Declarations.hs:97-103) — no `\+ ctx_fn(T)`
+%     guard is needed on the possible arms.
+%
+% INPUT SEAM (precondition P2): consumes COMMITTED CALLS edges on .go files —
+% produced by go_calls, which MUST run first (legacy fed go-calls output
+% in-process, Main.hs:78-79 extractCallEdges). Graph CALLS on .go files come
+% exclusively from the go packs / go-resolve (the analyzer's own CALLS
+% DeferredRefs are dropped at the serde boundary — verdict C5), so the seam
+% sees exactly the go_calls slice (plus, during legacy coexistence, the
+% legacy edges — the same set modulo the go_calls deltas).
+%
+% NUMBERED DELTAS vs the resolver (everything not listed is exact):
+%   DELTA G9-1 (structural substitute, REFINED): the enclosing function is
+%     the CALL's literal CONTAINS parent (only function/method/closure bodies
+%     push a scope — ControlFlow.hs has ZERO withScope sites — so the parent
+%     IS the enclosing function) instead of the legacy (dir, parsed-name)
+%     lookup, whose map is also last-wins (:104-112). Calls inside closures:
+%     EXACT on both sides — legacy finds no index entry (closures excluded
+%     :107-108), the pack's parent is the closure node, excluded by
+%     \+ closure_fn.
+%   DELTA G9-2 (metadata representation): `unresolved` rides the meta()
+%     projection as the string "true" vs legacy MetaBool true — consumers
+%     reading the node_attr/edge_attr string surface see the identical
+%     "true" (the js packs' resolvedVia-projection class).
+%   DELTA G9-3 (NEW — legacy caller-lookup defect, pack REFINES; found
+%     implementing, missed by both the spec and its verdict — TWO independent
+%     failure layers):
+%     (a) the node ids the daemon receives are the orchestrator's
+%         PERCENT-ENCODED URIs (`…#CALL-%3Echeck%5Bin:Validate,h:e1be%5D`,
+%         live-probed) — `T.breakOn "[in:"` (:53) never matches `%5Bin:`;
+%     (b) even unencoded, analyzer CALL ids ALWAYS carry a position hash
+%         (Calls.hs:106), and extractEnclosingName (:57-59) takes everything
+%         up to "]" — "Validate,h:e1be" can never equal a function name in
+%         the (dir, name) lookup.
+%     On real analyzer output legacy emits ZERO PROPAGATES_CONTEXT edges
+%     (its Spec.hs fixtures pass only because the handcrafted ids are
+%     unencoded and hash-free). The pack's CONTAINS parent restores the
+%     intended semantics; the differential asserts legacy = 0 and classifies
+%     every pack row here (proven on the multi-package corpus: legacy=0,
+%     pack=5 — exactly the intended caller→callee context edges).
+%     SPAWNS/DEFERS are unaffected (no caller lookup) — corpus-proven exact.
+%   File gate: ends_with .go on the CALL side (orchestrator stream filter).
+%
+% MAINTAIN ENVELOPE: negation + node_attr ⇒ scratch floor (accepted).
+%
+% ORDERING (CONSUMER): MUST run after go_calls (P2 — reads its CALLS as
+% committed EDB; this program does not materialize CALLS, so the read is
+% legal EDB consumption, the shape_verifier precedent).
+
+% ── Context-accepting functions (:79-94; bools surface as "true") ───────────
+ctx_fn(T)  :- node(T, "FUNCTION"), node_attr(T, "accepts_context", "true").
+poss_fn(T) :- node(T, "FUNCTION"), node_attr(T, "possible_context", "true").
+
+% ── Resolved go CALLS edges (the P2 seam) ───────────────────────────────────
+go_calls_e(C, T) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".go"),
+                    edge(C, T, "CALLS"), node(T, "FUNCTION").
+
+% ── Enclosing function (DELTA G9-1/G9-3): the CONTAINS parent ────────────────
+closure_fn(EF) :- node(EF, "FUNCTION"), node_attr(EF, "kind", "closure").
+iface_fn(EF)   :- node(EF, "FUNCTION"), node_attr(EF, "kind", "interface_method").
+enc_fn(C, EF)  :- go_calls_e(C, _), edge(EF, C, "CONTAINS"),
+                  node(EF, "FUNCTION"), \+ closure_fn(EF), \+ iface_fn(EF).
+caller_ok(C)   :- enc_fn(C, EF), ctx_fn(EF).
+caller_ok(C)   :- enc_fn(C, EF), poss_fn(EF).
+
+% ── PROPAGATES_CONTEXT: enclosing fn → target (:167-176) ────────────────────
+@materialize(edge_type = "PROPAGATES_CONTEXT", mode = "additive")
+go_prop(EF, T) :- go_calls_e(C, T), ctx_fn(T), caller_ok(C), enc_fn(C, EF).
+
+@materialize(edge_type = "PROPAGATES_CONTEXT", mode = "additive", meta(unresolved))
+go_prop_u(EF, T, "true") :- go_calls_e(C, T), poss_fn(T), caller_ok(C),
+                            enc_fn(C, EF).
+
+% ── SPAWNS_WITH_CONTEXT / DEFERS_WITH_CONTEXT: call → target (:177-194) ─────
+% goroutine/deferred are MetaBool, stamped only when true (Calls.hs:127-128).
+@materialize(edge_type = "SPAWNS_WITH_CONTEXT", mode = "additive")
+go_spawn(C, T) :- go_calls_e(C, T), ctx_fn(T), node_attr(C, "goroutine", "true").
+
+@materialize(edge_type = "SPAWNS_WITH_CONTEXT", mode = "additive", meta(unresolved))
+go_spawn_u(C, T, "true") :- go_calls_e(C, T), poss_fn(T),
+                            node_attr(C, "goroutine", "true").
+
+@materialize(edge_type = "DEFERS_WITH_CONTEXT", mode = "additive")
+go_defer(C, T) :- go_calls_e(C, T), ctx_fn(T), node_attr(C, "deferred", "true").
+
+@materialize(edge_type = "DEFERS_WITH_CONTEXT", mode = "additive", meta(unresolved))
+go_defer_u(C, T, "true") :- go_calls_e(C, T), poss_fn(T),
+                            node_attr(C, "deferred", "true").

--- a/packages/rfdb-server/src/derive/stdlib/go_imports.dl
+++ b/packages/rfdb-server/src/derive/stdlib/go_imports.dl
@@ -1,0 +1,100 @@
+% go_imports.dl — in-engine replacement for the GoImportResolution.hs resolver
+% (packages/go-resolve/src/GoImportResolution.hs): same-module IMPORT → MODULE
+% IMPORTS_FROM edges, driven by the GO module-path fact (precondition P1: the
+% orchestrator commits the go.mod module path as a WORKSPACE_PACKAGE node with
+% node_attr language="go" — main.rs P1 commit; before that fact the module
+% path was wire-only and invisible to packs).
+%
+% LEGACY ALGORITHM (resolveOneImport, Hs:116-145):
+%   * skip stdlib imports — "first path segment has no dot" (isStdLib :86-89);
+%   * strip the module-path prefix (PLAIN T.stripPrefix + dropWhile '/', :123-126)
+%     to a relative package directory;
+%   * look up the dir in the PackageIndex (dir → MODULE ids, buildPackageIndex
+%     :57-64) and emit IMPORTS_FROM to the FIRST module id (:129);
+%   * import path == module path resolves to the ROOT directory ("" key).
+%   The empty-module-path suffix fallback (findBySuffix :152-163) is NOT here —
+%   it is the separate `go_imports_nomod` VARIANT pack the orchestrator selects
+%   when go.mod is absent (precondition P3: an in-pack "fact is absent" test is
+%   the §3 cross-join the planner refuses).
+%
+% PLANNER-LEGAL SPELLING (verdict C1): `go_mod(MP)` may not appear as a leg
+% disconnected from the import path. The established respelling is the
+% js_module_imports `spec_pfx` idiom — derive every '/'-boundary PREFIX of the
+% import path by right-peel (strictly shrinking ⇒ terminates), EQUALITY-join
+% `go_mod` on the peeled prefix, then strip the "/"-boundary and join
+% `module_in_dir` on the BOUND relative dir. The root case (P == module path)
+% is its own clause with `go_mod(P)` as a bound filter-join. Requiring the
+% "/" boundary removes the legacy plain-stripPrefix boundary bug ("…/p"
+% string-prefix-matches "…/project2", then the dir lookup misses anyway) — no
+% edge-set effect (the legacy miss is reproduced as a non-match).
+%
+% NUMBERED DELTAS vs the resolver (everything not listed is exact):
+%   DELTA G2-1 (CLOSED, was REFINED in the spec): the spec's draft dropped the
+%     isStdLib guard from the same-module arm and accepted a divergence for
+%     dot-less module paths (`module myapp` — legacy's isStdLib skips
+%     "myapp/util" BEFORE prefix-stripping). With the `first_segment` builtin
+%     (the spec's missing capability M1, now shipped) the guard is spelled
+%     EXACTLY: first '/'-segment contains a dot. No residue.
+%   DELTA G2-2 (SUPERSET, bounded by files-per-package): legacy emits ONE edge
+%     to the FIRST module id in the target directory (`tid : _`, Hs:129 —
+%     insertion order, nondeterministic across runs); set semantics derives one
+%     edge per MODULE node (= per .go file) in the package directory. Arguably
+%     truer — a Go package IS the directory. Bound: #files in the imported
+%     package.
+%   DELTA G2-3 moved to the `go_imports_nomod` variant pack (the fallback arm
+%     lives there).
+%   File gate (the rust_imports DELTA-5 class): the legacy input gate was the
+%     orchestrator's Language::Go stream filter (config.rs:751/796) — encoded
+%     here as ends_with(F, ".go") on every base relation; MODULE/IMPORT are
+%     shared vocabulary across analyzers.
+%   Diagnostics: none in legacy either (no stderr edge-count for imports).
+%   Metadata: legacy edges carry EMPTY metadata (Hs:142) — no meta projected,
+%     exact parity (engine provenance _source/_generation only).
+%
+% MAINTAIN ENVELOPE: negation (\+ mod_subdir) + node_attr ⇒ scratch floor
+% (accepted, same stance as every import pack).
+%
+% ORDERING (PRODUCER): produces IMPORTS_FROM — must run BEFORE depends (which
+% derives MODULE-level DEPENDS_ON from every IMPORTS_FROM edge,
+% node-type-agnostically — verdict C4; the legacy go branch fed the
+% orchestrator's all_imports_from_edges the same way, main.rs:1699-1703).
+
+% ── The GO module-path fact (P1) ─────────────────────────────────────────────
+go_mod(MP) :- node(W, "WORKSPACE_PACKAGE"), node_attr(W, "language", "go"),
+              attr(W, "name", MP).
+
+% ── Package-directory kernel (buildPackageIndex :57-64) ─────────────────────
+% dirname via basename + concat + strip_suffix (no dirname builtin); root-level
+% files ("main.go") yield NO strip_suffix row → the complement clause derives
+% the "" directory via derived-negation (\+ mod_subdir).
+go_module(M, F)      :- node(M, "MODULE"), attr(M, "file", F), ends_with(F, ".go").
+mod_dir(M, D)        :- go_module(M, F), basename(F, B), concat("/", B, SB),
+                        strip_suffix(F, SB, D).
+mod_subdir(M)        :- mod_dir(M, _).
+module_in_dir(D, M)  :- mod_dir(M, D).
+module_in_dir("", M) :- go_module(M, _), \+ mod_subdir(M).
+
+% ── Importer side ────────────────────────────────────────────────────────────
+go_import(I, P) :- node(I, "IMPORT"), attr(I, "file", F), ends_with(F, ".go"),
+                   node_attr(I, "path", P).
+% Exact isStdLib gate (Hs:86-89): the FIRST '/'-segment contains a dot.
+go_import_nonstd(I, P) :- go_import(I, P), first_segment(P, "/", S1),
+                          string_contains(S1, ".").
+
+% '/'-boundary prefixes of each import path (the spec_pfx right-peel idiom).
+imp_pfx(P, P)  :- go_import(_, P).
+imp_pfx(P, D)  :- imp_pfx(P, X), last_segment(X, "/", L),
+                  concat("/", L, Tail), strip_suffix(X, Tail, D).
+
+% Resolved relative package directory per import. The root case binds Rel=""
+% as a BUILTIN OUTPUT (strip_prefix(P, P, Rel) — self-strip of a bound value),
+% NOT as a constant leg: `module_in_dir("", M)` standing alone is the exact
+% E-PLAN-003 shape verdict C1 rejected; a bound Rel makes the final join an
+% equality join (the verdict's prescription).
+imp_rel(I, Rel) :- go_import_nonstd(I, P), imp_pfx(P, MP), go_mod(MP),
+                   concat(MP, "/", MPS), strip_prefix(P, MPS, Rel).
+imp_rel(I, Rel) :- go_import_nonstd(I, P), go_mod(P), strip_prefix(P, P, Rel).
+
+% ── The materialized edge ────────────────────────────────────────────────────
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+go_import_from(I, M) :- imp_rel(I, Rel), module_in_dir(Rel, M).

--- a/packages/rfdb-server/src/derive/stdlib/go_imports_nomod.dl
+++ b/packages/rfdb-server/src/derive/stdlib/go_imports_nomod.dl
@@ -1,0 +1,68 @@
+% go_imports_nomod.dl — the NO-go.mod VARIANT of go_imports: the legacy
+% empty-module-path suffix fallback (GoImportResolution.hs findBySuffix
+% :152-163), selected by the ORCHESTRATOR (precondition P3): a pack cannot
+% test "the GO module-path fact does NOT exist" — a `has_go_mod()`-style
+% global literal shares no variable with the body, the §3 cross-join the
+% planner refuses (and per verdict C2 the filter-connected `ends_with(P, D)`
+% spelling of the suffix match is equally rejected). The orchestrator, which
+% knows whether go.mod resolved, runs this pack ONLY when it did not — the
+% faithful translation of legacy's global `T.null modulePath` branch. BOTH
+% variants are registered (registry order is pinned); selection is a runtime
+% skip in the orchestrator's pack loop (`run_stdlib_rule_packs`).
+%
+% LEGACY ALGORITHM (resolveOneImport :131-135 + findBySuffix :152-163, only
+% when the module path is empty): skip stdlib (isStdLib :86-89), then emit an
+% edge to the first MODULE of the alphabetically-first non-empty directory
+% that is a SUFFIX of the import path (Map.toList order).
+%
+% PLANNER-LEGAL SPELLING (verdict C2): the suffix match must be an EQUALITY
+% join — derive the '/'-boundary SUFFIXES of the import path by LEFT-peel
+% (`first_segment` + strip — the missing capability M1, now shipped; the dual
+% of the spec_pfx right-peel) and join `module_in_dir` on the bound suffix.
+%
+% NUMBERED DELTAS vs the resolver (everything not listed is exact):
+%   DELTA G2-3a (SUPERSET, bounded by #dirs sharing a suffix): legacy picks
+%     the alphabetically-first suffix-matching dir (Map.toList :152-163) and
+%     the first MODULE in it; set semantics derives ALL '/'-boundary suffix
+%     matches, one edge per MODULE in each (the G2-2 multiplicity compounds
+%     here). Every extra edge traces to the documented first-match tie-break.
+%   DELTA G2-3b (REFINED subset, ~0): legacy `T.isSuffixOf` is a RAW string
+%     suffix — directory "auth" matches import path "example.com/pkg/oauth".
+%     The left-peel derives only '/'-BOUNDARY suffixes, dropping that legacy
+%     false-positive class. Diverges only when a local dir is a non-boundary
+%     suffix of an import path (0 expected anywhere real).
+%   DELTA G2-1 (CLOSED): the isStdLib gate is exact via `first_segment`
+%     (see go_imports.dl).
+%   File gate: ends_with(F, ".go") on every base relation (the orchestrator's
+%     Language::Go stream filter, rust_imports DELTA-5 class).
+%
+% MAINTAIN ENVELOPE: negation (\+ mod_subdir) + node_attr ⇒ scratch floor.
+%
+% ORDERING (PRODUCER): produces IMPORTS_FROM — before depends (verdict C4).
+% Registered immediately after go_imports; never runs in the same selection
+% (go.mod either resolved or it did not).
+
+% ── Package-directory kernel (duplicated prelude, js packs precedent) ───────
+go_module(M, F)      :- node(M, "MODULE"), attr(M, "file", F), ends_with(F, ".go").
+mod_dir(M, D)        :- go_module(M, F), basename(F, B), concat("/", B, SB),
+                        strip_suffix(F, SB, D).
+mod_subdir(M)        :- mod_dir(M, _).
+module_in_dir(D, M)  :- mod_dir(M, D).
+module_in_dir("", M) :- go_module(M, _), \+ mod_subdir(M).
+
+% ── Importer side (exact stdlib gate, as go_imports.dl) ─────────────────────
+go_import(I, P) :- node(I, "IMPORT"), attr(I, "file", F), ends_with(F, ".go"),
+                   node_attr(I, "path", P).
+go_import_nonstd(I, P) :- go_import(I, P), first_segment(P, "/", S1),
+                          string_contains(S1, ".").
+
+% '/'-boundary SUFFIXES of each import path (left-peel via first_segment;
+% strictly shrinking ⇒ terminates; the empty suffix is excluded — legacy
+% requires a non-empty dir, findBySuffix :157).
+p_sfx(P, P) :- go_import_nonstd(_, P).
+p_sfx(P, S2) :- p_sfx(P, S), first_segment(S, "/", Seg),
+                concat(Seg, "/", SegS), strip_prefix(S, SegS, S2), neq(S2, "").
+
+% ── The materialized edge ────────────────────────────────────────────────────
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+go_import_suffix(I, M) :- go_import_nonstd(I, P), p_sfx(P, D), module_in_dir(D, M).

--- a/packages/rfdb-server/src/derive/stdlib/go_interfaces.dl
+++ b/packages/rfdb-server/src/derive/stdlib/go_interfaces.dl
@@ -1,0 +1,87 @@
+% go_interfaces.dl — in-engine replacement for the GoInterfaceSatisfaction.hs
+% resolver (packages/go-resolve/src/GoInterfaceSatisfaction.hs): structural
+% duck-typing CLASS → INTERFACE IMPLEMENTS edges by method-set subset
+% (:132-148 — non-empty interface method set ⊆ struct method set; NAME-only
+% matching, pointer/value receivers both match because the method's `receiver`
+% metadata is the bare type name).
+%
+% STRUCTURAL SUBSTITUTE (DELTA G6-1 — REFINED, legacy DEAD on real wire ids;
+% found implementing, missed by both the spec and its verdict): the legacy
+% parent interface comes from parsing the literal `[in:Iface]` semantic-id
+% suffix (extractParent :64-73, `T.breakOn "[in:"`), but the node ids the
+% daemon actually receives are the orchestrator's PERCENT-ENCODED URIs —
+% `…#FUNCTION-%3EGet%5Bin:Store%5D` (live-probed on a real analyze; `[`
+% encodes as `%5B`), so `[in:` never literally occurs and legacy emitted
+% ZERO IMPLEMENTS edges on any real analyzer output (its Spec.hs fixtures
+% pass only because the handcrafted ids are unencoded). The pack joins the
+% structural INTERFACE -CONTAINS-> FUNCTION(kind=interface_method) edge
+% (Declarations.hs:466-472) — the same construct, id-format-independent —
+% restoring the intended semantics (the js_same_file_calls DELTA-3
+% "membership is structural truth" precedent). Differential: expect
+% pack ⊋ legacy with legacy ≈ 0 (proven on the multi-package corpus:
+% legacy=0, pack=1 — the correct MemStore→Store edge; a half-implementing
+% struct correctly excluded).
+%
+% ∀-SUBSET ENCODING: two strata of negation. The CLASS×INTERFACE candidate
+% cross-product is planner-illegal (§3), so candidates are SEEDED through a
+% shared method NAME (`cand`) — sound because implementing a NON-EMPTY
+% interface requires sharing at least one method name (filter-before-
+% generator); the legacy non-empty gate (:144) is implied by the same seed.
+%
+% NUMBERED DELTAS vs the resolver (everything not listed is exact):
+%   DELTA G6-2 (SUPERSET, bounded): legacy StructMethodSet is GLOBAL,
+%     name-keyed (:108-116) — two same-named structs in different packages
+%     MERGE method sets (a legacy false-positive generator), and the
+%     name-keyed StructIndex (:121-126, Map.insert last-wins) gives the edge
+%     to ONE arbitrary same-named CLASS. The pack reproduces the name-keyed
+%     merge (struct_m joins methods by receiver NAME — parity) but emits the
+%     edge for EVERY same-named CLASS node. Bound: #duplicate struct names.
+%     The dir-scoped refinement (methods live in the type's package — a Go
+%     language guarantee) is deferred to the differential.
+%   DELTA G6-3 (verdict C3 — the interface-side name merge, SUPERSET both
+%     ways, bounded): legacy collectIfaceMethods UNIONS method sets across
+%     SAME-NAMED interfaces project-wide (:96-102, insertWith Set.union keyed
+%     by interface NAME) and pairs that union with ONE last-wins interface
+%     node id (:87-93 via Map.intersectionWith). The pack's iface_m is
+%     per-NODE: for duplicate interface names the pack's requirement set is
+%     SMALLER (per-node, not the union) ⇒ structs can satisfy an interface
+%     the legacy merged-set rejected, AND the pack emits an edge per actual
+%     interface node vs legacy's single arbitrary winner. Bound: #duplicate
+%     interface simple names (countable in the differential).
+%   Interface EXTENDS embedding stays un-expanded (legacy Phase-2 limitation
+%     :25-30) — parity. (The analyzer's EXTENDS-by-NAME defect,
+%     Declarations.hs:476-485, is outside this migration.)
+%   File gate: ends_with .go on every base relation (orchestrator stream
+%     filter; CLASS/INTERFACE/FUNCTION are shared vocabulary).
+%   Metadata: legacy edges carry EMPTY metadata (:137-142) — none projected.
+%
+% MAINTAIN ENVELOPE: negation (the subset complement) + node_attr ⇒ scratch
+% floor (accepted).
+%
+% ORDERING: consumes analyzer EDB only; produces IMPLEMENTS (no in-engine
+% consumer today) — position before the negators is conventional, not
+% load-bearing.
+
+% Interface requirement rows: per INTERFACE NODE (DELTA G6-3 — deliberately
+% NOT the legacy name-union).
+iface_m(I, MN) :- node(I, "INTERFACE"), attr(I, "file", IF),
+                  ends_with(IF, ".go"), edge(I, MF, "CONTAINS"),
+                  node(MF, "FUNCTION"),
+                  node_attr(MF, "kind", "interface_method"),
+                  attr(MF, "name", MN).
+
+% Struct method rows: methods join their type by receiver NAME (the legacy
+% global name-keyed merge — DELTA G6-2).
+recv_m(SN, MN)  :- node(MF, "FUNCTION"), attr(MF, "file", MFF),
+                   ends_with(MFF, ".go"), node_attr(MF, "kind", "method"),
+                   node_attr(MF, "receiver", SN), attr(MF, "name", MN).
+struct_m(S, MN) :- node(S, "CLASS"), attr(S, "file", SF),
+                   ends_with(SF, ".go"), attr(S, "name", SN), recv_m(SN, MN).
+
+% Seed candidates through a shared method name; a candidate LACKS the
+% interface iff some required method name is missing from its set.
+cand(S, I)  :- struct_m(S, MN), iface_m(I, MN).
+lacks(S, I) :- cand(S, I), iface_m(I, MN2), \+ struct_m(S, MN2).
+
+@materialize(edge_type = "IMPLEMENTS", mode = "additive")
+go_implements(S, I) :- cand(S, I), \+ lacks(S, I).

--- a/packages/rfdb-server/src/derive/stdlib/go_types.dl
+++ b/packages/rfdb-server/src/derive/stdlib/go_types.dl
@@ -1,0 +1,85 @@
+% go_types.dl — in-engine replacement for the GoTypeResolution.hs resolver
+% (packages/go-resolve/src/GoTypeResolution.hs): VARIABLE → CLASS/INTERFACE
+% TYPE_OF edges (:73-88) and FUNCTION → CLASS/INTERFACE RETURNS edges per
+% comma-separated return type (:95-111). Shared pipeline: recursive `*` /
+% `[]` prefix strip (:47-51), the 21-primitive skip (:27-34), and the global
+% name → node TypeIndex over CLASS + INTERFACE (:60-66).
+%
+% IDIOMS:
+%   * prefix strip = a recursive derived predicate over strictly-shrinking
+%     strings (terminates), one rule per prefix; the clean row is the
+%     fixpoint member with neither prefix (not_starts_with twice — spelled
+%     "[]" per verdict C6; the residual "map[…" / sized-array strings never
+%     match a type_node key, parity for free);
+%   * comma SPLIT = right-peel with `last_segment` (identity-when-no-
+%     separator, builtin.rs) + concat + strip_suffix — no split/3 builtin
+%     needed; return_type is comma-joined with NO spaces (Declarations.hs
+%     :126-128, goTypeToName emits no commas) so the legacy `T.strip` is a
+%     no-op — EXACT;
+%   * the 21 primitives are ground facts (the js_local_refs rt_global
+%     precedent), matching the legacy `primitives` set verbatim (:28-34).
+%
+% NUMBERED DELTAS vs the resolver (everything not listed is exact):
+%   DELTA G7-1 (SUPERSET, bounded by duplicate type names): the TypeIndex is
+%     global last-wins (Map.insert, :60-66 — and a CLASS/INTERFACE name
+%     collision resolves to whichever node folded last); set semantics
+%     derives one edge per same-named type node. Same class as the
+%     go_calls G5-1 / go_interfaces G6-2 tie-breaks.
+%   Qualified types ("pkg.User" — goTypeToName of a selector is the BARE
+%     `sel`, Declarations.hs:641, so these surface as "User" and resolve by
+%     bare name in legacy and pack alike), map/chan/func types (never a
+%     type_node key) — parity for free.
+%   Legacy emits one edge PER comma part including duplicates ("(*User,
+%     *User)") — duplicates collapse under the graph's edge-set semantics for
+%     legacy too, so set semantics is EXACT (spec step 8).
+%   File gate: ends_with .go on every base relation (orchestrator stream
+%     filter; VARIABLE/FUNCTION/CLASS/INTERFACE are shared vocabulary).
+%   Metadata: legacy edges carry EMPTY metadata (:75-79, :97-101) — none
+%     projected.
+%
+% MAINTAIN ENVELOPE: negation (\+ go_primitive) + node_attr ⇒ scratch floor.
+%
+% ORDERING: consumes analyzer EDB only; produces TYPE_OF / RETURNS (no
+% in-engine consumer today) — position not load-bearing.
+
+% ── The 21 Go primitives (verbatim from primitives :28-34) ──────────────────
+go_primitive("int"). go_primitive("int8"). go_primitive("int16").
+go_primitive("int32"). go_primitive("int64"). go_primitive("uint").
+go_primitive("uint8"). go_primitive("uint16"). go_primitive("uint32").
+go_primitive("uint64"). go_primitive("uintptr"). go_primitive("float32").
+go_primitive("float64"). go_primitive("complex64"). go_primitive("complex128").
+go_primitive("string"). go_primitive("bool"). go_primitive("byte").
+go_primitive("rune"). go_primitive("error"). go_primitive("any").
+
+% ── The type index (CLASS + INTERFACE by name, :60-66) ──────────────────────
+type_node(N, Ty) :- node(Ty, "CLASS"), attr(Ty, "file", TF),
+                    ends_with(TF, ".go"), attr(Ty, "name", N).
+type_node(N, Ty) :- node(Ty, "INTERFACE"), attr(Ty, "file", TF),
+                    ends_with(TF, ".go"), attr(Ty, "name", N).
+
+% ── TYPE_OF: VARIABLE `type` metadata → type node (:73-88) ──────────────────
+vt(V, T)  :- node(V, "VARIABLE"), attr(V, "file", F), ends_with(F, ".go"),
+             node_attr(V, "type", T).
+vt(V, T2) :- vt(V, T), strip_prefix(T, "*", T2).
+vt(V, T2) :- vt(V, T), strip_prefix(T, "[]", T2).
+vt_clean(V, T) :- vt(V, T), not_starts_with(T, "*"), not_starts_with(T, "[]"),
+                  neq(T, "").
+
+@materialize(edge_type = "TYPE_OF", mode = "additive")
+go_type_of(V, Ty) :- vt_clean(V, T), \+ go_primitive(T), type_node(T, Ty).
+
+% ── RETURNS: FUNCTION `return_type` comma parts → type node (:95-111) ───────
+% Right-peel: rt holds the comma-joined string and every "drop the last
+% part" prefix; ret0 takes the last part of each — together, every part.
+rt(Fn, R)  :- node(Fn, "FUNCTION"), attr(Fn, "file", F), ends_with(F, ".go"),
+              node_attr(Fn, "return_type", R).
+rt(Fn, R2) :- rt(Fn, R), last_segment(R, ",", L), concat(",", L, CL),
+              strip_suffix(R, CL, R2).
+ret0(Fn, T)  :- rt(Fn, R), last_segment(R, ",", T).
+ret0(Fn, T2) :- ret0(Fn, T), strip_prefix(T, "*", T2).
+ret0(Fn, T2) :- ret0(Fn, T), strip_prefix(T, "[]", T2).
+ret_clean(Fn, T) :- ret0(Fn, T), not_starts_with(T, "*"),
+                    not_starts_with(T, "[]"), neq(T, "").
+
+@materialize(edge_type = "RETURNS", mode = "additive")
+go_returns(Fn, Ty) :- ret_clean(Fn, T), \+ go_primitive(T), type_node(T, Ty).

--- a/packages/rfdb-server/src/derive/stdlib/java_annotations.dl
+++ b/packages/rfdb-server/src/derive/stdlib/java_annotations.dl
@@ -1,0 +1,31 @@
+% java_annotations.dl — in-engine replacement for AnnotationResolution.hs of
+% the java-resolve binary (packages/java-resolve/src/AnnotationResolution.hs:
+% 26-44): ANNOTATION_RESOLVES_TO from every annotation usage (ATTRIBUTE,
+% Annotations.hs) to the same-named ANNOTATION_TYPE declaration. Both names
+% are first-class — the simplest pack of the java family.
+% Lang-spec: _ai/research/lang-spec-java.md §4.4.
+%
+% LEGACY SEMANTICS: an ANNOTATION_TYPE index by bare name (Map last-wins),
+% probed with each ATTRIBUTE's name; emit with EMPTY metadata (Hs:46-53) ⇒
+% no meta(...) columns; additive (shared rollout discipline).
+%
+% The .java gates on BOTH legs are load-bearing: kotlin-analyzer emits
+% ATTRIBUTE and ANNOTATION_TYPE too (and cpp/python/swift emit ATTRIBUTE);
+% legacy only ever saw Java-streamed nodes (main.rs:1578) — without the gates
+% the pack would invent java↔kotlin edges legacy never derived.
+%
+% NUMBERED DELTAS vs the legacy resolver (everything not listed is exact):
+%   DELTA 1 (superset, spec §5 class 1): set semantics on duplicate
+%     annotation names — an edge per same-named ANNOTATION_TYPE candidate vs
+%     the Map's arbitrary last-wins winner.
+%   DELTA 2 (metadata): engine provenance _source/_generation (rust DELTA 6).
+%
+% MAINTAIN ENVELOPE: no node_attr, no negation — maintain-incremental
+% eligible (the negation-light end of the java family, spec §4 note).
+
+jattr(A, N) :- node(A, "ATTRIBUTE"), attr(A, "file", F), ends_with(F, ".java"),
+    attr(A, "name", N), neq(N, "").
+jann(N, T)  :- node(T, "ANNOTATION_TYPE"), attr(T, "file", F), ends_with(F, ".java"),
+    attr(T, "name", N), neq(N, "").
+@materialize(edge_type = "ANNOTATION_RESOLVES_TO", mode = "additive")
+ann_resolves(A, T) :- jattr(A, N), jann(N, T).

--- a/packages/rfdb-server/src/derive/stdlib/java_calls.dl
+++ b/packages/rfdb-server/src/derive/stdlib/java_calls.dl
@@ -1,0 +1,133 @@
+% java_calls.dl — in-engine replacement for CallResolution.hs of the
+% java-resolve binary (packages/java-resolve/src/CallResolution.hs):
+% INSTANTIATES + ctor CALLS (resolveConstructorCalls, Hs:146-176), same-class
+% method CALLS (resolveSameClassCalls, Hs:182-205 — production-latent-bugged,
+% spec §2 D3), static-style CALLS (resolveStaticCalls, Hs:208-226) and
+% super()/this() delegation CALLS (resolveSuperThisCalls, Hs:232-257).
+% Lang-spec: _ai/research/lang-spec-java.md §4.3 + VERDICT C3 (this pack is a
+% CALLS producer and MUST precede the CALLS negators method_calls /
+% shape_verifier in both registries).
+%
+% LEGACY SEMANTICS: class index by simple name (Hs:44-52, Map last-wins);
+% ctor index = FUNCTION kind ∈ {constructor, compact_constructor} keyed by
+% the sid's [in:Class] marker (Hs:70-85); method index keyed by
+% (className, methodName) from the FUNCTION sid (Hs:56-66). The pack replaces
+% every sid parse with GRAPH-NATIVE membership: HAS_METHOD covers methods and
+% constructors (Declarations.hs:402-410, :477-483); compact constructors get
+% CONTAINS-only from the record scope (:534-539) — the second ctor_of arm.
+% A CALL's enclosing body is its CONTAINS parent (blocks push no scopes,
+% spec §1). Java lambdas are CLOSURE nodes, NOT FUNCTIONs (Expressions.hs:
+% 352-355 expression body, :399-404 block body; both push the lambda scope,
+% so a CALL inside either lambda kind has the CLOSURE as CONTAINS parent) —
+% jbody = FUNCTION|CLOSURE and the fn_owner recursion hops CONTAINS parents
+% of either type, lifting lambda and local-fn nesting (CLOSUREs have no
+% HAS_METHOD). All edges EMPTY metadata (Hs:132-139) ⇒ no meta(...) columns;
+% every head additive (CALLS/INSTANTIATES shared vocab).
+%
+% NUMBERED DELTAS vs the legacy resolver (everything not listed is exact):
+%   DELTA 1 (superset, spec §5 class 1): set semantics on duplicate simple
+%     class names — an edge per candidate vs Map last-wins.
+%   DELTA 2 (superset, spec §5 class 2): ALL overloads/ctors derived vs
+%     legacy's head-of-list pick (Hs:174-175 — the argCount comment is NOT
+%     implemented). Neither side does real Java overload resolution
+%     (spec §10.2); exactly-one-edge semantics belongs to the binding-table/
+%     semiring layer, not a rule hack.
+%   DELTA 3 (DECLARED SUPERSET, spec §5 class 4 — the D3 fix): same-class
+%     no-receiver calls resolve in ALL method bodies. Legacy's method index
+%     is keyed by class name but probed with the CALL sid's [in:] marker —
+%     the enclosing METHOD name (Expressions.hs:101-103) — so it matched only
+%     where [in:] == class name: constructor bodies, PLUS expression-body
+%     lambdas directly under a constructor (LambdaExpr pushes no
+%     withEnclosingFn, Expressions.hs:343-386, so the [in:ctorName] sid leaks
+%     into the lambda body — that arm is PARITY, not delta). The pack's
+%     CONTAINS→HAS_METHOD route restores the resolver's documented intent
+%     (Hs:12-13; test/Spec.hs:214 fabricates [in:Service] to pass). Bound =
+%     plain calls outside ctor bodies and outside ctor expression-lambdas
+%     (ordinary methods, block lambdas — withEnclosingFn at :431 rebinds
+%     [in:] to "<lambda>"). No false-positive vector: the join requires an
+%     actual same-class method of that name.
+%   DELTA 4 (superset/fix, rare, spec §5 class 5): local classes nested in
+%     method bodies — legacy keyed their ctors under the WRONG name (sid
+%     parent = enclosing method); the edge-based ctor_of is correct.
+%   DELTA 5 (metadata): engine provenance _source/_generation (rust DELTA 6).
+% PARITY PINS (no delta):
+%   - field-initializer calls (CONTAINS parent is the CLASS node, not a
+%     FUNCTION/CLOSURE): nothing on BOTH sides — legacy's [in:] is absent,
+%     the pack's encl_fn requires a jbody-typed parent. Same for a lambda IN
+%     a field initializer: its CONTAINS parent is the CLASS, so the fn_owner
+%     recursion stops (legacy: no [in:] for the expression kind, dead
+%     [in:<lambda>] probe for the block kind).
+%   - expression-body lambda directly inside a constructor: legacy DOES emit
+%     (the [in:ctorName] leak above) and the pack's CLOSURE lift emits too —
+%     exact modulo DELTA 2's all-overloads.
+%   - a receiver naming a non-class identifier ("foo.bar()"): nothing on both
+%     sides (Hs test :243-249).
+%   - "new Unknown" (no such class): nothing on both sides.
+%
+% MAINTAIN ENVELOPE: node_attr + negation ⇒ scratch-only under maintain.
+
+% Java-gated kernels (§3 self-contained connectivity discipline).
+jdecl(T, F, N) :- node(T, "CLASS"),     attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "INTERFACE"), attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "ENUM"),      attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "RECORD"),    attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jclass_named(N, T) :- jdecl(T, F, N).
+
+jcall(C, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".java"), attr(C, "name", N).
+jfn(Fn) :- node(Fn, "FUNCTION"), attr(Fn, "file", F), ends_with(F, ".java").
+% A callable BODY a CALL can sit in: methods/ctors (FUNCTION) and lambdas
+% (CLOSURE — Expressions.hs:352-355, :399-404).
+jbody(B) :- jfn(B).
+jbody(B) :- node(B, "CLOSURE"), attr(B, "file", F), ends_with(F, ".java").
+
+% — classification (Hs:260-270) —
+ctor_call(C, CN) :- jcall(C, N), strip_prefix(N, "new ", CN), neq(CN, "").
+is_ctor_call(C)  :- ctor_call(C, CN).
+is_ctor_call(C)  :- jcall(C, N), node_attr(C, "kind", "constructor_call").
+this_call(C)  :- jcall(C, "this").
+this_call(C)  :- jcall(C, N), node_attr(C, "isThis", "true").
+super_call(C) :- jcall(C, "super").
+super_this(C) :- this_call(C).
+super_this(C) :- super_call(C).
+has_recv(C) :- jcall(C, N), node_attr(C, "receiver", R), neq(R, ""), neq(R, "this").
+
+% — membership (graph-native replacement of the [in:Class] sid parse) —
+ctor_of(Cls, Fn) :- jfn(Fn), edge(Cls, Fn, "HAS_METHOD"), node_attr(Fn, "kind", "constructor").
+ctor_of(Cls, Fn) :- jfn(Fn), node(Cls, "RECORD"), edge(Cls, Fn, "CONTAINS"),
+    node_attr(Fn, "kind", "compact_constructor").
+% Nearest FUNCTION/CLOSURE ancestor of a CALL, then the HAS_METHOD owner;
+% the recursion hops CONTAINS parents of EITHER body type, lifting lambda
+% (CLOSURE) and local-fn nesting (CLOSUREs never carry HAS_METHOD, so only
+% the FUNCTION base arm grounds the chain).
+encl_fn(C, B) :- jcall(C, N), edge(B, C, "CONTAINS"), jbody(B).
+fn_owner(Fn, Cls) :- jfn(Fn), edge(Cls, Fn, "HAS_METHOD").
+fn_owner(B, Cls) :- jbody(B), edge(Outer, B, "CONTAINS"), jbody(Outer),
+    fn_owner(Outer, Cls).
+encl_class(C, Cls) :- encl_fn(C, Fn), fn_owner(Fn, Cls).
+
+% S10 — constructor calls: INSTANTIATES to the class + CALLS to its ctors.
+@materialize(edge_type = "INSTANTIATES", mode = "additive")
+instantiates(C, Cls) :- ctor_call(C, CN), jclass_named(CN, Cls).
+@materialize(edge_type = "CALLS", mode = "additive")
+ctor_calls(C, Fn) :- ctor_call(C, CN), jclass_named(CN, Cls), ctor_of(Cls, Fn).
+
+% S11 — same-class no-receiver calls (DELTA 3).
+plain_call(C, N) :- jcall(C, N), \+ is_ctor_call(C), \+ super_this(C), \+ has_recv(C).
+@materialize(edge_type = "CALLS", mode = "additive")
+same_class_calls(C, M) :- plain_call(C, N), encl_class(C, Cls),
+    edge(Cls, M, "HAS_METHOD"), attr(M, "name", N).
+
+% S12 — static-style calls (the receiver IS a class simple name).
+recv_class(C, N, Cls) :- jcall(C, N), \+ is_ctor_call(C), \+ super_this(C),
+    node_attr(C, "receiver", R), neq(R, ""), neq(R, "this"), jclass_named(R, Cls).
+@materialize(edge_type = "CALLS", mode = "additive")
+static_calls(C, M) :- recv_class(C, N, Cls), edge(Cls, M, "HAS_METHOD"), attr(M, "name", N).
+
+% S13 — this()/super() delegating ctor calls (legacy works here by the D3
+% accident — [in:ctorName] == class name inside constructors; exact parity
+% modulo DELTA 2's all-ctors).
+@materialize(edge_type = "CALLS", mode = "additive")
+this_ctor_calls(C, Fn) :- this_call(C), encl_class(C, Cls), ctor_of(Cls, Fn).
+@materialize(edge_type = "CALLS", mode = "additive")
+super_ctor_calls(C, Fn) :- super_call(C), encl_class(C, Cls),
+    node_attr(Cls, "extends", SN), neq(SN, ""), jclass_named(SN, SCls), ctor_of(SCls, Fn).

--- a/packages/rfdb-server/src/derive/stdlib/java_imports.dl
+++ b/packages/rfdb-server/src/derive/stdlib/java_imports.dl
@@ -1,0 +1,80 @@
+% java_imports.dl — in-engine replacement for ImportResolution.hs of the
+% java-resolve binary (packages/java-resolve/src/ImportResolution.hs), the
+% IMPORTS_FROM producer of the `java-all` daemon command: IMPORT → class
+% declaration (resolveImport, Hs:75-92) and IMPORT_BINDING → class declaration
+% (resolveBinding, Hs:99-131). Lang-spec: _ai/research/lang-spec-java.md §4.1
+% + VERDICT C3 (this pack feeds @stdlib/depends and MUST precede it).
+%
+% LEGACY SEMANTICS: buildModuleIndex (Hs:41-50) maps file → MODULE metadata
+% `package`; buildClassIndex (Hs:53-68) keys CLASS/INTERFACE/ENUM/RECORD by
+% "<package>.<name>" — or the bare name for default-package files (the
+% pkg-or-empty discipline, Hs:63-66). resolveImport looks the IMPORT's name
+% (the full dotted path, first-class — Imports.hs:65-81) up in that index and
+% emits IMPORT -IMPORTS_FROM-> decl with EMPTY metadata (Hs:85-91).
+%
+% PRODUCTION-DEAD LEGACY ARMS (spec §2, differential predictions P1/P3):
+% - resolveBinding (Hs:99-131) reads node metadata `source`, which the
+%   analyzer NEVER stamps (Imports.hs:107-111: imported_name/local_name/
+%   static only); the intended source travels in DeferredRef.drSource, which
+%   the orchestrator's FileAnalysis struct DROPS (analyzer.rs:41-49 has no
+%   unresolvedRefs field). Legacy phase 3 emits ZERO edges in production.
+% - the `asterisk` glob skip reads a key the analyzer spells `glob`
+%   (Hs:78 vs Imports.hs:78) — benign: a glob IMPORT is *named*
+%   "com.example.*", which can never equal a qualified class name, so the
+%   no-edge outcome is identical and the pack inherits it for free.
+%
+% IMPORTS_FROM is SHARED vocabulary ⇒ mode = "additive". Legacy metadata is
+% empty ⇒ no meta(...) columns.
+%
+% NUMBERED DELTAS vs the legacy resolver (everything not listed is exact):
+%   DELTA 1 (superset, spec §5 class 1): set semantics on duplicate qualified
+%     names — legacy's Map.fromList kept ONE arbitrary last-wins winner per
+%     qualified name (Hs:57); the pack derives an edge per candidate.
+%     Bound = qualified names with >1 declaration node.
+%   DELTA 2 (DECLARED SUPERSET, spec §5 class 3 — the feature): IMPORT_BINDING
+%     edges are derived from the graph-native IMPORT -CONTAINS-> IMPORT_BINDING
+%     edge (Imports.hs:114-120 emits exactly it) + the parent IMPORT's resolved
+%     target, instead of the never-present metadata `source` — restoring the
+%     resolver's documented intent (Hs header :20, test/Spec.hs:79-91, which
+%     fabricates `source`). Legacy production derives 0 (P1); bound = java
+%     IMPORT_BINDINGs whose parent IMPORT name ∈ qual_class.
+%   DELTA 3 (metadata): engine provenance _source/_generation on every pack
+%     edge (the standing rust DELTA 6).
+% PARITY PINS (no delta): glob imports resolve nothing (P3, above); static
+% member imports ("com.example.Foo.bar") resolve nothing on BOTH sides — the
+% full-path lookup fails (a deliberate non-superset, spec §3 S2 honesty note).
+%
+% MAINTAIN ENVELOPE: node_attr (package probe) + stratified negation (the
+% default-package arm) ⇒ maintain-incremental refuses; scratch floor applies.
+%
+% ENCODING NOTE (§3 connectivity, the rust_trait_resolve discipline):
+% name-keyed lookups are SELF-CONTAINED derived relations joined on strings;
+% node/attr legs are never inlined next to a foreign leg.
+
+% Java-gated EDB surfaces. The daemon streamed ONLY Language::Java nodes
+% (main.rs:1578), so the .java gate on every leg IS legacy parity — the
+% vocabulary is shared polyglot-wide (kotlin emits the same node types).
+jmodule(M, F) :- node(M, "MODULE"), attr(M, "file", F), ends_with(F, ".java").
+jdecl(T, F, N) :- node(T, "CLASS"),     attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "INTERFACE"), attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "ENUM"),      attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "RECORD"),    attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+
+% S1 — the qualified-class kernel. MODULE metadata `package` exists only when
+% the file has a package declaration (Walker.hs:37-51 — no key otherwise);
+% default-package files contribute the bare class name (Hs:63-66).
+pkg_of(F, P) :- jmodule(M, F), node_attr(M, "package", P), neq(P, "").
+has_pkg(F)  :- pkg_of(F, P).
+qual_class(Q, T) :- jdecl(T, F, N), pkg_of(F, P), concat(P, ".", P1), concat(P1, N, Q).
+qual_class(N, T) :- jdecl(T, F, N), \+ has_pkg(F).
+
+% S2 — IMPORT → declaration. The IMPORT's first-class name IS the full dotted
+% path (Imports.hs:65-81); glob imports ("com.example.*") fall out naturally.
+jimport(I, Q, F) :- node(I, "IMPORT"), attr(I, "file", F), ends_with(F, ".java"), attr(I, "name", Q).
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+import_target(I, T) :- jimport(I, Q, F), qual_class(Q, T).
+
+% S3 — IMPORT_BINDING → declaration via the parent IMPORT (DELTA 2).
+jbinding(B, F) :- node(B, "IMPORT_BINDING"), attr(B, "file", F), ends_with(F, ".java").
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+binding_target(B, T) :- jbinding(B, F), edge(I, B, "CONTAINS"), jimport(I, Q, F), qual_class(Q, T).

--- a/packages/rfdb-server/src/derive/stdlib/java_types.dl
+++ b/packages/rfdb-server/src/derive/stdlib/java_types.dl
@@ -1,0 +1,107 @@
+% java_types.dl — in-engine replacement for TypeResolution.hs of the
+% java-resolve binary (packages/java-resolve/src/TypeResolution.hs):
+% RETURNS (resolveReturns, Hs:115-126), TYPE_OF (resolveTypeOf, Hs:129-140),
+% EXTENDS (resolveExtends, Hs:143-156), IMPLEMENTS (resolveImplements,
+% Hs:159-171) and THROWS_TYPE (resolveThrows, Hs:174-186).
+% Lang-spec: _ai/research/lang-spec-java.md §4.2 + VERDICT C1 (the right-peel
+% comma split CLOSES delta class 6 — S8/S9 multi-element values are full
+% parity, not a subset) + C2 (negated builtins are legal per-row anti-joins,
+% pinned by stdlib.rs::negated_builtin_literal_is_a_per_row_anti_join) +
+% C4 (the "<unknown>" skip is dead-letter on both sides).
+%
+% LEGACY SEMANTICS: buildClassIndex by SIMPLE name (Hs:41-50, Map last-wins);
+% normalizeType (Hs:81-94) strips ALL "[]", rejects the 10 primitives,
+% '?'-wildcards and the resolver-internal "<unknown>"; splitTypes (Hs:97-98)
+% comma-splits implements/throws (the analyzer comma-joins with NO spaces —
+% T.intercalate ",", Declarations.hs:118/169/219/272/391/467 — so legacy's
+% T.strip is a no-op and is not replicated). All edges carry EMPTY metadata
+% (Hs:188-195) ⇒ no meta(...) columns; every head additive (shared vocab).
+%
+% NUMBERED DELTAS vs the legacy resolver (everything not listed is exact):
+%   DELTA 1 (superset, spec §5 class 1): set semantics on duplicate SIMPLE
+%     names across the project — an edge per same-named candidate vs the
+%     Map's arbitrary last-wins winner. Bound = simple names with >1 decl.
+%   DELTA 2 (subset, pathological): EXTENDS carries neq(C, T) — the pack
+%     never derives a self-loop; legacy COULD (a dup-named class whose Map
+%     winner is the extending node itself). Self-EXTENDS is junk by
+%     construction; deliberately excluded.
+%   DELTA 3 (metadata): engine provenance _source/_generation (rust DELTA 6).
+% PARITY PINS (no delta):
+%   - S7 interface multi-extends ("extends A,B" comma-joined,
+%     Declarations.hs:169): legacy does NOT split extends — it looks up the
+%     literal "A,B" and fails (Hs:146-156). The comma-bearing string matches
+%     no class name here either: 0 edges on BOTH sides, exactly. (The split
+%     fix is available — C1 — but would be a deliberate superset; not taken.)
+%   - S8/S9 multi-element implements/throws: SPLIT on both sides (C1 closed
+%     the draft's subset) — one edge per resolved element, exact parity
+%     modulo DELTA 1.
+%   - the "<unknown>" reject never fires (C4): the analyzer's typeToName
+%     emits "<type>" for unhandled types (Expressions.hs:1114), never
+%     "<unknown>" — kept only as resolver-vocabulary parity.
+%
+% MAINTAIN ENVELOPE: node_attr generators + negation ⇒ maintain-incremental
+% refuses; the scratch floor applies (the standing Wave-2 expectation).
+
+prim("boolean"). prim("byte"). prim("char"). prim("short"). prim("int").
+prim("long"). prim("float"). prim("double"). prim("void"). prim("var").
+
+% Java-gated declaration kernel (S4) — simple-name keyed, self-contained
+% (§3 connectivity discipline).
+jdecl(T, F, N) :- node(T, "CLASS"),     attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "INTERFACE"), attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "ENUM"),      attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jdecl(T, F, N) :- node(T, "RECORD"),    attr(T, "file", F), ends_with(F, ".java"), attr(T, "name", N), neq(N, "").
+jclass_named(N, T) :- jdecl(T, F, N).
+
+% S5 — RETURNS from FUNCTION metadata return_type (methods stamp it,
+% Declarations.hs:376-391). normalizeType = strip-all-[] + the reject set,
+% spelled as direct negated-builtin filters (C2: lighter than aux relations,
+% and stratification-free — stratify.rs adds no edge for builtin literals).
+ret_strip(Fn, N) :- node(Fn, "FUNCTION"), attr(Fn, "file", F), ends_with(F, ".java"),
+    node_attr(Fn, "return_type", Raw), neq(Raw, ""), replace_all(Raw, "[]", "", N), neq(N, "").
+@materialize(edge_type = "RETURNS", mode = "additive")
+returns(Fn, T) :- ret_strip(Fn, N), \+ prim(N), \+ string_contains(N, "?"),
+    neq(N, "<unknown>"), jclass_named(N, T).
+
+% S6 — TYPE_OF from VARIABLE metadata type (fields/locals/params).
+vty_strip(V, N) :- node(V, "VARIABLE"), attr(V, "file", F), ends_with(F, ".java"),
+    node_attr(V, "type", Raw), neq(Raw, ""), replace_all(Raw, "[]", "", N), neq(N, "").
+@materialize(edge_type = "TYPE_OF", mode = "additive")
+type_of(V, T) :- vty_strip(V, N), \+ prim(N), \+ string_contains(N, "?"),
+    neq(N, "<unknown>"), jclass_named(N, T).
+
+% S7 — EXTENDS: all 4 decl types carry the metadata (Hs:146); NO split
+% (parity pin above); neq(C, T) is DELTA 2.
+ext_strip(C, N) :- jdecl(C, F, CN), node_attr(C, "extends", Raw), neq(Raw, ""),
+    replace_all(Raw, "[]", "", N), neq(N, "").
+@materialize(edge_type = "EXTENDS", mode = "additive")
+extends(C, T) :- ext_strip(C, N), \+ prim(N), \+ string_contains(N, "?"),
+    neq(N, "<unknown>"), jclass_named(N, T), neq(C, T).
+
+% S8 — IMPLEMENTS (CLASS + ENUM only, Hs:163 — the analyzer also stamps
+% RECORD `implements`, which legacy never read: parity keeps the omission).
+% The comma split is the right-peel recursion (C1; the js_module_imports
+% spec_pfx idiom): peel the last ","-segment off a strictly-shrinking list —
+% the fixpoint terminates at element depth; last_segment is identity on
+% separator-free strings, so single elements surface unchanged.
+impl_raw(C, L) :- node(C, "CLASS"), attr(C, "file", F), ends_with(F, ".java"),
+    node_attr(C, "implements", L), neq(L, "").
+impl_raw(C, L) :- node(C, "ENUM"),  attr(C, "file", F), ends_with(F, ".java"),
+    node_attr(C, "implements", L), neq(L, "").
+impl_list(C, L) :- impl_raw(C, L).
+impl_list(C, R) :- impl_list(C, L), last_segment(L, ",", E),
+    concat(",", E, Tail), strip_suffix(L, Tail, R).
+impl_elem(C, E) :- impl_list(C, L), last_segment(L, ",", E).
+@materialize(edge_type = "IMPLEMENTS", mode = "additive")
+implements(C, T) :- impl_elem(C, N), jclass_named(N, T).
+
+% S9 — THROWS_TYPE from FUNCTION metadata throws (comma-joined,
+% Declarations.hs:391/467), same right-peel split.
+throws_raw(Fn, L) :- node(Fn, "FUNCTION"), attr(Fn, "file", F), ends_with(F, ".java"),
+    node_attr(Fn, "throws", L), neq(L, "").
+throws_list(Fn, L) :- throws_raw(Fn, L).
+throws_list(Fn, R) :- throws_list(Fn, L), last_segment(L, ",", E),
+    concat(",", E, Tail), strip_suffix(L, Tail, R).
+throws_elem(Fn, E) :- throws_list(Fn, L), last_segment(L, ",", E).
+@materialize(edge_type = "THROWS_TYPE", mode = "additive")
+throws_type(Fn, T) :- throws_elem(Fn, N), jclass_named(N, T).

--- a/packages/rfdb-server/src/derive/stdlib/js_http_routes_edges.dl
+++ b/packages/rfdb-server/src/derive/stdlib/js_http_routes_edges.dl
@@ -1,0 +1,135 @@
+% js_http_routes_edges.dl — edge half of the JS HTTP-route feature vertical
+% (Wave 14): the libraryCallbackEnricher edge vocabulary over the http:route
+% nodes minted by js_http_routes_nodes.dl:
+%   EXPOSES : registration CALL -> http:route   (enricher :146-151)
+%   HANDLES : http:route -> callback target     (enricher :152-157)
+% MUST be declared AFTER js_http_routes_nodes in the pack runner: the minted
+% http:route endpoints are joined here as COMMITTED storage EDB (the
+% js_builtins two-pack split — a @materialize edge endpoint must be a node-ID
+% column, and a same-run-minted node's id exists only as the BLAKE3 of the
+% sid string the nodes pack builds).
+%
+% The match prelude (cand/corig/try/want/bnd/dnext/src_of/routed) is a
+% textual duplicate of js_http_routes_nodes.dl (derived relations are
+% per-program; the established per-pack include pattern), and the ecb_*
+% ground facts are PREPENDED at compile time from effects_callable_facts.dl
+% (stdlib.rs concat!). See the nodes pack header for the full enricher
+% provenance and NUMBERED DELTAS 1-9 — no additional edge-only deltas.
+%
+% ENDPOINT PIN: our http:route nodes carry meta `anchorCall` = the decimal
+% u128 id of the registration call (nodes pack delta 4/5) — the join
+% `node_attr(R, "anchorCall", Cid) ⋈ attr(C, "id", Cid)` is exact and 1:1.
+% Other producers' http:route nodes are NEVER joined: axum_routes' nodes
+% have no anchorCall key, and the legacy enricher's anchorCall holds a WIRE
+% semantic-id string (never equal to a decimal id rendering).
+%
+% EXPOSES / HANDLES are SHARED vocabulary (the enricher emits them for
+% cli:command / mcp:tool / vscode:command) ⇒ mode = "additive" is MANDATORY.
+% Additive edges do not retract: an EXPOSES/HANDLES edge whose http:route
+% node was retracted by the (exclusive) nodes pack dangles until the next
+% writer cleanup — the known additive-vocabulary class, same as the enricher.
+%
+% MAINTAIN ENVELOPE: negation ⇒ scratch-only under maintain (accepted).
+%
+% ORDERING (CONSUMER): strictly after js_http_routes_nodes (committed-EDB
+% endpoint join), enforced by both pack registries.
+
+% ── Registry slice + rules (duplicate prelude; see the nodes pack) ──────────
+hr_lib("express").
+hr_lib("fastify").
+hr_lib("koa").
+hr_lib("koa-router").
+hr_lib("@koa/router").
+hr_lib("hono").
+
+hr_rule(Lib, M, CbIdx) :-
+    hr_lib(Lib),
+    ecb_method(Lib, Full, M),
+    ecb_arg(Lib, Full, CbIdx, "ENTRY_POINT_CALLBACK").
+hr_m(M) :- hr_rule(_, M, _).
+
+% ── Candidate calls (8-ext gate; duplicate prelude) ─────────────────────────
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".js"),  attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".jsx"), attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".ts"),  attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".tsx"), attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".mjs"), attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".cjs"), attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".mts"), attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".cts"), attr(C, "name", N).
+
+% Two-step suffix gate: the builtin needs N bound, so the suffix rule is
+% planned off jcall alone; the registry gate joins the derived output
+% (the greedy planner would otherwise lead with the tiny hr_m relation
+% and strand method_suffix with both arguments free).
+msfx(C, F, M) :- jcall(C, F, N), method_suffix(N, M).
+cand(C, F, M) :- msfx(C, F, M), hr_m(M).
+
+% ── Receiver-chain machinery (duplicate prelude) ────────────────────────────
+rsrc(X)     :- edge(X, _, "RECEIVER_CALL").
+rpath(A, B) :- edge(A, B, "RECEIVER_CALL").
+rpath(A, B) :- rpath(A, X), edge(X, B, "RECEIVER_CALL").
+rorig(A, B) :- rpath(A, B), \+ rsrc(B).
+
+corig(C, O) :- cand(C, _, _), rorig(C, O).
+corig(C, C) :- cand(C, _, _), \+ rsrc(C).
+
+try(C, F, N) :- corig(C, O), attr(O, "name", N), attr(O, "file", F).
+try(C, F, R) :- try(C, F, N), method_suffix(N, S), concat(".", S, DS), strip_suffix(N, DS, R).
+
+want(F, N) :- try(_, F, N).
+want(F, N) :- dnext(F, _, N).
+
+bnd(F, N, Src) :-
+    want(F, N),
+    node(B, "IMPORT_BINDING"), attr(B, "file", F), attr(B, "name", N),
+    node_attr(B, "source", Src).
+
+dinit(F, N, I) :- want(F, N), node(D, "CONSTANT"), attr(D, "file", F), attr(D, "name", N), edge(D, I, "ASSIGNED_FROM"), node(I, "CALL").
+dinit(F, N, I) :- want(F, N), node(D, "VARIABLE"), attr(D, "file", F), attr(D, "name", N), edge(D, I, "ASSIGNED_FROM"), node(I, "CALL").
+dorig(F, N, O) :- dinit(F, N, I), rorig(I, O).
+dorig(F, N, I) :- dinit(F, N, I), \+ rsrc(I).
+dnext(F, N, ON) :- dorig(F, N, O), attr(O, "name", ON).
+dnext(F, N, R)  :- dnext(F, N, ON), method_suffix(ON, S), concat(".", S, DS), strip_suffix(ON, DS, R).
+
+src_of(F, N, Src) :- bnd(F, N, Src).
+src_of(F, N, Src) :- dnext(F, N, N2), src_of(F, N2, Src).
+
+res(C, Src) :- try(C, F, N), src_of(F, N, Src).
+
+% Library match: exact, or subpath import "<lib>/..." (enricher :114-117).
+% Subpath matching is the segment-shrink idiom (cf. js_runtime_globals dpfx):
+% every whole-"/"-segment prefix of the source is derived, then membership-
+% joined against hr_lib — the trailing-"/" boundary the enricher's
+% startsWith(lib + "/") enforces falls out of shrinking BY segments
+% ("@foo/barzooka" never shrinks to "@foo/bar").
+spfx(C, S) :- res(C, S).
+spfx(C, P) :- spfx(C, S), last_segment(S, "/", L), concat("/", L, T), strip_suffix(S, T, P).
+mlib(C, Lib) :- spfx(C, Lib), hr_lib(Lib).
+
+routed(C, Lib, M, H) :-
+    cand(C, _, M),
+    mlib(C, Lib),
+    hr_rule(Lib, M, CbIdx),
+    edge(C, H, "PASSES_ARGUMENT"),
+    edge_attr(C, H, "PASSES_ARGUMENT", "index", CbIdx).
+rnode(C) :- routed(C, _, _, _).
+
+% ── The materialized edges over the COMMITTED http:route endpoints ──────────
+% The decimal call id is read in its OWN rule so the attr leg always runs in
+% reader mode [B,B,F] off the bound call — fused into the join rule the
+% planner may bind Cid from the node_attr side first and flip attr into the
+% [F,B,B] reverse-lookup, which has no index for the "id" pseudo-attr.
+hcid(C, Cid, H) :- routed(C, _, _, H), attr(C, "id", Cid).
+
+@materialize(edge_type = "EXPOSES", mode = "additive")
+http_exposes(C, R) :-
+    hcid(C, Cid, _),
+    node(R, "http:route"),
+    node_attr(R, "anchorCall", Cid).
+
+@materialize(edge_type = "HANDLES", mode = "additive")
+http_handles(R, H) :-
+    hcid(C, Cid, H),
+    node(R, "http:route"),
+    node_attr(R, "anchorCall", Cid).

--- a/packages/rfdb-server/src/derive/stdlib/js_http_routes_nodes.dl
+++ b/packages/rfdb-server/src/derive/stdlib/js_http_routes_nodes.dl
@@ -1,0 +1,241 @@
+% js_http_routes_nodes.dl — node half of the JS HTTP-route feature vertical
+% (Wave 14, REG-1115 slice): Express / Fastify / Koa(+koa-router/@koa/router) /
+% Hono route registrations -> `http:route` nodes + ROUTES_TO edges, driven by
+% the effects-db callable registry (the `ecb_*` ground facts PREPENDED at
+% compile time from effects_callable_facts.dl; regenerate via
+% scripts/generate-effects-callable-facts.mjs). This is the derive-pack
+% REPLACEMENT for the HTTP slice of
+% packages/util/src/enrichers/libraryCallbackEnricher.ts: the 6 framework
+% entries (express/fastify/koa/koa-router/@koa/router/hono) were retired
+% from its LIBRARY_NODE_TYPE map in this wave, making this pack the SOLE
+% default producer of js http:route. (The enricher writes via
+% addNodes/addEdges — leaving both on would mint two http:route nodes per
+% registration: enricher id anchors the wire semantic id, pack sid anchors
+% the decimal u128 — plus duplicate EXPOSES/HANDLES and duplicate
+% SpecedContracts downstream in httpRouteExtractor.)
+%
+% WHAT THE ENRICHER DOES (the semantics being reproduced): for every CALL
+% whose name ends in ".<method>" where <method> carries an
+% ENTRY_POINT_CALLBACK arg role in effects-db, walk the RECEIVER_CALL chain
+% to its origin, resolve the receiver name to an import source (direct
+% IMPORT_BINDING `metadata.source`, or a CONSTANT/VARIABLE whose
+% ASSIGNED_FROM initializer chain originates in a constructor of an imported
+% class), match the source against the registry library (exact or
+% "<lib>/<subpath>"), then mint one domain node per registration call with
+% EXPOSES (call -> node) and HANDLES (node -> callback) edges. All shapes
+% live-verified on the dogfood copy 2026-06-12: IMPORT_BINDING
+% metadata.source, CALL metadata.kind="new", RECEIVER_CALL chains,
+% PASSES_ARGUMENT metadata.index, LITERAL `name` = RAW source text including
+% quotes ("'overview'").
+%
+% NUMBERED DELTAS vs libraryCallbackEnricher (all deliberate):
+%   1. Name decomposition is the FULL dot-suffix-strip chain (try/dnext probe
+%      the origin name plus every "strip one trailing .segment" variant); the
+%      enricher picks exactly one split (before-last-dot for receivers,
+%      first-segment for constructor names). Superset: a false hit needs a
+%      same-file binding named exactly one of the variants AND sourced from a
+%      registry lib.
+%   2. Factory initializers resolve: `const app = express(); app.get(...)`.
+%      The enricher's initializer arm requires a kind="new" chain origin, so
+%      it MISSES the primary express/fastify idiom (live-traced in its source,
+%      libraryCallbackEnricher.ts:404); this pack accepts ANY CALL origin and
+%      resolves its callee name. Superset, deliberate.
+%   3. "<obj>"-rooted chained-namespace receivers (the DERIVES_FROM[callee] /
+%      READS_FROM[receiver] metadata.base walk, enricher :295-330) are NOT
+%      implemented — subset; that arm exists for `vscode.commands.*`, and
+%      vscode is not in this pack's lib set. Placeholder names resolve to
+%      nothing naturally (no binding is named "<obj>...").
+%   4. Node identity: sid = "<file>::http:route::<name>::<callIdDecimal>" —
+%      the enricher anchors on the call's WIRE semantic id; the engine attr
+%      surface exposes the BLAKE3 u128 id only. Same per-registration-call
+%      granularity, different anchor encoding.
+%   5. Node metadata: meta(library, method, anchorCall) where method = the
+%      BARE method name. The enricher stored the FIRST matching rule's
+%      methodFullName ("Application.get" vs "Router.get" — object-iteration-
+%      order-dependent); the bare name makes the row set order-free.
+%   6. The node name / route path comes from the ROUTE_PATH-role argument's
+%      LITERAL only, quotes stripped (single/double/backtick matching pairs).
+%      The enricher probed COMMAND_NAME/TOOL_SCHEMA roles then arg 0
+%      regardless of role and accepted ANY node's `name` as a label; those
+%      junk name sources are deliberately dropped -> "<unnamed-http-route>".
+%   7. ROUTES_TO (CALL -> handler, meta(method, path)) is NEW vs the enricher
+%      (which emitted only EXPOSES/HANDLES; the wave mandates the axum_routes
+%      vocabulary here). Verbs map registration names (del -> DELETE,
+%      all -> ALL); non-verb registrations (use/on/register/addHook/...)
+%      derive no ROUTES_TO. Unlike axum_routes the path is NOT gated on a
+%      leading "/" (express accepts "*", regex-like strings, etc.).
+%   8. Handler-required gate: a node is minted only when the
+%      ENTRY_POINT_CALLBACK-index PASSES_ARGUMENT edge exists — enricher
+%      parity (it skipped calls without callbackArgId; note this DIFFERS from
+%      axum_routes delta 4, which mints handler-less nodes).
+%   9. Chained multi-route registrations `r.get('/a',h1).post('/b',h2)`: the
+%      enricher labeled EVERY route in the chain from the chain ORIGIN's
+%      arg 0; this pack reads each call's OWN ROUTE_PATH argument.
+%      Correctness divergence, deliberate.
+%
+% Meta-identity caveat (shared with axum_routes): if one call resolves to two
+% registry libs (same-file bindings to two frameworks under one name), the
+% node row set carries both library values for one sid — which lands is
+% set-order-defined. Not observed in any real corpus.
+%
+% `http:route` nodes: mode = "exclusive" is PROVENANCE-SCOPED (the engine
+% contract): only nodes stamped with THIS rule's _source are owned — the
+% axum_routes pack's nodes and the legacy enricher's nodes are never touched,
+% while a route removed from the code retracts its node on the next run.
+% ROUTES_TO is PRE-REGISTERED SHARED vocabulary (packages/types/src/edges.ts
+% RouteEdge) ⇒ mode = "additive" is MANDATORY.
+%
+% MAINTAIN ENVELOPE: negation + node minting ⇒ scratch-only under maintain
+% (accepted, same class as every resolver pack).
+%
+% ORDERING: consumes analyzer EDB only (CALL/IMPORT_BINDING/CONSTANT/VARIABLE
+% nodes; RECEIVER_CALL/ASSIGNED_FROM/PASSES_ARGUMENT edges + metadata) — no
+% pack-produced inputs. Registered at the registry tail after axum_routes;
+% js_http_routes_edges joins the nodes minted HERE as committed EDB, so this
+% pack MUST run strictly before it (the js_builtins two-pack split).
+
+% ── Registry slice: the libs that mint http:route (LIBRARY_NODE_TYPE's HTTP
+%    subset, libraryCallbackEnricher.ts:36-48) ────────────────────────────────
+hr_lib("express").
+hr_lib("fastify").
+hr_lib("koa").
+hr_lib("koa-router").
+hr_lib("@koa/router").
+hr_lib("hono").
+
+% Registration-method-name -> HTTP verb (ROUTES_TO meta; delta 7).
+hr_verb("get", "GET").
+hr_verb("post", "POST").
+hr_verb("put", "PUT").
+hr_verb("delete", "DELETE").
+hr_verb("del", "DELETE").
+hr_verb("patch", "PATCH").
+hr_verb("head", "HEAD").
+hr_verb("options", "OPTIONS").
+hr_verb("all", "ALL").
+
+% ── Rules from the generated facts: callback + path argument indexes ────────
+hr_rule(Lib, M, CbIdx) :-
+    hr_lib(Lib),
+    ecb_method(Lib, Full, M),
+    ecb_arg(Lib, Full, CbIdx, "ENTRY_POINT_CALLBACK").
+hr_pathidx(Lib, M, PIdx) :-
+    hr_lib(Lib),
+    ecb_method(Lib, Full, M),
+    ecb_arg(Lib, Full, PIdx, "ROUTE_PATH").
+hr_m(M) :- hr_rule(_, M, _).
+
+% ── Candidate calls: ".<method>" suffix in a JS-family file (8-ext gate) ────
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".js"),  attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".jsx"), attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".ts"),  attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".tsx"), attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".mjs"), attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".cjs"), attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".mts"), attr(C, "name", N).
+jcall(C, F, N) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".cts"), attr(C, "name", N).
+
+% Two-step suffix gate: the builtin needs N bound, so the suffix rule is
+% planned off jcall alone; the registry gate joins the derived output
+% (the greedy planner would otherwise lead with the tiny hr_m relation
+% and strand method_suffix with both arguments free).
+msfx(C, F, M) :- jcall(C, F, N), method_suffix(N, M).
+cand(C, F, M) :- msfx(C, F, M), hr_m(M).
+
+% ── Receiver-chain machinery (RECEIVER_CALL closure; EDB-negation only) ─────
+rsrc(X)     :- edge(X, _, "RECEIVER_CALL").
+rpath(A, B) :- edge(A, B, "RECEIVER_CALL").
+rpath(A, B) :- rpath(A, X), edge(X, B, "RECEIVER_CALL").
+rorig(A, B) :- rpath(A, B), \+ rsrc(B).
+
+corig(C, O) :- cand(C, _, _), rorig(C, O).
+corig(C, C) :- cand(C, _, _), \+ rsrc(C).
+
+% ── Name variants probed at the call site (delta 1) ─────────────────────────
+try(C, F, N) :- corig(C, O), attr(O, "name", N), attr(O, "file", F).
+try(C, F, R) :- try(C, F, N), method_suffix(N, S), concat(".", S, DS), strip_suffix(N, DS, R).
+
+% ── Need-set-driven binding resolution (mutually recursive with the
+%    initializer hop — the enricher's bounded recursion as a fixpoint) ───────
+want(F, N) :- try(_, F, N).
+want(F, N) :- dnext(F, _, N).
+
+bnd(F, N, Src) :-
+    want(F, N),
+    node(B, "IMPORT_BINDING"), attr(B, "file", F), attr(B, "name", N),
+    node_attr(B, "source", Src).
+
+% const/var initializer hop: `const app = express()` / `= new Hono()` /
+% `= new Router().use(...)` — chain origin's callee name (+ variants) is the
+% next name to resolve (deltas 1, 2).
+dinit(F, N, I) :- want(F, N), node(D, "CONSTANT"), attr(D, "file", F), attr(D, "name", N), edge(D, I, "ASSIGNED_FROM"), node(I, "CALL").
+dinit(F, N, I) :- want(F, N), node(D, "VARIABLE"), attr(D, "file", F), attr(D, "name", N), edge(D, I, "ASSIGNED_FROM"), node(I, "CALL").
+dorig(F, N, O) :- dinit(F, N, I), rorig(I, O).
+dorig(F, N, I) :- dinit(F, N, I), \+ rsrc(I).
+dnext(F, N, ON) :- dorig(F, N, O), attr(O, "name", ON).
+dnext(F, N, R)  :- dnext(F, N, ON), method_suffix(ON, S), concat(".", S, DS), strip_suffix(ON, DS, R).
+
+src_of(F, N, Src) :- bnd(F, N, Src).
+src_of(F, N, Src) :- dnext(F, N, N2), src_of(F, N2, Src).
+
+res(C, Src) :- try(C, F, N), src_of(F, N, Src).
+
+% Library match: exact, or subpath import "<lib>/..." (enricher :114-117).
+% Subpath matching is the segment-shrink idiom (cf. js_runtime_globals dpfx):
+% every whole-"/"-segment prefix of the source is derived, then membership-
+% joined against hr_lib — the trailing-"/" boundary the enricher's
+% startsWith(lib + "/") enforces falls out of shrinking BY segments
+% ("@foo/barzooka" never shrinks to "@foo/bar").
+spfx(C, S) :- res(C, S).
+spfx(C, P) :- spfx(C, S), last_segment(S, "/", L), concat("/", L, T), strip_suffix(S, T, P).
+mlib(C, Lib) :- spfx(C, Lib), hr_lib(Lib).
+
+% ── Routed calls: lib-matched + the callback argument EXISTS (delta 8) ──────
+routed(C, Lib, M, H) :-
+    cand(C, _, M),
+    mlib(C, Lib),
+    hr_rule(Lib, M, CbIdx),
+    edge(C, H, "PASSES_ARGUMENT"),
+    edge_attr(C, H, "PASSES_ARGUMENT", "index", CbIdx).
+rnode(C) :- routed(C, _, _, _).
+
+% ── Route path: the ROUTE_PATH-role argument's LITERAL, quotes stripped
+%    (delta 6; live shape: LITERAL name keeps raw source quoting) ────────────
+praw(C, Raw) :-
+    routed(C, Lib, M, _),
+    hr_pathidx(Lib, M, PIdx),
+    edge(C, P, "PASSES_ARGUMENT"),
+    edge_attr(C, P, "PASSES_ARGUMENT", "index", PIdx),
+    node(P, "LITERAL"),
+    attr(P, "name", Raw).
+
+sq(C) :- praw(C, Raw), starts_with(Raw, "'").
+dq(C) :- praw(C, Raw), starts_with(Raw, "\"").
+bq(C) :- praw(C, Raw), starts_with(Raw, "`").
+pth(C, P)   :- praw(C, Raw), strip_prefix(Raw, "'", T),  strip_suffix(T, "'", P).
+pth(C, P)   :- praw(C, Raw), strip_prefix(Raw, "\"", T), strip_suffix(T, "\"", P).
+pth(C, P)   :- praw(C, Raw), strip_prefix(Raw, "`", T),  strip_suffix(T, "`", P).
+pth(C, Raw) :- praw(C, Raw), \+ sq(C), \+ dq(C), \+ bq(C).
+
+named(C) :- pth(C, _).
+nname(C, P) :- pth(C, P).
+nname(C, "<unnamed-http-route>") :- rnode(C), \+ named(C).
+
+% ── The materialized ROUTES_TO edge (verb methods with a path; delta 7) ─────
+@materialize(edge_type = "ROUTES_TO", mode = "additive", meta(method, path))
+http_routes_to(C, H, V, P) :-
+    routed(C, Lib, M, H),
+    hr_verb(M, V),
+    pth(C, P).
+
+% ── The materialized http:route NODE (deltas 4, 5, 8) ───────────────────────
+@materialize_node(node_type = "http:route", mode = "exclusive", meta(library, method, anchorCall))
+http_route_js(Sid, Name, F, Lib, M, Cid) :-
+    routed(C, Lib, M, _),
+    nname(C, Name),
+    attr(C, "file", F),
+    attr(C, "id", Cid),
+    concat(F, "::http:route::", S1),
+    concat(S1, Name, S2),
+    concat(S2, "::", S3),
+    concat(S3, Cid, Sid).

--- a/packages/rfdb-server/src/derive/stdlib/kotlin_inheritance.dl
+++ b/packages/rfdb-server/src/derive/stdlib/kotlin_inheritance.dl
@@ -1,0 +1,186 @@
+% kotlin_inheritance.dl — Kotlin EXTENDS / IMPLEMENTS edges from the analyzer's
+% supertype metadata stamps. Closes the kotlin-spec step-5 gap (lang-spec-kotlin
+% §Step 5): kotlin classes had ZERO inheritance edges in production — supertypes
+% went ONLY into deferred InheritanceResolve refs (kotlin-analyzer Types.hs
+% emitInheritanceEdge) which the orchestrator drops (FileAnalysis has no
+% unresolvedRefs field, analyzer.rs:41-49), and the kotlin-resolve
+% resolveExtends/resolveImplements arms read `extends`/`implements` metadata the
+% analyzer never stamped (those arms are retired in this wave — DELTA 7).
+% EVERYTHING this pack derives is therefore a declared SUPERSET vs the
+% legacy-zero baseline (DELTA 7 below).
+%
+% EDB CONTRACT (the analyzer-side stamps, Rules/Declarations.hs inheritanceMeta):
+%   CLASS node metadata
+%     "extends"          — the single class supertype name (the parser's
+%                          constructor-call supertype entry; `class C : Base(1)`),
+%     "implements_0..n"  — indexed interface supertype names (bare / delegated
+%                          entries; the list-valued metadata convention —
+%                          node_attr-addressable, no split builtin needed).
+%   Names are simple ("Base") or scope-qualified as written ("java.util.List");
+%   generic type arguments are stripped at stamp time. Interfaces / enums /
+%   objects are all CLASS nodes with a `kind` metadata discriminator
+%   (kind = "interface" marks interfaces — kotlin-analyzer emits NO INTERFACE
+%   node type). CAVEAT: the parser's kind cascade checks isSealed() BEFORE
+%   isInterface() (kotlin-parser KotlinAstSerializer.kt:83-92), so a
+%   `sealed interface` serializes kind = "sealed" — indistinguishable from a
+%   sealed CLASS in the EDB. See DELTA 8.
+%
+% CLASSIFICATION RULE (the Kotlin syntactic ambiguity): the parser classifies a
+% supertype entry by the constructor-call '()' suffix — `Base(1)` → "extends",
+% bare `Greeter` → "implements". A class with NO primary constructor may extend
+% a class via a BARE entry (`class X : Base { constructor() : super() }`), which
+% lands in implements_N. This pack re-classifies by the RESOLVED declaration's
+% own kind: target kind = "interface" → IMPLEMENTS, anything else → EXTENDS
+% (the recovery arms). The ambiguity is thus resolved whenever the declaration
+% is in scope; out-of-scope names derive nothing either way (DELTA 2).
+%
+% RESOLUTION SCOPE (SUBSET DELTA 1): same-file + same-package-by-directory arms
+% ONLY. Kotlin import resolution is a separate migration step (lang-spec-kotlin
+% steps 1-2); cross-file resolution through imports is the next wave. Bound =
+% stamps whose names resolve only via an import.
+%
+% NUMBERED DELTAS (vs legacy kotlin-resolve AND vs ideal Kotlin semantics):
+%   DELTA 1 (scope subset): same-file + same-directory arms only — see above.
+%   DELTA 2 (classification): bare class supertypes of no-primary-ctor classes
+%     arrive in implements_N; re-classified by target kind (recovery arms).
+%     Residual: such a supertype that is OUT of resolution scope derives no
+%     edge — same as every out-of-scope name.
+%   DELTA 3 (ambiguity discipline): duplicate same-name declarations in the
+%     resolution scope are SKIPPED (the \+ ambig idiom — js_this_method_calls
+%     precedent), not derived per-candidate. Bound = duplicate (scope, name)
+%     pairs, measurable.
+%   DELTA 4 (index cap): want_impl enumerates implements_0..15 — a class with
+%     more than 16 interface supertypes loses the tail (real Kotlin: unheard of).
+%   DELTA 5 (qualified stamps): dotted names ("java.util.AbstractList") join
+%     only a declaration literally so named — practically never; external
+%     supertypes derive nothing (parity with the legacy zero).
+%   DELTA 6 (directory ≈ package): the same-package arm joins by the file's
+%     directory prefix (last_segment/strip_suffix peel), not the MODULE
+%     `package` metadata — files in one directory with different package
+%     declarations (or one package split across directories) deviate from true
+%     package scope. Top-level files (no '/') share the "" directory.
+%   DELTA 7 (baseline): legacy production output is ZERO (header) — every edge
+%     is new, resolvedVia = "kotlin-inheritance" meta marks the producer.
+%     KEPT TRUE BY CONSTRUCTION: the kotlin-resolve resolveExtends /
+%     resolveImplements arms (which read the same `extends` / un-suffixed
+%     `implements` metadata through an UNSCOPED project-wide last-wins
+%     simple-name index) are retired in the same wave that lands the analyzer
+%     stamps — otherwise the `extends` stamp would wake resolveExtends into a
+%     second, scope-undisciplined EXTENDS producer (kotlin-resolve
+%     TypeResolution.hs — see the retirement note there).
+%   DELTA 8 (sealed targets of bare entries): kind = "sealed" is BOTH sealed
+%     classes and sealed interfaces (the parser cascade, EDB contract above).
+%     A bare supertype entry (implements_N stamp) resolving to a kind="sealed"
+%     declaration is therefore unclassifiable — the recovery arms refuse it
+%     (\+ kind=sealed guard) rather than derive EXTENDS toward what may be a
+%     sealed INTERFACE. Bound = bare entries naming an in-scope sealed
+%     declaration: `class C : SealedIface` derives nothing (was: silent wrong
+%     EXTENDS). Constructor-call supertypes are unaffected — `class C :
+%     SealedClass()` arrives as the `extends` stamp and kt_ext_file/dir carry
+%     no kind guard. Full fix is parser-side (an explicit interface flag).
+%
+% MAINTAIN ENVELOPE: node_attr reads metadata blobs outside the delta algebra —
+% maintain-incremental refuses this pack; it runs at the scratch floor (the
+% accepted stance of every node_attr pack — js_class_inheritance precedent).
+%
+% ORDERING (producer): EXTENDS is consumed by shape_verifier's EXTENDS-closed
+% member lookup — this pack MUST run before shape_verifier. It consumes
+% analyzer EDB only (no pack-produced inputs), so it has no run-after seam.
+
+% Every CLASS in a Kotlin file — file gate inlined per base relation
+% (ends_with is a filter, it cannot generate F; config.rs:749 maps both
+% .kt and .kts to Language::Kotlin).
+ktc(C, F) :- node(C, "CLASS"), attr(C, "file", F), ends_with(F, ".kt").
+ktc(C, F) :- node(C, "CLASS"), attr(C, "file", F), ends_with(F, ".kts").
+
+% The stamped class-supertype want: one per class ("extends" is single-valued).
+want_ext(C, F, N) :- ktc(C, F), node_attr(C, "extends", N), neq(N, "").
+
+% The stamped interface-supertype wants: many per class, one clause per
+% indexed key implements_0..15 (DELTA 4) — node_attr requires a bound key and
+% a fact-table key generator is a planner-rejected cross-join (E-PLAN-003,
+% observed on this pack), so the keys are inlined per clause (the
+% one-clause-per-constant idiom — js file-extension gates precedent).
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_0", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_1", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_2", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_3", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_4", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_5", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_6", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_7", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_8", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_9", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_10", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_11", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_12", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_13", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_14", N), neq(N, "").
+want_impl(C, F, N) :- ktc(C, F), node_attr(C, "implements_15", N), neq(N, "").
+
+% Same-file declaration index (file, name) → CLASS node.
+cls_in(F, N, T) :- ktc(T, F), attr(T, "name", N), neq(N, "").
+
+% Duplicate same-name declarations in one file — the exactly-one guard.
+amb_f(F, N) :- cls_in(F, N, T1), cls_in(F, N, T2), neq(T1, T2).
+
+% Directory of a kotlin file: F = D ++ Base, Base the post-'/' tail
+% (identity when no '/' → D = "", DELTA 6).
+dir_of(F, D) :- ktc(_, F), last_segment(F, "/", B), strip_suffix(F, B, D).
+
+% Same-directory declaration index + its exactly-one guard (same-file
+% duplicates are dir duplicates too — the dir arm inherits the skip).
+cls_dir(D, N, T) :- cls_in(F, N, T), dir_of(F, D).
+amb_d(D, N) :- cls_dir(D, N, T1), cls_dir(D, N, T2), neq(T1, T2).
+
+% Interface discriminator (kotlin interfaces are CLASS kind=interface).
+iface(T) :- ktc(T, _), node_attr(T, "kind", "interface").
+
+% Sealed discriminator — covers sealed classes AND sealed interfaces (the
+% parser cascade collapses both to kind="sealed", DELTA 8).
+sealed_t(T) :- ktc(T, _), node_attr(T, "kind", "sealed").
+
+% Fall-through gates: a same-file candidate suppresses the directory arm
+% (js_class_inheritance has_local precedent; per-name for the multi-valued
+% implements list).
+has_f_ext(C) :- want_ext(C, F, N), cls_in(F, N, _).
+has_f_impl(C, N) :- want_impl(C, F, N), cls_in(F, N, _).
+
+% ── EXTENDS from the "extends" stamp ────────────────────────────────────────
+
+@materialize(edge_type = "EXTENDS", mode = "additive", meta(resolvedVia))
+kt_ext_file(C, T, "kotlin-inheritance") :-
+    want_ext(C, F, N), cls_in(F, N, T), \+ amb_f(F, N), neq(C, T).
+
+@materialize(edge_type = "EXTENDS", mode = "additive", meta(resolvedVia))
+kt_ext_dir(C, T, "kotlin-inheritance") :-
+    want_ext(C, F, N), \+ has_f_ext(C),
+    dir_of(F, D), cls_dir(D, N, T), \+ amb_d(D, N), neq(C, T).
+
+% ── IMPLEMENTS from implements_N stamps resolving to an interface ───────────
+
+@materialize(edge_type = "IMPLEMENTS", mode = "additive", meta(resolvedVia))
+kt_impl_file(C, T, "kotlin-inheritance") :-
+    want_impl(C, F, N), cls_in(F, N, T), iface(T), \+ amb_f(F, N), neq(C, T).
+
+@materialize(edge_type = "IMPLEMENTS", mode = "additive", meta(resolvedVia))
+kt_impl_dir(C, T, "kotlin-inheritance") :-
+    want_impl(C, F, N), \+ has_f_impl(C, N),
+    dir_of(F, D), cls_dir(D, N, T), iface(T), \+ amb_d(D, N), neq(C, T).
+
+% ── EXTENDS recovery: implements_N stamp resolving to a NON-interface — the
+%    no-primary-constructor bare class supertype (DELTA 2). kind = "sealed"
+%    targets are REFUSED (DELTA 8): sealed interfaces also serialize
+%    kind="sealed", so re-classifying a bare entry toward a sealed target as
+%    EXTENDS would silently mis-edge `class C : SealedIface` ────────────────
+
+@materialize(edge_type = "EXTENDS", mode = "additive", meta(resolvedVia))
+kt_ext_rec_file(C, T, "kotlin-inheritance") :-
+    want_impl(C, F, N), cls_in(F, N, T), \+ iface(T), \+ sealed_t(T),
+    \+ amb_f(F, N), neq(C, T).
+
+@materialize(edge_type = "EXTENDS", mode = "additive", meta(resolvedVia))
+kt_ext_rec_dir(C, T, "kotlin-inheritance") :-
+    want_impl(C, F, N), \+ has_f_impl(C, N),
+    dir_of(F, D), cls_dir(D, N, T), \+ iface(T), \+ sealed_t(T),
+    \+ amb_d(D, N), neq(C, T).

--- a/packages/rfdb-server/src/derive/stratify.rs
+++ b/packages/rfdb-server/src/derive/stratify.rs
@@ -203,6 +203,7 @@ const BUILTINS: &[&str] = &[
     "strip_prefix",
     "strip_suffix",
     "last_segment",
+    "first_segment",
     "replace_all",
     "path_resolve",
     "edge_attr",

--- a/packages/util/src/enrichers/libraryCallbackEnricher.ts
+++ b/packages/util/src/enrichers/libraryCallbackEnricher.ts
@@ -37,14 +37,14 @@ const LIBRARY_NODE_TYPE: Record<string, string> = {
   commander: 'cli:command',
   '@modelcontextprotocol/sdk': 'mcp:tool',
   vscode: 'vscode:command',
-  // HTTP frameworks (REG-1115). Each route registration call becomes one
-  // `http:route` FEATURE; httpRouteExtractor builds the SpecedContract.
-  express: 'http:route',
-  fastify: 'http:route',
-  koa: 'http:route',
-  'koa-router': 'http:route',
-  '@koa/router': 'http:route',
-  hono: 'http:route',
+  // HTTP frameworks (REG-1115) — express/fastify/koa/koa-router/@koa/router/
+  // hono — were retired from this map in Wave 14: their `http:route` FEATURE
+  // nodes are now minted by the default-on derive packs
+  // (rfdb-server/src/derive/stdlib/js_http_routes_nodes.dl + _edges.dl).
+  // Keeping them here would make this enricher a second default producer of
+  // the same feature with byte-different node ids (wire-sid anchor vs the
+  // pack's decimal anchorCall), duplicating EXPOSES/HANDLES and the
+  // SpecedContracts httpRouteExtractor derives from them.
 };
 
 interface Rule {

--- a/plugins/type-inference.mjs
+++ b/plugins/type-inference.mjs
@@ -98,6 +98,11 @@ const client = new RFDBClient(socketPath, 'type-inference');
 
 try {
   await client.connect();
+  // Negotiate protocol v3 so queryNodes streams in chunks. Without hello() the
+  // client stays on the non-streaming path, and a single QueryNodes over a large
+  // node type (e.g. ~93k CALL nodes on the Grafema dogfood graph) exceeds the
+  // client's fixed 60s request timeout — the plugin then exits 1 every run.
+  await client.hello();
   if (dbName) await client.openDatabase(dbName);
 
   // Phase 1: Create builtin CLASS + METHOD nodes (same in both paths)
@@ -111,6 +116,10 @@ try {
     await typeInferenceLegacy(client);
   }
 
+  // Publish staged writes: under MVCC (visibility=publish) addNodes/addEdges are
+  // not visible to other connections — or durable — until a flush. Without this,
+  // every INSTANCE_OF edge created above is silently dropped when the process exits.
+  await client.flush();
   await client.close();
 } catch (err) {
   console.error(`[type-inference] Error: ${err.message}`);

--- a/plugins/type-inference.mjs
+++ b/plugins/type-inference.mjs
@@ -525,8 +525,8 @@ async function typeInferenceLegacy(client) {
 
 async function createBuiltinNodes(client) {
   const classIds = new Map();
-  const nodes = [];
   const edgesBatch = [];
+  let nodesCreated = 0;
 
   for (const [className, methods] of Object.entries(BUILTINS)) {
     let classNodeId = null;
@@ -538,74 +538,82 @@ async function createBuiltinNodes(client) {
     }
 
     if (!classNodeId) {
+      // The server derives the numeric node id deterministically by hashing the
+      // string id we supply (string_id_to_u128), so the id is known at write
+      // time. Do NOT re-query for it: under MVCC an unflushed node is invisible
+      // to same-session reads, so a read-after-add returns null and the
+      // HAS_METHOD edge would be silently dropped (and skipped forever on
+      // later runs, because the node then exists).
+      classNodeId = `builtin::${className}`;
       await client.addNodes([{
-        id: `builtin::${className}`,
+        id: classNodeId,
         type: 'CLASS',
         name: className,
         file: '<builtin>',
         exported: true,
         metadata: JSON.stringify({ _source: 'type-inference', builtin: true }),
       }]);
-      for await (const n of client.queryNodes({ type: 'CLASS', name: className })) {
-        if (n.file === '<builtin>') {
-          classNodeId = String(n.id);
-          break;
-        }
-      }
+      nodesCreated++;
     }
-
-    if (!classNodeId) continue;
     classIds.set(className, classNodeId);
 
     for (const methodName of methods) {
-      let exists = false;
+      let methodId = null;
       for await (const n of client.queryNodes({ type: 'METHOD', name: methodName })) {
         if (n.file === '<builtin>') {
           const meta = typeof n.metadata === 'string' ? JSON.parse(n.metadata || '{}') : {};
-          if (meta.parentClass === className) { exists = true; break; }
+          if (meta.parentClass === className) { methodId = String(n.id); break; }
         }
       }
-      if (exists) continue;
 
-      await client.addNodes([{
-        id: `builtin::${className}::${methodName}`,
-        type: 'METHOD',
-        name: methodName,
-        file: '<builtin>',
-        exported: true,
-        metadata: JSON.stringify({
-          _source: 'type-inference', builtin: true, kind: 'method',
-          parentClass: className,
-        }),
-      }]);
+      if (!methodId) {
+        methodId = `builtin::${className}::${methodName}`;
+        await client.addNodes([{
+          id: methodId,
+          type: 'METHOD',
+          name: methodName,
+          file: '<builtin>',
+          exported: true,
+          metadata: JSON.stringify({
+            _source: 'type-inference', builtin: true, kind: 'method',
+            parentClass: className,
+          }),
+        }]);
+        nodesCreated++;
+      }
 
-      let methodNumId = null;
-      for await (const n of client.queryNodes({ type: 'METHOD', name: methodName })) {
-        if (n.file === '<builtin>') {
-          const meta = typeof n.metadata === 'string' ? JSON.parse(n.metadata || '{}') : {};
-          if (meta.parentClass === className) { methodNumId = String(n.id); break; }
-        }
-      }
-      if (methodNumId) {
-        edgesBatch.push({
-          src: classNodeId,
-          dst: methodNumId,
-          type: 'HAS_METHOD',
-          metadata: JSON.stringify({ _source: 'type-inference' }),
-        });
-      }
+      // Always (re-)assert the edge — addEdges is an upsert, so this is
+      // idempotent AND heals graphs where a previous run created the METHOD
+      // node but lost the edge to the read-after-add bug.
+      edgesBatch.push({
+        src: classNodeId,
+        dst: methodId,
+        type: 'HAS_METHOD',
+        metadata: JSON.stringify({ _source: 'type-inference' }),
+      });
     }
   }
 
-  if (nodes.length > 0) {
-    await client.addNodes(nodes);
-    console.error(`[type-inference] Created ${nodes.length} builtin nodes`);
+  if (nodesCreated > 0) {
+    console.error(`[type-inference] Created ${nodesCreated} builtin nodes`);
+    // Publish the new nodes before adding edges that reference them by string
+    // id: the server resolves a string src/dst via get_node(hash) only for
+    // published nodes — an unpublished endpoint falls into a full-graph
+    // semantic-id scan per edge. Flushing also makes the builtin CLASS nodes
+    // visible to the classIndex queries later in this same session.
+    await client.flush();
   }
+
   if (edgesBatch.length > 0) {
     const BATCH = 500;
     for (let i = 0; i < edgesBatch.length; i += BATCH) {
       await client.addEdges(edgesBatch.slice(i, i + BATCH));
     }
+    // Publish HAS_METHOD edges now rather than relying on the end-of-process
+    // flush: if a later phase crashes the plugin, every staged write is lost
+    // and the builtin METHOD nodes (already published above) become permanent
+    // orphans — the exact failure mode this function used to have.
+    await client.flush();
   }
 
   return classIds;

--- a/scripts/generate-effects-callable-facts.mjs
+++ b/scripts/generate-effects-callable-facts.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+// Generate the effects-db CALLABLE-REGISTRY ground facts (Wave 14, feature
+// detection as derive packs) — the structured (v2/v3) entry surface that
+// packages/util/src/enrichers/libraryCallbackEnricher.ts consumes through
+// EffectsLookup.getEntry(): per-method argument ROLES (ENTRY_POINT_CALLBACK,
+// ROUTE_PATH, COMMAND_NAME, ...), declared returns.type, and channel metadata.
+//
+// DESIGN SPLIT (the wave decision): parsing/IO lives HERE (a deterministic,
+// re-run-safe generator over effects-db YAML); DERIVATION lives in the .dl
+// packs that join these facts against the graph (js_http_routes_* first).
+// JSON-schema parsing (MCP inputSchema, vscode contributes) is OUT of scope.
+//
+// INCLUSION RULE: an entry qualifies iff it carries ≥1 role-annotated arg
+// (`args[N].role`) OR a `channel` map. Returns-only fluent-chain entries
+// (e.g. commander's dozens of `returns: Command` setters) are EXCLUDED —
+// no pack consumes bare returns yet and they would triple the facts size;
+// `ecb_returns` rows are still emitted for QUALIFYING entries.
+//
+// Output (stdout) — the facts .dl block:
+//   ecb_method(Lib, Full, Bare).      one per qualifying entry; Bare = the
+//                                     segment after the LAST '.' of the fn key
+//                                     (libraryCallbackEnricher.ts:188-190).
+//   ecb_arg(Lib, Full, Idx, Role).    one per role-annotated arg; Idx is the
+//                                     YAML index VERBATIM as a string ("0").
+//   ecb_returns(Lib, Full, Type).     returns.type of qualifying entries.
+//   ecb_channel(Lib, Full, Key, Spec). channel rows of qualifying entries.
+// Lib is the top-level YAML key VERBATIM (incl. "node:"/"python:" prefixes
+// and scoped names like "@koa/router") — prefix normalization is a CONSUMER
+// concern (EffectsLookup.getEntry probes "node:"+module first).
+//
+// DETERMINISM / COLLISION POLICY (documented, mirrors EffectsLookup.load):
+//   - files are read in SORTED name order (legacy readdirSync order is
+//     OS-defined — recorded delta, same as the runtime-globals generator);
+//   - the same library key in TWO files of one subdir: the later file (in
+//     sorted order) wins WHOLESALE — EffectsLookup.load assigns
+//     db.packages[pkg] per file, so a later file replaces the whole lib;
+//     reported on stderr;
+//   - the same library key in runtimes/ AND packages/: runtimes wins
+//     (EffectsLookup.getEntry probes runtimes first); reported on stderr.
+//
+// FAILSAFE_SCHEMA is MANDATORY (the Wave-4 YAML bool-key lesson): js-yaml's
+// default schema resolves keys/values like `True:`/`on:` to booleans while
+// the legacy loaders keep mapping-key text verbatim. Under FAILSAFE all
+// scalars stay strings — which is also exactly what .dl literals need
+// (arg indexes arrive as "0"/"1" verbatim).
+//
+// Usage: node scripts/generate-effects-callable-facts.mjs \
+//          > packages/rfdb-server/src/derive/stdlib/effects_callable_facts.dl
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const dbDir = join(root, 'effects-db');
+
+// js-yaml is not a root dependency; resolve it out of the pnpm store.
+const yaml = (() => {
+  try {
+    return require('js-yaml');
+  } catch {
+    const store = join(root, 'node_modules', '.pnpm');
+    const hit = readdirSync(store).find((d) => d.startsWith('js-yaml@'));
+    if (!hit) throw new Error('js-yaml not found (root require failed and no .pnpm entry)');
+    return require(join(store, hit, 'node_modules', 'js-yaml'));
+  }
+})();
+
+/** Parse one fn entry (FAILSAFE: every scalar is a string). Returns the
+ *  qualifying-entry record or null. */
+function parseEntry(fnKey, val, where) {
+  if (!val || typeof val !== 'object' || Array.isArray(val)) return null;
+  const args = [];
+  if (Array.isArray(val.args)) {
+    for (const a of val.args) {
+      if (!a || typeof a !== 'object' || typeof a.role !== 'string') continue;
+      const idx = a.index;
+      if (typeof idx !== 'string' || !/^[0-9]+$/.test(idx)) {
+        console.error(`FATAL: non-numeric arg index ${JSON.stringify(idx)} at ${where} :: ${fnKey}`);
+        process.exit(1);
+      }
+      args.push({ index: idx, role: a.role });
+    }
+  }
+  const channel = [];
+  if (val.channel && typeof val.channel === 'object' && !Array.isArray(val.channel)) {
+    for (const [k, v] of Object.entries(val.channel)) {
+      if (typeof v === 'string') channel.push([k, v]);
+    }
+  }
+  if (args.length === 0 && channel.length === 0) return null;
+  const returns =
+    val.returns && typeof val.returns === 'object' && typeof val.returns.type === 'string'
+      ? val.returns.type
+      : null;
+  const dot = fnKey.lastIndexOf('.');
+  const bare = dot >= 0 ? fnKey.slice(dot + 1) : fnKey;
+  return { full: fnKey, bare, args, returns, channel };
+}
+
+/** Load one subdir → Map lib → { file, entries: Map full → entry }.
+ *  Later sorted file wins WHOLESALE per lib (EffectsLookup.load parity). */
+function loadSubdir(sub, reports) {
+  const dir = join(dbDir, sub);
+  const out = new Map();
+  if (!existsSync(dir)) return out;
+  const files = readdirSync(dir).filter((f) => f.endsWith('.yaml')).sort();
+  for (const f of files) {
+    const doc = yaml.load(readFileSync(join(dir, f), 'utf8'), { schema: yaml.FAILSAFE_SCHEMA });
+    if (!doc || typeof doc !== 'object' || Array.isArray(doc)) continue;
+    for (const [lib, fns] of Object.entries(doc)) {
+      if (!fns || typeof fns !== 'object' || Array.isArray(fns)) continue;
+      const entries = new Map();
+      for (const [fnKey, fnVal] of Object.entries(fns)) {
+        const e = parseEntry(fnKey, fnVal, `${sub}/${f}`);
+        if (e) entries.set(e.full, e);
+      }
+      if (out.has(lib)) {
+        reports.push(`lib collision in ${sub}/: "${lib}" redefined by ${f} (file ${out.get(lib).file}) — later file wins wholesale`);
+      }
+      if (entries.size > 0 || out.has(lib)) out.set(lib, { file: f, entries });
+    }
+  }
+  return out;
+}
+
+const reports = [];
+const runtimes = loadSubdir('runtimes', reports);
+const packages = loadSubdir('packages', reports);
+const db = new Map(packages);
+for (const [lib, rec] of runtimes) {
+  if (db.has(lib)) reports.push(`lib "${lib}" in BOTH runtimes/ and packages/ — runtimes wins (getEntry order)`);
+  db.set(lib, rec); // runtimes win
+}
+for (const r of reports) console.error('NOTE:', r);
+
+// Datalog string literals: keep facts escape-free (quote/backslash/newline
+// would need the parser's \"-escapes; nothing in the registry uses them).
+let rows = { method: [], arg: [], returns: [], channel: [] };
+const lit = (s) => {
+  if (s.includes('"') || s.includes('\\') || s.includes('\n')) {
+    console.error(`FATAL: value needs escaping in a .dl literal: ${JSON.stringify(s)}`);
+    process.exit(1);
+  }
+  return `"${s}"`;
+};
+for (const lib of [...db.keys()].sort()) {
+  const { entries } = db.get(lib);
+  for (const full of [...entries.keys()].sort()) {
+    const e = entries.get(full);
+    rows.method.push(`ecb_method(${lit(lib)}, ${lit(full)}, ${lit(e.bare)}).`);
+    for (const a of e.args) rows.arg.push(`ecb_arg(${lit(lib)}, ${lit(full)}, ${lit(a.index)}, ${lit(a.role)}).`);
+    if (e.returns) rows.returns.push(`ecb_returns(${lit(lib)}, ${lit(full)}, ${lit(e.returns)}).`);
+    for (const [k, v] of e.channel) rows.channel.push(`ecb_channel(${lit(lib)}, ${lit(full)}, ${lit(k)}, ${lit(v)}).`);
+  }
+}
+
+const lines = [];
+lines.push('% ── GENERATED ground facts — DO NOT EDIT BY HAND ──────────────────────────');
+lines.push('% Source: effects-db/{runtimes,packages}/*.yaml — the structured-entry');
+lines.push('% callable registry (args[N].role / returns.type / channel) that');
+lines.push('% libraryCallbackEnricher consumes via EffectsLookup.getEntry.');
+lines.push('% Generator: scripts/generate-effects-callable-facts.mjs (Wave 14); re-run');
+lines.push('% it and replace this file when the registry changes.');
+lines.push(`% ${rows.method.length} entries (${rows.arg.length} arg roles, ${rows.returns.length} returns, ${rows.channel.length} channel rows).`);
+lines.push('%');
+lines.push('% ecb_method(Lib, Full, Bare): one per role-or-channel-carrying entry;');
+lines.push('%   Lib = top-level YAML key VERBATIM, Bare = fn key after the last dot.');
+lines.push('% ecb_arg(Lib, Full, Idx, Role): role-annotated argument positions.');
+lines.push('% ecb_returns(Lib, Full, Type): declared returns.type of those entries.');
+lines.push('% ecb_channel(Lib, Full, Key, Spec): channel metadata rows (e.g. url -> arg[0]).');
+for (const k of ['method', 'arg', 'returns', 'channel']) lines.push(...rows[k]);
+console.log(lines.join('\n'));
+console.error(
+  `OK: ${rows.method.length} entries, ${rows.arg.length} arg roles, ` +
+    `${rows.returns.length} returns, ${rows.channel.length} channel rows, ${reports.length} collisions`,
+);

--- a/test/unit/httpRouteExtractor.test.js
+++ b/test/unit/httpRouteExtractor.test.js
@@ -2,7 +2,8 @@
  * Tests for httpRouteExtractor (REG-1115).
  *
  * Each test seeds a small synthetic graph that mirrors what the JS analyzer +
- * libraryCallbackEnricher would produce for one of:
+ * the `js_http_routes_nodes` / `js_http_routes_edges` DERIVE PACKS now produce
+ * for one of:
  *
  *   const app = express();
  *   app.get('/users', handler)
@@ -11,113 +12,57 @@
  *   app.use('/api', router)        // mountpoint — extractor returns null
  *   app.delete('/x/:id?', handler) // optional path param
  *
- * We run libraryCallbackEnricher first to produce the http:route FEATURE,
- * then invoke the extractor directly (bypassing the framework) and verify the
- * returned SpecedContractData. Going through the framework as well would be
- * redundant — the framework's own tests already cover dispatch.
+ * HISTORY: these tests used to materialise the `http:route` FEATURE by running
+ * `libraryCallbackEnricher`. As of Wave 14 (PR #397, feature-detection) the
+ * 6 HTTP frameworks (express/fastify/koa/koa-router/@koa/router/hono) were
+ * RETIRED from that enricher's LIBRARY_NODE_TYPE map — the default-on
+ * `js_http_routes_nodes`/`js_http_routes_edges` derive packs are now the sole
+ * producer of js `http:route` nodes. So the enricher seeding no longer mints a
+ * FEATURE and the extractor tests had nothing to consume.
  *
- * One smoke test loads each new HTTP-framework YAML cleanly via EffectsLookup
- * to guard against typos.
+ * `httpRouteExtractor` itself is NOT retired — it still transforms any
+ * `http:route` node → SpecedContractData at runtime regardless of who minted
+ * it. These tests now seed the `http:route` node + its anchor CALL DIRECTLY in
+ * the exact shape the derive pack emits (node `metadata.anchorCall` = the
+ * registration call id, `metadata.method` = the BARE HTTP method name, the
+ * route path as a quoted LITERAL at PASSES_ARGUMENT[index=0]). This exercises
+ * the REAL runtime input contract of the extractor — the same contract the
+ * pack's @materialize_node + ROUTES_TO output satisfies in production.
+ *
+ * One smoke test loads each HTTP-framework YAML cleanly via EffectsLookup to
+ * guard against typos — that path is independent of the enricher/pack split.
  */
 
-import { describe, it, before, after, beforeEach } from 'node:test';
+import { describe, it, after, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { join } from 'node:path';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
 
 import { EffectsLookup } from '@grafema/util';
-import { enrichLibraryCallbacks } from '@grafema/util/enrichers/libraryCallbackEnricher';
 import {
   httpRouteExtractor,
   parsePathParams,
 } from '@grafema/util/enrichers/extractors/httpRouteExtractor';
 import { createTestDatabase, cleanupAllTestDatabases } from '../helpers/TestRFDB.js';
 
-// ---------------------------------------------------------------------------
-// One effects-db with the express entries the enricher uses.
-// ---------------------------------------------------------------------------
-
-let effectsDbDir;
-let effectsLookup;
-
-before(() => {
-  effectsDbDir = mkdtempSync(join(tmpdir(), 'effectsdb-http-extr-'));
-  mkdirSync(join(effectsDbDir, 'packages'), { recursive: true });
-  mkdirSync(join(effectsDbDir, 'runtimes'), { recursive: true });
-  writeFileSync(
-    join(effectsDbDir, 'packages', 'express.yaml'),
-    [
-      'express:',
-      '  express:',
-      '    effects: [PURE]',
-      '    returns: { type: Application }',
-      '  Application.get:',
-      '    effects: [MUTATION]',
-      '    args:',
-      '      - index: 0',
-      '        role: ROUTE_PATH',
-      '      - index: 1',
-      '        role: ENTRY_POINT_CALLBACK',
-      '    returns: { type: Application }',
-      '  Application.post:',
-      '    effects: [MUTATION]',
-      '    args:',
-      '      - index: 0',
-      '        role: ROUTE_PATH',
-      '      - index: 1',
-      '        role: ENTRY_POINT_CALLBACK',
-      '    returns: { type: Application }',
-      '  Application.put:',
-      '    effects: [MUTATION]',
-      '    args:',
-      '      - index: 0',
-      '        role: ROUTE_PATH',
-      '      - index: 1',
-      '        role: ENTRY_POINT_CALLBACK',
-      '    returns: { type: Application }',
-      '  Application.delete:',
-      '    effects: [MUTATION]',
-      '    args:',
-      '      - index: 0',
-      '        role: ROUTE_PATH',
-      '      - index: 1',
-      '        role: ENTRY_POINT_CALLBACK',
-      '    returns: { type: Application }',
-      '  Application.use:',
-      '    effects: [MUTATION]',
-      '    args:',
-      '      - index: 0',
-      '        role: MOUNTPOINT',
-      '      - index: 1',
-      '        role: ENTRY_POINT_CALLBACK',
-      '    returns: { type: Application }',
-      '',
-    ].join('\n'),
-  );
-  effectsLookup = EffectsLookup.load(effectsDbDir);
-});
-
 after(async () => {
-  if (effectsDbDir) rmSync(effectsDbDir, { recursive: true, force: true });
   await cleanupAllTestDatabases();
 });
 
 // ---------------------------------------------------------------------------
-// Fixture builder. Seeds:
-//   - MODULE + SCOPE
-//   - IMPORT_BINDING(name='express', source='express')
-//   - CONSTANT(name='app') --ASSIGNED_FROM--> CALL(name='express', kind='new')
-//     (libraryCallbackEnricher's findImportSourceForName traces this back to
-//     the import binding via the constructor name)
-//   - CALL(name='<obj>.<method>', kind=method) with the route path literal
-//     at PASSES_ARGUMENT[index=0] and a handler FUNCTION at index=1.
+// Fixture builder. Seeds the shape the js_http_routes_* derive packs emit:
+//   - MODULE
+//   - CALL(name='app.<method>')                      ← the anchor registration
+//       --PASSES_ARGUMENT[index=0]--> LITERAL("'<path>'")   (ROUTE_PATH arg)
+//       --PASSES_ARGUMENT[index=1]--> FUNCTION(handler)     (ENTRY_POINT_CALLBACK)
+//   - http:route FEATURE node, with metadata:
+//       { anchorCall: <callId>, method: '<bare-method>', library: 'express' }
+//       --EXPOSES--> seeded from the registration CALL; --HANDLES--> handler.
 //
-// The receiver-tracing path in libraryCallbackEnricher needs an additional
-// piece: the IMPORT_BINDING for `express` so the enricher can resolve
-// `app.get(...)` back to the `express` library. We seed an IMPORT_BINDING
-// directly named `app` that points at express; libraryCallbackEnricher's
-// findImportSourceForName matches IMPORT_BINDING by name first.
+// The extractor reads ONLY metadata.anchorCall + metadata.method off the
+// http:route node, then walks PASSES_ARGUMENT[index=0] on the anchor CALL for
+// the path literal — so we seed exactly those. `method` is the BARE name
+// (e.g. 'get', 'use'), matching delta 5 of js_http_routes_nodes.dl (the pack
+// stores the bare verb; the legacy enricher stored 'Application.get').
 // ---------------------------------------------------------------------------
 
 let nodeCounter = 0;
@@ -125,29 +70,30 @@ function nextId(prefix) {
   return `t${++nodeCounter}::${prefix}`;
 }
 
-async function seedRoute(backend, file, method, path, { handlerArgIndex = 1, omitPathArg = false } = {}) {
+/**
+ * Seed an anchor registration CALL + its path/handler arguments, plus the
+ * `http:route` node the derive pack would mint for it. Returns the seeded ids.
+ *
+ * @param {object} backend  the TestDatabase backend
+ * @param {string} file     source file path
+ * @param {string} method   bare HTTP method (e.g. 'get', 'post', 'use')
+ * @param {string} path     route path literal (e.g. '/users/:id')
+ * @param {object} [opts]
+ * @param {number} [opts.handlerArgIndex=1]  index of the handler PASSES_ARGUMENT
+ * @param {boolean} [opts.omitPathArg=false] skip seeding the path literal arg
+ * @param {boolean} [opts.omitFeature=false] skip seeding the http:route node
+ * @param {boolean} [opts.omitAnchorMeta=false] mint the http:route node WITHOUT
+ *        anchorCall/method metadata (orphan FEATURE case)
+ */
+async function seedRoute(backend, file, method, path, {
+  handlerArgIndex = 1,
+  omitPathArg = false,
+  omitFeature = false,
+  omitAnchorMeta = false,
+} = {}) {
   const moduleId = nextId('module');
-  const scopeId = nextId('scope');
-  const ibId = nextId('ib');
   await backend.addNodes([
     { id: moduleId, type: 'MODULE', name: file, file, relativePath: file, contentHash: 'h1' },
-    { id: scopeId, type: 'SCOPE', name: 'global', file, scopeType: 'module' },
-    {
-      // Seed the receiver `app` directly as an import binding pointing at
-      // express. The actual JS analyzer would emit IMPORT_BINDING for `express`
-      // and a CONSTANT `app` with ASSIGNED_FROM -> CALL(express()); for unit
-      // tests we collapse this into a single IMPORT_BINDING named `app`.
-      id: ibId,
-      type: 'IMPORT_BINDING',
-      name: 'app',
-      file,
-      importedName: 'default',
-      source: 'express',
-    },
-  ]);
-  await backend.addEdges([
-    { src: moduleId, dst: scopeId, type: 'HAS_SCOPE' },
-    { src: scopeId, dst: ibId, type: 'DECLARES' },
   ]);
 
   const callId = nextId(`call-${method}`);
@@ -164,6 +110,9 @@ async function seedRoute(backend, file, method, path, { handlerArgIndex = 1, omi
     await backend.addNode({
       id: pathArgId,
       type: 'LITERAL',
+      // The pack reads the LITERAL `name` = RAW source text INCLUDING quotes
+      // (header: LITERAL name keeps raw source quoting, "'overview'"); the
+      // extractor strips matching quote pairs in readLiteralValue.
       name: `'${path}'`,
       file,
       value: `'${path}'`,
@@ -194,10 +143,37 @@ async function seedRoute(backend, file, method, path, { handlerArgIndex = 1, omi
     index: handlerArgIndex,
   });
 
-  return { callId, handlerId };
+  let featureId = null;
+  if (!omitFeature) {
+    featureId = nextId('http-route');
+    // Mint the http:route node in the pack's shape. The pack's
+    // @materialize_node stores meta(library, method, anchorCall) with `method`
+    // the BARE verb. We anchor on the same CALL id we seeded (the extractor
+    // does client.getNode(anchorCall) — a semantic-id round-trip that the
+    // shared test client resolves directly since we store nodes under that id).
+    const featureMeta = omitAnchorMeta
+      ? { library: 'express' }
+      : { library: 'express', method, anchorCall: callId };
+    await backend.addNode({
+      id: featureId,
+      type: 'http:route',
+      name: omitPathArg ? '<unnamed-http-route>' : path,
+      file,
+      ...featureMeta,
+    });
+    // EXPOSES (registration CALL -> http:route) + HANDLES (http:route -> handler)
+    // — the edge-pack vocabulary; seeded for fidelity though the extractor does
+    // not currently traverse them (it reaches the call via anchorCall metadata).
+    await backend.addEdges([
+      { src: callId, dst: featureId, type: 'EXPOSES' },
+      { src: featureId, dst: handlerId, type: 'HANDLES' },
+    ]);
+  }
+
+  return { callId, handlerId, featureId };
 }
 
-/** Look up the http:route FEATURE node (after enricher run). */
+/** Look up the http:route FEATURE node(s) currently in the graph. */
 async function getRouteFeatures(client) {
   const out = [];
   for await (const wn of client.queryNodes({ type: 'http:route' })) out.push(wn);
@@ -205,15 +181,10 @@ async function getRouteFeatures(client) {
 }
 
 /**
- * Run libraryCallbackEnricher to materialise the http:route FEATURE, then
- * invoke httpRouteExtractor on it. Returns { feature, data }.
+ * Fetch the (single) seeded http:route FEATURE and run the extractor on it.
+ * Returns { feature, data }.
  */
-async function runEnricherThenExtract(client) {
-  const r = await enrichLibraryCallbacks(client, effectsLookup);
-  assert.ok(
-    r.domainNodesCreated >= 1,
-    `libraryCallbackEnricher should have created http:route (got ${r.domainNodesCreated}, unresolved=${r.unresolvedCalls})`,
-  );
+async function extractSeededRoute(client) {
   const features = await getRouteFeatures(client);
   assert.ok(features.length >= 1, 'http:route FEATURE should exist');
   const data = await httpRouteExtractor.extract(client, features[0]);
@@ -280,7 +251,7 @@ describe('httpRouteExtractor', () => {
 
   it('GET /users with no path params yields 0 inputs and "GET /users" output', async () => {
     await seedRoute(backend, 'app.ts', 'get', '/users');
-    const { data } = await runEnricherThenExtract(client);
+    const { data } = await extractSeededRoute(client);
     assert.ok(data, 'extractor should not return null');
     assert.equal(data.source, 'http-route');
     assert.equal(data.inputs.length, 0);
@@ -291,7 +262,7 @@ describe('httpRouteExtractor', () => {
 
   it('POST /users/:id yields one input "id" and "POST /users/:id" output', async () => {
     await seedRoute(backend, 'app.ts', 'post', '/users/:id');
-    const { data } = await runEnricherThenExtract(client);
+    const { data } = await extractSeededRoute(client);
     assert.ok(data);
     assert.equal(data.inputs.length, 1);
     assert.equal(data.inputs[0].name, 'id');
@@ -302,7 +273,7 @@ describe('httpRouteExtractor', () => {
 
   it('PUT /orders/:orderId/items/:itemId yields two required inputs', async () => {
     await seedRoute(backend, 'app.ts', 'put', '/orders/:orderId/items/:itemId');
-    const { data } = await runEnricherThenExtract(client);
+    const { data } = await extractSeededRoute(client);
     assert.ok(data);
     assert.equal(data.inputs.length, 2);
     assert.equal(data.inputs[0].name, 'orderId');
@@ -313,26 +284,22 @@ describe('httpRouteExtractor', () => {
   });
 
   it("app.use('/api', router) is a mountpoint — extractor returns null", async () => {
-    // Mountpoint case: the libraryCallbackEnricher will still see args[1]
-    // (a router-handler) annotated as ENTRY_POINT_CALLBACK and produce a
-    // FEATURE; but the extractor must reject because metadata.method is
-    // `Application.use`.
+    // Mountpoint case: `use` carries an ENTRY_POINT_CALLBACK arg so the derive
+    // pack DOES mint an http:route node for it (it doesn't distinguish
+    // mountpoint registrations at mint time — `use` is simply not in hr_verb,
+    // so no ROUTES_TO is derived, but the node still exists). The extractor
+    // must reject it because the BARE metadata.method is `use`, which is in
+    // MOUNTPOINT_METHODS.
     await seedRoute(backend, 'app.ts', 'use', '/api');
-    const features = await getRouteFeatures(client);
-    // Run the enricher so the FEATURE is materialised:
-    const r = await enrichLibraryCallbacks(client, effectsLookup);
-    assert.equal(r.domainNodesCreated, 1, 'use() still produces a FEATURE');
     const feats = await getRouteFeatures(client);
-    assert.equal(feats.length, 1);
+    assert.equal(feats.length, 1, 'use() still produces a FEATURE node');
     const data = await httpRouteExtractor.extract(client, feats[0]);
     assert.equal(data, null, 'extractor must return null for mountpoint');
-    // Quiet linter — `features` baseline is captured for symmetry with other tests.
-    void features;
   });
 
   it('GET /static/*name captures named wildcard as optional input', async () => {
     await seedRoute(backend, 'app.ts', 'get', '/static/*name');
-    const { data } = await runEnricherThenExtract(client);
+    const { data } = await extractSeededRoute(client);
     assert.ok(data);
     assert.equal(data.inputs.length, 1);
     assert.equal(data.inputs[0].name, 'name');
@@ -341,7 +308,7 @@ describe('httpRouteExtractor', () => {
 
   it('DELETE /x/:id? produces optional path parameter', async () => {
     await seedRoute(backend, 'app.ts', 'delete', '/x/:id?');
-    const { data } = await runEnricherThenExtract(client);
+    const { data } = await extractSeededRoute(client);
     assert.ok(data);
     assert.equal(data.inputs.length, 1);
     assert.equal(data.inputs[0].name, 'id');
@@ -351,7 +318,7 @@ describe('httpRouteExtractor', () => {
 
   it('v2: top-level name = "<METHOD> <path>" and outputs carry kind="http"', async () => {
     await seedRoute(backend, 'app.ts', 'get', '/users/:id');
-    const { data } = await runEnricherThenExtract(client);
+    const { data } = await extractSeededRoute(client);
     assert.ok(data);
     assert.equal(data.name, 'GET /users/:id');
     assert.equal(data.outputs.length, 1);
@@ -361,8 +328,9 @@ describe('httpRouteExtractor', () => {
 
   it('returns null when the FEATURE has no anchorCall metadata', async () => {
     // Build a synthetic http:route FEATURE with no anchorCall metadata —
-    // simulating a future code path that produces FEATUREs without the
-    // libraryCallbackEnricher chain (e.g. user-authored fixture).
+    // simulating a producer (or a user-authored fixture) that emits a
+    // FEATURE without the pack's meta(anchorCall). The extractor cannot reach
+    // a registration call and must bail.
     const file = 'orphan.ts';
     await backend.addNodes([
       { id: 'orphan::module', type: 'MODULE', name: file, file, relativePath: file, contentHash: 'h1' },
@@ -380,20 +348,13 @@ describe('httpRouteExtractor', () => {
   });
 
   it('returns null when the path-literal arg is missing on the anchor call', async () => {
-    // Force anchorCall to exist but have no PASSES_ARGUMENT[index=0].
+    // The pack mints a node (name "<unnamed-http-route>") whenever the handler
+    // arg exists, even if the ROUTE_PATH literal is absent. The anchorCall
+    // resolves, but PASSES_ARGUMENT[index=0] yields no literal, so the
+    // extractor must return null.
     await seedRoute(backend, 'app.ts', 'get', '/never-read', { omitPathArg: true });
-    // The libraryCallbackEnricher requires the callback at args[1]; with no
-    // path literal at args[0], the FEATURE may still be created (the enricher
-    // looks up the callback target via its own PASSES_ARGUMENT walk). The
-    // extractor must then return null.
-    const r = await enrichLibraryCallbacks(client, effectsLookup);
-    if (r.domainNodesCreated === 0) {
-      // Acceptable outcome: enricher couldn't create the FEATURE without
-      // a recoverable handler binding. Nothing to extract.
-      return;
-    }
     const features = await getRouteFeatures(client);
-    if (features.length === 0) return;
+    assert.equal(features.length, 1, 'http:route FEATURE should still be minted');
     const data = await httpRouteExtractor.extract(client, features[0]);
     assert.equal(data, null);
   });


### PR DESCRIPTION
Unifies the 6 outstanding language-round PRs into one verified-together branch (they conflicted pairwise on the shared pack registries — union-of-list-append, resolved here with one coherent producer-before-consumer order).

## Supersedes / closes
- #393 type-inference (exit-1 fix + HAS_METHOD orphan + plugin-fail aborts)
- #395 j/k/g migration specs
- #397 feature-detection HTTP packs (effects-db facts + js_http_routes)
- #400 java 4 derive packs
- #401 kotlin inheritance (analyzer stamps + pack)
- #402 go 6 derive packs (+ first_segment builtin)

## Integration verification (all run TOGETHER on this branch)
- 35 packs, none dropped; both registries (orchestrator STDLIB_RULE_PACKS + derive STDLIB_PACKS) byte-identical in order
- producer-before-consumer order verified positionally (all import/calls/extends producers before depends + the negators)
- rfdb-server lib **1377/0** (debug+release), derive:: **292/0**, plan gate pass, cross-registry order pin pass
- Gate A **51/51**, orchestrator **478/0**
- JS unit **725/0** (the 7 stale httpRouteExtractor tests from #397 reseeded for the derive-pack era)

## The language-round finding (×3)
Each legacy resolver was half-dead in production from analyzer↔resolver vocabulary drift, masked by unit tests fed hand-crafted metadata; the spec+verdict each missed one analyzer reality (CLOSURE lambdas / sealed-class cascade / percent-encoded wire ids), caught only at the pack layer with live probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)