### PR TITLE
feat(beam): emit message shape-tree as graph nodes+edges

### DIFF
--- a/packages/beam-analyzer/lib/beam_analyzer/rules/infrastructure.ex
+++ b/packages/beam-analyzer/lib/beam_analyzer/rules/infrastructure.ex
@@ -149,7 +149,8 @@ defmodule BeamAnalyzer.Rules.Infrastructure do
       # REG-1098 W3: extract normalized shape of the message argument.
       # For GenServer.call/cast/Process.send/Process.send_after/send: msg is
       # the 2nd arg; target is the 1st.
-      message_shape_meta = extract_message_shape(args)
+      message_shape_term = extract_message_shape_term(args)
+      message_shape_meta = message_shape_term && BeamAnalyzer.Rules.Patterns.shape_to_meta(message_shape_term)
       target_is_self = self_target?(args, ctx)
       target_hint = explicit_target_hint(args, ctx)
       sender_via = sender_handler_type(base_call)
@@ -168,6 +169,23 @@ defmodule BeamAnalyzer.Rules.Infrastructure do
         |> maybe_put(:target_hint, target_hint)
 
       ctx = Context.merge_node_metadata(ctx, call_id, call_extras)
+
+      # REG-1098 W-shape: materialize the sent-message shape as a SHAPE
+      # subgraph on the send-site CALL, so derive rules can join it against
+      # a handler's HAS_PATTERN_SHAPE tree (structural unification as an
+      # edge-walk). Additive — message_shape metadata is still set above.
+      ctx =
+        if message_shape_term do
+          BeamAnalyzer.Rules.Patterns.emit_shape_tree(
+            ctx,
+            message_shape_term,
+            call_id,
+            ctx.file,
+            "HAS_SENT_SHAPE"
+          )
+        else
+          ctx
+        end
 
       target = resolve_message_target(ctx)
 
@@ -250,17 +268,16 @@ defmodule BeamAnalyzer.Rules.Infrastructure do
 
   defp explicit_target_hint(_, _), do: nil
 
-  defp extract_message_shape(args) when is_list(args) do
+  # The normalized shape() TERM of the message arg (2nd arg), or nil. Used
+  # both for the legacy meta serialization and the SHAPE-subgraph emission.
+  defp extract_message_shape_term(args) when is_list(args) do
     case Enum.at(args, 1) do
       nil -> nil
-      msg_ast ->
-        msg_ast
-        |> BeamAnalyzer.Rules.Patterns.normalize()
-        |> BeamAnalyzer.Rules.Patterns.shape_to_meta()
+      msg_ast -> BeamAnalyzer.Rules.Patterns.normalize(msg_ast)
     end
   end
 
-  defp extract_message_shape(_), do: nil
+  defp extract_message_shape_term(_), do: nil
 
   defp detect_handler(ctx, func_name, func_id, first_arg, meta, body) do
     # Detect handle_call, handle_cast, handle_info callbacks
@@ -368,6 +385,11 @@ defmodule BeamAnalyzer.Rules.Infrastructure do
         }
 
         ctx = Context.add_node(ctx, msg_node)
+
+        # REG-1098 W-shape: also materialize the pattern shape as a SHAPE
+        # subgraph so the derive engine can unify it structurally (the
+        # pattern_shape metadata above stays for the native resolvers).
+        ctx = BeamAnalyzer.Rules.Patterns.emit_shape_tree(ctx, shape, msg_id, ctx.file, "HAS_PATTERN_SHAPE")
 
         # RECEIVES edge from process to message type
         ctx = Context.add_edge(ctx, %{

--- a/packages/beam-analyzer/lib/beam_analyzer/rules/patterns.ex
+++ b/packages/beam-analyzer/lib/beam_analyzer/rules/patterns.ex
@@ -199,6 +199,142 @@ defmodule BeamAnalyzer.Rules.Patterns do
   end
 
   # ====================================================================
+  # SHAPE-TREE GRAPH EMISSION (REG-1098 W-shape)
+  # ====================================================================
+  #
+  # Lowers a `shape()` term into a first-class subgraph: one `SHAPE` node
+  # per shape constructor + structural edges (HAS_ELEMENT / HAS_HEAD /
+  # HAS_TAIL / HAS_FIELD), rooted at an owner node (a MESSAGE_TYPE's
+  # pattern or a send-site CALL's message) via `root_edge_type`.
+  #
+  # WHY: the `pattern_shape` / `message_shape` metadata is a non-scalar
+  # nested list that the derive engine's `node_attr` builtin CANNOT read
+  # (it returns no row on non-scalar values). Materializing the shape as
+  # nodes+edges turns structural unification (send-shape vs handler-pattern)
+  # from data-structure recursion — impossible in Datalog — into a
+  # recursive edge-walk, which the derive engine does natively. This is
+  # purely ADDITIVE: the metadata is still emitted for the native Haskell
+  # resolvers (BeamShape / BeamMessageFindings) that consume it today.
+  #
+  # Node `metadata.kind` is the discriminator (wildcard|unknown|number|
+  # atom|str|tuple|list|cons|map|struct), all top-level scalars so
+  # `node_attr(S,"kind",K)` / `node_attr(S,"value",V)` work. Map/struct
+  # field keys and tuple/list element indices live on the EDGE metadata
+  # (`key` / `index`), readable via `edge_attr`.
+
+  @doc """
+  Emit the `shape()` tree rooted at `owner_id` as SHAPE nodes + structural
+  edges, plus an `owner -root_edge_type-> root` edge. Returns the updated
+  context. Additive: callers keep emitting the `*_shape` metadata too.
+  """
+  @spec emit_shape_tree(Context.t(), shape() | any(), String.t(), String.t(), String.t()) ::
+          Context.t()
+  def emit_shape_tree(ctx, shape, owner_id, file, root_edge_type)
+      when is_binary(owner_id) and is_binary(file) and is_binary(root_edge_type) do
+    root_id = shape_node_id(owner_id, "root")
+    ctx = emit_shape_node(ctx, shape, root_id, file)
+    Context.add_edge(ctx, shape_edge(owner_id, root_id, root_edge_type, %{}))
+  end
+
+  defp shape_node_id(owner_id, path), do: "#{owner_id}->SHAPE->#{path}"
+
+  defp shape_edge(src, dst, type, meta), do: %{src: src, dst: dst, type: type, metadata: meta}
+
+  defp shape_node(id, file, kind, name, extra) do
+    %{
+      id: id,
+      type: "SHAPE",
+      name: name,
+      file: file,
+      line: 0,
+      column: 0,
+      endLine: 0,
+      endColumn: 0,
+      exported: false,
+      metadata: Map.merge(%{kind: kind}, extra)
+    }
+  end
+
+  # Leaves.
+  defp emit_shape_node(ctx, :_, id, file),
+    do: Context.add_node(ctx, shape_node(id, file, "wildcard", "_", %{}))
+
+  defp emit_shape_node(ctx, :unknown, id, file),
+    do: Context.add_node(ctx, shape_node(id, file, "unknown", "?", %{}))
+
+  defp emit_shape_node(ctx, :number, id, file),
+    do: Context.add_node(ctx, shape_node(id, file, "number", "num", %{}))
+
+  defp emit_shape_node(ctx, {:atom, a}, id, file) do
+    v = Atom.to_string(a)
+    Context.add_node(ctx, shape_node(id, file, "atom", v, %{value: v}))
+  end
+
+  defp emit_shape_node(ctx, {:str, s}, id, file) when is_binary(s),
+    do: Context.add_node(ctx, shape_node(id, file, "str", "str", %{value: s}))
+
+  # Ordered composites: tuple / list — children via HAS_ELEMENT[index].
+  defp emit_shape_node(ctx, {:tuple, elems}, id, file) do
+    ctx = Context.add_node(ctx, shape_node(id, file, "tuple", "tuple", %{arity: length(elems)}))
+    emit_elements(ctx, elems, id, file)
+  end
+
+  defp emit_shape_node(ctx, {:list, elems}, id, file) do
+    ctx = Context.add_node(ctx, shape_node(id, file, "list", "list", %{arity: length(elems)}))
+    emit_elements(ctx, elems, id, file)
+  end
+
+  # cons — HAS_HEAD / HAS_TAIL.
+  defp emit_shape_node(ctx, {:cons, h, t}, id, file) do
+    ctx = Context.add_node(ctx, shape_node(id, file, "cons", "cons", %{}))
+    hid = shape_child_id(id, "h")
+    tid = shape_child_id(id, "t")
+    ctx = emit_shape_node(ctx, h, hid, file)
+    ctx = Context.add_edge(ctx, shape_edge(id, hid, "HAS_HEAD", %{}))
+    ctx = emit_shape_node(ctx, t, tid, file)
+    Context.add_edge(ctx, shape_edge(id, tid, "HAS_TAIL", %{}))
+  end
+
+  # Keyed composites: map / struct — children via HAS_FIELD[key].
+  defp emit_shape_node(ctx, {:map, pairs}, id, file) do
+    ctx = Context.add_node(ctx, shape_node(id, file, "map", "map", %{}))
+    emit_fields(ctx, pairs, id, file)
+  end
+
+  defp emit_shape_node(ctx, {:struct, mod, pairs}, id, file) do
+    modname = Atom.to_string(mod)
+    ctx = Context.add_node(ctx, shape_node(id, file, "struct", "%#{modname}{}", %{struct_module: modname}))
+    emit_fields(ctx, pairs, id, file)
+  end
+
+  defp emit_shape_node(ctx, _other, id, file),
+    do: Context.add_node(ctx, shape_node(id, file, "unknown", "?", %{}))
+
+  defp emit_elements(ctx, elems, parent_id, file) do
+    elems
+    |> Enum.with_index()
+    |> Enum.reduce(ctx, fn {el, i}, acc ->
+      cid = shape_child_id(parent_id, Integer.to_string(i))
+      acc = emit_shape_node(acc, el, cid, file)
+      Context.add_edge(acc, shape_edge(parent_id, cid, "HAS_ELEMENT", %{index: i}))
+    end)
+  end
+
+  defp emit_fields(ctx, pairs, parent_id, file) do
+    pairs
+    |> Enum.with_index()
+    # child id keyed by INDEX (not key text) to avoid id collisions on
+    # duplicate/non-scalar keys; the field key lives on the edge metadata.
+    |> Enum.reduce(ctx, fn {{k, v}, i}, acc ->
+      cid = shape_child_id(parent_id, "k#{i}")
+      acc = emit_shape_node(acc, v, cid, file)
+      Context.add_edge(acc, shape_edge(parent_id, cid, "HAS_FIELD", %{key: key_to_string(k)}))
+    end)
+  end
+
+  defp shape_child_id(parent_id, seg), do: "#{parent_id}/#{seg}"
+
+  # ====================================================================
   # LEGACY: PATTERN node emission (used by Rules.Functions walker)
   # ====================================================================
 

--- a/packages/beam-analyzer/test/beam_analyzer_test.exs
+++ b/packages/beam-analyzer/test/beam_analyzer_test.exs
@@ -2305,4 +2305,219 @@ defmodule BeamAnalyzerTest do
       assert {:ok, _} = Jason.encode(result)
     end
   end
+
+  # ==================================================================
+  # REG-1098 W-shape — SHAPE-tree graph emission
+  # ==================================================================
+  #
+  # The shape() term that today lives only as non-scalar
+  # pattern_shape / message_shape metadata (which node_attr cannot read)
+  # is ALSO materialized as a first-class SHAPE subgraph: one SHAPE node
+  # per constructor + structural edges (HAS_ELEMENT / HAS_HEAD / HAS_TAIL
+  # / HAS_FIELD), rooted on the owner node via HAS_PATTERN_SHAPE (handler)
+  # or HAS_SENT_SHAPE (send-site CALL). Purely additive — the legacy
+  # metadata stays for the native Haskell resolvers.
+
+  describe "SHAPE-tree emission (REG-1098 W-shape)" do
+    # Self-registering GenServer fixture (PROCESS node exists so MESSAGE_TYPE
+    # and SENDS_TO emission fire) carrying BOTH a handler and a send-site that
+    # share a compound shape.
+    defp shape_analyze(body_source) do
+      source = """
+      defmodule WShape.Server do
+        use GenServer
+
+        def start_link(arg) do
+          GenServer.start_link(__MODULE__, arg, name: __MODULE__)
+        end
+
+      #{body_source}
+      end
+      """
+
+      BeamAnalyzer.analyze("lib/wshape_server.ex", source)
+    end
+
+    defp shape_nodes(result),
+      do: Enum.filter(result.nodes, &(&1.type == "SHAPE"))
+
+    defp node_by_id(result, id),
+      do: Enum.find(result.nodes, &(&1.id == id))
+
+    # The single edge of `type` whose src is `src_id`; raises if not exactly one.
+    defp one_edge(result, src_id, type) do
+      edges = Enum.filter(result.edges, &(&1.type == type and &1.src == src_id))
+      assert [edge] = edges, "expected exactly one #{type} edge from #{src_id}, got #{inspect(edges)}"
+      edge
+    end
+
+    defp shared_fixture do
+      shape_analyze("""
+        def handle_info({:tick, n}, state) do
+          {:noreply, Map.put(state, :n, n)}
+        end
+
+        def emit do
+          GenServer.cast(__MODULE__, {:tick, 5})
+        end
+      """)
+    end
+
+    test "handler tuple pattern lowers to a SHAPE tree with HAS_PATTERN_SHAPE root" do
+      result = shared_fixture()
+
+      msg =
+        result.nodes
+        |> Enum.filter(&(&1.type == "MESSAGE_TYPE"))
+        |> Enum.find(&(&1.metadata.handler_type == "info"))
+
+      assert msg != nil
+
+      # owner -HAS_PATTERN_SHAPE-> root SHAPE node, kind tuple, arity 2.
+      pat_edge = one_edge(result, msg.id, "HAS_PATTERN_SHAPE")
+      assert pat_edge.dst == "#{msg.id}->SHAPE->root"
+
+      root = node_by_id(result, pat_edge.dst)
+      assert root != nil
+      assert root.type == "SHAPE"
+      assert root.metadata.kind == "tuple"
+      assert root.metadata.arity == 2
+
+      # HAS_ELEMENT[index:0] -> SHAPE{kind:atom, value:"tick"}
+      elems = Enum.filter(result.edges, &(&1.type == "HAS_ELEMENT" and &1.src == root.id))
+      assert length(elems) == 2
+
+      e0 = Enum.find(elems, &(&1.metadata.index == 0))
+      e1 = Enum.find(elems, &(&1.metadata.index == 1))
+      assert e0 != nil
+      assert e1 != nil
+
+      atom_node = node_by_id(result, e0.dst)
+      assert atom_node.metadata.kind == "atom"
+      assert atom_node.metadata.value == "tick"
+
+      # HAS_ELEMENT[index:1] -> SHAPE{kind:wildcard}. The pattern element is
+      # the bare variable `n`, which normalize/1 collapses to `:_` (a pattern
+      # binds, it is not a literal number) — so the lowered SHAPE is a
+      # wildcard leaf, NOT a number. The literal-number case is exercised by
+      # the send-site test below (`{:tick, 5}`).
+      wild_node = node_by_id(result, e1.dst)
+      assert wild_node.metadata.kind == "wildcard"
+
+      # Child ids are parent-id derived: root/0 and root/1.
+      assert e0.dst == "#{root.id}/0"
+      assert e1.dst == "#{root.id}/1"
+    end
+
+    test "send-site CALL lowers to an equivalent tuple SHAPE tree via HAS_SENT_SHAPE" do
+      result = shared_fixture()
+
+      call =
+        Enum.find(result.nodes, &(&1.type == "CALL" and &1.name == "GenServer.cast"))
+
+      assert call != nil
+
+      sent_edge = one_edge(result, call.id, "HAS_SENT_SHAPE")
+      assert sent_edge.dst == "#{call.id}->SHAPE->root"
+
+      root = node_by_id(result, sent_edge.dst)
+      assert root.metadata.kind == "tuple"
+      assert root.metadata.arity == 2
+
+      elems = Enum.filter(result.edges, &(&1.type == "HAS_ELEMENT" and &1.src == root.id))
+
+      e0 = Enum.find(elems, &(&1.metadata.index == 0))
+      e1 = Enum.find(elems, &(&1.metadata.index == 1))
+
+      assert node_by_id(result, e0.dst).metadata.kind == "atom"
+      assert node_by_id(result, e0.dst).metadata.value == "tick"
+      assert node_by_id(result, e1.dst).metadata.kind == "number"
+    end
+
+    test "legacy non-scalar metadata (pattern_shape / message_shape) is still present (additive)" do
+      result = shared_fixture()
+
+      msg =
+        result.nodes
+        |> Enum.filter(&(&1.type == "MESSAGE_TYPE"))
+        |> Enum.find(&(&1.metadata.handler_type == "info"))
+
+      # Handler still carries the lowered-list pattern_shape metadata.
+      assert msg.metadata.pattern_shape ==
+               ["tuple", [["atom", "tick"], ["wildcard"]]]
+
+      # Send CALL still carries message_shape metadata.
+      call =
+        Enum.find(result.nodes, &(&1.type == "CALL" and &1.name == "GenServer.cast"))
+
+      # Send-site message is `{:tick, 5}` — the literal 5 normalizes to :number.
+      assert call.metadata.message_shape ==
+               ["tuple", [["atom", "tick"], ["number"]]]
+    end
+
+    test "all SHAPE node ids are unique (no collisions)" do
+      result = shared_fixture()
+
+      ids = shape_nodes(result) |> Enum.map(& &1.id)
+      assert ids == Enum.uniq(ids),
+             "duplicate SHAPE ids: #{inspect(ids -- Enum.uniq(ids))}"
+
+      # Sanity: the fixture produced both a handler tree and a send tree,
+      # so there is more than one root SHAPE node overall.
+      roots = Enum.filter(shape_nodes(result), &String.ends_with?(&1.id, "->SHAPE->root"))
+      assert length(roots) >= 2
+    end
+
+    test "map pattern emits SHAPE{kind:map} with HAS_FIELD edge keyed by field name" do
+      result =
+        shape_analyze("""
+          def handle_call(%{type: t}, _from, state) do
+            {:reply, t, state}
+          end
+        """)
+
+      msg =
+        result.nodes
+        |> Enum.filter(&(&1.type == "MESSAGE_TYPE"))
+        |> Enum.find(&(&1.metadata.handler_type == "call"))
+
+      assert msg != nil
+
+      pat_edge = one_edge(result, msg.id, "HAS_PATTERN_SHAPE")
+      root = node_by_id(result, pat_edge.dst)
+      assert root.metadata.kind == "map"
+
+      field_edges = Enum.filter(result.edges, &(&1.type == "HAS_FIELD" and &1.src == root.id))
+      assert [field_edge] = field_edges
+      assert field_edge.metadata.key == "type"
+
+      # The field value is a bare variable -> wildcard SHAPE leaf.
+      field_node = node_by_id(result, field_edge.dst)
+      assert field_node.type == "SHAPE"
+      assert field_node.metadata.kind == "wildcard"
+    end
+
+    test "SHAPE nodes are not auto-CONTAINed by the active handler clause" do
+      # add_node only auto-adds a CONTAINS edge for CALL/BRANCH/LOOP — SHAPE
+      # is exempt. A leaking CONTAINS from the handler clause to a SHAPE node
+      # would pollute the clause-body subgraph.
+      result = shared_fixture()
+
+      shape_ids = shape_nodes(result) |> Enum.map(& &1.id) |> MapSet.new()
+
+      leaking =
+        Enum.filter(result.edges, fn e ->
+          e.type == "CONTAINS" and MapSet.member?(shape_ids, e.dst)
+        end)
+
+      assert leaking == [], "SHAPE nodes must not be CONTAINed: #{inspect(leaking)}"
+    end
+
+    test "full analysis result with SHAPE subgraphs is Jason-encodable" do
+      result = shared_fixture()
+
+      assert {:ok, _} = Jason.encode(result)
+      assert shape_nodes(result) != []
+    end
+  end
 end


### PR DESCRIPTION
## What

Lower BEAM message shapes into a first-class subgraph so the derive engine can structurally unify a sent-message shape against a handler pattern shape via a **recursive edge-walk**, instead of recursing over opaque non-scalar `pattern_shape`/`message_shape` metadata that the `node_attr` builtin cannot read.

This is the analyzer-side enabler that `_ai/research/lang-spec-beam.md` §5 item 3 flagged as the blocker for migrating the beam message-flow resolvers (#6/#7/#8) to derive packs.

## How

- **`patterns.ex` — `emit_shape_tree/5`**: lowers a `shape()` term into one `SHAPE` node per constructor. `metadata.kind` ∈ {wildcard,unknown,number,atom,str,tuple,list,cons,map,struct} (top-level scalars → `node_attr`-readable); atom/str also carry `metadata.value`, struct carries `struct_module`, tuple/list carry `arity`. Structural edges: `HAS_ELEMENT` (`metadata.index`), `HAS_HEAD`/`HAS_TAIL`, `HAS_FIELD` (`metadata.key`).
- **`infrastructure.ex`**: wire `HAS_PATTERN_SHAPE` on the handler `MESSAGE_TYPE` and `HAS_SENT_SHAPE` on the send-site `CALL`.

## Additive guarantee

`pattern_shape`/`message_shape` metadata is **still emitted unchanged** for the native Haskell resolvers (`BeamShape`/`BeamMessageFindings`). Element index and field key live on **edge** metadata, so node fields stay scalar.

## Verification

- `mix test` → **187 tests, 0 failures** (+7 new SHAPE-emission tests; baseline 180).
- Live escript run on a GenServer fixture (`handle_info({:tick, n}, …)` + `GenServer.cast(__MODULE__, {:tick, 5})` + `handle_call(%{type: t}, …)`) yields the 3 expected shape trees: tuple→[atom:tick, number] (sent), tuple→[atom:tick, wildcard] (handler — `n` is a pattern var → wildcard), map→HAS_FIELD[key:type]→wildcard.
- Adversarial review (workflow) confirmed: id-collision-safe (disjoint per-parent seg namespaces), additive metadata intact, SHAPE exempt from the handler-clause auto-CONTAINS.

## Follow-up (not in this PR)

Emit lexical scope/containment as edges (JS-style `SCOPE`/`HAS_SCOPE`) so the beam resolve packs (imports/local-refs/behaviours) can scope-walk graph-recursively rather than flat-name-match — same "structure → edges" standard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)