### PR TITLE
fix(derive): scope-walk rework — js_class_inheritance A1 (#23)

### DIFF
--- a/packages/rfdb-server/src/derive/stdlib.rs
+++ b/packages/rfdb-server/src/derive/stdlib.rs
@@ -2699,17 +2699,31 @@ mod tests {
     fn js_class_inheritance_same_file_and_cross_file_arms() {
         let mut v = FixtureStorageView::new(1);
 
+        // A1 now scope-walks CONTAINS to the enclosing MODULE binder (gold idiom),
+        // not a flat (file,name) match — every file-resident CLASS is contained by
+        // its file's MODULE on a real graph, so the fixture wires MODULE -CONTAINS->
+        // CLASS for the A1 classes (a.ts, b.ts, g.ts). has_local still uses the flat
+        // class_in, so the A2-A4 gates are unchanged.
+        named_node(&mut v, "m_a", "a", "MODULE", "a.ts");
+        named_node(&mut v, "m_b", "b", "MODULE", "b.ts");
+        named_node(&mut v, "m_g", "g", "MODULE", "g.ts");
+
         // A1 same-file: Dog extends Animal in a.ts; Plain has no superClass.
         named_node(&mut v, "cls_animal", "Animal", "CLASS", "a.ts");
         named_node(&mut v, "cls_dog", "Dog", "CLASS", "a.ts");
         v.put_node_metadata(id_of("cls_dog"), r#"{"superClass":"Animal"}"#);
         named_node(&mut v, "cls_plain", "Plain", "CLASS", "a.ts");
+        edge(&mut v, "m_a", "cls_animal", "CONTAINS");
+        edge(&mut v, "m_a", "cls_dog", "CONTAINS");
+        edge(&mut v, "m_a", "cls_plain", "CONTAINS");
 
         // Fall-through gate: Cat extends Base — Base exists BOTH same-file and
         // as an import binding; only the same-file edge may derive.
         named_node(&mut v, "cls_base_local", "Base", "CLASS", "b.ts");
         named_node(&mut v, "cls_cat", "Cat", "CLASS", "b.ts");
         v.put_node_metadata(id_of("cls_cat"), r#"{"superClass":"Base"}"#);
+        edge(&mut v, "m_b", "cls_base_local", "CONTAINS");
+        edge(&mut v, "m_b", "cls_cat", "CONTAINS");
         named_node(&mut v, "b_base", "Base", "IMPORT_BINDING", "b.ts");
         named_node(&mut v, "cls_base_remote", "Base", "CLASS", "base.ts");
         edge(&mut v, "b_base", "cls_base_remote", "IMPORTS_FROM");
@@ -2750,6 +2764,27 @@ mod tests {
         v.put_node_metadata(id_of("cls_twin"), r#"{"superClass":"Dup"}"#);
         named_node(&mut v, "cls_dup1", "Dup", "CLASS", "g.ts");
         named_node(&mut v, "cls_dup2", "Dup", "CLASS", "g.ts");
+        edge(&mut v, "m_g", "cls_twin", "CONTAINS");
+        edge(&mut v, "m_g", "cls_dup1", "CONTAINS");
+        edge(&mut v, "m_g", "cls_dup2", "CONTAINS");
+
+        // PRECISION (the rework's only semantic gain): a nested class shadowing a
+        // top-level same-name superclass. In h.ts, Panel extends Widget: there is a
+        // top-level `Widget` (MODULE-contained) AND a nested `Widget` declared
+        // inside a function (CONTAINS parent = a SCOPE, NOT the MODULE). The flat
+        // (file,name) lookup over-resolved to BOTH Widgets; the MODULE scope-walk
+        // binds ONLY the top-level Widget — the nested class is not in the MODULE's
+        // CONTAINS set, so it cannot bind a sibling-module reference.
+        named_node(&mut v, "m_h", "h", "MODULE", "h.ts");
+        named_node(&mut v, "cls_widget_top", "Widget", "CLASS", "h.ts");
+        named_node(&mut v, "cls_panel", "Panel", "CLASS", "h.ts");
+        v.put_node_metadata(id_of("cls_panel"), r#"{"superClass":"Widget"}"#);
+        edge(&mut v, "m_h", "cls_widget_top", "CONTAINS");
+        edge(&mut v, "m_h", "cls_panel", "CONTAINS");
+        // The shadowing nested Widget — contained by a function SCOPE, not the MODULE.
+        named_node(&mut v, "h_fn_scope", "scope", "SCOPE", "h.ts");
+        named_node(&mut v, "cls_widget_nested", "Widget", "CLASS", "h.ts");
+        edge(&mut v, "h_fn_scope", "cls_widget_nested", "CONTAINS");
 
         // File gate: the same shape in a .rs file derives nothing.
         named_node(&mut v, "cls_rs_animal", "RsAnimal", "CLASS", "main.rs");
@@ -2778,9 +2813,13 @@ mod tests {
                 ("cls_cat", "cls_base_local"),
                 ("cls_twin", "cls_dup1"),
                 ("cls_twin", "cls_dup2"),
+                // PRECISION: Panel binds ONLY the MODULE-contained top-level Widget,
+                // NOT the function-nested Widget (the scope-walk's semantic gain).
+                ("cls_panel", "cls_widget_top"),
             ]),
-            "A1: same-file superclass (+ DELTA 1 both duplicates); the self-name \
-             class (neq), the no-superClass class and the .rs file derive nothing"
+            "A1: same-file superclass resolved by MODULE scope-walk (+ DELTA 1 both \
+             duplicates); the self-name class (neq), the no-superClass class and the \
+             .rs file derive nothing; a function-nested same-name class does NOT bind"
         );
         assert_eq!(
             triples(&eval, "ext_cross_file"),
@@ -4838,9 +4877,13 @@ mod tests {
         );
 
         // A1-suppression: a same-file class named Error wins over the builtin.
+        // A1 scope-walks CONTAINS to the enclosing MODULE, so wire d.ts's MODULE.
+        named_node(&mut v, "m_d", "d", "MODULE", "d.ts");
         named_node(&mut v, "cls_localerr", "Error", "CLASS", "d.ts");
         named_node(&mut v, "cls_shadow", "Shadow", "CLASS", "d.ts");
         v.put_node_metadata(id_of("cls_shadow"), r#"{"superClass":"Error"}"#);
+        edge(&mut v, "m_d", "cls_localerr", "CONTAINS");
+        edge(&mut v, "m_d", "cls_shadow", "CONTAINS");
 
         // A2c chain: import { Base } from './barrel' where barrel.ts star
         // re-exports base.ts; the binding has NO legacy IMPORTS_FROM edge.

--- a/packages/rfdb-server/src/derive/stdlib/js_class_inheritance.dl
+++ b/packages/rfdb-server/src/derive/stdlib/js_class_inheritance.dl
@@ -122,17 +122,48 @@ jsts_class(C, F) :- node(C, "CLASS"), attr(C, "file", F), ends_with(F, ".cjs").
 % stores superClass only when non-empty; the neq guards other producers).
 super_of(C, F, SC) :- jsts_class(C, F), node_attr(C, "superClass", SC), neq(SC, "").
 
-% Same-file class index (file, name) → node (Hs:53-60).
+% Same-file class index (file, name) → node (Hs:53-60). RETAINED for the
+% has_local fall-through gate ONLY (see below) — keeping it FLAT keeps the A2/
+% A2c/A3/A4 cross-file/builtin arms BYTE-IDENTICAL in behaviour: those arms gate
+% on `\+ has_local(C)`, so their firing condition must not move. On every real
+% JS/TS graph one file is exactly one MODULE and there are no same-(file,name)
+% class collisions, so flat class_in and the MODULE-scoped lookup below coincide
+% (LIVE-VERIFIED on the dogfood graph: flat A1 = 8 edges ≡ MODULE-scoped A1 = 8
+% edges, byte-for-byte same C→T pairs; same-(file,name) collisions = 0; nested
+% classes = 0).
 class_in(F, N, T) :- node(T, "CLASS"), attr(T, "file", F), attr(T, "name", N), neq(N, "").
 
 % Same-file candidate EXISTS — the resolver's fall-through gate (Hs:97/106).
-% Counts C itself (DELTA 2: gate parity over edge parity).
+% Counts C itself (DELTA 2: gate parity over edge parity). KEPT on the FLAT
+% class_in so A2-A4 stay byte-identical (see class_in note above).
 has_local(C) :- super_of(C, F, SC), class_in(F, SC, T).
 
-% A1: same-file superclass.
+% ── A1 binder = LEXICAL SCOPE-WALK over CONTAINS (gold idiom: js_same_file_calls
+%    B1 / js_property_access_full encl_* walk CONTAINS+HAS_SCOPE to the nearest
+%    binder) ─────────────────────────────────────────────────────────────────
+% A CLASS is MODULE-contained (LIVE-VERIFIED: every file-resident CLASS has
+% exactly one CONTAINS parent and it is a MODULE; <builtin> classes have none).
+% The binder for a same-file superclass NAME is therefore the CLASS reachable in
+% the referencing class's enclosing MODULE — `[M:MODULE] -CONTAINS-> {C, T}` —
+% NOT a raw (file, name) match. This disambiguates a nested class (CONTAINS
+% parent ≠ MODULE) shadowing a top-level same-name superclass: such a class is
+% NOT contained by the MODULE, so it cannot bind a sibling-module reference.
+% (0 nested-class instances on the current corpus ⇒ measurable delta is 0; the
+% rework is a soundness/precision hardening that pays off on a future graph.)
+class_module(C, M) :- node(C, "CLASS"), edge(M, C, "CONTAINS"), node(M, "MODULE").
+
+% The referencing class's enclosing-MODULE class index (binder = a CLASS sharing
+% the same MODULE container, keyed by name). Replaces the FLAT (file,name)
+% lookup for the A1 head only.
+class_in_mod(M, N, T) :-
+    edge(M, T, "CONTAINS"), node(T, "CLASS"), node(M, "MODULE"),
+    attr(T, "name", N), neq(N, "").
+
+% A1: same-file superclass, resolved by lexical scope-walk to the enclosing
+% MODULE's class binder (not flat file,name). super_of stays the SC seed.
 @materialize(edge_type = "EXTENDS", mode = "additive", meta(resolvedVia))
 ext_same_file(C, T, "class-inheritance") :-
-    super_of(C, F, SC), class_in(F, SC, T), neq(C, T).
+    super_of(C, F, SC), class_module(C, M), class_in_mod(M, SC, T), neq(C, T).
 
 % A2: cross-file superclass through the import-binding's legacy IMPORTS_FROM
 % edge (hybrid EDB seam), only when the same-file index missed. MODULE targets


### PR DESCRIPTION
## ⚠ NIGHT MODE — DO NOT MERGE until Vadim's morning go
Overnight fleet PR (#23). **Last flat pack of the JS/Rust round.** Verified; awaiting human merge.

## What
Only arm **A1** (same-file superclass resolution) was flat `(file,name)`; **A2-A4** (cross-file via IMPORTS_FROM, builtin, global) were already sound and are **byte-identical** here.
- A1: flat `class_in (file,name)` → scope-walk over `CONTAINS` to the enclosing MODULE binder (gold idiom). New helpers `class_module/2` + `class_in_mod/3`. Disambiguates a **function-nested class shadowing a top-level same-name superclass** — the only semantic gain (new precision unit test covers it).
- A2-A4 byte-identical (flat `class_in`/`has_local` kept for the gate so cross-file fall-through fires under identical conditions).

## Differential vs legacy (real-graph /tmp copy) — HONEST
- EXTENDS **8 → 8**, dropped_superset **0**, lost_real **0**. On the current corpus there are **0** same-file same-name class collisions and **0** nested classes, so scope-walk **≡ flat today**. This is a **soundness hardening** (pays off only on future nested-class shadowing), not a measurable delta — reported truthfully.
- `meta(resolvedVia)` + additive + EXTENDS shape unchanged.
- **Gate A PASS**: full rfdb-server lib suite 1400/0, derive 305/0, js_class_inheritance 2/2. pre-commit green.

## #23 JS/Rust round COMPLETE (5 packs)
`js_local_refs` (#416), `js_same_file_calls`+`rust_calls` (#415), `js_this_method_calls` (#417), `js_class_inheritance` (this). hbp (Go/Haskell/Java/beam) needs analyzer scope-emission first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)