### PR TITLE
fix(derive): scope-walk rework — js_this_method_calls (#23)

### DIFF
--- a/packages/rfdb-server/src/derive/stdlib.rs
+++ b/packages/rfdb-server/src/derive/stdlib.rs
@@ -2033,46 +2033,128 @@ mod tests {
         );
     }
 
-    /// The bundled js_this_method_calls pack reproduces JsThisMethodCalls.hs exactly:
-    /// - unique same-file METHOD resolves (the arm firing);
-    /// - two same-named METHODs in the file → ambiguity skip (the neq/ambig idiom);
-    /// - "this.a.b" derives NOTHING even with a METHOD named "b" present — the
-    ///   concat-equality construction reproduces the resolver's stripThis miss and
-    ///   CORRECTS the migration spec's anticipated method_suffix superset delta;
-    /// - non-this calls, cross-file methods, .rs files derive nothing;
-    /// - DELTA 2 PINNED: .mts is rejected (the resolver's OWN 6-extension gate,
+    /// The bundled js_this_method_calls pack resolves this.-method calls SOUNDLY
+    /// via the live SCOPE chain (resolve-pack #23 rework — the flat (file,name)
+    /// arm was both imprecise and ambiguity-blind):
+    /// - a this.-call inside a METHOD body resolves to its enclosing class's member
+    ///   (the HAS_METHOD-owner path, shared with js_same_file_calls.dl B1);
+    /// - DELTA 2b PINNED: a this.-call inside an ARROW-FUNCTION CLASS PROPERTY (no
+    ///   METHOD/FUNCTION HAS_METHOD owner — the `<arrow>` FUNCTION owner is NOT a
+    ///   class member) resolves via the CLASS -HAS_SCOPE-> enclosing-scope path —
+    ///   the exact SceneManager.ts `_animate`/`_tickFly` case B1 alone MISSES;
+    /// - DELTA 2 PRECISION: two same-named members in distinct classes in one file
+    ///   each bind their OWN enclosing class (the old flat `ambig` guard refused
+    ///   BOTH — a false negative; the scope chain resolves each correctly);
+    /// - "this.a.b" derives NOTHING even with a member named "b" — concat-equality
+    ///   first-dot parity (the migration spec's method_suffix superset delta is
+    ///   eliminated by construction);
+    /// - a this.-call not lexically inside any class derives nothing;
+    /// - cross-file / .rs negatives;
+    /// - DELTA 4 PINNED: .mts is rejected (the resolver's OWN 6-extension gate,
     ///   narrower than the orchestrator's 8-extension stream filter).
     #[test]
-    fn js_this_method_calls_unique_method_with_ambiguity_skip() {
+    fn js_this_method_calls_scope_walk_with_arrow_property_and_precision() {
         let mut v = FixtureStorageView::new(1);
 
-        // Arm fires: unique "save" METHOD in app.ts.
-        named_node(&mut v, "m_save", "save", "METHOD", "app.ts");
-        named_node(&mut v, "c1", "this.save", "CALL", "app.ts");
+        // ── Method-body path: class App { init() { { this.render() } } } ──────────
+        // m_init -HAS_SCOPE-> s_fn (function scope) -HAS_SCOPE-> s_blk (lexical
+        // child block) -CONTAINS-> the call.
+        named_node(&mut v, "cls_app", "App", "CLASS", "app.ts");
+        named_node(&mut v, "m_init", "init", "METHOD", "app.ts");
+        named_node(&mut v, "m_render", "render", "METHOD", "app.ts");
+        edge(&mut v, "cls_app", "m_init", "HAS_METHOD");
+        edge(&mut v, "cls_app", "m_render", "HAS_METHOD");
+        named_node(&mut v, "s_app_cls", "class", "SCOPE", "app.ts");
+        named_node(&mut v, "s_fn", "function", "SCOPE", "app.ts");
+        named_node(&mut v, "s_blk", "block", "SCOPE", "app.ts");
+        edge(&mut v, "cls_app", "s_app_cls", "HAS_SCOPE");
+        edge(&mut v, "m_init", "s_fn", "HAS_SCOPE");
+        edge(&mut v, "s_app_cls", "s_fn", "HAS_SCOPE"); // lexical: class body owns the method scope
+        edge(&mut v, "s_fn", "s_blk", "HAS_SCOPE");
+        named_node(&mut v, "c_method", "this.render", "CALL", "app.ts");
+        edge(&mut v, "s_blk", "c_method", "CONTAINS");
 
-        // Ambiguity skip: two "load" METHODs in app.ts.
-        named_node(&mut v, "m_load1", "load", "METHOD", "app.ts");
-        named_node(&mut v, "m_load2", "load", "METHOD", "app.ts");
-        named_node(&mut v, "c2", "this.load", "CALL", "app.ts");
+        // Multi-dot pin inside the same class — METHOD-less, must derive nothing.
+        named_node(&mut v, "c_md", "this.a.b", "CALL", "app.ts");
+        edge(&mut v, "s_blk", "c_md", "CONTAINS");
 
-        // Multi-dot exactness pin: METHOD "b" exists, "this.a.b" must NOT resolve.
-        named_node(&mut v, "m_b", "b", "METHOD", "app.ts");
-        named_node(&mut v, "c3", "this.a.b", "CALL", "app.ts");
+        // ── DELTA 2b: arrow-function CLASS PROPERTY. Owner of the arrow scope is a
+        // FUNCTION (NOT a HAS_METHOD member); the class reaches the arrow scope only
+        // through CLASS -HAS_SCOPE-> arrow-fn-scope. Mirrors SceneManager._tickFly.
+        named_node(&mut v, "cls_scene", "Scene", "CLASS", "scene.ts");
+        named_node(&mut v, "m_tick", "_tickFly", "METHOD", "scene.ts");
+        edge(&mut v, "cls_scene", "m_tick", "HAS_METHOD");
+        named_node(&mut v, "s_scene_cls", "class", "SCOPE", "scene.ts");
+        named_node(&mut v, "f_arrow", "<arrow>", "FUNCTION", "scene.ts");
+        named_node(&mut v, "s_arrow_fn", "function", "SCOPE", "scene.ts");
+        named_node(&mut v, "s_arrow_blk", "block", "SCOPE", "scene.ts");
+        edge(&mut v, "cls_scene", "s_scene_cls", "HAS_SCOPE");
+        edge(&mut v, "f_arrow", "s_arrow_fn", "HAS_SCOPE"); // owner FUNCTION, NOT a class member
+        edge(&mut v, "s_scene_cls", "s_arrow_fn", "HAS_SCOPE"); // class body owns the arrow scope
+        edge(&mut v, "s_arrow_fn", "s_arrow_blk", "HAS_SCOPE");
+        named_node(&mut v, "c_arrow", "this._tickFly", "CALL", "scene.ts");
+        edge(&mut v, "s_arrow_blk", "c_arrow", "CONTAINS");
 
-        // File gate: .rs is not JS.
+        // ── DELTA 2 precision: two classes in one file, each a private "shouldLog".
+        // The old flat `ambig` guard refused BOTH; the scope chain resolves each
+        // call to its OWN class's member. (Mirrors util/.../Logger.ts.)
+        named_node(&mut v, "cls_cons", "ConsoleLogger", "CLASS", "log.ts");
+        named_node(&mut v, "m_cons_sl", "shouldLog", "METHOD", "log.ts");
+        named_node(&mut v, "m_cons_w", "write", "METHOD", "log.ts");
+        edge(&mut v, "cls_cons", "m_cons_sl", "HAS_METHOD");
+        edge(&mut v, "cls_cons", "m_cons_w", "HAS_METHOD");
+        named_node(&mut v, "s_cons_cls", "class", "SCOPE", "log.ts");
+        named_node(&mut v, "s_cons_fn", "function", "SCOPE", "log.ts");
+        edge(&mut v, "cls_cons", "s_cons_cls", "HAS_SCOPE");
+        edge(&mut v, "m_cons_w", "s_cons_fn", "HAS_SCOPE");
+        edge(&mut v, "s_cons_cls", "s_cons_fn", "HAS_SCOPE");
+        named_node(&mut v, "c_cons_sl", "this.shouldLog", "CALL", "log.ts");
+        edge(&mut v, "s_cons_fn", "c_cons_sl", "CONTAINS");
+
+        named_node(&mut v, "cls_file", "FileLogger", "CLASS", "log.ts");
+        named_node(&mut v, "m_file_sl", "shouldLog", "METHOD", "log.ts");
+        named_node(&mut v, "m_file_w", "writeLine", "METHOD", "log.ts");
+        edge(&mut v, "cls_file", "m_file_sl", "HAS_METHOD");
+        edge(&mut v, "cls_file", "m_file_w", "HAS_METHOD");
+        named_node(&mut v, "s_file_cls", "class", "SCOPE", "log.ts");
+        named_node(&mut v, "s_file_fn", "function", "SCOPE", "log.ts");
+        edge(&mut v, "cls_file", "s_file_cls", "HAS_SCOPE");
+        edge(&mut v, "m_file_w", "s_file_fn", "HAS_SCOPE");
+        edge(&mut v, "s_file_cls", "s_file_fn", "HAS_SCOPE");
+        named_node(&mut v, "c_file_sl", "this.shouldLog", "CALL", "log.ts");
+        edge(&mut v, "s_file_fn", "c_file_sl", "CONTAINS");
+
+        // ── Negative: this.-call inside a plain top-level function (no class).
+        named_node(&mut v, "f_free", "standalone", "FUNCTION", "free.ts");
+        named_node(&mut v, "m_orphan", "render", "METHOD", "free.ts"); // same-file METHOD, no class
+        named_node(&mut v, "s_free", "function", "SCOPE", "free.ts");
+        edge(&mut v, "f_free", "s_free", "HAS_SCOPE");
+        named_node(&mut v, "c_free", "this.render", "CALL", "free.ts");
+        edge(&mut v, "s_free", "c_free", "CONTAINS");
+
+        // ── File gate: .rs is not JS (a fully-wired class+scope, still rejected).
+        named_node(&mut v, "cls_rs", "Rs", "CLASS", "main.rs");
         named_node(&mut v, "m_go", "go", "METHOD", "main.rs");
-        named_node(&mut v, "c4", "this.go", "CALL", "main.rs");
+        edge(&mut v, "cls_rs", "m_go", "HAS_METHOD");
+        named_node(&mut v, "s_rs_cls", "class", "SCOPE", "main.rs");
+        named_node(&mut v, "s_rs_fn", "function", "SCOPE", "main.rs");
+        edge(&mut v, "cls_rs", "s_rs_cls", "HAS_SCOPE");
+        edge(&mut v, "m_go", "s_rs_fn", "HAS_SCOPE");
+        edge(&mut v, "s_rs_cls", "s_rs_fn", "HAS_SCOPE");
+        named_node(&mut v, "c_rs", "this.go", "CALL", "main.rs");
+        edge(&mut v, "s_rs_fn", "c_rs", "CONTAINS");
 
-        // Prefix negative: not a this-call.
-        named_node(&mut v, "c5", "notthis.save", "CALL", "app.ts");
-
-        // Cross-file negative: METHOD only in b.ts.
-        named_node(&mut v, "m_far", "far", "METHOD", "b.ts");
-        named_node(&mut v, "c6", "this.far", "CALL", "app.ts");
-
-        // DELTA 2 pin: .mts rejected by the resolver's own 6-extension gate.
+        // ── DELTA 4: .mts rejected by the resolver's own 6-extension gate.
+        named_node(&mut v, "cls_mts", "Mts", "CLASS", "app.mts");
         named_node(&mut v, "m_mts", "save", "METHOD", "app.mts");
-        named_node(&mut v, "c7", "this.save", "CALL", "app.mts");
+        edge(&mut v, "cls_mts", "m_mts", "HAS_METHOD");
+        named_node(&mut v, "s_mts_cls", "class", "SCOPE", "app.mts");
+        named_node(&mut v, "s_mts_fn", "function", "SCOPE", "app.mts");
+        edge(&mut v, "cls_mts", "s_mts_cls", "HAS_SCOPE");
+        edge(&mut v, "m_mts", "s_mts_fn", "HAS_SCOPE");
+        edge(&mut v, "s_mts_cls", "s_mts_fn", "HAS_SCOPE");
+        named_node(&mut v, "c_mts", "this.save", "CALL", "app.mts");
+        edge(&mut v, "s_mts_fn", "c_mts", "CONTAINS");
 
         let (eval, specs, _node_specs) = evaluate_with_materialize(
             &v,
@@ -2083,15 +2165,25 @@ mod tests {
         )
         .expect("js_this_method_calls.dl evaluates");
 
+        let via = |pairs: &[(&str, &str)]| -> BTreeSet<(u128, u128, String)> {
+            pairs
+                .iter()
+                .map(|(c, t)| (id_of(c), id_of(t), "js-this-method-calls".to_string()))
+                .collect()
+        };
         assert_eq!(
             triples(&eval, "js_this_method_call"),
-            BTreeSet::from([(
-                id_of("c1"),
-                id_of("m_save"),
-                "js-this-method-calls".to_string()
-            )]),
-            "exactly c1→m_save: ambiguous 'load', multi-dot 'this.a.b', .rs, non-this, \
-             cross-file and .mts (DELTA 2) all derive nothing"
+            via(&[
+                ("c_method", "m_render"),
+                ("c_arrow", "m_tick"),
+                ("c_cons_sl", "m_cons_sl"),
+                ("c_file_sl", "m_file_sl"),
+            ]),
+            "scope-walk: method-body c_method→m_render; arrow-property c_arrow→m_tick \
+             (DELTA 2b, the class-scope path B1 misses); the two same-named shouldLog \
+             calls each bind their OWN class (DELTA 2 precision — no flat ambig skip); \
+             'this.a.b' multi-dot, the class-less c_free, cross-file, .rs and .mts \
+             (DELTA 4) all derive nothing"
         );
 
         let calls_specs: Vec<_> = specs.iter().filter(|s| s.edge_type == "CALLS").collect();

--- a/packages/rfdb-server/src/derive/stdlib/js_this_method_calls.dl
+++ b/packages/rfdb-server/src/derive/stdlib/js_this_method_calls.dl
@@ -3,35 +3,42 @@
 % sole reason for the orchestrator's SECOND full-graph streaming pass
 % (main.rs js-this-method-calls — pure IPC overhead); the pack kills that pass.
 %
-% Resolver semantics reproduced EXACTLY (deliberately file-flat — the resolver
-% never looked at the enclosing class; parity over ambition. The scope-aware
-% enclosing-class arm lives in js_same_file_calls.dl B1, which legacy ALSO ran on
-% the same calls — the two packs overlap on additive CALLS exactly as the two
-% resolvers did):
-%   - CALL whose name starts with "this." in a JS/TS file (the resolver's OWN
-%     6-extension gate, Hs:45 — see DELTA 2);
-%   - the rest of the name after "this." is looked up among the file's METHOD
-%     nodes by (file, name) (Hs:29-36);
-%   - resolve ONLY when exactly one candidate exists (Hs:56-66) — the documented
-%     neq/ambig negation idiom;
-%   - empty method names never indexed (Hs:35) — the neq(MN, "") guard.
+% SCOPE-WALK rework (resolve-pack #23): the flat (file, name)→METHOD rule was
+% UNSOUND-by-imprecision and ambiguity-blind. On the real Grafema graph
+% (503296 nodes) the flat arm and js_same_file_calls.dl B1 (the scope-walk
+% this-arm) diverged BOTH ways: the flat `ambig` guard refused every member of
+% any (file, name) collision (e.g. two private `shouldLog` in Logger.ts — one per
+% class), giving false NEGATIVES; while B1's scope-walk bound the enclosing class
+% as a NODE and resolved each call to its OWN class. Conversely B1 alone MISSED
+% the call inside an arrow-function class property (DELTA 2b: js_same_file_calls.dl
+% :49-51) — e.g. SceneManager.ts `private _animate = () => { … this._tickFly() }`,
+% whose `<arrow>` FUNCTION owner is NOT a CLASS -HAS_METHOD-> member, so B1's
+% encl_member→encl_class link breaks at the arrow-property boundary.
 %
-% Multi-dot names are NOT a delta: concat in check mode pins
-% Full == "this." ++ MethodName — "this.a.b" only matches a METHOD literally
-% named "a.b" (never exists), identical to the resolver's index miss after
-% stripThis. This CORRECTS the migration spec's anticipated method_suffix
-% superset delta — eliminated by construction.
+% This pack now resolves this.-prefixed method calls SOUNDLY via the same
+% live SCOPE chain B1 uses (CALL <-CONTAINS- SCOPE, lexical HAS_SCOPE parents,
+% owner METHOD/FUNCTION → CLASS via HAS_METHOD) AND additionally derives the
+% enclosing CLASS directly from any enclosing SCOPE the CLASS owns
+% (CLASS -HAS_SCOPE-> enclosing-scope) — covering the arrow-property / static-block
+% case the HAS_METHOD-owner path cannot. CALLS is SHARED vocabulary ⇒ "additive";
+% the pack overlaps B1's additive CALLS exactly as the two resolvers did. Pack
+% scoped to this.-prefix only; super./<obj>. method calls are left to B1.
 %
-% CALLS is SHARED vocabulary ⇒ mode = "additive".
-%
-% NUMBERED DELTAS vs the resolver (everything not listed is exact):
+% NUMBERED DELTAS vs the original flat resolver (everything not listed is exact):
 %   DELTA 1 (metadata): resolvedVia="js-this-method-calls" projected as a meta
 %     column; engine provenance (_source/_generation) added.
-%   DELTA 2 (file gate, exact parity — recorded for the harness): the pack uses
-%     the resolver's own 6-extension gate (.ts/.tsx/.js/.jsx/.mjs/.cjs, Hs:45),
-%     which is NARROWER than the orchestrator's 8-extension stream filter —
-%     .mts/.cts this-calls were streamed to the resolver and rejected by it;
-%     the pack rejects them identically.
+%   DELTA 2 (precision, was a flat false-NEGATIVE): two same-named members in one
+%     file (distinct classes) no longer trigger the flat `ambig` skip — each call
+%     site binds its OWN enclosing class as a node and resolves to that class's
+%     member (mirrors js_same_file_calls.dl DELTA 2c).
+%   DELTA 3 (recall, was a flat false-POSITIVE source removed): the call must be
+%     lexically inside an enclosing CLASS via the live scope chain, not merely
+%     share a (file, name) with some METHOD anywhere in the file.
+%   DELTA 4 (file gate, exact parity, recorded for the harness): the pack keeps the
+%     resolver's own 6-extension gate (.ts/.tsx/.js/.jsx/.mjs/.cjs, Hs:45), which
+%     is NARROWER than the orchestrator's 8-extension stream filter — .mts/.cts
+%     this-calls were streamed to the resolver and rejected by it; the pack rejects
+%     them identically.
 
 % The resolver's own JS/TS gate — 6 extensions (Hs:45), NOT the orchestrator's 8 —
 % expanded as one clause per extension with a CONSTANT ends_with filter. (A
@@ -46,15 +53,42 @@ this_call6(C, F, Full) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".js
 this_call6(C, F, Full) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".mjs"), attr(C, "name", Full), starts_with(Full, "this.").
 this_call6(C, F, Full) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".cjs"), attr(C, "name", Full), starts_with(Full, "this.").
 
-% (file, name) → METHOD node (the resolver's MethodIndex, Hs:29-36).
-meth(F, N, M) :- node(M, "METHOD"), attr(M, "file", F), attr(M, "name", N), neq(N, "").
+% ── Scope chain (Wave-0 verified shape) — B1's enclosing-class idiom, reused ────
+% Seeded ONLY from the gated this-calls (planner-filter-before-generator: the
+% closure must not enumerate every scope content in the graph).
+%
+% The scope directly containing the call, then lexical parents: a scope's
+% HAS_SCOPE sources are its owner (FUNCTION/METHOD) AND its lexical parent scope
+% (and, at the top of a class body, the CLASS's own scope) — the node-type filter
+% separates them.
+encl_scope(C, S)  :- this_call6(C, F, Full), edge(S, C, "CONTAINS"), node(S, "SCOPE").
+encl_scope(C, S2) :- encl_scope(C, S), edge(S2, S, "HAS_SCOPE"), node(S2, "SCOPE").
 
-% More than one same-named METHOD in the file — the exactly-one guard (Hs:56-66).
-ambig(F, N) :- meth(F, N, M1), meth(F, N, M2), neq(M1, M2).
+% Scope owners along the chain (METHOD for class methods; FUNCTION kept for parity
+% with the resolver's FUNCTION|METHOD member index, Hs:75).
+encl_member(C, M) :- encl_scope(C, S), edge(M, S, "HAS_SCOPE"), node(M, "METHOD").
+encl_member(C, M) :- encl_scope(C, S), edge(M, S, "HAS_SCOPE"), node(M, "FUNCTION").
+
+% Every enclosing class of the call. Two sound paths into the CLASS node:
+%   (a) the method-owner path — the class owns the enclosing member via HAS_METHOD
+%       (the call sits in a method/function body); identical to B1.
+%   (b) the class-scope path — the class owns an enclosing SCOPE directly via
+%       HAS_SCOPE (the call sits in a class-body position with no METHOD/FUNCTION
+%       owner: an arrow-function class property or a static block). This closes the
+%       DELTA 2b gap that the HAS_METHOD-owner path alone cannot reach.
+encl_class(C, Cls) :- encl_member(C, M), edge(Cls, M, "HAS_METHOD"), node(Cls, "CLASS").
+encl_class(C, Cls) :- encl_scope(C, S), edge(Cls, S, "HAS_SCOPE"), node(Cls, "CLASS").
+
+% this. method call → a member of an enclosing class. concat in
+% check mode pins Full == Prefix ++ MemberName — the resolver's first-dot split,
+% exactly (so "this.a.b" only matches a member literally named "a.b", which never
+% exists — the migration spec's anticipated method_suffix superset delta is
+% eliminated by construction). One clause per prefix constant (a this_prefix fact
+% relation would be a §3 cross-join).
+this_method(C, M) :-
+    this_call6(C, F, Full), encl_class(C, Cls),
+    edge(Cls, M, "HAS_METHOD"), attr(M, "name", MN), neq(MN, ""),
+    concat("this.", MN, Full).
 
 @materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
-js_this_method_call(C, M, "js-this-method-calls") :-
-    this_call6(C, F, Full),
-    meth(F, MN, M),
-    \+ ambig(F, MN),
-    concat("this.", MN, Full).
+js_this_method_call(C, M, "js-this-method-calls") :- this_method(C, M).


### PR DESCRIPTION
## ⚠ NIGHT MODE — DO NOT MERGE until Vadim's morning go
Overnight fleet PR (#23 resolver-soundness). Verified; awaiting human merge.

## verify-task-premise: REWORK, not retire
This pack overlaps `js_same_file_calls` **B1** (this. method calls), so retirement was on the table. Grounded on the real graph: the two are **NOT** redundant — each arm resolves sound calls the other misses (flat-only 1, B1-only 10). **Retire would drop a real sound edge** (`this._tickFly` → `SceneManager._tickFly`). → REWORK.

## What
- Flat `(file,name)`→METHOD replaced with scope-walk reusing B1's `encl_*` idiom (this.-prefix only; super./<obj>. stay with B1).
- **Key extension over a plain B1 copy**: a second clause reaches the enclosing CLASS via `CLASS -HAS_SCOPE-> enclosing-scope` (not only via the `HAS_METHOD` owner). Covers the **arrow-function class-property / static-block** case (DELTA 2b) where the call's owner is an `<arrow>` FUNCTION with no `HAS_METHOD` membership — the exact gap B1 alone misses.
- Two-same-named-classes precision: `Logger.ts` ConsoleLogger/FileLogger `shouldLog` now each resolve to their own class (flat's ambiguity guard refused all = false negatives; scope-walk binds the enclosing class as a node).

## Differential vs legacy (real-graph /tmp copy)
- this-method CALLS **441 → 442** (+1 sound DELTA-2b edge B1 misses), **lost_real 0**, 0 over-binds. This is a **coverage gain**, not just a superset shrink.
- `meta(resolvedVia)` + `mode=additive` + edge shape unchanged. Registry unchanged (rework, not retire).
- **Gate A PASS**: derive 328/0, datalog 267/0, stdlib 53/0. pre-commit green.

Companion PRs: #415 (rust_calls + js_same_file_calls), #416 (js_local_refs). P5 (js_class_inheritance A1) + hbp follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)