### PR TITLE
docs: haskell/beam/python resolver migration specs (verified, with verdicts)

### DIFF
--- a/_ai/research/lang-spec-beam.md
+++ b/_ai/research/lang-spec-beam.md
@@ -1,0 +1,260 @@
+# Migration spec: `beam-resolve` (BEAM / Elixir+Erlang resolvers) → derive (datalog2) packs
+
+Round: resolve-datalog2, lang = **beam**. Base: `origin/main` @ `6e609746` (verified `git merge-base HEAD origin/main`).
+Precedent followed: `_ai/research/resolve-datalog2-migration-specs.json` + `…-synthesis.md` §3 (differential harness) / §4 (missing-cap ranking) / §5.
+Builtin set verified live against `packages/rfdb-server/src/derive/builtin.rs` registry (HEAD): see §0.
+
+---
+
+## §0. Available builtin vocabulary (verified `builtin.rs:1188-1372` registry())
+
+Generators: `node/2` (=`type/2`), `edge/3`, `incoming/3`.
+Function/probe: `attr/3` ([B,B,F]/[B,B,B]/**[F,B,B]** generator), `edge_attr/5`, `node_attr/3` (top-level JSON scalar only; **NO** generator mode).
+Filters: `neq/2`, `gt/lt/gte/lte /2`, `starts_with/2`, `not_starts_with/2`, `string_contains/2`, `ends_with/2`.
+String fns: `concat/3`, `str_lower/2`, `basename/2`, `strip_quotes/2`, `strip_prefix/3`, `strip_suffix/3`, `last_segment/3`, `replace_all/4`, `path_resolve/3`, `method_suffix/2`.
+
+`node_attr/3` (`builtin.rs:1093-1115`) reads ONLY a **top-level** JSON String/Number/Bool field; a non-scalar value (list/object/null) or absent key ⇒ NO row. This is load-bearing for beam (see §5).
+
+---
+
+## §1. Resolver inventory (read `packages/beam-resolve/src/` FULLY)
+
+`Main.hs` dispatches **9** commands (lines 88-98). Source-of-truth file:line per step below.
+
+| # | command | module | edge(s) emitted | node(s) minted | legacy `resolvedVia`/`source` |
+|---|---|---|---|---|---|
+| 1 | `beam-imports` | `BeamImportResolution.hs` | `IMPORTS_FROM` | — | (none stamped) |
+| 2 | `beam-local-refs` | `BeamLocalRefs.hs` | `CALLS` (3 arms) | `EXTERNAL_FUNCTION` `BEAM_GLOBAL::<fn>` | `beam-local-refs` |
+| 3 | `beam-protocols` | `BeamProtocolResolution.hs` | `IMPLEMENTS` | — | `beam-protocols` |
+| 4 | `beam-behaviours` | `BeamBehaviourResolution.hs` | `IMPLEMENTS` | `MODULE` `BEAM_GLOBAL::Module::<n>` | `beam-behaviours` |
+| 5 | `beam-runtime-globals` | `BeamRuntimeGlobals.hs` | `CALLS` | `GLOBAL_DEFINITION` | (effects-db driven) |
+| 6 | `beam-wrapper-resolve` | `BeamWrapperResolution.hs` | `SENDS_TO`/`SUBSCRIBES_TO`/`BROADCASTS_TO` | synthetic `PUBSUB_TOPIC` | (via meta only) |
+| 7 | `beam-message-types` | `BeamMessageTypeResolution.hs` | `SENDS_MESSAGE`/`SELF_SCHEDULE` | — | `beam-message-type-resolution` |
+| 8 | `beam-pubsub-delivery` | `BeamPubsubDelivery.hs` | `PUBLISHES` | — | `beam-pubsub-delivery` |
+| 9 | `beam-message-findings` | `BeamMessageFindings.hs` | `CONTAINS` | `ISSUE` (6 finding kinds) | (finding_kind meta) |
+
+Shared helper `BeamShape.hs` — structural `parseShape`/`unify` over a nested-list shape tree; used by #7, #8, #9.
+
+### Per-step detail
+
+**#1 imports** (`BeamImportResolution.hs:39-88`): index MODULE by `gnName`; for each `IMPORT` node, candidates = `[name, dropWhile (==':') name]` (Erlang `:lists` → `lists`); first match → `IMPORTS_FROM` IMPORT→MODULE. External (unmatched) skipped.
+
+**#2 local-refs** (`BeamLocalRefs.hs:209-362`): for each `CALL`, resolution order:
+  1. exact same-file `(file, name)` against FUNCTION decl index (BEAM `name` includes arity `foo/2`).
+  2. same-file `(file, baseName)` (baseName = `foo/2`→`foo`).
+  3. if `baseName` is qualified (has `.`): split on **last** dot → `(modAlias, funcName)`; `lookupQualified` tries `(fullMod,func,arity)` then `(fullMod,func)`, then **module-suffix** index (alias `Accounts` → `MyApp.Accounts`); arity from `metadata.arity`.
+  4. else if `baseName ∈ beamBuiltins` (hardcoded ~50-set, lines 191-207) → mint `EXTERNAL_FUNCTION` `BEAM_GLOBAL::<base>` + `CALLS`.
+
+**#3 protocols** (`BeamProtocolResolution.hs:37-67`): MODULE with `metadata.protocol` (a defimpl) → look up the protocol MODULE by that name → `IMPLEMENTS` impl→protocol.
+
+**#4 behaviours** (`BeamBehaviourResolution.hs:54-141`): `IMPORT` with `metadata.kind ∈ {behaviour, use}`. Owner MODULE found by **file** (`byFile` index, the IMPORT's file). Target = MODULE named `gnName import` if present, else mint virtual `MODULE` `BEAM_GLOBAL::Module::<name>` (dedup via seen-set). Edge `IMPLEMENTS` owner→target.
+
+**#5 runtime-globals** (`BeamRuntimeGlobals.hs` + shared `Grafema.RuntimeGlobals`): TWO strategies (Elixir prefix `BEAM_GLOBAL::`, Erlang `ERLANG_BIF::`), both separator `.`, filter = CALLs not already locally resolved; all dot-suffixes of the call name tried against effects-db YAML symbol DB; on match mint `GLOBAL_DEFINITION` + `CALLS` carrying effect metadata. **Reads external YAML (effects-db).**
+
+**#6 wrapper-resolve** (`BeamWrapperResolution.hs:356-521`): re-runs #2's CALL→FUNCTION resolution; keeps callers of FUNCTIONs carrying a `wraps` **MetaMap** sub-object `{kind,target,target_hint,message_shape,topic}`. Per `kind`: call/cast/send/send_after → `SENDS_TO` to a PROCESS (resolved by file for `module_self`, by module-name index for `literal` hint); sub → `SUBSCRIBES_TO` caller-MODULE→PUBSUB_TOPIC; broadcast → `BROADCASTS_TO` CALL→PUBSUB_TOPIC. Topic resolved from `wraps.topic`, falling back to file-local topic or a **synthetic** `PUBSUB_TOPIC` node. `target=var` → skip.
+
+**#7 message-types** (`BeamMessageTypeResolution.hs:171-227`): direct send-sites = CALL nodes carrying `sender_via`/`sender_base`/`message_shape`/`target_is_self`/`target_hint`; plus wrapper-sites from #6. Candidate MESSAGE_TYPEs = same file (self) or PROCESS's file (by `target_hint` name). Keep those with `handler_type == sender_via` AND **`unify(sentShape, pattern_shape)`**. Edge = `SELF_SCHEDULE` (send_after+self) else `SENDS_MESSAGE`. May emit MANY edges per CALL (non-determinism).
+
+**#8 pubsub-delivery** (`BeamPubsubDelivery.hs:149-253`): broadcast CALLs (`pubsub_op=broadcast`, `pubsub_topic`, `pubsub_server`, `message_shape`) + wrapper-broadcasts. Subscribers indexed by `(server,topic)` (from `pubsub_op=subscribe` CALLs + sub-wrappers under sentinel `<wrapper>` server). For each broadcast, candidate `handle_info` MESSAGE_TYPEs in each subscriber file with `unify(shape, pattern_shape)` → `PUBLISHES` CALL→MESSAGE_TYPE.
+
+**#9 message-findings** (`BeamMessageFindings.hs`): a **diagnostics** pass — emits `ISSUE` nodes (+`CONTAINS`) for six finding kinds (silent handler, unreachable handler, heterogeneous key type, etc.) using `unify` and `topLevelMapKV` shape recursion. NOT a resolution step; out of Datalog scope entirely (parallels the JS message-findings exclusion).
+
+---
+
+## §2. Draft `.dl` rules (TODAY's builtins). Migratable steps only.
+
+Conventions: `M#<file>` = orchestrator's MODULE# kernel facts if available; here drafted directly on stored graph shapes verified in §4. Each pack is provenance-scoped (`@materialize`).
+
+### Pack `beam_imports` (#1) — FULLY EXPRESSIBLE
+
+```prolog
+% Exact-name match: IMPORT.name == MODULE.name → IMPORTS_FROM.
+beam_import(I, Mod) :-
+    node(I, "IMPORT"),
+    attr(I, "name", N),
+    node(Mod, "MODULE"),
+    attr(Mod, "name", N).
+
+% Erlang colon-stripped form: IMPORT name ":lists" → MODULE "lists".
+beam_import(I, Mod) :-
+    node(I, "IMPORT"),
+    attr(I, "name", N),
+    strip_prefix(N, ":", Bare),          % no row if no leading ':'
+    node(Mod, "MODULE"),
+    attr(Mod, "name", Bare).
+
+@materialize edge IMPORTS_FROM(I, Mod) :- beam_import(I, Mod).
+```
+Delta vs legacy: legacy `firstMatch` prefers exact over colon-stripped (Map last-wins → ONE edge); set-union here emits BOTH if a `:lists` IMPORT AND a literal `lists` MODULE both exist — extremely rare. → **SUPERSET (bounded: imports whose `:`-stripped form ALSO equals a distinct MODULE name; expect 0 in practice).**
+
+### Pack `beam_local_refs` (#2) — arms 1, 2 EXPRESSIBLE; arms 3, 4 PARTIAL
+
+```prolog
+% Arm 1: exact same-file (file, name-with-arity).
+beam_call(C, F) :-
+    node(C, "CALL"), attr(C, "file", File), attr(C, "name", Nm),
+    node(F, "FUNCTION"), attr(F, "file", File), attr(F, "name", Nm).
+
+% Arm 2: same-file base-name (CALL "foo" vs FUNCTION "foo/2").
+beam_call(C, F) :-
+    node(C, "CALL"), attr(C, "file", File), attr(C, "name", Base),
+    node(F, "FUNCTION"), attr(F, "file", File),
+    strip_suffix_anyarity(F, Base).      % see note — needs arity-strip on FUNCTION name
+
+@materialize edge CALLS(C, F) :- beam_call(C, F).
+```
+Arm 2 needs FUNCTION `"foo/2"` → base `"foo"`: `attr(F,"name",FN), last_segment` won't help (separator is `/` but we want PREFIX before `/`). There is **no `prefix_before_sep` / `first_segment` builtin** — `last_segment` returns the tail, `basename` is hardwired `/` and returns the TAIL `2`. To get `foo` from `foo/2` need `strip_suffix(FN, "/<arity>", base)` but arity is unbound. **Workaround:** join CALL.name (no arity) directly and require FUNCTION name `concat(Base,"/",AritySfx)` — but AritySfx (`/2`) is a free unbound tail, and `concat` needs all inputs bound. **Missing builtin: `first_segment(S, Sep, Head)` (the prefix-before-first-sep twin of `last_segment`).** Until then arm 2 is NOT expressible. Arm 1 is exact and fine.
+
+Arm 3 (qualified cross-file, module-suffix alias): split last `.`, suffix-fanout over all module names. `last_segment(CallName, ".", Func)` gives the func part; the module-alias part needs `strip_suffix(CallName, concat(".",Func), ModAlias)` (the prefix) — same first-segment gap. And the **suffix-index** ("Accounts" matches "MyApp.Accounts") is a per-module dot-suffix enumeration with no fact form (parallels JS star-re-export: "no fact-enumeration workaround exists"). → **NOT expressible without (a) first-segment builtin AND (b) a MODULE-suffix fact or `ends_with`-join.** `ends_with(ModName, ModAlias)` exists and could approximate the suffix join, but legacy requires alias to be a **dot-aligned** suffix (`Accounts` of `MyApp.Accounts`, not `ccounts`) — `ends_with` would over-match. PARTIAL/deferred.
+
+Arm 4 (beamBuiltins → mint EXTERNAL_FUNCTION): the ~50-name set is hardcoded Haskell. Needs an **external-data-as-facts** beam-builtin fact pack (parallels JS builtins pack `js_builtins_nodes`). Two-pack node-then-edge split (like `axum_routes.dl`). Expressible ONCE the fact pack exists.
+
+### Pack `beam_protocols` (#3) — EXPRESSIBLE (gated on `node_attr` for top-level scalar `protocol`)
+
+```prolog
+beam_impl(Impl, Proto) :-
+    node(Impl, "MODULE"),
+    node_attr(Impl, "protocol", PName),   % top-level scalar string — OK
+    node(Proto, "MODULE"),
+    attr(Proto, "name", PName).
+@materialize edge IMPLEMENTS(Impl, Proto) :- beam_impl(Impl, Proto).
+```
+`protocol` is a top-level string field (analyzer `modules.ex:87`, fixture `Spec.hs:400`). **FULLY EXPRESSIBLE.** Delta vs legacy: EXACT (legacy is a single Map lookup; set semantics identical since protocol-name→MODULE is unique).
+
+### Pack `beam_behaviours` (#4) — PARTIAL
+
+```prolog
+% Owner MODULE of the @behaviour/use IMPORT, by FILE.
+beam_behaviour_real(Owner, Target) :-
+    node(I, "IMPORT"), node_attr(I, "kind", K),
+    behaviour_kind(K),                     % K == "behaviour" OR "use"
+    attr(I, "file", File), attr(I, "name", BName),
+    node(Owner, "MODULE"), attr(Owner, "file", File),
+    node(Target, "MODULE"), attr(Target, "name", BName).
+@materialize edge IMPLEMENTS(Owner, Target) :- beam_behaviour_real(Owner, Target).
+```
+`behaviour_kind` needs a 2-value OR → two rule bodies (one per literal). Real-target arm EXPRESSIBLE. The **virtual `BEAM_GLOBAL::Module::<name>` mint** for stdlib behaviours (GenServer etc.) needs a node-minting pack with a deterministic id; the seen-set dedup maps to `@materialize_node` natural dedup. Expressible as a second pack but: the synthetic id is `"BEAM_GLOBAL::Module::"<>name` — `concat("BEAM_GLOBAL::Module::", BName, Id)` works. → real arm EXACT; virtual arm SUPERSET-shaped node mint, **expressible with concat + @materialize_node**, but ordering (node-before-edge) needs the two-pack split. PARTIAL-now / fully-doable.
+
+### Pack `beam_runtime_globals` (#5) — NOT expressible now
+
+Driven by **external effects-db YAML** + dot-suffix matching + effect-metadata copy. Needs the effects-db-YAML-facts-pack generator (synthesis §4 item 3, unbuilt) and the "filter CALLs already locally resolved" negation (stratified `!beam_call`). Deferred to the globals wave (parallels JS/Rust runtime-globals which stayed NATIVE per the ledger).
+
+### Packs #6, #7, #8 — NOT expressible (shape unification)
+
+All three depend on `BeamShape.unify` — structural recursion over a nested-list shape tree (`tuple`/`list`/`cons`/`map`/`struct`, arbitrary depth, key-intersection compatibility). Datalog2 has no recursion-over-data-structure, and `message_shape`/`pattern_shape`/`wraps` are stored as **non-scalar `MetaList`/`MetaMap`** which `node_attr` cannot even read (it returns NO row on non-scalar; §0, §5). Hard product limitation. Plus #6 re-runs the whole #2 call-resolution (inherits its gaps).
+
+### Pack #9 — out of scope (diagnostics, ISSUE emission via shape recursion).
+
+---
+
+## §3. Predicted deltas (per migratable pack, classes per synthesis §3.4)
+
+| pack | class | bound |
+|---|---|---|
+| `beam_imports` | **SUPERSET** | extra = #IMPORTs whose `:`-stripped name == a *distinct* MODULE; predicted **0** on real corpora |
+| `beam_local_refs` arm1 (exact) | **EXACT** | modulo multi-decl same (file,name/arity) — beam name+arity is unique ⇒ 0 |
+| `beam_local_refs` arm2/3/4 | **SUBSET (deferred)** | missing = all base-name + qualified-alias + builtin CALLS until first-segment builtin + suffix-facts + builtin-facts land |
+| `beam_protocols` | **EXACT** | 0 (unique protocol→MODULE) |
+| `beam_behaviours` real arm | **EXACT** | 0 |
+| `beam_behaviours` virtual arm | **SUPERSET** | set-union vs seen-set Map = identical after @materialize_node dedup ⇒ 0; ordering caveat |
+| `beam_runtime_globals` | deferred | n/a |
+| #6/#7/#8 | NOT MIGRATABLE | product limitation |
+
+No live differential possible this round: dogfood graph has **zero** beam nodes (§4). Deltas are predicted from source, to be measured on a beam fixture corpus in the executing wave.
+
+---
+
+## §4. Analyzer-shape spot-verification (THE ROUND'S LESSON)
+
+Every shape the draft rules assume, checked against analyzer source AND (where possible) live probe.
+
+| assumed shape | evidence | verified? |
+|---|---|---|
+| `node(M,"MODULE")` exists | live probe `findByType MODULE` non-empty (491535-node dogfood) | ✅ live |
+| `node(I,"IMPORT")` exists | live probe non-empty | ✅ live |
+| `node(F,"FUNCTION")`, `node(C,"CALL")` exist | live probe non-empty | ✅ live |
+| `PROCESS`/`MESSAGE_TYPE`/`PUBSUB_TOPIC` exist | live probe **EMPTY (0)** — beam-only, no Elixir in dogfood | ⚠ **NOT live-verifiable**; grounded on analyzer src + `Spec.hs` fixtures only |
+| FUNCTION name = `"foo/2"` (arity in name) | `semantic_id.ex:9` `name/arity`; `BeamLocalRefs.hs:33` comment; fixture | ✅ src |
+| CALL name = **no arity**; arity in `metadata.arity` (int) | `calls.ex:171,179` `name: name … metadata: %{arity: arity}`; `BeamLocalRefs.hs:185-188 callArity` | ✅ src |
+| FUNCTION sid carries `[in:Module]` | `semantic_id.ex:9`; URI form `%5Bin:%5D` per `BeamLocalRefs.hs:143-167` | ✅ src — **⚠ orchestrator MODULE# bug risk (see note)** |
+| MODULE defimpl has top-level scalar `protocol` + `for_type` | `modules.ex:86-88`; fixture `Spec.hs:399-401` | ✅ src+fixture |
+| IMPORT `metadata.kind ∈ {alias,import,use,behaviour}` (top-level string) | `imports.ex:7,15,62,85,112,133` | ✅ src |
+| `wraps` is a nested `MetaMap`; `message_shape`/`pattern_shape` nested `MetaList` | `BeamWrapperResolution.hs:88 MetaMap`; `BeamShape.hs:55-67`; fixture `Spec.hs:420,454,671` | ✅ src+fixture — **NOT scalar ⇒ `node_attr` returns NO row** |
+| send-site meta `sender_via/sender_base/target_is_self/target_hint` top-level scalars | `BeamMessageTypeResolution.hs:95-99`; fixture `Spec.hs:908-910` | ✅ src+fixture |
+| `pubsub_op/pubsub_topic/pubsub_server` top-level scalars | `BeamPubsubDelivery.hs:77-98` | ✅ src |
+
+**Unverified-shape flags (live):** PROCESS, MESSAGE_TYPE, PUBSUB_TOPIC node presence and their metadata layout are grounded only on source + test fixtures — there is no Elixir/Erlang code in the dogfood graph to probe. The executing wave MUST run the differential on a beam corpus (e.g. the `kami`/`ichi` Elixir project the comments reference) before trusting #2-arm3/#7/#8 verdicts.
+
+**Note — orchestrator MODULE# parser bug (carried from synthesis):** the resolvers recover the owning module from the `[in:Module]` marker in the FUNCTION **semantic id** (`extractModuleFromId`), reading the sid out of metadata in production (gnId is a u128 hash). Any pack arm needing module-ownership (#2 arm3) must read the sid, not gnId — and the known orchestrator MODULE#-sid parser that "drops Haskell deps" (MEMORY) may similarly mishandle the beam `[in:]`/`%5Bin:%5D` URI form. Flag for the executing wave.
+
+---
+
+## §5. Missing capabilities (ranked, beam-specific, on top of synthesis §4)
+
+1. **`first_segment(S, Sep, Head)`** — the prefix-before-FIRST-separator twin of `last_segment`. Blocks `beam_local_refs` arm 2 (`"foo/2"`→`"foo"`) and arm 3's module-alias extraction (`"Accounts.list"`→`"Accounts"`). Highest leverage: arm 2 is the bulk of beam CALLS. (Same eval discipline as `last_segment`; ~15 LOC.)
+2. **Dot-aligned suffix join for module aliases** — legacy "alias `Accounts` resolves to `MyApp.Accounts`" needs a MODULE dot-suffix **fact** (each suffix → full name) OR a builtin `is_dot_suffix(Alias, Full)` (= `ends_with` AND the char before the match is `.` or the alias is the whole name). `ends_with/2` alone over-matches (`ccounts`). Blocks arm 3.
+3. **Shape-tree unification as data** — `BeamShape.unify` is structural recursion over nested `MetaList`/`MetaMap`. No Datalog2 construct expresses it; `node_attr` cannot even read non-scalar metadata. **Hard product limitation** — gates #6/#7/#8 (the message-flow precise edges). Either keep these NATIVE (recommended, mirroring JS/Rust runtime-globals staying native) or pre-flatten the shape into a canonical scalar key in the analyzer + emit shape-bucket facts (large design, own effort).
+4. **effects-db-YAML facts-pack generator** (synthesis §4 item 3, already ranked) — gates #5 beam-runtime-globals.
+5. **stratified negation `!beam_call(C,_)`** — #5 filters CALLs already locally resolved; needs the local-refs pack's output as a stratum input (datalog2 has stratified negation; wiring it cross-pack is the work).
+6. **beam-builtin name facts** (the ~50 Kernel/BIF set, `BeamLocalRefs.hs:191-207`) — external-data-as-facts; gates arm 4. Low effort (a generated fact pack).
+
+---
+
+## §6. Honesty section
+
+- **No live differential this round.** Dogfood graph (`/Users/vadimr/grafema/.grafema/graph.rfdb`, loaded 491535 nodes via `/tmp/beam-probe.rfdb` copy + own server on `/tmp/beam-probe.sock`) has **0** PROCESS / MESSAGE_TYPE / PUBSUB_TOPIC nodes — no BEAM source in the monorepo. MODULE/IMPORT/FUNCTION/CALL exist but are TS/Rust/Haskell, NOT beam-shaped (no `[in:]` arity names, no `protocol` metadata). So every beam-specific verdict is **source-grounded, not graph-grounded**. Probe server cleaned up after.
+- **Only 3 of 9 steps are cleanly migratable now**: `beam_imports` (full), `beam_protocols` (full, needs `node_attr` which EXISTS), `beam_local_refs` arm 1 (exact same-file+arity). `beam_behaviours` real-arm is doable; its virtual mint needs a 2-pack split. That is the honest "expressible now" set.
+- **The shape-unification trio (#6/#7/#8) is a genuine product limitation**, not a builtin gap — the same way JS/Rust runtime-globals were left native. Do NOT pretend a `node_attr` patch unblocks them; it does not (non-scalar metadata).
+- **The round's lesson held twice here:** (1) the protocol resolver's `protocol`/`for_type` are top-level scalars on the *impl* MODULE (verified `modules.ex:86`), readable by `node_attr` — but `wraps`/`message_shape` are NOT scalars, a distinction invisible from the resolver's `Map.lookup` alone and only caught by reading the analyzer + `BeamShape`. (2) CALL `name` carries NO arity (arity is metadata), so any arm matching `(file,name)` against FUNCTION `foo/2` must base-name-strip — the missing `first_segment` builtin, surfaced only by reading `calls.ex:179` + `semantic_id.ex:9` together.
+- Unverified-against-live-graph shapes are flagged ⚠ in §4 and MUST be re-checked on a beam corpus before the executing wave records pass/fail.
+
+---
+
+## ADVERSARIAL VERDICT (independent review, 2026-06-13)
+
+Reviewer re-read all 9 `beam-resolve/src/` modules, the analyzer emission
+(`beam-analyzer/lib/beam_analyzer/rules/{calls,modules,functions,infrastructure,pubsub}.ex`,
+`semantic_id.ex`), the live `derive/builtin.rs` registry + mode tables, and the synthesis.
+No live beam nodes exist in the dogfood graph (confirmed: PROCESS/MESSAGE_TYPE/PUBSUB_TOPIC = 0),
+so beam-specific shapes are SOURCE-grounded; all general builtins were live-checked.
+
+### CONFIRMED by independent evidence
+- FUNCTION `name: "#{name}/#{arity}"` (functions.ex:31, semantic_id.ex:9) — arity IS in the name.
+  CALL `name: name, metadata: %{arity: arity}` (calls.ex:170,179) — arity NOT in CALL name.
+  => the `first_segment` gap for arm 2 (`"foo/2"`→`"foo"`) is REAL: `last_segment(name,"/",X)` would
+  bind the ARITY `"2"`, not `"foo"`; no prefix-before-first-sep builtin exists (registry verified).
+  This catch is correct and well-grounded.
+- `wraps: refined` is a MAP and `message_shape = shape_to_meta(...)` is a nested shape
+  (functions.ex:100, infrastructure.ex:253-261). `node_attr` returns NO row on non-scalar
+  (builtin.rs:1093-1115, verified). => the #6/#7/#8 "hard product limitation" is correct.
+- `protocol`/`for_type` are top-level scalars on the impl MODULE (modules.ex:86-89); the resolver
+  filters `Map.member "protocol"` then looks up `metadata.protocol` → MODULE by name
+  (BeamProtocolResolution.hs:44-58). The `beam_protocols` pack is faithful.
+- Import colon-strip: resolver uses `T.dropWhile (== ':')` (BeamImportResolution.hs:19) +
+  `firstMatch` over `[name, stripped]` taking the FIRST — the spec's two-arm set-union SUPERSET
+  classification is correct.
+
+### MINOR CORRECTIONS (do not change the verdict, tighten it)
+1. `beam_protocols` and `beam_behaviours` real-arm: legacy stamps `meta(resolvedVia, kind)`
+   (BeamProtocolResolution.hs:62-64). The draft `@materialize edge IMPLEMENTS(...)` omits the meta.
+   For clean per-step differential SLICING (the synthesis §3 partition is by `resolvedVia`), the
+   packs MUST carry `meta(resolvedVia="beam-protocols")` / `meta(resolvedVia="beam-behaviours")`,
+   else the IMPLEMENTS slice cannot be isolated from any other IMPLEMENTS producer. Add the meta.
+2. Import colon-strip nuance: `strip_prefix(N, ":", Bare)` strips exactly ONE colon; the resolver's
+   `dropWhile (==':')` strips a run. Equivalent for the normal `:lists` single-colon case; a `::x`
+   form (rare) would diverge. Note as an additional (negligible) SUPERSET edge case.
+3. `beam_local_refs` arm 1 EXACT claim: the resolver `declIdx = Map.fromList` is last-wins ONE id
+   per (file, name-with-arity). Since beam FUNCTION name INCLUDES arity, (file,name/arity) collisions
+   are genuinely ~0, so arm-1 EXACT survives — but state the bound as "modulo duplicate (file,
+   name/arity)" explicitly, matching the haskell finding's discipline.
+
+### CONFIRMED GAPS (spec's missing-capability ranking is sound)
+`first_segment` (#1, highest leverage), dot-aligned suffix join (#2), shape-unification as data
+(#3, hard limit), effects-db-YAML facts pack (#4), cross-pack stratified negation (#5), beam-builtin
+name facts (#6) — all independently verified against source. The ranking is correct.
+
+### READY FOR PACKS: **PARTIAL — as the spec itself states.** 3 steps migratable now
+(`beam_imports` full, `beam_protocols` full, `beam_local_refs` arm 1) + `beam_behaviours` real-arm,
+ONCE the provenance `meta()` stamps (correction #1) are added so the differential can slice. The
+#6/#7/#8 trio is a genuine product limitation, correctly excluded. This is the most rigorous of the
+three specs; only the missing `meta()` stamps are a real (small) blocker for a clean differential.

--- a/_ai/research/lang-spec-haskell.md
+++ b/_ai/research/lang-spec-haskell.md
@@ -1,0 +1,437 @@
+# lang-spec: haskell resolver → derive packs
+
+Migration spec for `packages/haskell-resolve/` (binary `haskell-resolve`, daemon + 5 CLI
+subcommands) → in-engine `derive` (Datalog v2) packs. Same format as
+`_ai/research/resolve-datalog2-migration-specs.json` (js/rust precedent).
+
+Grounded on: resolver source (READ fully), analyzer emission source
+(`packages/haskell-analyzer/src/Rules/{Imports,Exports,Expressions}.hs`,
+`Grafema/SemanticId.hs`), and LIVE probes on the dogfood graph
+(`.grafema/graph.rfdb`, 491,535 nodes, Jun-11 snapshot, HEAD Jun-13 — 2 days stale but
+adequate for SHAPE/presence verification; flagged where freshness matters).
+
+Builtin registry verified at `packages/rfdb-server/src/derive/builtin.rs` HEAD: `node`,
+`edge`, `incoming`, `attr` ([B,B,F]/[B,B,B]/[F,B,B]), `neq`, `gt/lt/gte/lte`,
+`starts_with`, `not_starts_with`, `string_contains`, `ends_with`, `method_suffix`,
+`concat`, `str_lower`, `basename`, `strip_quotes`, `strip_prefix`, `strip_suffix`,
+`last_segment`, `replace_all`, `path_resolve`, `edge_attr`, **`node_attr` (B,B,F / B,B,B —
+NO generator mode)**. The dominant unblock that the js spec lacked (`node_attr`) EXISTS now.
+
+---
+
+## HEADLINE
+
+The Haskell resolver is **structurally simpler than JS** and **almost fully expressible
+TODAY**, because:
+
+1. **Module resolution is by NAME, not path.** Haskell `import Data.Map.Strict` resolves to
+   the MODULE node whose `name == "Data.Map.Strict"` — a plain attr join. NO `path_resolve`
+   kernel, NO extension-swap ladder, NO workspace-package facts. (The js spec's #2 missing
+   capability is irrelevant here.)
+2. **No metadata-only blockers on the hot paths.** The module name a binding came from is
+   **graph-reachable** via `IMPORT -CONTAINS-> IMPORT_BINDING` + `IMPORT.name` (verified
+   100% coverage: all 2498 .hs IMPORT_BINDINGs have the CONTAINS parent). NO sid `[in:...]`
+   parsing needed, NO `node_attr` needed for the import/call chain.
+3. **No aliasing on the export side.** Haskell `EXPORT_BINDING.name` IS the exported name
+   first-class; there is no `import {x as y}` / `export {x as y}` alias surface and no
+   re-export-source metadata on EXPORT_BINDING (verified: 0 EXPORTS edges in .hs, 0 EXPORT
+   nodes in .hs). Resolution is pure name-matching against the target file's decl index.
+
+The only genuine SUBSET debt is the `haskell-globals` (effects-db SymbolDB) step, which is
+EXTERNAL YAML data and is kept out of the wave-1 packs (same recommendation the js spec made
+for runtime-globals). `haskell-local-refs`' Prelude-name table is finite and ships as ground
+facts (the `js_local_refs` rt_global precedent).
+
+---
+
+## INVENTORY — the 5 resolver commands (Main.hs:83-87)
+
+| cmd | module | reads | writes | expressible |
+|---|---|---|---|---|
+| `haskell-imports` | HaskellImportResolution | IMPORT, IMPORT_BINDING, MODULE, EXPORT_BINDING + decls | IMPORTS_FROM (IMPORT→MODULE, IMPORT_BINDING→decl) | **fully** |
+| `haskell-local-refs` | HaskellLocalRefs | REFERENCE, 8 decl types, IMPORT_BINDING skip-set, Prelude table | READS_FROM (+virtual EXTERNAL_FUNCTION for Prelude) | **fully** (2-pack split for the virtual node) |
+| `haskell-local-calls` | HaskellLocalCalls | CALL, 6 callable types, IMPORT_BINDING skip-set | CALLS (same-file) | **fully** |
+| `haskell-cross-module-calls` | HaskellCrossModuleCalls | CALL, IMPORT_BINDING(+module via CONTAINS), MODULE, decls | CALLS (cross-module) | **fully** |
+| `haskell-globals` | Grafema.RuntimeGlobals | CALL unresolved, effects-db SymbolDB (EXTERNAL YAML) | CALLS→GLOBAL_DEFINITION | **no** (external data; wave-2, kept out) |
+
+---
+
+## ANALYZER EMISSION — verified shapes (spot-verified, the round's lesson)
+
+| shape | claim | evidence |
+|---|---|---|
+| IMPORT.name | full dotted module name `"Data.Map.Strict"` | Imports.hs:53 `modName`; live: IMPORT name="Data.Map.Strict" in HaskellLocalRefs.hs |
+| IMPORT meta | `alias`, `qualified`, `hiding` (node_attr-readable) | Imports.hs:71-74; live: `"alias":"T","qualified":true` |
+| IMPORT_BINDING sid | `file->IMPORT_BINDING->name[in:ModuleName]` (parent=module) | Imports.hs:144 `semanticId file "IMPORT_BINDING" name (Just importName)`; SemanticId.hs:26 `[in:p]` |
+| IMPORT→IMPORT_BINDING | CONTAINS edge, 100% | Imports.hs:160-165; **live probe: 2498/2498 have CONTAINS parent IMPORT** |
+| IMPORT_BINDING.name | local name, no metadata | Imports.hs:145-156 `gnMetadata = Map.empty` |
+| MODULE.name | dotted module name, MODULE#file id | SemanticId.hs:42 + Walker; **live: MODULE name="Grafema.Types"** |
+| EXPORT_BINDING | name=exported name, gnExported=True, **NO metadata, NO source** | Exports.hs:71-90 `gnMetadata = Map.empty` |
+| EXPORT nodes in .hs | **ZERO** (Haskell has no EXPORT node, only EXPORT_BINDING) | **live probe: 0 EXPORT in .hs** |
+| EXPORTS edges in .hs | **ZERO** (export = name-match, not an edge) | **live probe: 0 EXPORTS from EXPORT_BINDING or MODULE in .hs** |
+| `module Foo (module Bar)` | ExportInfo only (orchestrator-side), **NO EXPORT_BINDING node** | Exports.hs:93-99 `eiNodeId = ""` |
+| CALL.name for `Map.lookup` | **bare `"lookup"`** — analyzer strips the qualifier | Expressions.hs:489 `occNameString (rdrNameOcc name)`; **live: CALL "lookup"=3, "Map.lookup"=0** |
+| dotted CALL names in .hs | 112 total, **almost all OPERATORS** (`.&.`,`.`,`.!=`,`.:`) NOT qualified calls | **live probe + samples** |
+
+### ⚠ THE ONE REALITY THE RESOLVER (and a naive port) WOULD MISS
+
+`HaskellLocalCalls`/`HaskellCrossModuleCalls`/`resolveOne` strip a qualified prefix with
+`T.breakOnEnd "."` (LocalCalls.hs:64-66). **The analyzer already strips qualification**
+(`rdrNameOcc` → occurrence name), so for real qualified calls (`Map.lookup`→`"lookup"`) the
+strip is a **no-op** — and the only dotted CALL names that survive are **operators**
+(`.&.`, `.`, `.:`). Applying `last_segment(N, ".", Bare)` to those mangles them
+(`.&.` → `&.` or empty). **Therefore the pack must NOT blindly port the breakOnEnd strip.**
+The faithful port joins on the bare `CALL.name` directly (the common path), and a dotted
+operator like `.` simply won't match a same-file FUNCTION named `.` unless one exists — which
+is the resolver's behavior too (it would strip `.&.`→`&.`, also a miss). Net: **omitting
+last_segment is MORE faithful, not less**, and avoids a class of operator false-positives.
+Flagged as DELTA in each call pack.
+
+---
+
+## DRAFT RULES (today's builtins)
+
+### Pack 1 — `@stdlib/haskell_imports` (haskell-imports, both arms)
+
+```prolog
+% Haskell file gate (the orchestrator's detect_language Haskell stream = .hs only;
+% one constant-pattern clause per the js_local_refs ENCODING NOTE — a derived gate
+% cannot bind a head var, and an ext-facts join is a cross-join).
+% Haskell has ONE extension, so the gate is a single ends_with filter inline.
+
+% --- Arm A: IMPORT -> MODULE (resolveImport, ImportResolution.hs:119-130) ---
+% Module resolution is by NAME (not path): IMPORT.name == MODULE.name.
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+hs_import_module(I, M) :-
+    node(I, "IMPORT"), attr(I, "file", F), ends_with(F, ".hs"), attr(I, "name", Mod),
+    node(M, "MODULE"), attr(M, "name", Mod).
+
+% --- Export side: a file's exported names (buildExportIndex, ImportResolution.hs:60-93) ---
+% Files WITH explicit exports: only the EXPORT_BINDING names are exported.
+file_has_explicit_exports(TF) :- node(EB, "EXPORT_BINDING"), attr(EB, "file", TF).
+% Explicit export entry -> the same-file declaration with that name (8 decl types).
+% (The resolver's ExportEntry pairs name+nodeId; the EXPORT_BINDING node is just the
+%  name marker, the target is the same-file decl — Haskell has no EXPORTS edge.)
+hs_decl(TF, N, D) :- node(D, "FUNCTION"),       attr(D, "file", TF), attr(D, "name", N), neq(N, "").
+hs_decl(TF, N, D) :- node(D, "VARIABLE"),       attr(D, "file", TF), attr(D, "name", N), neq(N, "").
+hs_decl(TF, N, D) :- node(D, "DATA_TYPE"),      attr(D, "file", TF), attr(D, "name", N), neq(N, "").
+hs_decl(TF, N, D) :- node(D, "TYPE_CLASS"),     attr(D, "file", TF), attr(D, "name", N), neq(N, "").
+hs_decl(TF, N, D) :- node(D, "TYPE_SYNONYM"),   attr(D, "file", TF), attr(D, "name", N), neq(N, "").
+hs_decl(TF, N, D) :- node(D, "TYPE_FAMILY"),    attr(D, "file", TF), attr(D, "name", N), neq(N, "").
+hs_decl(TF, N, D) :- node(D, "CONSTRUCTOR"),    attr(D, "file", TF), attr(D, "name", N), neq(N, "").
+hs_decl(TF, N, D) :- node(D, "TYPE_SIGNATURE"), attr(D, "file", TF), attr(D, "name", N), neq(N, "").
+
+% Exported decl = name appears in EXPORT_BINDING list AND a decl of that name exists.
+exported_in(TF, N, D) :-
+    node(EB, "EXPORT_BINDING"), attr(EB, "file", TF), attr(EB, "name", N), neq(N, ""),
+    hs_decl(TF, N, D).
+% Implicit export-all: file with NO EXPORT_BINDING -> every top-level decl is exported.
+exported_in(TF, N, D) :-
+    hs_decl(TF, N, D), \+ file_has_explicit_exports(TF).
+
+% --- Arm B: IMPORT_BINDING -> exported decl (resolveBinding, ImportResolution.hs:138-169) ---
+% The binding's source module is GRAPH-REACHABLE via the parent IMPORT (CONTAINS),
+% NO sid [in:..] parsing, NO node_attr. Module -> file via the MODULE node.
+binding_src(B, LocalN, Mod) :-
+    node(B, "IMPORT_BINDING"), attr(B, "file", F), ends_with(F, ".hs"), attr(B, "name", LocalN),
+    edge(I, B, "CONTAINS"), node(I, "IMPORT"), attr(I, "name", Mod).
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+hs_binding_import(B, D) :-
+    binding_src(B, N, Mod), node(M, "MODULE"), attr(M, "name", Mod), attr(M, "file", TF),
+    exported_in(TF, N, D).
+```
+
+### Pack 2 — `@stdlib/haskell_local_refs` (haskell-local-refs, decl arm)
+
+```prolog
+% READS_FROM is SHARED vocabulary => additive. 8 decl types (HaskellLocalRefs.hs:40-45)
+% NOTE: declTypes here include PARAMETER (refs to lambda/fn params) but NOT
+% TYPE_SIGNATURE (refs target the value, sig is separate). Matches the resolver list.
+ld(F, N, D) :- node(D, "FUNCTION"),     attr(D, "file", F), attr(D, "name", N), neq(N, "").
+ld(F, N, D) :- node(D, "VARIABLE"),     attr(D, "file", F), attr(D, "name", N), neq(N, "").
+ld(F, N, D) :- node(D, "CONSTANT"),     attr(D, "file", F), attr(D, "name", N), neq(N, "").
+ld(F, N, D) :- node(D, "DATA_TYPE"),    attr(D, "file", F), attr(D, "name", N), neq(N, "").
+ld(F, N, D) :- node(D, "TYPE_SYNONYM"), attr(D, "file", F), attr(D, "name", N), neq(N, "").
+ld(F, N, D) :- node(D, "CONSTRUCTOR"),  attr(D, "file", F), attr(D, "name", N), neq(N, "").
+ld(F, N, D) :- node(D, "RECORD_FIELD"), attr(D, "file", F), attr(D, "name", N), neq(N, "").
+ld(F, N, D) :- node(D, "PARAMETER"),    attr(D, "file", F), attr(D, "name", N), neq(N, "").
+
+imported(F, N) :- node(B, "IMPORT_BINDING"), attr(B, "file", F), attr(B, "name", N).
+
+@materialize(edge_type = "READS_FROM", mode = "additive", meta(resolvedVia))
+hs_local_ref(R, D, "haskell-local-refs") :-
+    node(R, "REFERENCE"), attr(R, "file", F), ends_with(F, ".hs"), attr(R, "name", N),
+    \+ imported(F, N),
+    ld(F, N, D).
+```
+
+### Pack 2b/2c — Prelude virtual-node + READS_FROM (the `haskellPreludeNames` arm)
+
+The resolver, on a REFERENCE that is NOT a same-file decl, checks a ~140-name compiled-in
+Prelude table (HaskellLocalRefs.hs:69-99) and, if matched, mints a virtual
+`EXTERNAL_FUNCTION` node `HASKELL_GLOBAL::<name>` + READS_FROM edge. Ground-facts +
+two-pack node-then-edge split (the `js_runtime_globals_{facts,nodes,edges}` precedent):
+
+```prolog
+% --- haskell_prelude_facts (ground facts, the EXACT HaskellLocalRefs.hs:69-99 list) ---
+hs_prelude("Just"). hs_prelude("Nothing"). hs_prelude("pure"). hs_prelude("return").
+hs_prelude("show"). hs_prelude("map"). hs_prelude("filter"). hs_prelude("foldr"). % ...~140
+
+% --- haskell_prelude_nodes (@materialize_node, exclusive) ---
+@materialize_node(node_type = "EXTERNAL_FUNCTION", mode = "exclusive", meta(category, source))
+hs_prelude_node(Sid, N, "", "haskell-prelude", "haskell-local-refs") :-
+    node(R, "REFERENCE"), attr(R, "file", F), ends_with(F, ".hs"), attr(R, "name", N),
+    \+ imported(F, N), \+ ld(F, N, _), hs_prelude(N),
+    concat("HASKELL_GLOBAL::", N, Sid).
+
+% --- haskell_prelude_edges (declared AFTER nodes; cross-pack EDB visibility) ---
+@materialize(edge_type = "READS_FROM", mode = "additive", meta(resolvedVia, globalCategory))
+hs_prelude_ref(R, X, "haskell-local-refs", "haskell-prelude") :-
+    node(R, "REFERENCE"), attr(R, "file", F), ends_with(F, ".hs"), attr(R, "name", N),
+    \+ imported(F, N), \+ ld(F, N, _), hs_prelude(N),
+    node(X, "EXTERNAL_FUNCTION"), attr(X, "name", N), attr(X, "file", "").
+```
+
+(The `seen`-set dedup in the resolver, HaskellLocalRefs.hs:149-167, is subsumed by
+`@materialize_node mode="exclusive"` set semantics + the `attr(X,"file","")` disambiguator so
+prelude EXTERNAL_FUNCTIONs don't collide with JS/runtime ones. ⚠ verify the `file==""`
+disambiguator is enough vs the js EXTERNAL_FUNCTION namespace on a mixed graph — see
+honesty §.)
+
+### Pack 3 — `@stdlib/haskell_local_calls` (haskell-local-calls)
+
+```prolog
+% 6 callable types (HaskellLocalCalls.hs:35-38). NO breakOnEnd strip (see ⚠ reality).
+cd(F, N, D) :- node(D, "FUNCTION"),       attr(D, "file", F), attr(D, "name", N), neq(N, "").
+cd(F, N, D) :- node(D, "VARIABLE"),       attr(D, "file", F), attr(D, "name", N), neq(N, "").
+cd(F, N, D) :- node(D, "CONSTANT"),       attr(D, "file", F), attr(D, "name", N), neq(N, "").
+cd(F, N, D) :- node(D, "CONSTRUCTOR"),    attr(D, "file", F), attr(D, "name", N), neq(N, "").
+cd(F, N, D) :- node(D, "RECORD_FIELD"),   attr(D, "file", F), attr(D, "name", N), neq(N, "").
+cd(F, N, D) :- node(D, "TYPE_SIGNATURE"), attr(D, "file", F), attr(D, "name", N), neq(N, "").
+
+imp(F, N) :- node(B, "IMPORT_BINDING"), attr(B, "file", F), attr(B, "name", N).
+
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+hs_local_call(C, D, "haskell-local-calls") :-
+    node(C, "CALL"), attr(C, "file", F), ends_with(F, ".hs"), attr(C, "name", N),
+    \+ imp(F, N),
+    cd(F, N, D).
+```
+
+### Pack 4 — `@stdlib/haskell_cross_module_calls` (haskell-cross-module-calls)
+
+Reuses `exported_in` + `binding_src` from pack 1 conceptually (re-declared in-pack, or
+piggyback on pack-1's committed IMPORTS_FROM — see ordering note). Faithful join: a CALL
+whose bare name has an IMPORT_BINDING in the same file → that binding's module → exported
+decl. NO breakOnEnd strip.
+
+```prolog
+% binding's source module (graph-native, as pack 1)
+xb(F, N, Mod) :-
+    node(B, "IMPORT_BINDING"), attr(B, "file", F), attr(B, "name", N),
+    edge(I, B, "CONTAINS"), node(I, "IMPORT"), attr(I, "name", Mod).
+
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+hs_xmod_call(C, D, "haskell-cross-module") :-
+    node(C, "CALL"), attr(C, "file", F), ends_with(F, ".hs"), attr(C, "name", N),
+    xb(F, N, Mod),
+    node(M, "MODULE"), attr(M, "name", Mod), attr(M, "file", TF),
+    exported_in(TF, N, D).
+```
+
+(`exported_in` must be the SAME relation as pack 1 — either re-declared identically in this
+pack, or pack 4 declared AFTER pack 1 and reading nothing cross-pack since `exported_in` is
+an intra-pack derived; simplest is to re-declare the export-side block in each pack that
+needs it, as the js packs do.)
+
+---
+
+## PREDICTED DELTAS (declared before diffing — predictions-first)
+
+Partition: legacy stamps `meta.resolvedVia` per module
+(`haskell-local-refs`/`haskell-local-calls`/`haskell-cross-module`); `haskell-imports`
+emits unstamped IMPORTS_FROM. Pack edges carry `_source` = rule hash. Per-step slicing
+is exact.
+
+### EXACT (modulo set-semantics)
+- **haskell-imports Arm A** (IMPORT→MODULE): exact. Both sides do name-equality lookup;
+  resolver `Map.lookup` keeps one MODULE per name, set semantics derives all — but module
+  names are unique per project in practice (one MODULE per file, name=module). Bound: extras
+  ≤ count of duplicate MODULE.name (expected 0; live: MODULE "Grafema.Types" = 1).
+- **haskell-imports Arm B** (IMPORT_BINDING→decl): exact for un-ambiguous names.
+- **haskell-local-refs** decl arm, **haskell-local-calls**, **haskell-cross-module-calls**:
+  exact for the common bare-name case.
+
+### EXPECTED-SUPERSET (pack ⊇ legacy — enumerate-and-bound)
+- **DELTA-S1 duplicate (file,name) decls**: resolver's `Map.fromList`/`Map.fromListWith`
+  keeps ONE winner (Import: `filter ... (entry:_)` first; Local: `Map.fromList` last-wins);
+  set semantics derives an edge to EVERY candidate. Bound: count of (file,name) decl
+  collisions per type. Order-independent, strict superset.
+- **DELTA-S2 implicit-export-all granularity**: `exported_in` implicit arm derives an edge
+  for every decl-name in a no-export-list file; if two same-name decls exist (e.g. a
+  `TYPE_SIGNATURE` and a `FUNCTION` both named `foo` — Haskell norm!), the binding resolves
+  to BOTH. The resolver's ExportEntry list also held both (`++`), but `filter ... (entry:_)`
+  took the first → SUBSET on the resolver side here. **Net: pack is superset.** This is
+  REAL and frequent in Haskell (every function has a sibling TYPE_SIGNATURE node). Bound:
+  per imported name, ≤ (# decl types sharing that name in the target file). LARGEST expected
+  delta — must be counted carefully.
+
+### EXPECTED-SUBSET (pack ⊆ legacy — must be explained, not silently dropped)
+- **DELTA-B1 haskell-globals NOT ported** (wave-1): all CALLS→GLOBAL_DEFINITION from the
+  effects-db SymbolDB are absent. Bound: exactly the legacy `haskell-globals` edge slice.
+  Closes when the effects-db→facts pack ships (wave-2, the lang-spec corpus→generated-pack
+  pattern). DECISION: keep out of wave-1, like js runtime-globals.
+- **DELTA-B2 operator dotted-name calls**: the resolver's `breakOnEnd "."` would resolve a
+  call named `&.` after stripping `.&.` IF a same-file decl `&.` existed (rare). The pack
+  omits the strip → won't match. Bound: ≤ 112 dotted .hs CALL names project-wide, almost all
+  operators with no matching local decl; expected real difference ≈ 0. (Verified: dotted
+  .hs CALLs are operators, not qualified names.)
+
+### Any delta OUTSIDE these classes = pack bug or new resolver knowledge → stop, witness
+(`explain_fact`/`why()` on extras; replay resolver stderr for misses), classify, then proceed.
+
+---
+
+## MISSING CAPABILITIES
+
+None are blocking for wave-1 (unlike the js spec). Enumerated for completeness:
+
+1. **External-data-as-facts for `haskell-globals`** (NOT an engine change): the effects-db
+   YAML SymbolDB → generated `hs_global(Name, ...)` facts pack + preloaded GLOBAL_DEFINITION
+   nodes (the lang-spec corpus→generated-pack pattern). Wave-2. This is the ONLY resolver
+   step not expressible today, and it is data-plumbing, not a builtin gap.
+2. **(nice-to-have) prelude-name disambiguation** for the EXTERNAL_FUNCTION virtual node on a
+   MIXED-language graph: `HASKELL_GLOBAL::map` vs a JS `map` global. The `attr(X,"file","")`
+   join + the distinct semantic-id prefix should separate them, but this needs a live diff to
+   confirm no collision on the real graph (the EXTERNAL_FUNCTION namespace is shared). ⚠
+3. **(not needed) `node_attr`, `path_resolve`, `strip_*`**: all EXIST; Haskell uses none of
+   them on the hot paths (module-by-name + graph-native CONTAINS seam). `node_attr` would
+   only be touched for IMPORT `alias`/`qualified` metadata — and the resolver IGNORES those
+   (it resolves by occurrence name regardless of qualification), so the pack should too.
+
+---
+
+## HONESTY SECTION
+
+- **Graph freshness**: dogfood snapshot is Jun-11, HEAD Jun-13 (2 days). All probes were
+  SHAPE/presence checks (node-type counts, edge existence, sid format), which are stable
+  across a 2-day window; no edge-count differential was claimed from this snapshot. A real
+  differential-acceptance run MUST re-analyze at HEAD first (the stale-graph lesson).
+- **Spot-verified vs assumed**: IMPORT→CONTAINS→IMPORT_BINDING (100%, probed), MODULE.name
+  (probed), 0 EXPORT/EXPORTS in .hs (probed), bare CALL name for qualified calls (probed +
+  source-confirmed at Expressions.hs:489), IMPORT_BINDING sid `[in:Module]` (source-confirmed,
+  SemanticId.hs:26 — NOT probed live, but the pack does not depend on it: it uses the
+  graph-native CONTAINS seam instead). The dotted-name=operators reality is the one a naive
+  port would miss (the round's lesson) — verified by sampling 5 dotted .hs CALL names.
+- **`exported_in` implicit arm is the riskiest rule**: in Haskell every top-level binding
+  typically has BOTH a `TYPE_SIGNATURE` node and a `FUNCTION` node with the same name, so an
+  imported name will resolve to 2+ targets where the resolver took 1. This is a CORRECT
+  superset (both are legitimately "the exported foo") but the differential WILL show a large
+  count delta here — it must be classified as DELTA-S2, not a bug. Recommend measuring
+  `hs_decl` (file,name) multiplicity on the live graph before the diff to pre-bound it.
+- **Not ported, by design**: `haskell-globals` (external YAML). The daemon's msgpack/IPC
+  framing, the CLI subcommand surface, and stderr diagnostics have no pack analog (the js
+  precedent excludes these too).
+- **Maintain envelope**: every pack uses negation (`\+ imported`/`\+ imp`/`\+ ld`) ⇒
+  maintain-incremental refuses them; scratch floor applies (accepted, per the js precedent —
+  these share the dominant CALL/REFERENCE/IMPORT_BINDING base scans served by build-once
+  hash-join; estimate well under the ≤60s pack budget given Haskell is a fraction of the
+  491k-node graph).
+- **Pack ordering**: haskell_imports (produces IMPORTS_FROM) → haskell_prelude_nodes →
+  haskell_prelude_edges; the call packs are independent (they re-derive their own
+  export/binding seams intra-pack, the js convention). No cross-language ordering coupling.
+
+---
+
+## EXPRESSIBLE-NOW SUMMARY
+
+4 of 5 resolver commands (haskell-imports, haskell-local-refs incl. prelude virtual node,
+haskell-local-calls, haskell-cross-module-calls) are **fully expressible with TODAY's
+builtins** — 6 packs total (imports, local_refs, prelude_facts, prelude_nodes,
+prelude_edges, local_calls, cross_module_calls = 7 if counting prelude split as 3). The 5th
+(haskell-globals) needs an external-data-as-facts pack (wave-2, data plumbing, not a builtin
+gap). No `node_attr`/`path_resolve` dependency on any hot path — Haskell's by-name module
+resolution + the graph-native IMPORT→CONTAINS→IMPORT_BINDING seam make this the SIMPLEST of
+the resolver migrations.
+
+---
+
+## ADVERSARIAL VERDICT (independent review, 2026-06-13)
+
+Reviewer re-read the resolver modules (`HaskellImportResolution.hs`, `HaskellLocalCalls.hs`,
+`HaskellCrossModuleCalls.hs`, `HaskellLocalRefs.hs`), the analyzer emission
+(`Imports.hs`, `Expressions.hs:485-495`), the live `derive/builtin.rs` registry + mode tables,
+and ran LIVE probes on a `/tmp` copy of the dogfood graph (491,535 nodes; own server, cleaned up).
+
+### CONFIRMED by independent evidence
+- Builtin set + modes verified at `builtin.rs:1119-1188`: `node_attr` is `[B,B,F]`/`[B,B,B]` (NO
+  generator). `strip_prefix`/`strip_suffix` produce NO row on non-match; `last_segment` is
+  identity-on-no-sep. No `first_segment`. The spec uses only existing builtins correctly.
+- CALL "lookup"=304, "Map.lookup"=0 in .hs (LIVE) — the qualifier-strip "round's lesson" catch
+  (Expressions.hs:489 `occNameString (rdrNameOcc name)`) is REAL and correct.
+- IMPORT_BINDING→CONTAINS→IMPORT = 2498/2498 (LIVE) — graph-native seam claim holds.
+- 835 EXPORT_BINDING, 0 EXPORT nodes in .hs (LIVE) — export-as-name-match model holds.
+- 814 module-level IMPORTS_FROM edges exist (LIVE) — `resolveImport` (IMPORT→MODULE by name) ran.
+
+### ⚠ THE ONE REALITY THIS SPEC MISSED (the round's lesson, and it is load-bearing)
+**The cross-module CALLS / import-binding IMPORTS_FROM edges target the EXPORT_BINDING node, NOT
+the declaration node, for explicitly-exported modules.** Evidence:
+- SOURCE: `HaskellImportResolution.resolveBinding` and `HaskellCrossModuleCalls` both build
+  `buildExportIndex` where `explicitExports = ExportEntry (gnName n) (gnId n)` over EXPORT_BINDING
+  nodes (ImportResolution.hs:62-67, CrossModuleCalls.hs:62-66). The emitted edge is
+  `geTarget = exNodeId entry` — i.e. the **EXPORT_BINDING's own id** when the target file has any
+  explicit exports. Only the IMPLICIT-export-all branch targets a real decl.
+- LIVE: in the dogfood graph, **CALLS target=EXPORT_BINDING = 1618** vs CALLS target=FUNCTION = 2310,
+  CONSTRUCTOR = 152, EXTERNAL_FUNCTION = 3615. EXPORT_BINDING is a *plurality* of cross-module
+  resolved CALLS targets — it is NOT a corner case.
+
+The spec's Pack 1 Arm B (`hs_binding_import(B, D) :- ... exported_in(TF, N, D)`) and Pack 4
+(`hs_xmod_call(C, D, ...) :- ... exported_in(TF, N, D)`) resolve to the **decl `D`** (FUNCTION /
+DATA_TYPE / etc.). For explicitly-exported names the legacy resolves to the **EXPORT_BINDING**.
+=> the pack's edge TARGET differs from legacy on every explicit-export edge. This is NOT an
+EXACT delta; it is a **target-identity SUPERSET/MISMATCH** that the spec's PREDICTED DELTAS,
+HEADLINE point 3, and HONESTY section all get wrong (they all treat the target as the decl).
+**FIX:** `exported_in` must split: for a file WITH explicit exports, the target is the
+EXPORT_BINDING node itself (`exported_in(TF, N, EB) :- node(EB,"EXPORT_BINDING"), attr(EB,"file",TF),
+attr(EB,"name",N)`); only for files with NO EXPORT_BINDING does it target a decl. This is two
+arms, both expressible today (the `file_has_explicit_exports` gate already exists in the draft —
+it just routes to the wrong target).
+
+### ⚠ SECOND MISS — decl-type lists over-include vs the resolver's last-wins Map
+- LIVE: CALLS target=TYPE_SIGNATURE = 0, VARIABLE = 0, DATA_TYPE = 0. READS_FROM target
+  TYPE_SIGNATURE = 0, VARIABLE = 0, DATA_TYPE = 0 (PARAMETER = 11324, FUNCTION = 5103,
+  EXTERNAL_FUNCTION = 4986, CONSTRUCTOR/RECORD_FIELD small).
+- The resolver builds `declIdx = Map.fromList [((file,name), id)]` (LocalCalls.hs:40-46) — LAST-WINS,
+  ONE id per (file,name). The spec's `cd`/`ld` derive an edge to EVERY callable/decl sharing
+  (file,name) under set-semantics. Since the live graph shows ZERO edges ever landing on
+  TYPE_SIGNATURE/VARIABLE/DATA_TYPE, including those types in `cd`/`ld` would emit edges the legacy
+  never produced => SUPERSET, not "faithful". The spec's DELTA-S2 ("TYPE_SIGNATURE+FUNCTION pairing
+  → 2+ targets") is real in DIRECTION but the spec mis-frames it as a property of the *legacy* taking
+  one — the live data shows the legacy targets the FUNCTION and NEVER the TYPE_SIGNATURE, so the
+  superset is entirely pack-introduced. **FIX/BOUND:** either drop TYPE_SIGNATURE/VARIABLE/DATA_TYPE
+  from the call/ref decl sets (they contribute 0 legacy edges), or accept and explicitly bound the
+  superset by the (file,name) collision count — but do NOT call it EXACT.
+
+### ⚠ THIRD MISS — Prelude EXTERNAL_FUNCTION disambiguator is empirically wrong
+- LIVE: `EXTERNAL_FUNCTION` with `attr(X,"file","") = 0` rows; 99 EXTERNAL_FUNCTION nodes total.
+  The spec's Pack 2b/2c uses `node(X,"EXTERNAL_FUNCTION"), attr(X,"name",N), attr(X,"file","")` as
+  the join/disambiguator — that join matches ZERO existing nodes, so the proposed edge rule would
+  derive nothing against the current namespace, and the mint's collision-avoidance premise is
+  untested (no file="" EXTERNAL_FUNCTION exists). The spec already flagged this ⚠ as needing a live
+  diff; the live diff says the `file==""` assumption does not hold on this graph. **Re-derive the
+  disambiguator** (e.g. by the `HASKELL_GLOBAL::` sid prefix the mint itself uses) before relying on it.
+
+### NON-BLOCKING / accepted
+- haskell-globals correctly deferred (external YAML, wave-2). Maintain-envelope (negation→scratch)
+  correctly noted. Module-by-name Arm A is genuinely EXACT and the simplest arm.
+
+### COULD-NOT-VERIFY (honest gap)
+- IMPORT_BINDING→IMPORTS_FROM = **0** in the dogfood snapshot (the binding-level import arm produced
+  NO edges, while the module-level arm produced 814). So the explicit-export-target finding for the
+  IMPORTS_FROM Arm B is SOURCE-grounded only; it is LIVE-confirmed for the structurally-identical
+  CALLS cross-module arm (CALLS→EXPORT_BINDING=1618). The differential-acceptance run must re-analyze
+  at HEAD (the binding arm may be a separate orchestrator gap worth recording independently).
+
+### READY FOR PACKS: **NO** — fix the EXPORT_BINDING-vs-decl target split (blocking) and the
+decl-type over-inclusion (correctness/superset) first. After those two fixes the 4 commands are
+expressible today; the spec's "simplest migration" thesis survives, but its delta classes do not.

--- a/_ai/research/lang-spec-python.md
+++ b/_ai/research/lang-spec-python.md
@@ -1,0 +1,400 @@
+# Python resolver → derive packs — migration spec
+
+Branch: `feat/datalog`. Base: origin/main `6e609746`. Round: lang-spec (python), 2026-06-13.
+Author-context: read js/rust precedent (`_ai/research/resolve-datalog2-migration-{specs.json,synthesis.md}`),
+the live builtin registry (`packages/rfdb-server/src/derive/builtin.rs::registry()` line 1188),
+and stdlib pack idioms (`stdlib/{method_calls,rust_imports,js_import_bindings,js_class_inheritance}.dl`).
+
+## 0. GROUNDING / PROBE STATUS
+
+- **Dogfood graph has ZERO Python nodes.** The Grafema corpus (`config.yaml`) is TS/Rust/Haskell only.
+  The few `.py` files in the repo (`scripts/*.py`, `_bench/*.py`) are NOT in `include:`. Verified:
+  `config.yaml` has no `.py` glob; no python MODULE/CLASS in `.grafema/graph.rfdb`.
+  → **No live probe possible. Grounded on resolver source + analyzer emission + package test fixtures**
+    (`packages/python-resolve/test/Spec.hs`, `packages/python-analyzer/test/Spec.hs`).
+  → **Every shape below is flagged ANALYZER-VERIFIED (read emission source) or FIXTURE-ONLY (test asserts it)
+    or UNVERIFIED. No shape is live-probed. Treat the DELTA bounds as source-derived, not measured.**
+
+- Legacy resolver = `packages/python-resolve/src/` (Haskell binary `python-resolve`), 4 commands dispatched
+  from `Main.hs:60-71`: `python-imports` (ImportResolution), `python-types` (TypeResolution),
+  `python-calls` (CallResolution), `python-classes` (ClassInheritance); plus `python-all` runs all 4.
+  Analyzer = `packages/python-analyzer/src/` (binary `python-analyzer`), emission rules in `src/Rules/`.
+
+## 1. ANALYZER EMISSION VOCABULARY (what the resolver consumes)
+
+ANALYZER-VERIFIED from `packages/python-analyzer/src/Rules/{Imports,Declarations,Calls}.hs` +
+`packages/grafema-common/src/Grafema/SemanticId.hs`:
+
+### Node types
+| Node | Emitted at | Key metadata (ALL via node_attr — NOT first-class) |
+|---|---|---|
+| `MODULE` | (per file, by orchestrator/walker) | — (file is first-class) |
+| `IMPORT` | Imports.hs:65,158 | `path`, `glob`(bool), `relative_level`(int, from-import only), `module`(from-import, present only when module part non-empty) |
+| `IMPORT_BINDING` | Imports.hs:93,201 | `imported_name`, `local_name`, **`source_module`** (from-import ONLY; plain `import foo` binding has NO source_module — Imports.hs:103-106 omits it) |
+| `FUNCTION` | Declarations.hs:118 | `kind` (function/async_function/method/classmethod/staticmethod/property/lambda), `return_annotation`(opt), `decorator_names`(opt), `paramCount`, `async` |
+| `CLASS` | Declarations.hs:189 | `bases`(opt, comma-joined base NAMES via exprToText), `decorator_names`(opt), `has_metaclass`(bool) |
+| `VARIABLE` | Declarations.hs (assign/annassign/param) | `kind` (assignment/annotated_assignment/class_variable/instance_variable/parameter/variadic_parameter/keyword_parameter/variadic_keyword_parameter), `annotation`(opt), `mutable` |
+| `CALL` | Calls.hs:91 | `receiver`(opt — present iff dotted call), `argCount`, `kwargCount`, `kind`(="constructor" iff name starts uppercase) |
+| `PROPERTY_ACCESS` | Calls.hs:137 | `receiver` |
+| `REFERENCE` | Calls.hs:172 | — |
+
+### Edge types emitted by ANALYZER (intra-file, the substrate)
+| Edge | Source→Target | Emitted at | Notes |
+|---|---|---|---|
+| `CONTAINS` | scope→decl, IMPORT→IMPORT_BINDING | everywhere | scope-chain substrate |
+| `HAS_METHOD` | CLASS→FUNCTION | Declarations.hs:151-156 | **method↔class link — the clean `member_of` substrate** |
+| `HAS_PROPERTY` | CLASS→VARIABLE | Declarations.hs:294,335,436,476 | class/instance vars |
+| `EXTENDS` (STUB) | CLASS→`file->CLASS->BaseName` (synthesized, Nothing-parent) | Declarations.hs:219-228 | metadata `base_name`. **Target ID is synthesized; correct ONLY for same-file base; cross-file base targets a non-existent node.** Resolver re-emits authoritative ones. |
+| `ASSIGNED_FROM` | VARIABLE→(CALL/PROPERTY_ACCESS/REFERENCE) | Declarations.hs:516-542 | forward-ref edge |
+
+### Semantic ID format (SemanticId.hs:21-29) — ANALYZER-VERIFIED
+`file->TYPE->name`, `file->TYPE->name[in:parent]`, `file->TYPE->name[in:parent,h:hhhh]`.
+- **Methods**: `semanticId file "FUNCTION" name parent Nothing` → `file->FUNCTION->save[in:User]` (NO hash;
+  parent = `askNamedParent` = enclosing class name, set by `withNamedParent name` on ClassDef body, Declarations.hs:239).
+  ⚠ **FIXTURE-vs-ANALYZER MISMATCH:** the resolver test (`python-resolve/test/Spec.hs:210`) uses
+  `...->save[in:User,h:y]` (artificial hash). Real analyzer emits `[in:User]` with no `,h:`. `extractClassName`
+  (`CallResolution.hs:138-159`) strips both `,h:` and the closing bracket, so it parses both — but a migration
+  pack that string-matches `[in:Cls,h:` would silently drop ALL real methods. **Use HAS_METHOD edges, not SID parsing.**
+- Methods nested under a function-in-class get `[in:functionName]`, not the class — a precision corner the SID
+  approach gets wrong and HAS_METHOD gets right (the class still HAS_METHOD only its direct defs).
+
+## 2. RESOLVE-STEP INVENTORY (legacy → pack)
+
+### STEP A — python-imports (ImportResolution.hs)
+Builds `ModuleIndex: file → (moduleNodeId, dottedModulePath)` and
+`NameIndex: (modulePath, exportedName) → (file, nodeId)`. Then:
+- **A1** Resolve each `IMPORT_BINDING` to its declaration via `IMPORTS_FROM` edge:
+  - `imported_name` defaults to `gnName` when metadata absent.
+  - `source_module` present (from-import): `resolveRelativeImport` → look up `(modPath, importedName)` in NameIndex
+    → `IMPORTS_FROM` to that decl. Fallback: `(modPath ++ "." ++ importedName)` as a submodule → `IMPORTS_FROM` to MODULE.
+  - `source_module` ABSENT (plain `import foo`): look up `importedName` as a module path → `IMPORTS_FROM` to MODULE.
+- **A2** Resolve glob `IMPORT` (`glob=True`): `resolveRelativeImport(gnName)` → `IMPORTS_FROM` to MODULE node,
+  metadata `glob=True`. (`gnName` of a from-import IMPORT = the full dotted path incl. leading dots, e.g. `.models`.)
+
+`fileToModulePath` (ImportResolution.hs:62-73): strip `.pyi`/`.py`, strip `src/`|`lib/`|`source/` prefix,
+`/`→`.`, drop trailing `.__init__`.
+
+`resolveRelativeImport` (ImportResolution.hs:126-148): count leading dots = `level`; drop `level` components
+from the importer's module path; append the rest. `level=0` → return absolute as-is.
+
+### STEP B — python-types (TypeResolution.hs)
+ClassIndex: `name → (file, classId)` (GLOBAL by name, last-write-wins — no file scoping). Then:
+- **B1** FUNCTION `return_annotation` → `TYPE_OF` (FUNCTION→CLASS), metadata `annotation`.
+- **B2** VARIABLE `annotation` → `TYPE_OF` (VARIABLE→CLASS), metadata `annotation`.
+- **B3** PARAMETER `annotation` → `TYPE_OF`. ⚠ **DEAD CODE**: matches `gnType=="PARAMETER"`, but the analyzer
+  emits parameters as `VARIABLE kind=parameter` (Declarations.hs:629-654, `gnType="VARIABLE"`). There are NO
+  PARAMETER nodes. Param annotations are actually resolved by B2 (they're VARIABLEs). **Do not port B3 as a
+  PARAMETER rule.** (FIXTURE-ONLY: Spec.hs:137-145 fabricates a PARAMETER node that the real graph never has.)
+- **B4** CLASS `bases` (comma-split) → `TYPE_OF`... no: → `EXTENDS` (TypeResolution.hs:152-164), name lookup in
+  ClassIndex, builtins skipped. **This DUPLICATES ClassInheritance's EXTENDS** but with GLOBAL-by-name lookup
+  (no import-awareness) and no `resolvedVia` tag.
+- `normalizeType`: strip generic `X[...]`→`X`; skip builtins (`str,int,float,bool,bytes,complex,list,dict,set,
+  tuple,frozenset,None,type,object,property`). `parseAnnotation`/`stripGeneric` only strip the OUTER `[...]`;
+  inner type of `Optional[User]` is NOT recursed (Optional itself isn't a class → 0 edges; FIXTURE Spec.hs:184
+  asserts `Optional[User]`→1 edge, which only fires if a class named `Optional` exists — a corner).
+
+### STEP C — python-calls (CallResolution.hs)
+Indexes: FunctionIndex `(file,name)→[ids]`, MethodIndex `(class,method)→[ids]` (class from SID `[in:]` parse,
+gated on `kind∈{method,classmethod,staticmethod}`), TypeIndex `(file,var)→class` (from VARIABLE `annotation`
+matching a known class name), HierarchyIndex `parent→[children]` (from CLASS `bases`). Then per CALL:
+- **C1** receiver present → resolve receiver's type via TypeIndex (trying name variants: exact, strip leading
+  `_`, strip `self.`/`self._`); expand the class + all transitive subclasses via HierarchyIndex; emit `CALLS`
+  to every matching `(class,method)` in MethodIndex, metadata `dispatch=virtual`. Fallback C2.
+- **C2** receiver present but no type / no virtual hit → imprecise: first METHOD anywhere with matching name → `CALLS`.
+- **C3** receiver absent → same-file FUNCTION by `(file,name)` → `CALLS` (first match). Else C4.
+- **C4** cross-file: first FUNCTION anywhere with matching name → `CALLS`.
+
+### STEP D — python-classes (ClassInheritance.hs)
+The authoritative EXTENDS resolver (tags `resolvedVia="python-class-inheritance"`). Per CLASS with `bases`:
+- **D1** same-file: base name in ClassIndex `(file,base)` → `EXTENDS`.
+- **D2** cross-file: base name in ImportBindingIndex `(file,base)` → `resolveRelativeImport(source_module)` →
+  NameIndex `(modPath, importedName)` → `EXTENDS`, metadata `importedFrom=source_module`.
+
+## 3. DRAFT .dl RULES (today's builtin set)
+
+Shared prelude (textual include, per synthesis §1a). File gate: `py(F) :- ends_with(F, ".py").` plus
+`py(F) :- ends_with(F, ".pyi").`
+
+```prolog
+% ── module path of a file (fileToModulePath) ──
+% strip .py / .pyi, strip src/|lib/|source/ prefix, /→., drop trailing .__init__
+% (each transform an arm; pyi handled symmetrically)
+mod_noext(M, R) :- node(M, "MODULE"), attr(M, "file", F), strip_suffix(F, ".py", R).
+mod_noext(M, R) :- node(M, "MODULE"), attr(M, "file", F), strip_suffix(F, ".pyi", R).
+% prefix strip (3 arms + identity-when-no-prefix via \+ better)
+mod_pfx(M, R)  :- mod_noext(M, S), strip_prefix(S, "src/", R).
+mod_pfx(M, R)  :- mod_noext(M, S), strip_prefix(S, "lib/", R).
+mod_pfx(M, R)  :- mod_noext(M, S), strip_prefix(S, "source/", R).
+mod_pfx(M, S)  :- mod_noext(M, S), \+ starts_with(S, "src/"),
+                  \+ starts_with(S, "lib/"), \+ starts_with(S, "source/").
+% init drop + /→.
+mod_initdrop(M, P) :- mod_pfx(M, R), strip_suffix(R, "/__init__", Q), replace_all(Q, "/", ".", P).
+mod_initdrop(M, P) :- mod_pfx(M, R), \+ ends_with(R, "/__init__"), replace_all(R, "/", ".", P).
+module_path(M, P)  :- mod_initdrop(M, P).
+```
+
+```prolog
+% ── name index: a decl exported by its module's dotted path ──
+% decl_at(D, ModPath, Name): a FUNCTION/CLASS/VARIABLE D in file F, F's module ModPath.
+file_module(F, P) :- module_path(M, P), node(M, "MODULE"), attr(M, "file", F).
+decl_at(D, P, N) :- node(D, "FUNCTION"), attr(D, "file", F), file_module(F, P), attr(D, "name", N).
+decl_at(D, P, N) :- node(D, "CLASS"),    attr(D, "file", F), file_module(F, P), attr(D, "name", N).
+decl_at(D, P, N) :- node(D, "VARIABLE"), attr(D, "file", F), file_module(F, P), attr(D, "name", N).
+% re-export via IMPORT_BINDING (lower priority; only if no decl owns (P,N))
+reexport_at(B, P, N) :- node(B, "IMPORT_BINDING"), attr(B, "file", F), file_module(F, P), attr(B, "name", N).
+```
+
+```prolog
+% ── STEP A1: from-import binding → IMPORTS_FROM (ABSOLUTE source_module only) ──
+% binding's source_module + imported_name; imported_name defaults to name.
+b_imported(B, IN) :- node(B, "IMPORT_BINDING"), node_attr(B, "imported_name", IN).
+b_src(B, S)       :- node(B, "IMPORT_BINDING"), node_attr(B, "source_module", S).
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+imp_from_decl(B, D) :-
+    b_src(B, S), \+ starts_with(S, "."),          % ABSOLUTE only (relative = blocker §4)
+    b_imported(B, IN),
+    decl_at(D, S, IN).
+% submodule fallback: source_module ++ "." ++ imported_name names a MODULE
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+imp_from_submod(B, M) :-
+    b_src(B, S), \+ starts_with(S, "."),
+    b_imported(B, IN),
+    concat(S, ".", SDot), concat(SDot, IN, SubPath),   % concat is arity-3 (A,B,Out)
+    module_path(M, SubPath),
+    \+ decl_at(_, S, IN).
+% plain `import foo` (NO source_module): imported_name IS the module path
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+imp_plain(B, M) :-
+    node(B, "IMPORT_BINDING"), \+ b_src(B, _),
+    b_imported(B, IN),
+    module_path(M, IN).
+```
+
+```prolog
+% ── STEP B1/B2: annotation → TYPE_OF (FUNCTION return + VARIABLE annotation) ──
+% class index by NAME (global, mirrors legacy global ClassIndex). generic strip + builtin skip.
+class_named(C, N) :- node(C, "CLASS"), attr(C, "name", N).
+% raw annotation, then strip outer generic [...] via last_segment? NO — need PREFIX before "[".
+% strip_suffix can't drop "[...]" (variable tail). Use: annotation with no "[" matches directly;
+% the generic-strip arm is a BLOCKER (§4, "prefix-before-delim" builtin missing).
+fn_ann(Fn, A)  :- node(Fn, "FUNCTION"), node_attr(Fn, "return_annotation", A).
+var_ann(V, A)  :- node(V, "VARIABLE"),  node_attr(V, "annotation", A).
+@materialize(edge_type = "TYPE_OF", mode = "additive", meta(annotation))
+type_of_fn(Fn, C, A) :- fn_ann(Fn, A), \+ string_contains(A, "["), class_named(C, A), \+ builtin_type(A).
+@materialize(edge_type = "TYPE_OF", mode = "additive", meta(annotation))
+type_of_var(V, C, A) :- var_ann(V, A), \+ string_contains(A, "["), class_named(C, A), \+ builtin_type(A).
+% builtin_type/1 = generated ground facts (str,int,...) — same pattern as rt_global facts.
+```
+
+```prolog
+% ── STEP C: CALL → CALLS ──
+% C3 same-file function call (no receiver)
+call_no_recv(C) :- node(C, "CALL"), \+ node_attr(C, "receiver", _).
+call_name(C, N) :- node(C, "CALL"), attr(C, "name", N).
+@materialize(edge_type = "CALLS", mode = "additive")
+call_samefile(C, Fn) :-
+    call_no_recv(C), call_name(C, N), attr(C, "file", F),
+    node(Fn, "FUNCTION"), attr(Fn, "file", F), attr(Fn, "name", N).
+% C1 method via declared receiver type → HAS_METHOD (member_of substrate, mirrors method_calls.dl)
+% receiver_type via TYPE_OF on the receiver VARIABLE; HAS_METHOD on the class + subclasses (EXTENDS*).
+recv_var(C, V)   :- node(C, "CALL"), node_attr(C, "receiver", R),
+                    node(V, "VARIABLE"), attr(V, "file", F), attr(C, "file", F), attr(V, "name", R).
+recv_class(C, Cls) :- recv_var(C, V), edge(V, Cls, "TYPE_OF").
+% subclass expansion via EXTENDS (resolved edges, child -EXTENDS-> parent)
+sub_or_self(Base, Base) :- node(Base, "CLASS").
+sub_or_self(Base, Sub)  :- sub_or_self(Base, Mid), edge(Sub, Mid, "EXTENDS").
+@materialize(edge_type = "CALLS", mode = "additive", meta(dispatch))
+call_virtual(C, M) :-
+    recv_class(C, Base), sub_or_self(Base, Cls),
+    edge(Cls, M, "HAS_METHOD"), node(M, "FUNCTION"),
+    call_name(C, MN), attr(M, "name", MN),
+    eq_const(Dispatch, "virtual").   % ⚠ no eq_const builtin — see §4
+```
+
+```prolog
+% ── STEP D: class inheritance EXTENDS ──
+% D1 same-file base
+class_base(Sub, BaseName) :- node(Sub, "CLASS"), node_attr(Sub, "bases", Bases) ... % ⚠ comma-split blocker §4
+@materialize(edge_type = "EXTENDS", mode = "additive", meta(resolvedVia))
+extends_samefile(Sub, Base) :-
+    class_base(Sub, BN), attr(Sub, "file", F),
+    node(Base, "CLASS"), attr(Base, "file", F), attr(Base, "name", BN).
+% D2 cross-file base via import binding (ABSOLUTE source only)
+@materialize(edge_type = "EXTENDS", mode = "additive", meta(resolvedVia, importedFrom))
+extends_crossfile(Sub, Base) :-
+    class_base(Sub, BN), attr(Sub, "file", F),
+    node(B, "IMPORT_BINDING"), attr(B, "file", F), attr(B, "name", BN),
+    b_src(B, S), \+ starts_with(S, "."),
+    b_imported(B, IN), decl_at(Base, S, IN), node(Base, "CLASS").
+```
+
+## 4. MISSING CAPABILITIES (blockers — ordered by impact)
+
+1. **`relative_import_resolve(ImporterModPath, RawSpec, Out)` builtin — THE dominant blocker.**
+   `resolveRelativeImport` (ImportResolution.hs:126-148) counts leading dots, drops that many components from
+   the importer's dotted module path, appends the rest. No existing builtin counts a leading-dot run nor drops
+   N path components. `path_resolve` is filesystem-`./..`-on-slash-paths, not dotted-module-with-dot-prefix.
+   **Without it, ALL relative imports (`from .base import X`, `from ..pkg import Y`) are unresolvable** — and in
+   real Python packages relative imports are the MAJORITY of intra-package imports. This blocks A1 (relative
+   arm), A2 (glob, whose `gnName` like `.models` is relative), and D2 (cross-file inheritance via relative import).
+   ABSOLUTE imports (`from pkg.mod import X`) ARE expressible today (drafted above).
+   *Mitigation options:* (a) add the builtin; or (b) materialize an `absolute_module(BindingId, AbsPath)` helper
+   in a Rust pre-pass / analyzer enrichment so the pack joins against a first-class fact. Recommend (b)-via-analyzer:
+   the analyzer already knows `relative_level` (Imports.hs:171) and the importer file — it could stamp the resolved
+   absolute `source_module` at emit time, making the pack trivially `node_attr`-join. **This is the single
+   highest-leverage change.**
+
+2. **Comma-split of a multi-value metadata string (`bases`, and generally).** `bases="User,Auditable"` must split
+   into individual base names (Python multiple inheritance). No `split`/`nth`/`first_segment` builtin exists
+   (`last_segment` returns only the LAST segment; `method_suffix` is rfind-`.`-only). One-base classes work
+   (`bases="User"` → whole string is the name); **multi-inheritance is unresolvable** for B4/D1/D2.
+   *Mitigation:* analyzer should emit one `BASE_OF`/per-base metadata node OR emit the stub `EXTENDS` edges with
+   per-base `base_name` (it ALREADY does — Declarations.hs:219-228, one edge per base, `base_name` metadata!).
+   **Recommend: drive D off the analyzer's stub EXTENDS edges + their `edge_attr(... "base_name" ...)`**, not the
+   `bases` string. That sidesteps the split entirely and is the same move js/rust packs made (edges over strings).
+
+3. **Generic-annotation outer-strip `X[...]` → `X` (a "prefix-before-first-delimiter" function).** `normalizeType`
+   (TypeResolution.hs:53-56) takes everything before the first `[`. No builtin extracts a prefix before a
+   delimiter (`strip_suffix` needs a fixed literal tail; `method_suffix` gives the SUFFIX after last `.`).
+   *Impact:* annotations like `List[str]`, `Optional[User]` are SKIPPED in the draft (`\+ string_contains(A,"[")`).
+   Legacy resolves the OUTER name only (`List`, `Optional`) which rarely matches a project class anyway, so the
+   real-edge loss is small — but `dict[str, MyClass]` inner types were never resolved by legacy either. **Low impact;
+   acceptable to defer.** A `prefix_before(S, Delim, Out)` builtin would close it.
+
+4. **No `eq_const` / literal-binding builtin for `meta(...)` constant columns.** The draft `call_virtual` wants
+   `dispatch="virtual"` as edge metadata. `meta(col)` projects a HEAD column, so the rule head needs a column
+   already bound to the literal `"virtual"`. There is no builtin binding a free var to a constant. *Mitigation:*
+   use a 1-row ground fact `dispatch_virtual("virtual").` and join it (`dispatch_virtual(Dispatch)`), or omit the
+   `dispatch` metadata (it's informational, not edge-identity). **Low impact** — drop the meta or use a ground fact.
+
+5. **`builtin_type/1` ground-fact set** (str,int,float,…). Trivially generated as facts (same as `rt_global`
+   in js packs). Not a real blocker — just must be generated into the pack. Gated on facts-e2e (synthesis Wave 0).
+
+6. **C2/C4 "first match anywhere" (imprecise fallbacks).** Datalog set-semantics emits an edge to EVERY matching
+   target, not the FIRST. Legacy C2 (first METHOD with name) and C4 (first FUNCTION with name) take `head`.
+   *Impact:* SUPERSET delta — the pack emits all same-named targets where legacy picked one arbitrarily. For C4
+   cross-file same-named functions this is arguably MORE correct (legacy's "first" is nondeterministic), matching
+   the js-resolve precedent which accepted superset CALLS. **Expressible, but DELTA = SUPERSET (see §5).**
+
+7. **`node_attr` MAINTAIN ENVELOPE.** Every pack rule using `node_attr` (imports, types, calls-with-receiver,
+   inheritance-via-bases) **refuses incremental maintenance and forces full recompute** (verified: js_import_bindings.dl:91).
+   Not a correctness blocker; a perf note — the python packs will be recompute-only until metadata moves to the row surface.
+
+## 5. PREDICTED DELTAS (vs legacy, per step) — SOURCE-DERIVED, NOT MEASURED
+
+| Step | Pack | Delta class | Bound / rationale |
+|---|---|---|---|
+| A1 absolute from-import | imp_from_decl/submod | **EXACT** (on absolute-import subset) | same NameIndex/ModuleIndex join; set-semantics dedups. Legacy "declaration takes priority over re-export" (ImportResolution.hs:101-104) — draft must add `\+ decl_at(_,P,N)` guard to reexport arm to match (TODO in draft). |
+| A1 relative from-import | — | **SUBSET (→0 until blocker #1)** | 0 relative imports resolved. In a real package this could be the MAJORITY of IMPORTS_FROM. **Hard SUBSET, large.** |
+| A2 glob | (relative) | **SUBSET (→0)** | glob targets are relative (`gnName=".models"`) → blocker #1. |
+| B1/B2 annotation TYPE_OF | type_of_fn/var | **SUBSET (small)** + EXACT on non-generic | drops `X[...]` annotations (blocker #3); those rarely match a project class. Bound: ≤ (count of generic-annotated decls whose OUTER name is a project class). |
+| B3 PARAMETER TYPE_OF | (not ported) | **EXACT (0=0)** | dead code in legacy too (no PARAMETER nodes); params resolved via B2 as VARIABLEs. |
+| B4 vs D EXTENDS | (use D) | **n/a** | B4 duplicates D with worse (global, import-blind) lookup; do NOT port B4 — D supersedes it. |
+| C1 virtual dispatch | call_virtual | **EXACT to SUPERSET** | subclass expansion via EXTENDS* mirrors HierarchyIndex; superset only if a base/sub pair has same-named methods legacy's traversal also hit (it does — `nub $ concatMap` over allClasses). Likely EXACT. **Depends on resolved EXTENDS existing (blocker #1 for cross-file bases).** |
+| C2 imprecise method | (fallback) | **SUPERSET** | emits all same-named METHODs; legacy takes head. Bounded by Σ(name-collision multiplicity). |
+| C3 same-file function | call_samefile | **EXACT to SUPERSET** | same-file (file,name); superset only on duplicate-named same-file funcs (rare). Legacy takes head of `(file,name)` list. |
+| C4 cross-file function | (fallback) | **SUPERSET** | emits all same-named funcs project-wide; legacy head. Largest superset risk for CALLS — accept per js precedent, or gate with uniqueness `\+ ambiguous`. |
+| D1 same-file inheritance | extends_samefile | **EXACT** (single base) / SUBSET (multi-base via `bases` string) | use edge-driven (blocker #2 mitigation) → EXACT. |
+| D2 cross-file inheritance | extends_crossfile | **EXACT on absolute import** / SUBSET on relative | blocker #1 for relative; otherwise EXACT. |
+
+**Net honest verdict:** absolute-import + same-file slices are EXACT-expressible today. The relative-import family
+(A1-rel, A2, D2-rel) is a HARD ZERO without blocker #1, and that family is structurally the bulk of real Python
+intra-package edges. **Python migration is NOT viable for a clean differential until blocker #1 (relative-import
+resolution) lands** — ideally as analyzer-stamped absolute `source_module`, which also unblocks #2 (drive D off
+EXTENDS stub edges). Recommend sequencing: (1) analyzer enrichment for absolute source_module + keep per-base EXTENDS
+stubs → (2) pack absolute-imports + same-file calls + inheritance-via-edges (EXACT) → (3) defer generics + imprecise
+fallbacks (small/superset) → (4) differential.
+
+## 6. HONESTY SECTION (unverified / risk register)
+
+- **NO LIVE PROBE.** Zero Python nodes in the dogfood graph. All shapes are read from analyzer SOURCE and/or
+  package test fixtures, never from a real materialized Python graph. The DELTA bounds are reasoned, not measured.
+  A real probe requires analyzing an actual Python project (none in-repo in config).
+- **FIXTURE-vs-ANALYZER mismatches found (both flagged inline):**
+  (a) method SID `[in:Cls,h:y]` in resolver test vs real `[in:Cls]` no-hash — `extractClassName` survives, naive
+  string-match packs would not; (b) PARAMETER nodes in type-resolver test that the analyzer never emits (B3 dead).
+- **`attr` reads ONLY first-class columns** {name,file,type,id} (builtin.rs:547-553). EVERY python metadata key
+  (`source_module`, `imported_name`, `bases`, `annotation`, `return_annotation`, `receiver`, `kind`, `glob`,
+  `relative_level`, `base_name`) needs `node_attr`/`edge_attr`. Verified against builtin source; not a guess.
+- **`extractClassName`/SID-`[in:]` approach intentionally NOT used in the draft** — replaced by HAS_METHOD edges
+  per the js/rust precedent (synthesis §1a `member_of`). This is a deliberate divergence from legacy mechanism;
+  it is MORE correct (handles nested-in-function methods) but must be verified to produce the same MethodIndex
+  membership on a real graph before claiming EXACT for C1/C2.
+- **`sub_or_self`/EXTENDS* recursion** assumes RESOLVED EXTENDS edges exist (child→parent). On a fresh graph the
+  only EXTENDS edges pre-pack are the analyzer STUBS (correct same-file, wrong cross-file target). So C1's
+  subclass expansion depends on the inheritance pack (D) running FIRST in the pack-order, OR on the stubs being
+  same-file-correct. **Pack-order dependency: D before C.** (Synthesis warns pack-order is load-bearing.)
+- **Re-export priority** (decl over IMPORT_BINDING in NameIndex, ImportResolution.hs:101-104) is NOT yet in the
+  draft reexport arm — needs `\+ decl_at(_,P,N)` guard to avoid a double IMPORTS_FROM. Flagged as draft TODO.
+- **`concat` arity-3** `(A, B, Out)` verified (builtin.rs:1296). The submodule-path build uses two concats; could
+  also be one rule if a 3-arg-join concat existed (it doesn't). Minor.
+- I did NOT run the python-analyzer or python-resolve binaries (no Python corpus to feed). I did NOT verify the
+  orchestrator's python resolve dispatch wiring (`grafema-orchestrator` python_parser.rs) — out of scope for the
+  rule draft, but the skip-flag/pack-runner integration must mirror js/rust (`GRAFEMA_SKIP_RESOLVE_STEPS`).
+
+---
+
+## ADVERSARIAL VERDICT (independent review, 2026-06-13)
+
+Reviewer re-read the resolver modules (`ImportResolution.hs`, `TypeResolution.hs`,
+`CallResolution.hs`, `ClassInheritance.hs`), the analyzer emission
+(`python-analyzer/src/Rules/{Imports,Declarations,Calls}.hs`, `Analysis/Types.hs`), the live
+`derive/builtin.rs` registry + mode tables. No Python nodes in the dogfood graph (confirmed —
+`config.yaml` has no `.py` glob), so all shapes are SOURCE-grounded; general builtins live-checked.
+
+### CONFIRMED by independent evidence
+- `node_attr` is `[B,B,F]`/`[B,B,B]`, no generator (builtin.rs:1186); `concat/3`, `replace_all/4`,
+  `strip_prefix/strip_suffix/3` exist with no-row-on-non-match; no `first_segment`, no `eq_const`,
+  no `split` (registry verified). Every metadata key the spec lists (`source_module`, `bases`,
+  `annotation`, etc.) genuinely needs `node_attr` (not `attr`) — `attr` reads only first-class
+  {name,file,type,id}. Correct.
+- from-import IMPORT_BINDING carries `source_module = fullPath` where
+  `fullPath = dots <> modulePart` (Imports.hs:146-148, 214) — i.e. source_module INCLUDES the
+  leading-dot prefix for relative imports (`from .base` → `".base"`). The spec's `\+ starts_with(S,".")`
+  ABSOLUTE-only guard is therefore CORRECT, and blocker #1 (relative-import resolution = dominant
+  blocker) is real and correctly the single highest-leverage gap.
+- plain-import IMPORT_BINDING has NO `source_module` (Imports.hs:88-114, only imported_name+local_name)
+  — the spec's `\+ b_src(B,_)` plain-import arm is correct.
+- CLASS `bases = MetaText (T.intercalate "," baseNames)` (Declarations.hs:209) — comma-joined string;
+  the split blocker #2 is REAL. The analyzer ALSO emits one EXTENDS stub edge per base with
+  `base_name` metadata (Declarations.hs:218-228) — the spec's recommended mitigation (drive D off the
+  stub EXTENDS + `edge_attr base_name`, not the `bases` string) is sound and sidesteps the split.
+- HAS_METHOD (CLASS→FUNCTION, Declarations.hs:151-156) exists — the spec's use of HAS_METHOD as the
+  `member_of` substrate (over SID `[in:]` parsing) is verified and is MORE correct (the spec's
+  nested-method observation holds).
+- B3 PARAMETER dead-code: analyzer emits parameters as VARIABLE (no PARAMETER node) — the spec's
+  "do not port B3" is correct.
+
+### ⚠ ONE REALITY TO FLAG (the round's lesson) — analyzer-stamped mitigation is under-specified
+The spec's recommended fix for blocker #1 is "(b)-via-analyzer: stamp the resolved absolute
+`source_module` at emit time". Independent read shows the analyzer ALSO stamps `relative_level`
+(MetaInt) on BOTH the IMPORT node (Imports.hs:171) AND the from-import IMPORT_BINDING
+(Imports.hs:240, `[("relative_level", MetaInt level) | level > 0]`) — the spec only mentions it on
+the IMPORT. So the binding already carries (source_module-with-dots, relative_level, importer file) —
+enough for a Rust pre-pass or analyzer enrichment to compute the absolute path WITHOUT a new builtin.
+This STRENGTHENS the spec's recommendation (b) and should be stated: the enrichment input already
+exists on the binding node; it is purely a dotted-path arithmetic, not new analyzer extraction.
+
+### ⚠ SECOND FLAG — deferred-ref baseline not accounted for
+The analyzer emits a `DeferredRef ImportResolve` with `drSource = fullPath`, `drEdgeType =
+"IMPORTS_FROM"` for every from-import binding (Imports.hs:225-235). The IMPORTS_FROM the differential
+compares against is produced by the python-resolve binary consuming/re-deriving these — but the spec
+does not state whether ANY IMPORTS_FROM are produced by an orchestrator deferred-ref pass independent
+of python-resolve. If the orchestrator resolves some deferred refs itself, the legacy baseline is not
+"python-resolve output" alone. The executing wave MUST confirm the IMPORTS_FROM baseline source on a
+real Python corpus before classifying A1 deltas as EXACT (the round's deferred-ref-drop lesson).
+
+### CONFIRMED — correctly classified
+- C2/C4 "first match anywhere" → SUPERSET (set-semantics emits all same-named): correct, matches js
+  precedent. `eq_const` gap for `meta(dispatch)` is real (no such builtin) — the ground-fact
+  mitigation or dropping the informational meta is the right call.
+- Pack-order D-before-C dependency (C1 subclass expansion needs resolved EXTENDS): correctly flagged.
+- `sub_or_self`/EXTENDS* recursion is expressible (datalog supports recursion); the spec is right that
+  it depends on resolved (not stub) EXTENDS edges, hence the D-before-C ordering.
+
+### READY FOR PACKS: **NO — and the spec says so.** The relative-import family (A1-rel, A2-glob,
+D2-rel) is a HARD ZERO without blocker #1, and that family is the bulk of real Python intra-package
+edges. Absolute-import + same-file slices ARE expressible today (EXACT, drafted correctly). The spec's
+honest net verdict — "not viable for a clean differential until blocker #1 lands, ideally as
+analyzer-stamped absolute source_module" — is correct and the right sequencing. The two flags above
+(enrichment input already on the binding; deferred-ref baseline) tighten but do not overturn it.


### PR DESCRIPTION
Spec round for the next language wave (haskell/beam/python), two-agent discipline + adversarial verdicts. None is immediately pack-ready — each VERDICT lists blocking corrections (haskell EXPORT_BINDING target identity; beam message-flow product limit; python relative-import resolution). Common small gaps: first_segment (already shipped) + a comma-split builtin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)