### PR TITLE
fix(release): SSOT for platform-binary pins — fix 0.4.0 npm binary skew (0.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - feat(derive): `cli:command` / `mcp:tool` / `vscode:command` FEATURE detection moved to default-on derive packs (`@stdlib/js_entrypoint_features_nodes` + `@stdlib/js_entrypoint_features_edges`), continuing the Wave-14 HTTP-route precedent. These mint the commander / `@modelcontextprotocol/sdk` / vscode entry-point FEATURE nodes (+ `EXPOSES`/`HANDLES` edges) the `libraryCallbackEnricher` used to produce, resolving receivers via both the `RECEIVER_CALL` chain and the `DERIVES_FROM[callee]`/`READS_FROM[receiver]` PROPERTY_ACCESS walk for `<obj>.`-rooted namespace receivers (e.g. `vscode.commands.registerCommand`). The three slices were RETIRED from `libraryCallbackEnricher`'s `LIBRARY_NODE_TYPE` map — the pack is the single producer (no duplicate byte-different-id nodes). The MCP `setRequestHandler` ~4-call subset is unchanged; the ~30 per-tool `mcp:tool` nodes remain the separate `mcpToolDefinitionEnricher`'s job.
 
+### Bug Fixes
+
+- fix(release): platform-binary `optionalDependencies` are now injected at release time into **every** pin-bearing package (`packages/grafema` **and** `packages/cli`) from the single source `$NEW_VERSION` — single source of truth. Fixes the 0.4.0 skew where `@grafema/cli@0.4.0` shipped a stale hardcoded `0.3.29` pin (only `packages/grafema` was injected): `npm i grafema@0.4.0` then installed a `0.3.29` binary nested under `@grafema/cli` that shadowed the hoisted `0.4.0`, so the CLI ran a pre-derive binary against derive-required 0.4.0 — making 0.4.0 effectively non-functional from npm. Requires a 0.4.1 publish to take effect.
+
 ## [0.3.31] - 2026-06-11
 
 ### Features

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -377,25 +377,36 @@ for pkg in "${PLATFORM_PACKAGES[@]}"; do
     fi
 done
 
-# Inject optionalDependencies into grafema package for publish.
-# These are NOT in the workspace package.json (they cause cross-platform
-# lockfile conflicts with --frozen-lockfile on CI). They are injected
-# here at release time so npm users get the correct native binaries.
-GRAFEMA_PKG="$ROOT_DIR/packages/grafema/package.json"
-if [ -f "$GRAFEMA_PKG" ]; then
+# Inject platform-binary optionalDependencies for publish — SINGLE SOURCE OF TRUTH.
+# These are NOT relied on from the workspace package.json (they cause cross-platform
+# lockfile conflicts with --frozen-lockfile on CI). They are injected here at release
+# time, from the single source $NEW_VERSION, into EVERY package that ships them.
+#
+# 0.4.0 bug (fixed here): only packages/grafema was injected; packages/cli kept a
+# stale hardcoded pin (0.3.29) in source, so `npm i grafema@0.4.0` installed a 0.4.0
+# binary (hoisted from the meta) AND a 0.3.29 binary nested under @grafema/cli — and
+# the CLI resolved the nested 0.3.29 (a pre-derive binary) → 0.4.0 broken. Looping the
+# inject over all pin-bearing packages keeps every shipped pin == $NEW_VERSION.
+PIN_PACKAGES=(
+    "packages/grafema"
+    "packages/cli"
+)
+for PIN_PKG in "${PIN_PACKAGES[@]}"; do
+    PKG_JSON="$ROOT_DIR/$PIN_PKG/package.json"
+    [ -f "$PKG_JSON" ] || continue
     node -e "
       const fs = require('fs');
-      const pkg = JSON.parse(fs.readFileSync('$GRAFEMA_PKG', 'utf8'));
+      const pkg = JSON.parse(fs.readFileSync('$PKG_JSON', 'utf8'));
       pkg.optionalDependencies = {
         '@grafema/grafema-darwin-arm64': '$NEW_VERSION',
         '@grafema/grafema-darwin-x64': '$NEW_VERSION',
         '@grafema/grafema-linux-arm64': '$NEW_VERSION',
         '@grafema/grafema-linux-x64': '$NEW_VERSION',
       };
-      fs.writeFileSync('$GRAFEMA_PKG', JSON.stringify(pkg, null, 2) + '\n');
+      fs.writeFileSync('$PKG_JSON', JSON.stringify(pkg, null, 2) + '\n');
     "
-    echo -e "${GREEN}[x] Injected optionalDependencies in packages/grafema${NC}"
-fi
+    echo -e "${GREEN}[x] Injected optionalDependencies in $PIN_PKG -> $NEW_VERSION${NC}"
+done
 
 # Update rfdb-server Cargo.toml to match npm version
 CARGO_TOML="$ROOT_DIR/packages/rfdb-server/Cargo.toml"


### PR DESCRIPTION
## The bug (shipped in 0.4.0, npm)

`@grafema/cli@0.4.0` pins platform binaries to **0.3.29** in `optionalDependencies`, while the meta `grafema@0.4.0` correctly pins **0.4.0**. `release.sh` injected the pins into `packages/grafema` **only** — `packages/cli` kept a stale hardcoded `0.3.29`.

Result: `npm i grafema@0.4.0` installs a `0.4.0` binary (hoisted from the meta) **and** a `0.3.29` binary nested under `@grafema/cli`. The CLI's `findAnalyzerBinary` resolves the nested `0.3.29` — a **pre-derive** binary — against derive-required 0.4.0 (breaking release). So the published CLI is effectively non-functional.

Triangulated independently by two fleet sessions (laptop + ops) over the coordination channel; confirmed against npm (`npm view @grafema/cli@0.4.0 optionalDependencies` → all four `0.3.29`; binary `@grafema/grafema-linux-x64@0.4.0` exists).

## The fix (single source of truth)

`release.sh` now injects `optionalDependencies = $NEW_VERSION` into **every** pin-bearing package via a `PIN_PACKAGES` loop (`packages/grafema` + `packages/cli`). One source (`$NEW_VERSION`) drives all shipped pins; source-tree values are vestigial (overwritten at release). Takes effect on the next publish (**0.4.1**), which also carries the RFD-74 crash-recovery fix already merged via #409.

Pure release-mechanics change (`release.sh` + CHANGELOG); no package source / lockfile churn.