### PR TITLE
WIP haskell resolve packs — STAGING (parity decision needed, do not merge)

### DIFF
--- a/packages/rfdb-server/src/derive/stdlib/haskell_cross_module_calls.dl
+++ b/packages/rfdb-server/src/derive/stdlib/haskell_cross_module_calls.dl
@@ -1,0 +1,83 @@
+% haskell_cross_module_calls.dl — in-engine replacement for
+% HaskellCrossModuleCalls.hs (packages/haskell-resolve/src/HaskellCrossModuleCalls.hs):
+% a CALL whose bare name has an IMPORT_BINDING in the same file resolves to the
+% exported target in that binding's source module → CALLS (resolveOne, Hs:131-152).
+%
+% CALLS is SHARED vocabulary ⇒ mode = "additive". Legacy stamps
+% resolvedVia = "haskell-cross-module" (Hs:150); projected via meta(resolvedVia).
+%
+% C-R1 (the load-bearing verdict correction — TARGET IDENTITY): lookupExportTarget
+% returns `exNodeId entry` (Hs:128), and buildExportIndex (Hs:56-83) is identical
+% to the import resolver's: for a file WITH explicit exports, exNodeId is the
+% EXPORT_BINDING's OWN id; only the implicit-export-all branch targets a decl.
+% LIVE: every resolved cross-module CALLS target on the dogfood graph is an
+% EXPORT_BINDING — CALLS→EXPORT_BINDING = 1618, CALLS→FUNCTION = 0,
+% CALLS→CONSTRUCTOR = 0. Targeting the decl would mismatch ALL 1618 edges.
+% So `exported_in` SPLITS (re-declared intra-pack, the js convention):
+%   * file WITH explicit exports → the EXPORT_BINDING node itself;
+%   * file with NO EXPORT_BINDING → the same-file decl (8 implicit declTypes).
+%
+% QUALIFIER-STRIP OMITTED (verdict, same reasoning as haskell_local_calls): the
+% analyzer emits bare occurrence names; the resolver's breakOnEnd "." strip is a
+% no-op on real calls and would mangle the surviving dotted OPERATORS. Join on
+% the bare CALL.name → the same-file IMPORT_BINDING directly.
+%
+% BINDING SEAM (graph-native): the binding's source module rides on the
+% containing IMPORT's name via the committed IMPORT -CONTAINS-> IMPORT_BINDING
+% edge (LIVE: 2498/2498 .hs bindings carry it) — NO sid `[in:..]` parse.
+%
+% NUMBERED DELTAS vs the resolver (everything not listed is exact):
+%   DELTA 1 (SUPERSET by set semantics, explicit-export arm — MEASURED): the
+%     resolver's buildBindingIndex (Hs:85-92) is Map.fromList = ONE binding per
+%     (file,name); the export filter (entry:_) takes the FIRST EXPORT_BINDING.
+%     Set semantics derives an edge via EVERY same-(file,name) binding to EVERY
+%     same-(file,name) EXPORT_BINDING in the source module. MEASURED on the
+%     dogfood copy: legacy = 1618 (ALL EXPORT_BINDING targets — C-R1 confirmed),
+%     pack = 6782 (superset 5164), ZERO legacy-only rows (legacy ⊆ pack exactly).
+%     The superset is the binding × EXPORT_BINDING per-(file,name) multiplicity
+%     where the resolver's two nested first-wins Maps collapsed to one.
+%   DELTA 2 (implicit-export arm, superset): a no-export-list source module with
+%     two same-name decls of different types derives an edge per candidate; the
+%     resolver took the first. Bounded by per-(file,name) decl multiplicity in
+%     no-export files.
+%   DELTA 3 (operator dotted-name calls, ~0): breakOnEnd-strip omitted; same
+%     bound as haskell_local_calls DELTA 2.
+%   DELTA 4 (file gate): ends_with(F,".hs") on the CALL leg and the binding leg —
+%     the orchestrator's detect_language == Haskell stream filter.
+%
+% MAINTAIN ENVELOPE: negation (\+ xb_file_has_explicit_exports) ⇒ scratch floor.
+%
+% ORDERING: produces CALLS, so before the CALLS negators
+% (method_calls / shape_verifier). Re-derives its own export/binding seams
+% intra-pack (the js convention) — no inter-pack EDB seam.
+
+% Binding's source module (graph-native CONTAINS seam, as the import pack).
+xb(F, N, Mod) :-
+    node(B, "IMPORT_BINDING"), attr(B, "file", F), ends_with(F, ".hs"), attr(B, "name", N),
+    edge(I, B, "CONTAINS"), node(I, "IMPORT"), attr(I, "name", Mod).
+
+% Export side (re-declared intra-pack) — C-R1 split.
+xb_file_has_explicit_exports(TF) :-
+    node(EB, "EXPORT_BINDING"), attr(EB, "file", TF), ends_with(TF, ".hs").
+
+xb_decl(TF, N, D) :- node(D, "FUNCTION"),       attr(D, "file", TF), ends_with(TF, ".hs"), attr(D, "name", N), neq(N, "").
+xb_decl(TF, N, D) :- node(D, "VARIABLE"),       attr(D, "file", TF), ends_with(TF, ".hs"), attr(D, "name", N), neq(N, "").
+xb_decl(TF, N, D) :- node(D, "DATA_TYPE"),      attr(D, "file", TF), ends_with(TF, ".hs"), attr(D, "name", N), neq(N, "").
+xb_decl(TF, N, D) :- node(D, "TYPE_CLASS"),     attr(D, "file", TF), ends_with(TF, ".hs"), attr(D, "name", N), neq(N, "").
+xb_decl(TF, N, D) :- node(D, "TYPE_SYNONYM"),   attr(D, "file", TF), ends_with(TF, ".hs"), attr(D, "name", N), neq(N, "").
+xb_decl(TF, N, D) :- node(D, "TYPE_FAMILY"),    attr(D, "file", TF), ends_with(TF, ".hs"), attr(D, "name", N), neq(N, "").
+xb_decl(TF, N, D) :- node(D, "CONSTRUCTOR"),    attr(D, "file", TF), ends_with(TF, ".hs"), attr(D, "name", N), neq(N, "").
+xb_decl(TF, N, D) :- node(D, "TYPE_SIGNATURE"), attr(D, "file", TF), ends_with(TF, ".hs"), attr(D, "name", N), neq(N, "").
+
+xb_exported_in(TF, N, EB) :-
+    node(EB, "EXPORT_BINDING"), attr(EB, "file", TF), ends_with(TF, ".hs"),
+    attr(EB, "name", N), neq(N, "").
+xb_exported_in(TF, N, D) :-
+    xb_decl(TF, N, D), \+ xb_file_has_explicit_exports(TF).
+
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+hs_xmod_call(C, D, "haskell-cross-module") :-
+    node(C, "CALL"), attr(C, "file", F), ends_with(F, ".hs"), attr(C, "name", N),
+    xb(F, N, Mod),
+    node(M, "MODULE"), attr(M, "name", Mod), attr(M, "file", TF),
+    xb_exported_in(TF, N, D).

--- a/packages/rfdb-server/src/derive/stdlib/haskell_imports.dl
+++ b/packages/rfdb-server/src/derive/stdlib/haskell_imports.dl
@@ -1,0 +1,116 @@
+% haskell_imports.dl — in-engine replacement for HaskellImportResolution.hs
+% (packages/haskell-resolve/src/HaskellImportResolution.hs): the two import
+% phases, IMPORTS_FROM edges.
+%
+%   Arm A — IMPORT → MODULE (resolveImport, Hs:119-130): Haskell resolves an
+%     import by MODULE NAME, not path. `import Data.Map.Strict` resolves to the
+%     MODULE node whose name == "Data.Map.Strict" — a plain attr-equality join.
+%     NO path_resolve, NO extension ladder, NO workspace facts (the js/rust
+%     blockers do not exist here). geMetadata = Map.empty (Hs:127) — no meta.
+%   Arm B — IMPORT_BINDING → exported declaration (resolveBinding, Hs:138-169):
+%     the binding's source module rides on the containing IMPORT's name via the
+%     committed IMPORT -CONTAINS-> IMPORT_BINDING edge (LIVE: 2498/2498 .hs
+%     bindings carry it — the graph-native seam, NO sid `[in:..]` parsing, NO
+%     node_attr). module name → MODULE → target file → exported decl in that file.
+%
+% C-R1 (the load-bearing verdict correction — TARGET IDENTITY): the resolver's
+% buildExportIndex (Hs:60-93) sets `geTarget = exNodeId entry`. For a file WITH
+% explicit exports, exNodeId is the EXPORT_BINDING's OWN id (explicitExports =
+% ExportEntry (gnName n) (gnId n) over EXPORT_BINDING nodes, Hs:68-72). ONLY the
+% implicit-export-all branch (a file with NO EXPORT_BINDING, Hs:82-88) targets a
+% real declaration. So `exported_in` MUST SPLIT:
+%   * file WITH explicit exports → target the EXPORT_BINDING node itself;
+%   * file with NO EXPORT_BINDING → target the same-file decl (8 declTypes).
+% LIVE (the structurally-identical cross-module CALLS arm): CALLS→EXPORT_BINDING
+% = 1618 vs CALLS→FUNCTION = 0 — EXPORT_BINDING is the *entirety* of resolved
+% cross-module targets on the dogfood graph. Targeting the decl would mismatch
+% every explicit-export edge.
+%
+% The implicit-export decl set is the resolver's EXACT 8 declTypes (Hs:76-79):
+% FUNCTION, VARIABLE, DATA_TYPE, TYPE_CLASS, TYPE_SYNONYM, TYPE_FAMILY,
+% CONSTRUCTOR, TYPE_SIGNATURE. (This is the implicit-export branch — it targets
+% the DECL, so it keeps the resolver's full list verbatim; the verdict's
+% "drop TYPE_SIGNATURE/VARIABLE/DATA_TYPE" applies to the call/ref decl sets in
+% the other packs, NOT to this implicit-export branch which mirrors the resolver
+% literally. The implicit branch fires only for no-export-list files, a minority.)
+%
+% IMPORTS_FROM is SHARED vocabulary (rust/js/java/go packs + legacy emit it) ⇒
+% mode = "additive". Legacy edges carry EMPTY metadata (Hs:127,162) — no meta
+% projected, exact parity (engine provenance _source/_generation only).
+%
+% NUMBERED DELTAS vs the resolver (everything not listed is exact):
+%   DELTA 1 (Arm A, SUPERSET by set semantics — MEASURED): IMPORT.name ==
+%     MODULE.name both-sides name lookup. resolver Map.lookup keeps ONE MODULE
+%     per name (arbitrary winner); set semantics derives an edge to EVERY MODULE
+%     of that name. The dogfood is a multi-package Haskell monorepo with 25
+%     distinct MODULE names shared by >1 MODULE node (e.g. `Analysis.Types`,
+%     `ImportResolution` recur across packages), so this is REAL collision, not
+%     the spec's predicted ~0. MEASURED: legacy Arm A = 814, pack = 3090
+%     (superset 2276), ZERO legacy-only rows. The pack covers every legacy edge
+%     and additionally resolves the candidates the resolver's arbitrary winner
+%     dropped. Bounded by duplicate MODULE.name count.
+%   DELTA 2 (Arm B explicit, EXACT modulo set): every (file,name) EXPORT_BINDING
+%     of an explicitly-exported imported name. resolver filter (entry:_) takes
+%     the FIRST matching EXPORT_BINDING; set semantics derives ALL same-(file,name)
+%     EXPORT_BINDINGs — superset bounded by per-(file,name) EXPORT_BINDING
+%     multiplicity (expected ~1, EXPORT_BINDING.name is first-class). LIVE: legacy
+%     Arm B = 0 edges in the dogfood snapshot (the binding arm produced nothing —
+%     a separate orchestrator gap, verdict COULD-NOT-VERIFY), so this arm is
+%     SOURCE-grounded; the C-R1 target identity is LIVE-confirmed via the
+%     structurally-identical cross-module CALLS arm (1618 → EXPORT_BINDING).
+%   DELTA 3 (Arm B implicit, superset by set semantics): a no-export-list file
+%     with two same-name decls of different types (the Haskell norm: a
+%     TYPE_SIGNATURE node AND a FUNCTION node both named foo) derives an edge to
+%     EVERY candidate; resolver Map.fromListWith (++) + filter (entry:_) took the
+%     first. Bounded by per-(file,name) decl-type multiplicity in no-export files.
+%
+% MAINTAIN ENVELOPE: negation (\+ file_has_explicit_exports) ⇒ scratch floor
+% (accepted, the import-pack stance).
+%
+% ORDERING (PRODUCER): produces IMPORTS_FROM — must run BEFORE depends (which
+% consumes EVERY IMPORTS_FROM edge node-type-agnostically). No inter-pack EDB
+% seam with the call packs (they re-derive their own export/binding seams).
+
+% ── Arm A: IMPORT → MODULE (by module NAME) ─────────────────────────────────
+% The .hs gate is the cross-language leakage guard — IMPORT/MODULE are shared
+% vocabulary across analyzers.
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+hs_import_module(I, M) :-
+    node(I, "IMPORT"), attr(I, "file", F), ends_with(F, ".hs"), attr(I, "name", Mod),
+    node(M, "MODULE"), attr(M, "name", Mod).
+
+% ── Export side (buildExportIndex, Hs:60-93) ────────────────────────────────
+% Files WITH explicit exports: any .hs file that owns an EXPORT_BINDING node.
+file_has_explicit_exports(TF) :-
+    node(EB, "EXPORT_BINDING"), attr(EB, "file", TF), ends_with(TF, ".hs").
+
+% The 8 implicit-export declTypes (Hs:76-79) — used ONLY for the implicit branch
+% (no-export-list files), where the resolver targets the DECL. Verbatim list.
+hs_decl(TF, N, D) :- node(D, "FUNCTION"),       attr(D, "file", TF), ends_with(TF, ".hs"), attr(D, "name", N), neq(N, "").
+hs_decl(TF, N, D) :- node(D, "VARIABLE"),       attr(D, "file", TF), ends_with(TF, ".hs"), attr(D, "name", N), neq(N, "").
+hs_decl(TF, N, D) :- node(D, "DATA_TYPE"),      attr(D, "file", TF), ends_with(TF, ".hs"), attr(D, "name", N), neq(N, "").
+hs_decl(TF, N, D) :- node(D, "TYPE_CLASS"),     attr(D, "file", TF), ends_with(TF, ".hs"), attr(D, "name", N), neq(N, "").
+hs_decl(TF, N, D) :- node(D, "TYPE_SYNONYM"),   attr(D, "file", TF), ends_with(TF, ".hs"), attr(D, "name", N), neq(N, "").
+hs_decl(TF, N, D) :- node(D, "TYPE_FAMILY"),    attr(D, "file", TF), ends_with(TF, ".hs"), attr(D, "name", N), neq(N, "").
+hs_decl(TF, N, D) :- node(D, "CONSTRUCTOR"),    attr(D, "file", TF), ends_with(TF, ".hs"), attr(D, "name", N), neq(N, "").
+hs_decl(TF, N, D) :- node(D, "TYPE_SIGNATURE"), attr(D, "file", TF), ends_with(TF, ".hs"), attr(D, "name", N), neq(N, "").
+
+% C-R1 SPLIT — exported target identity:
+%   * explicit-export file → the EXPORT_BINDING node itself (geTarget = its id);
+exported_in(TF, N, EB) :-
+    node(EB, "EXPORT_BINDING"), attr(EB, "file", TF), ends_with(TF, ".hs"),
+    attr(EB, "name", N), neq(N, "").
+%   * no-export-list file → the same-file declaration.
+exported_in(TF, N, D) :-
+    hs_decl(TF, N, D), \+ file_has_explicit_exports(TF).
+
+% ── Arm B: IMPORT_BINDING → exported decl (graph-native CONTAINS seam) ───────
+binding_src(B, LocalN, Mod) :-
+    node(B, "IMPORT_BINDING"), attr(B, "file", F), ends_with(F, ".hs"), attr(B, "name", LocalN),
+    edge(I, B, "CONTAINS"), node(I, "IMPORT"), attr(I, "name", Mod).
+
+@materialize(edge_type = "IMPORTS_FROM", mode = "additive")
+hs_binding_import(B, D) :-
+    binding_src(B, N, Mod),
+    node(M, "MODULE"), attr(M, "name", Mod), attr(M, "file", TF),
+    exported_in(TF, N, D).

--- a/packages/rfdb-server/src/derive/stdlib/haskell_local_calls.dl
+++ b/packages/rfdb-server/src/derive/stdlib/haskell_local_calls.dl
@@ -1,0 +1,62 @@
+% haskell_local_calls.dl — in-engine replacement for HaskellLocalCalls.hs
+% (packages/haskell-resolve/src/HaskellLocalCalls.hs): a CALL that is not an
+% imported name resolves to a same-file callable declaration → CALLS
+% (resolveOne, Hs:59-79).
+%
+% CALLS is SHARED vocabulary ⇒ mode = "additive". Legacy stamps
+% resolvedVia = "haskell-local-calls" (Hs:77); projected via meta(resolvedVia).
+%
+% CALLABLE SET (verdict SECOND-MISS correction). The resolver's callableTypes
+% (Hs:34-38) are 6: FUNCTION, VARIABLE, CONSTANT, CONSTRUCTOR, RECORD_FIELD,
+% TYPE_SIGNATURE. buildDeclIndex is Map.fromList = LAST-WINS, ONE id per
+% (file,name); the LIVE legacy CALLS target breakdown is:
+%   FUNCTION = 2310, CONSTRUCTOR = 152, RECORD_FIELD = 160, CONSTANT = 0,
+%   TYPE_SIGNATURE = 0, VARIABLE = 0  (total 2622).
+% TYPE_SIGNATURE / VARIABLE contribute ZERO legacy edges; including them would
+% emit pack-only superset edges. We keep only the empirically-targeted types:
+% FUNCTION, CONSTRUCTOR, RECORD_FIELD, CONSTANT (CONSTANT 0 here but a real
+% callable, kept with a 0 bound).
+%
+% QUALIFIER-STRIP OMITTED (verdict — MORE faithful, not less). The resolver
+% strips a dotted prefix with T.breakOnEnd "." (Hs:64-66). But the analyzer
+% already emits the BARE occurrence name for qualified calls
+% (Expressions.hs:489 occNameString (rdrNameOcc name) — LIVE: CALL "lookup"=304,
+% "Map.lookup"=0), so the strip is a NO-OP on real calls. The only dotted .hs
+% CALL names that survive are OPERATORS (`.&.`, `.`, `.:`); stripping those
+% (last_segment) would mangle them and risk matching an unrelated local decl.
+% Joining on the bare CALL.name directly is the faithful common path and avoids
+% the operator false-positive class. OMIT last_segment (DELTA 2 below).
+%
+% NUMBERED DELTAS vs the resolver (everything not listed is exact):
+%   DELTA 1 (EXACT modulo set semantics): resolver Map.fromList last-wins keeps
+%     ONE callable per (file,name); set semantics derives an edge to EVERY
+%     same-(file,name) callable of the kept types. Superset bounded by
+%     per-(file,name) callable multiplicity.
+%   DELTA 2 (operator dotted-name calls, ~0): the resolver's breakOnEnd "." would
+%     resolve a dotted call (e.g. `.&.` → `&.`) IF a same-file decl `&.` existed
+%     (rare). The pack omits the strip → won't match. Bounded by the ≤112 dotted
+%     .hs CALL names (almost all operators with no local decl); expected ≈ 0.
+%   DELTA 3 (file gate): ends_with(F,".hs") on the CALL and each decl leg — the
+%     orchestrator's detect_language == Haskell stream filter (cross-language
+%     leakage guard; CALL/decl node types are shared vocabulary).
+%
+% MAINTAIN ENVELOPE: negation (\+ imp) ⇒ scratch floor (accepted).
+%
+% ORDERING: produces CALLS, so before the CALLS negators
+% (method_calls / shape_verifier). Consumes analyzer EDB only — no producer seam.
+
+% Same-file callables (verdict-narrowed to the empirically-targeted types).
+cd(F, N, D) :- node(D, "FUNCTION"),     attr(D, "file", F), ends_with(F, ".hs"), attr(D, "name", N), neq(N, "").
+cd(F, N, D) :- node(D, "CONSTANT"),     attr(D, "file", F), ends_with(F, ".hs"), attr(D, "name", N), neq(N, "").
+cd(F, N, D) :- node(D, "CONSTRUCTOR"),  attr(D, "file", F), ends_with(F, ".hs"), attr(D, "name", N), neq(N, "").
+cd(F, N, D) :- node(D, "RECORD_FIELD"), attr(D, "file", F), ends_with(F, ".hs"), attr(D, "name", N), neq(N, "").
+
+% Imported-name skip set (buildImportIndex, Hs:49-56): imported names are handled
+% by the cross-module call pack, not here.
+imp(F, N) :- node(B, "IMPORT_BINDING"), attr(B, "file", F), ends_with(F, ".hs"), attr(B, "name", N).
+
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+hs_local_call(C, D, "haskell-local-calls") :-
+    node(C, "CALL"), attr(C, "file", F), ends_with(F, ".hs"), attr(C, "name", N),
+    \+ imp(F, N),
+    cd(F, N, D).

--- a/packages/rfdb-server/src/derive/stdlib/haskell_local_refs.dl
+++ b/packages/rfdb-server/src/derive/stdlib/haskell_local_refs.dl
@@ -1,0 +1,80 @@
+% haskell_local_refs.dl — in-engine replacement for HaskellLocalRefs.hs
+% (packages/haskell-resolve/src/HaskellLocalRefs.hs), the SAME-FILE decl arm:
+% a REFERENCE that is not an imported name resolves to a same-file declaration
+% of that name → READS_FROM (resolveRef, Hs:117-134).
+%
+% READS_FROM is SHARED vocabulary ⇒ mode = "additive". Legacy stamps
+% resolvedVia = "haskell-local-refs" (Hs:132); projected via meta(resolvedVia).
+%
+% DECL SET (verdict SECOND-MISS correction). The resolver's declTypes (Hs:40-45)
+% are 8: FUNCTION, VARIABLE, CONSTANT, DATA_TYPE, TYPE_SYNONYM, CONSTRUCTOR,
+% RECORD_FIELD, PARAMETER. But buildDeclIndex is Map.fromList = LAST-WINS, ONE id
+% per (file,name), and the LIVE legacy READS_FROM target breakdown is:
+%   FUNCTION = 5103, PARAMETER = 11324, CONSTRUCTOR = 258, RECORD_FIELD = 249,
+%   CONSTANT = 0, VARIABLE = 0, DATA_TYPE = 0, TYPE_SYNONYM = 0
+%   (+ EXTERNAL_FUNCTION = 4986 — the prelude arm, see RESIDUE below).
+% VARIABLE / DATA_TYPE / TYPE_SYNONYM contribute ZERO legacy edges; including
+% them would emit pack-only superset edges the legacy never produced. We keep
+% only the empirically-targeted types: FUNCTION, PARAMETER, CONSTRUCTOR,
+% RECORD_FIELD, CONSTANT. (CONSTANT is 0 on this graph but is a legitimate
+% callable in the resolver and a real Haskell pattern — kept, with a 0 bound.)
+%
+% PRELUDE RESIDUE — DEFERRED to wave-2 (the haskell-globals pack), with EVIDENCE.
+% The resolver's prelude arm (Hs:135-168) mints a virtual EXTERNAL_FUNCTION node
+% `HASKELL_GLOBAL::<name>` with gnFile = "" and emits READS_FROM to it for ~140
+% compiled-in Prelude names. The dogfood graph DISAGREES with that source: its
+% prelude EXTERNAL_FUNCTION nodes live at file = "<runtime/haskell>" (NOT ""),
+% are minted by the haskell-globals / RuntimeGlobals step (which also emits 5788
+% _source="haskell-runtime-globals" CALLS edges), and carry node category
+% "haskell-prelude" / "haskell-stdlib". The verdict's `attr(X,"file","")`
+% disambiguator matches 0/99 EXTERNAL_FUNCTION nodes (LIVE: ext_file_empty=0).
+% So the prelude EDGE arm depends on nodes that the DEFERRED haskell-globals node
+% minter owns — minting a parallel `HASKELL_GLOBAL::` file="" namespace here
+% would (a) not match the live nodes and (b) couple wave-1 to the deferred wave.
+% DECISION: ship the decl arm now; defer the prelude node+edge arm to wave-2
+% alongside haskell-globals (the external-YAML SymbolDB → facts pack). The 4986
+% local-refs READS_FROM→EXTERNAL_FUNCTION edges are documented as the prelude
+% RESIDUE of the local-refs slice, closed by the same wave-2 pack.
+%
+% NUMBERED DELTAS vs the resolver (everything not listed is exact):
+%   DELTA 1 (decl arm, SUPERSET by set semantics — the LARGEST delta, measured):
+%     resolver buildDeclIndex = Map.fromList last-wins keeps ONE decl per
+%     (file,name); set semantics derives an edge to EVERY same-(file,name) decl
+%     of the kept types. The dominant driver is PARAMETER: a REFERENCE name (e.g.
+%     `x`, `acc`) resolves to EVERY same-(file,name) PARAMETER scope, where the
+%     resolver kept one arbitrary winner. MEASURED on the dogfood copy: legacy
+%     decl-slice = 16934, pack = 117400 (PARAMETER-target multiplicity = 109940).
+%     pack ⊇ legacy with ZERO legacy-only rows (every legacy edge reproduced).
+%     This is a name-match resolver's known imprecision (neither legacy's
+%     arbitrary winner nor the pack's all-candidates is scope-correct — scope
+%     resolution needs SCOPE edges, out of this resolver's contract); the pack
+%     reproduces the legacy COVERAGE as a superset. Bounded by per-(file,name)
+%     decl multiplicity (PARAMETER-dominated).
+%   DELTA 2 (prelude RESIDUE, subset): the 4986 READS_FROM→EXTERNAL_FUNCTION
+%     prelude edges are NOT emitted here (deferred, see PRELUDE RESIDUE).
+%   DELTA 3 (file gate): the legacy gate was the orchestrator's
+%     detect_language == Haskell stream filter — reproduced as ends_with(F,".hs")
+%     on the REFERENCE and on each decl leg (the cross-language leakage guard;
+%     REFERENCE/decl node types are shared vocabulary).
+%
+% MAINTAIN ENVELOPE: negation (\+ imported) ⇒ scratch floor (accepted).
+%
+% ORDERING: produces READS_FROM, so before the READS_FROM consumers/negators
+% (method_calls / shape_verifier). Consumes analyzer EDB only — no producer seam.
+
+% Same-file declarations (verdict-narrowed to the empirically-targeted types).
+ld(F, N, D) :- node(D, "FUNCTION"),     attr(D, "file", F), ends_with(F, ".hs"), attr(D, "name", N), neq(N, "").
+ld(F, N, D) :- node(D, "CONSTANT"),     attr(D, "file", F), ends_with(F, ".hs"), attr(D, "name", N), neq(N, "").
+ld(F, N, D) :- node(D, "CONSTRUCTOR"),  attr(D, "file", F), ends_with(F, ".hs"), attr(D, "name", N), neq(N, "").
+ld(F, N, D) :- node(D, "RECORD_FIELD"), attr(D, "file", F), ends_with(F, ".hs"), attr(D, "name", N), neq(N, "").
+ld(F, N, D) :- node(D, "PARAMETER"),    attr(D, "file", F), ends_with(F, ".hs"), attr(D, "name", N), neq(N, "").
+
+% Imported-name skip set (buildImportIndex, Hs:58-64): imported names are handled
+% by the import pack, not here.
+imported(F, N) :- node(B, "IMPORT_BINDING"), attr(B, "file", F), ends_with(F, ".hs"), attr(B, "name", N).
+
+@materialize(edge_type = "READS_FROM", mode = "additive", meta(resolvedVia))
+hs_local_ref(R, D, "haskell-local-refs") :-
+    node(R, "REFERENCE"), attr(R, "file", F), ends_with(F, ".hs"), attr(R, "name", N),
+    \+ imported(F, N),
+    ld(F, N, D).


### PR DESCRIPTION
## Status: DRAFT — decision artifact, do not merge as-is

Four adversarially-reviewed `derive` packs that replace the native `haskell-resolve` arms (imports / local-calls / cross-module-calls / local-refs). **Inert** in this PR: not wired into `STDLIB_PACKS` (rfdb) or `STDLIB_RULE_PACKS` (orchestrator), so graph output is unchanged and the cross-registry uniformity test passes. This banks the validated authoring work and surfaces the activation decision.

## The decision

js/rust reached **exact** differential parity (679/679, 7800/7800 → 0) before native was retired. These haskell packs are documented **supersets** of native, with **zero native-only rows** (full coverage) but extra rows:

| arm | native | pack | Δ |
|---|---|---|---|
| local_refs | 16,934 | 117,400 | +100,466 (scope-incorrect PARAMETER name-multiplicity) |
| imports ArmA (IMPORT→MODULE) | 814 | 3,090 | +2,276 (duplicate MODULE.name across packages) |
| cross_module_calls | 1,618 | 6,782 | +5,164 |

The superset is intrinsic: native precision comes from `Map.fromList` keeping **one arbitrary winner** per `(file,name)`; set-semantics Datalog derives **all** same-`(file,name)` candidates and cannot replicate an insertion-order winner. Neither is scope-correct (proper scope resolution needs SCOPE edges, outside this resolver's contract) — native just emits fewer, arbitrarily-chosen edges.

**Choose before activation:**
1. **Accept the superset** as the haskell graph (full coverage, lower scope-precision), gate the 4 native arms off, keep `haskell-globals` native.
2. **Hold** for a scope-edge precision pass so packs match native's edge count.

Globals/prelude arm is deferred to a wave-2 pack regardless (the `HASKELL_GLOBAL::` minter).

Each pack's header carries the full per-arm delta accounting and live-query evidence.