### PR TITLE
fix(derive): #23 scope-walk rework — 5 packs (js_local_refs/js_same_file_calls/rust_calls/js_this_method_calls/js_class_inheritance)

### DIFF
--- a/packages/rfdb-server/src/derive/stdlib.rs
+++ b/packages/rfdb-server/src/derive/stdlib.rs
@@ -2033,46 +2033,128 @@ mod tests {
         );
     }
 
-    /// The bundled js_this_method_calls pack reproduces JsThisMethodCalls.hs exactly:
-    /// - unique same-file METHOD resolves (the arm firing);
-    /// - two same-named METHODs in the file → ambiguity skip (the neq/ambig idiom);
-    /// - "this.a.b" derives NOTHING even with a METHOD named "b" present — the
-    ///   concat-equality construction reproduces the resolver's stripThis miss and
-    ///   CORRECTS the migration spec's anticipated method_suffix superset delta;
-    /// - non-this calls, cross-file methods, .rs files derive nothing;
-    /// - DELTA 2 PINNED: .mts is rejected (the resolver's OWN 6-extension gate,
+    /// The bundled js_this_method_calls pack resolves this.-method calls SOUNDLY
+    /// via the live SCOPE chain (resolve-pack #23 rework — the flat (file,name)
+    /// arm was both imprecise and ambiguity-blind):
+    /// - a this.-call inside a METHOD body resolves to its enclosing class's member
+    ///   (the HAS_METHOD-owner path, shared with js_same_file_calls.dl B1);
+    /// - DELTA 2b PINNED: a this.-call inside an ARROW-FUNCTION CLASS PROPERTY (no
+    ///   METHOD/FUNCTION HAS_METHOD owner — the `<arrow>` FUNCTION owner is NOT a
+    ///   class member) resolves via the CLASS -HAS_SCOPE-> enclosing-scope path —
+    ///   the exact SceneManager.ts `_animate`/`_tickFly` case B1 alone MISSES;
+    /// - DELTA 2 PRECISION: two same-named members in distinct classes in one file
+    ///   each bind their OWN enclosing class (the old flat `ambig` guard refused
+    ///   BOTH — a false negative; the scope chain resolves each correctly);
+    /// - "this.a.b" derives NOTHING even with a member named "b" — concat-equality
+    ///   first-dot parity (the migration spec's method_suffix superset delta is
+    ///   eliminated by construction);
+    /// - a this.-call not lexically inside any class derives nothing;
+    /// - cross-file / .rs negatives;
+    /// - DELTA 4 PINNED: .mts is rejected (the resolver's OWN 6-extension gate,
     ///   narrower than the orchestrator's 8-extension stream filter).
     #[test]
-    fn js_this_method_calls_unique_method_with_ambiguity_skip() {
+    fn js_this_method_calls_scope_walk_with_arrow_property_and_precision() {
         let mut v = FixtureStorageView::new(1);
 
-        // Arm fires: unique "save" METHOD in app.ts.
-        named_node(&mut v, "m_save", "save", "METHOD", "app.ts");
-        named_node(&mut v, "c1", "this.save", "CALL", "app.ts");
+        // ── Method-body path: class App { init() { { this.render() } } } ──────────
+        // m_init -HAS_SCOPE-> s_fn (function scope) -HAS_SCOPE-> s_blk (lexical
+        // child block) -CONTAINS-> the call.
+        named_node(&mut v, "cls_app", "App", "CLASS", "app.ts");
+        named_node(&mut v, "m_init", "init", "METHOD", "app.ts");
+        named_node(&mut v, "m_render", "render", "METHOD", "app.ts");
+        edge(&mut v, "cls_app", "m_init", "HAS_METHOD");
+        edge(&mut v, "cls_app", "m_render", "HAS_METHOD");
+        named_node(&mut v, "s_app_cls", "class", "SCOPE", "app.ts");
+        named_node(&mut v, "s_fn", "function", "SCOPE", "app.ts");
+        named_node(&mut v, "s_blk", "block", "SCOPE", "app.ts");
+        edge(&mut v, "cls_app", "s_app_cls", "HAS_SCOPE");
+        edge(&mut v, "m_init", "s_fn", "HAS_SCOPE");
+        edge(&mut v, "s_app_cls", "s_fn", "HAS_SCOPE"); // lexical: class body owns the method scope
+        edge(&mut v, "s_fn", "s_blk", "HAS_SCOPE");
+        named_node(&mut v, "c_method", "this.render", "CALL", "app.ts");
+        edge(&mut v, "s_blk", "c_method", "CONTAINS");
 
-        // Ambiguity skip: two "load" METHODs in app.ts.
-        named_node(&mut v, "m_load1", "load", "METHOD", "app.ts");
-        named_node(&mut v, "m_load2", "load", "METHOD", "app.ts");
-        named_node(&mut v, "c2", "this.load", "CALL", "app.ts");
+        // Multi-dot pin inside the same class — METHOD-less, must derive nothing.
+        named_node(&mut v, "c_md", "this.a.b", "CALL", "app.ts");
+        edge(&mut v, "s_blk", "c_md", "CONTAINS");
 
-        // Multi-dot exactness pin: METHOD "b" exists, "this.a.b" must NOT resolve.
-        named_node(&mut v, "m_b", "b", "METHOD", "app.ts");
-        named_node(&mut v, "c3", "this.a.b", "CALL", "app.ts");
+        // ── DELTA 2b: arrow-function CLASS PROPERTY. Owner of the arrow scope is a
+        // FUNCTION (NOT a HAS_METHOD member); the class reaches the arrow scope only
+        // through CLASS -HAS_SCOPE-> arrow-fn-scope. Mirrors SceneManager._tickFly.
+        named_node(&mut v, "cls_scene", "Scene", "CLASS", "scene.ts");
+        named_node(&mut v, "m_tick", "_tickFly", "METHOD", "scene.ts");
+        edge(&mut v, "cls_scene", "m_tick", "HAS_METHOD");
+        named_node(&mut v, "s_scene_cls", "class", "SCOPE", "scene.ts");
+        named_node(&mut v, "f_arrow", "<arrow>", "FUNCTION", "scene.ts");
+        named_node(&mut v, "s_arrow_fn", "function", "SCOPE", "scene.ts");
+        named_node(&mut v, "s_arrow_blk", "block", "SCOPE", "scene.ts");
+        edge(&mut v, "cls_scene", "s_scene_cls", "HAS_SCOPE");
+        edge(&mut v, "f_arrow", "s_arrow_fn", "HAS_SCOPE"); // owner FUNCTION, NOT a class member
+        edge(&mut v, "s_scene_cls", "s_arrow_fn", "HAS_SCOPE"); // class body owns the arrow scope
+        edge(&mut v, "s_arrow_fn", "s_arrow_blk", "HAS_SCOPE");
+        named_node(&mut v, "c_arrow", "this._tickFly", "CALL", "scene.ts");
+        edge(&mut v, "s_arrow_blk", "c_arrow", "CONTAINS");
 
-        // File gate: .rs is not JS.
+        // ── DELTA 2 precision: two classes in one file, each a private "shouldLog".
+        // The old flat `ambig` guard refused BOTH; the scope chain resolves each
+        // call to its OWN class's member. (Mirrors util/.../Logger.ts.)
+        named_node(&mut v, "cls_cons", "ConsoleLogger", "CLASS", "log.ts");
+        named_node(&mut v, "m_cons_sl", "shouldLog", "METHOD", "log.ts");
+        named_node(&mut v, "m_cons_w", "write", "METHOD", "log.ts");
+        edge(&mut v, "cls_cons", "m_cons_sl", "HAS_METHOD");
+        edge(&mut v, "cls_cons", "m_cons_w", "HAS_METHOD");
+        named_node(&mut v, "s_cons_cls", "class", "SCOPE", "log.ts");
+        named_node(&mut v, "s_cons_fn", "function", "SCOPE", "log.ts");
+        edge(&mut v, "cls_cons", "s_cons_cls", "HAS_SCOPE");
+        edge(&mut v, "m_cons_w", "s_cons_fn", "HAS_SCOPE");
+        edge(&mut v, "s_cons_cls", "s_cons_fn", "HAS_SCOPE");
+        named_node(&mut v, "c_cons_sl", "this.shouldLog", "CALL", "log.ts");
+        edge(&mut v, "s_cons_fn", "c_cons_sl", "CONTAINS");
+
+        named_node(&mut v, "cls_file", "FileLogger", "CLASS", "log.ts");
+        named_node(&mut v, "m_file_sl", "shouldLog", "METHOD", "log.ts");
+        named_node(&mut v, "m_file_w", "writeLine", "METHOD", "log.ts");
+        edge(&mut v, "cls_file", "m_file_sl", "HAS_METHOD");
+        edge(&mut v, "cls_file", "m_file_w", "HAS_METHOD");
+        named_node(&mut v, "s_file_cls", "class", "SCOPE", "log.ts");
+        named_node(&mut v, "s_file_fn", "function", "SCOPE", "log.ts");
+        edge(&mut v, "cls_file", "s_file_cls", "HAS_SCOPE");
+        edge(&mut v, "m_file_w", "s_file_fn", "HAS_SCOPE");
+        edge(&mut v, "s_file_cls", "s_file_fn", "HAS_SCOPE");
+        named_node(&mut v, "c_file_sl", "this.shouldLog", "CALL", "log.ts");
+        edge(&mut v, "s_file_fn", "c_file_sl", "CONTAINS");
+
+        // ── Negative: this.-call inside a plain top-level function (no class).
+        named_node(&mut v, "f_free", "standalone", "FUNCTION", "free.ts");
+        named_node(&mut v, "m_orphan", "render", "METHOD", "free.ts"); // same-file METHOD, no class
+        named_node(&mut v, "s_free", "function", "SCOPE", "free.ts");
+        edge(&mut v, "f_free", "s_free", "HAS_SCOPE");
+        named_node(&mut v, "c_free", "this.render", "CALL", "free.ts");
+        edge(&mut v, "s_free", "c_free", "CONTAINS");
+
+        // ── File gate: .rs is not JS (a fully-wired class+scope, still rejected).
+        named_node(&mut v, "cls_rs", "Rs", "CLASS", "main.rs");
         named_node(&mut v, "m_go", "go", "METHOD", "main.rs");
-        named_node(&mut v, "c4", "this.go", "CALL", "main.rs");
+        edge(&mut v, "cls_rs", "m_go", "HAS_METHOD");
+        named_node(&mut v, "s_rs_cls", "class", "SCOPE", "main.rs");
+        named_node(&mut v, "s_rs_fn", "function", "SCOPE", "main.rs");
+        edge(&mut v, "cls_rs", "s_rs_cls", "HAS_SCOPE");
+        edge(&mut v, "m_go", "s_rs_fn", "HAS_SCOPE");
+        edge(&mut v, "s_rs_cls", "s_rs_fn", "HAS_SCOPE");
+        named_node(&mut v, "c_rs", "this.go", "CALL", "main.rs");
+        edge(&mut v, "s_rs_fn", "c_rs", "CONTAINS");
 
-        // Prefix negative: not a this-call.
-        named_node(&mut v, "c5", "notthis.save", "CALL", "app.ts");
-
-        // Cross-file negative: METHOD only in b.ts.
-        named_node(&mut v, "m_far", "far", "METHOD", "b.ts");
-        named_node(&mut v, "c6", "this.far", "CALL", "app.ts");
-
-        // DELTA 2 pin: .mts rejected by the resolver's own 6-extension gate.
+        // ── DELTA 4: .mts rejected by the resolver's own 6-extension gate.
+        named_node(&mut v, "cls_mts", "Mts", "CLASS", "app.mts");
         named_node(&mut v, "m_mts", "save", "METHOD", "app.mts");
-        named_node(&mut v, "c7", "this.save", "CALL", "app.mts");
+        edge(&mut v, "cls_mts", "m_mts", "HAS_METHOD");
+        named_node(&mut v, "s_mts_cls", "class", "SCOPE", "app.mts");
+        named_node(&mut v, "s_mts_fn", "function", "SCOPE", "app.mts");
+        edge(&mut v, "cls_mts", "s_mts_cls", "HAS_SCOPE");
+        edge(&mut v, "m_mts", "s_mts_fn", "HAS_SCOPE");
+        edge(&mut v, "s_mts_cls", "s_mts_fn", "HAS_SCOPE");
+        named_node(&mut v, "c_mts", "this.save", "CALL", "app.mts");
+        edge(&mut v, "s_mts_fn", "c_mts", "CONTAINS");
 
         let (eval, specs, _node_specs) = evaluate_with_materialize(
             &v,
@@ -2083,15 +2165,25 @@ mod tests {
         )
         .expect("js_this_method_calls.dl evaluates");
 
+        let via = |pairs: &[(&str, &str)]| -> BTreeSet<(u128, u128, String)> {
+            pairs
+                .iter()
+                .map(|(c, t)| (id_of(c), id_of(t), "js-this-method-calls".to_string()))
+                .collect()
+        };
         assert_eq!(
             triples(&eval, "js_this_method_call"),
-            BTreeSet::from([(
-                id_of("c1"),
-                id_of("m_save"),
-                "js-this-method-calls".to_string()
-            )]),
-            "exactly c1→m_save: ambiguous 'load', multi-dot 'this.a.b', .rs, non-this, \
-             cross-file and .mts (DELTA 2) all derive nothing"
+            via(&[
+                ("c_method", "m_render"),
+                ("c_arrow", "m_tick"),
+                ("c_cons_sl", "m_cons_sl"),
+                ("c_file_sl", "m_file_sl"),
+            ]),
+            "scope-walk: method-body c_method→m_render; arrow-property c_arrow→m_tick \
+             (DELTA 2b, the class-scope path B1 misses); the two same-named shouldLog \
+             calls each bind their OWN class (DELTA 2 precision — no flat ambig skip); \
+             'this.a.b' multi-dot, the class-less c_free, cross-file, .rs and .mts \
+             (DELTA 4) all derive nothing"
         );
 
         let calls_specs: Vec<_> = specs.iter().filter(|s| s.edge_type == "CALLS").collect();

--- a/packages/rfdb-server/src/derive/stdlib.rs
+++ b/packages/rfdb-server/src/derive/stdlib.rs
@@ -1864,6 +1864,11 @@ mod tests {
     /// - A2 direct → VARIABLE/CONSTANT, with DELTA 1 PINNED (both var+const derive);
     /// - A3 uppercase ctor → CLASS, with a lowercase negative AND the ladder
     ///   suppression (a VARIABLE of the same name beats the CLASS);
+    /// - DELTA 6 (resolve rework) PINNED: A1/A2/A3 SCOPE-WALK the B1/B2 encl_*
+    ///   idiom (SCOPE+HAS_SCOPE+CONTAINS chain, enclosing MODULE for top-level
+    ///   binders + classes) instead of a flat (file, name) join; a same-name
+    ///   FUNCTION in an UNRELATED scope (`orphan`) does NOT resolve a module-level
+    ///   call — the cross-scope false positive the flat match made is dropped;
     /// - the import-binding skip-set on direct calls;
     /// - B1 this./super./<obj>. via the Wave-0 scope chain (block scope →
     ///   lexical parent → METHOD owner → class), with the multi-dot exactness
@@ -1876,33 +1881,75 @@ mod tests {
     fn js_same_file_calls_resolves_all_arms_with_preference_ladder() {
         let mut v = FixtureStorageView::new(1);
 
-        // A1: direct call → FUNCTION.
-        named_node(&mut v, "f_run", "run", "FUNCTION", "app.ts");
-        named_node(&mut v, "c_fn", "run", "CALL", "app.ts");
+        // ── A-arm scope shape (Wave-0 verified on the real graph) ─────────────
+        // The direct-call arms now SCOPE-WALK (DELTA 6): a call resolves only to a
+        // binder declared in a LEXICALLY ENCLOSING container, not any same-(file,
+        // name) binder. The file MODULE owns the top scope (MODULE -HAS_SCOPE->
+        // s_mod) and CONTAINS the top-level binders + classes; s_mod CONTAINS the
+        // direct-call CALLs. Top-level FUNCTION/VARIABLE/CONSTANT are reached via
+        // the enclosing-MODULE leg; CLASS is ONLY ever MODULE-contained.
+        named_node(&mut v, "mod_app", "app.ts", "MODULE", "app.ts");
+        named_node(&mut v, "s_mod", "module", "SCOPE", "app.ts");
+        edge(&mut v, "mod_app", "s_mod", "HAS_SCOPE");
 
-        // Ladder: FUNCTION beats VARIABLE.
+        // A1: direct call → FUNCTION (declared at module top level).
+        named_node(&mut v, "f_run", "run", "FUNCTION", "app.ts");
+        edge(&mut v, "mod_app", "f_run", "CONTAINS");
+        named_node(&mut v, "c_fn", "run", "CALL", "app.ts");
+        edge(&mut v, "s_mod", "c_fn", "CONTAINS");
+
+        // Ladder: FUNCTION beats VARIABLE (both module-level, same chain).
         named_node(&mut v, "f_make", "make", "FUNCTION", "app.ts");
         named_node(&mut v, "v_make", "make", "VARIABLE", "app.ts");
+        edge(&mut v, "mod_app", "f_make", "CONTAINS");
+        edge(&mut v, "mod_app", "v_make", "CONTAINS");
         named_node(&mut v, "c_pref", "make", "CALL", "app.ts");
+        edge(&mut v, "s_mod", "c_pref", "CONTAINS");
 
         // A2 + DELTA 1: VARIABLE and CONSTANT both derive (no FUNCTION).
         named_node(&mut v, "v_cb", "cb", "VARIABLE", "app.ts");
         named_node(&mut v, "k_cb", "cb", "CONSTANT", "app.ts");
+        edge(&mut v, "mod_app", "v_cb", "CONTAINS");
+        edge(&mut v, "mod_app", "k_cb", "CONTAINS");
         named_node(&mut v, "c_var", "cb", "CALL", "app.ts");
+        edge(&mut v, "s_mod", "c_var", "CONTAINS");
 
         // A3: uppercase ctor → CLASS; lowercase negative; ladder suppression.
         named_node(&mut v, "cls_widget", "Widget", "CLASS", "app.ts");
+        edge(&mut v, "mod_app", "cls_widget", "CONTAINS");
         named_node(&mut v, "c_ctor", "Widget", "CALL", "app.ts");
+        edge(&mut v, "s_mod", "c_ctor", "CONTAINS");
         named_node(&mut v, "cls_low", "widget2", "CLASS", "app.ts");
+        edge(&mut v, "mod_app", "cls_low", "CONTAINS");
         named_node(&mut v, "c_low", "widget2", "CALL", "app.ts");
+        edge(&mut v, "s_mod", "c_low", "CONTAINS");
         named_node(&mut v, "v_box", "Box", "VARIABLE", "app.ts");
         named_node(&mut v, "cls_box", "Box", "CLASS", "app.ts");
+        edge(&mut v, "mod_app", "v_box", "CONTAINS");
+        edge(&mut v, "mod_app", "cls_box", "CONTAINS");
         named_node(&mut v, "c_box", "Box", "CALL", "app.ts");
+        edge(&mut v, "s_mod", "c_box", "CONTAINS");
 
         // Import-binding skip on direct calls.
         named_node(&mut v, "b_ext", "ext", "IMPORT_BINDING", "app.ts");
         named_node(&mut v, "f_ext", "ext", "FUNCTION", "app.ts");
+        edge(&mut v, "mod_app", "f_ext", "CONTAINS");
         named_node(&mut v, "c_ext", "ext", "CALL", "app.ts");
+        edge(&mut v, "s_mod", "c_ext", "CONTAINS");
+
+        // DELTA 6 precision lock: a same-name FUNCTION declared in an UNRELATED
+        // scope (a different function body) must NOT resolve a module-level call.
+        // 'orphan' is declared ONLY inside f_other's body scope; the call c_orph
+        // sits at module top level → no enclosing container holds the binder, so
+        // the flat (file, name) match's cross-scope false positive is dropped.
+        named_node(&mut v, "f_other", "other", "FUNCTION", "app.ts");
+        edge(&mut v, "mod_app", "f_other", "CONTAINS");
+        named_node(&mut v, "s_other", "function", "SCOPE", "app.ts");
+        edge(&mut v, "f_other", "s_other", "HAS_SCOPE");
+        named_node(&mut v, "f_orphan", "orphan", "FUNCTION", "app.ts");
+        edge(&mut v, "s_other", "f_orphan", "CONTAINS");
+        named_node(&mut v, "c_orph", "orphan", "CALL", "app.ts");
+        edge(&mut v, "s_mod", "c_orph", "CONTAINS");
 
         // B1 scope-chain fixture: class App { init() { { this.render() } } }.
         // Owner-vs-lexical shape: METHOD m_init -HAS_SCOPE-> s_fn (function scope);
@@ -2019,8 +2066,15 @@ mod tests {
         );
 
         // Every head is CALLS + additive (shared vocabulary) with resolvedVia meta.
+        // A3 (sf_call_ctor) is one logical arm expanded into 26 clauses (one per
+        // uppercase letter, the inline ctor-name check — see ENCODING NOTES), so the
+        // CALLS materialize-spec count is A1(1)+A2(1)+A3(26)+B1(1)+B2(1) = 30.
         let calls_specs: Vec<_> = specs.iter().filter(|s| s.edge_type == "CALLS").collect();
-        assert_eq!(calls_specs.len(), 5, "five CALLS heads (A1, A2, A3, B1, B2)");
+        assert_eq!(
+            calls_specs.len(),
+            30,
+            "CALLS heads: A1, A2, B1, B2 + A3 expanded into 26 uppercase-letter clauses"
+        );
         assert!(
             calls_specs.iter().all(|s| s.additive),
             "CALLS is shared with the analyzers — every head must be additive"
@@ -2100,60 +2154,113 @@ mod tests {
         assert_eq!(calls_specs[0].meta, vec!["resolvedVia".to_string()]);
     }
 
-    /// The bundled rust_calls pack reproduces RustCallResolution.hs:
-    /// - R1 exact (file,name) match, including a receiver-shaped method call (the
-    ///   Wave-0 direct CALL -READS_FROM-> receiver — the resolver never conditioned
-    ///   on it, the bare-name exact arm covers it);
-    /// - R2 '::'-suffix fallback with the segment boundary ("do_y" must NOT match
-    ///   FUNCTION "y") and the exact-beats-suffix preference negation;
+    /// The bundled rust_calls pack resolves same-file CALLs by SCOPE-WALK to the
+    /// nearest enclosing FUNCTION binder (not flat (file,name)):
+    /// - R1 scope-walk exact: a bare-name call resolves to the same-name FUNCTION
+    ///   lexically visible from the call's enclosing FUNCTION — sibling in the same
+    ///   IMPL_BLOCK/MODULE owner, or a file-level free function. Covers the call
+    ///   directly under a FUNCTION, a call nested in a block SCOPE (HAS_SCOPE walk),
+    ///   and a MODULE-level call (no enclosing fn → free-fn arm);
+    /// - R1 PRECISION (the rework, ex-DELTA-1): two `fn process` in two different
+    ///   impl blocks — a call inside `impl A` resolves to ONLY `A::process`, NOT the
+    ///   same-named `B::process` (flat resolution emitted BOTH; the scope-walk drops
+    ///   the out-of-scope twin);
+    /// - R2 '::'-suffix fallback (FLAT by design — a qualified path names its type)
+    ///   with the segment boundary ("do_y" must NOT match FUNCTION "y") and the
+    ///   exact-beats-suffix preference negation;
     /// - cross-file and non-.rs negatives;
-    /// - DELTA 1 PINNED: duplicate (file,name) FUNCTIONs derive an edge per
-    ///   candidate (the resolver's Map kept the last one);
-    /// - DELTA 2 PINNED: a multi-segment FUNCTION name ("b::c") matches via the
+    /// - DELTA 2 PINNED (R2): a multi-segment FUNCTION name ("b::c") matches via the
     ///   suffix arm (the resolver's lastSegment comparison never could).
+    ///
+    /// Scope shape mirrors rust_analyzer.rs: the file is one MODULE; free fns and
+    /// IMPL_BLOCKs are MODULE-CONTAINS children; an IMPL_BLOCK CONTAINS its methods;
+    /// a FUNCTION directly CONTAINS its top-level CALLs (the fn IS its own scope, no
+    /// separate body SCOPE); block bodies are SCOPE nodes the fn HAS_SCOPEs.
     #[test]
-    fn rust_calls_exact_then_suffix_fallback() {
+    fn rust_calls_scope_walk_exact_then_suffix_fallback() {
         let mut v = FixtureStorageView::new(1);
 
-        // R1 exact.
+        // The file MODULE (one per file; inline `mod` is walked inline).
+        named_node(&mut v, "m_lib", "lib", "MODULE", "lib.rs");
+
+        // R1: free fn `helper`, called from a sibling free fn `caller_a`.
         named_node(&mut v, "f_helper", "helper", "FUNCTION", "lib.rs");
+        named_node(&mut v, "f_caller_a", "caller_a", "FUNCTION", "lib.rs");
+        edge(&mut v, "m_lib", "f_helper", "CONTAINS");
+        edge(&mut v, "m_lib", "f_caller_a", "CONTAINS");
         named_node(&mut v, "c1", "helper", "CALL", "lib.rs");
+        edge(&mut v, "f_caller_a", "c1", "CONTAINS"); // call directly under the fn
+
+        // R1 nested-block: a call to `helper` inside an if-block SCOPE of caller_a
+        // resolves through the HAS_SCOPE walk up to caller_a → m_lib → free fn.
+        named_node(&mut v, "s_blk", "block", "SCOPE", "lib.rs");
+        edge(&mut v, "f_caller_a", "s_blk", "HAS_SCOPE");
+        named_node(&mut v, "c1b", "helper", "CALL", "lib.rs");
+        edge(&mut v, "s_blk", "c1b", "CONTAINS");
+
+        // R1 PRECISION: `process` exists in BOTH impl A and impl B. A call inside
+        // a method of impl A must resolve to A's process only.
+        named_node(&mut v, "ib_a", "A", "IMPL_BLOCK", "lib.rs");
+        named_node(&mut v, "ib_b", "B", "IMPL_BLOCK", "lib.rs");
+        edge(&mut v, "m_lib", "ib_a", "CONTAINS");
+        edge(&mut v, "m_lib", "ib_b", "CONTAINS");
+        named_node(&mut v, "f_process_a", "process", "FUNCTION", "lib.rs");
+        named_node(&mut v, "f_process_b", "process", "FUNCTION", "lib.rs");
+        edge(&mut v, "ib_a", "f_process_a", "CONTAINS");
+        edge(&mut v, "ib_b", "f_process_b", "CONTAINS");
+        // method `run` in impl A that calls `process()` (bare name / self.process).
+        named_node(&mut v, "f_run_a", "run", "FUNCTION", "lib.rs");
+        edge(&mut v, "ib_a", "f_run_a", "CONTAINS");
+        named_node(&mut v, "c4", "process", "CALL", "lib.rs");
+        edge(&mut v, "f_run_a", "c4", "CONTAINS");
+
+        // R1 MODULE-level call to a free fn (no enclosing FUNCTION → free-fn arm).
+        named_node(&mut v, "f_init", "init", "FUNCTION", "lib.rs");
+        edge(&mut v, "m_lib", "f_init", "CONTAINS");
+        named_node(&mut v, "c_mod", "init", "CALL", "lib.rs");
+        edge(&mut v, "m_lib", "c_mod", "CONTAINS"); // top-level const-initializer call
 
         // R2 suffix.
         named_node(&mut v, "f_helper2", "helper2", "FUNCTION", "lib.rs");
+        edge(&mut v, "m_lib", "f_helper2", "CONTAINS");
         named_node(&mut v, "c2", "utils::helper2", "CALL", "lib.rs");
+        edge(&mut v, "f_caller_a", "c2", "CONTAINS");
 
-        // Exact beats suffix: both "m::foo" and "foo" exist; only the exact fires.
+        // Exact beats suffix: both "m::foo" and "foo" exist; only the scoped exact
+        // fires for the bare call "m::foo"? No — the call name IS "m::foo" (qualified
+        // path). The bare-name exact arm requires FUNCTION.name == call name, so a
+        // FUNCTION literally named "m::foo" matches R1 (scoped); the "::"-suffix R2
+        // is then suppressed by the has_scoped preference negation.
         named_node(&mut v, "f_qual", "m::foo", "FUNCTION", "lib.rs");
         named_node(&mut v, "f_foo", "foo", "FUNCTION", "lib.rs");
+        edge(&mut v, "m_lib", "f_qual", "CONTAINS");
+        edge(&mut v, "m_lib", "f_foo", "CONTAINS");
         named_node(&mut v, "c3", "m::foo", "CALL", "lib.rs");
+        edge(&mut v, "f_caller_a", "c3", "CONTAINS");
 
-        // Method call with a Wave-0 receiver shape — resolves by bare name (R1).
-        named_node(&mut v, "f_process", "process", "FUNCTION", "lib.rs");
-        named_node(&mut v, "c4", "process", "CALL", "lib.rs");
-        named_node(&mut v, "recv", "w", "REFERENCE", "lib.rs");
-        edge(&mut v, "c4", "recv", "READS_FROM");
-
-        // Cross-file negative.
+        // Cross-file negative: `far` is in other.rs; the call is in lib.rs.
         named_node(&mut v, "f_far", "far", "FUNCTION", "other.rs");
         named_node(&mut v, "c5", "far", "CALL", "lib.rs");
+        edge(&mut v, "f_caller_a", "c5", "CONTAINS");
 
         // File gate negative: same shape in a .ts file.
+        named_node(&mut v, "m_app", "app", "MODULE", "app.ts");
         named_node(&mut v, "f_js", "jsfn", "FUNCTION", "app.ts");
+        edge(&mut v, "m_app", "f_js", "CONTAINS");
         named_node(&mut v, "c6", "jsfn", "CALL", "app.ts");
+        edge(&mut v, "f_js", "c6", "CONTAINS");
 
         // Suffix boundary negative: "do_y" must not match FUNCTION "y".
         named_node(&mut v, "f_y", "y", "FUNCTION", "lib.rs");
+        edge(&mut v, "m_lib", "f_y", "CONTAINS");
         named_node(&mut v, "c7", "do_y", "CALL", "lib.rs");
+        edge(&mut v, "f_caller_a", "c7", "CONTAINS");
 
-        // DELTA 1: two `fn new` in one file — both derive.
-        named_node(&mut v, "f_new1", "new", "FUNCTION", "lib.rs");
-        named_node(&mut v, "f_new2", "new", "FUNCTION", "lib.rs");
-        named_node(&mut v, "c8", "Widget::new", "CALL", "lib.rs");
-
-        // DELTA 2: multi-segment FUNCTION name matches as a suffix.
+        // R2 DELTA 2: multi-segment FUNCTION name matches as a suffix.
         named_node(&mut v, "f_bc", "b::c", "FUNCTION", "lib.rs");
+        edge(&mut v, "m_lib", "f_bc", "CONTAINS");
         named_node(&mut v, "c9", "a::b::c", "CALL", "lib.rs");
+        edge(&mut v, "f_caller_a", "c9", "CONTAINS");
 
         let (eval, specs, _node_specs) = evaluate_with_materialize(
             &v,
@@ -2172,21 +2279,29 @@ mod tests {
         };
         assert_eq!(
             triples(&eval, "rust_call"),
-            via(&[("c1", "f_helper"), ("c3", "f_qual"), ("c4", "f_process")]),
-            "R1: exact matches incl. the qualified name and the receiver-shaped \
-             method call; cross-file/.ts/empty negatives derive nothing"
+            via(&[
+                ("c1", "f_helper"),     // free fn, sibling-of-caller via m_lib
+                ("c1b", "f_helper"),    // nested block SCOPE → HAS_SCOPE walk → free fn
+                ("c4", "f_process_a"),  // PRECISION: impl-A method calling process →
+                                        // ONLY A::process (B::process out of scope)
+                ("c_mod", "f_init"),    // MODULE-level call → free fn
+                ("c3", "f_qual"),       // qualified-name FUNCTION matched bare-exact
+            ]),
+            "R1 scope-walk: free fns resolve via the file MODULE, the nested-block \
+             call walks HAS_SCOPE to its fn, the impl-A `process` call resolves to \
+             A::process ONLY (not B::process — the precision fix), the MODULE-level \
+             call resolves the free fn, and the qualified-name FUNCTION matches the \
+             bare exact arm. Cross-file/.ts negatives derive nothing"
         );
         assert_eq!(
             triples(&eval, "rust_suffix_call"),
             via(&[
                 ("c2", "f_helper2"),
-                ("c8", "f_new1"),
-                ("c8", "f_new2"),
                 ("c9", "f_bc"),
             ]),
-            "R2: suffix fallback — c3 is suppressed by its exact match (preference \
-             negation), 'do_y' misses the '::y' boundary, c8 derives BOTH dup \
-             functions (DELTA 1), c9 matches the multi-segment name (DELTA 2)"
+            "R2: suffix fallback — c3 is suppressed by its scoped exact match \
+             (preference negation), 'do_y' misses the '::y' boundary, c9 matches the \
+             multi-segment name (DELTA 2)"
         );
 
         let calls_specs: Vec<_> = specs.iter().filter(|s| s.edge_type == "CALLS").collect();
@@ -2217,17 +2332,28 @@ mod tests {
     fn rust_calls_macro_invocations_are_excluded() {
         let mut v = FixtureStorageView::new(1);
 
+        // The file MODULE + a calling fn (scope-walk needs an enclosing binder /
+        // file MODULE for R1 to resolve the plain call).
+        named_node(&mut v, "m_lib", "lib", "MODULE", "lib.rs");
+        named_node(&mut v, "f_caller", "caller", "FUNCTION", "lib.rs");
+        edge(&mut v, "m_lib", "f_caller", "CONTAINS");
+
         named_node(&mut v, "f_helper", "helper", "FUNCTION", "lib.rs");
+        edge(&mut v, "m_lib", "f_helper", "CONTAINS");
         // (a) macro invocation `helper!()` — same name, same file.
         named_node(&mut v, "c_mac", "helper", "CALL", "lib.rs");
+        edge(&mut v, "f_caller", "c_mac", "CONTAINS");
         v.put_node_metadata(id_of("c_mac"), r#"{"macro":true,"method":false}"#);
         // (b) plain call `helper()`.
         named_node(&mut v, "c_plain", "helper", "CALL", "lib.rs");
+        edge(&mut v, "f_caller", "c_plain", "CONTAINS");
 
         // (c) macro `paths::mk!()` — would suffix-match fn mk across R2's
         // "::" boundary if not filtered.
         named_node(&mut v, "f_mk", "mk", "FUNCTION", "lib.rs");
+        edge(&mut v, "m_lib", "f_mk", "CONTAINS");
         named_node(&mut v, "c_macq", "paths::mk", "CALL", "lib.rs");
+        edge(&mut v, "f_caller", "c_macq", "CONTAINS");
         v.put_node_metadata(id_of("c_macq"), r#"{"macro":true,"method":false}"#);
 
         let (eval, _specs, _node_specs) = evaluate_with_materialize(

--- a/packages/rfdb-server/src/derive/stdlib.rs
+++ b/packages/rfdb-server/src/derive/stdlib.rs
@@ -2699,17 +2699,31 @@ mod tests {
     fn js_class_inheritance_same_file_and_cross_file_arms() {
         let mut v = FixtureStorageView::new(1);
 
+        // A1 now scope-walks CONTAINS to the enclosing MODULE binder (gold idiom),
+        // not a flat (file,name) match — every file-resident CLASS is contained by
+        // its file's MODULE on a real graph, so the fixture wires MODULE -CONTAINS->
+        // CLASS for the A1 classes (a.ts, b.ts, g.ts). has_local still uses the flat
+        // class_in, so the A2-A4 gates are unchanged.
+        named_node(&mut v, "m_a", "a", "MODULE", "a.ts");
+        named_node(&mut v, "m_b", "b", "MODULE", "b.ts");
+        named_node(&mut v, "m_g", "g", "MODULE", "g.ts");
+
         // A1 same-file: Dog extends Animal in a.ts; Plain has no superClass.
         named_node(&mut v, "cls_animal", "Animal", "CLASS", "a.ts");
         named_node(&mut v, "cls_dog", "Dog", "CLASS", "a.ts");
         v.put_node_metadata(id_of("cls_dog"), r#"{"superClass":"Animal"}"#);
         named_node(&mut v, "cls_plain", "Plain", "CLASS", "a.ts");
+        edge(&mut v, "m_a", "cls_animal", "CONTAINS");
+        edge(&mut v, "m_a", "cls_dog", "CONTAINS");
+        edge(&mut v, "m_a", "cls_plain", "CONTAINS");
 
         // Fall-through gate: Cat extends Base — Base exists BOTH same-file and
         // as an import binding; only the same-file edge may derive.
         named_node(&mut v, "cls_base_local", "Base", "CLASS", "b.ts");
         named_node(&mut v, "cls_cat", "Cat", "CLASS", "b.ts");
         v.put_node_metadata(id_of("cls_cat"), r#"{"superClass":"Base"}"#);
+        edge(&mut v, "m_b", "cls_base_local", "CONTAINS");
+        edge(&mut v, "m_b", "cls_cat", "CONTAINS");
         named_node(&mut v, "b_base", "Base", "IMPORT_BINDING", "b.ts");
         named_node(&mut v, "cls_base_remote", "Base", "CLASS", "base.ts");
         edge(&mut v, "b_base", "cls_base_remote", "IMPORTS_FROM");
@@ -2750,6 +2764,27 @@ mod tests {
         v.put_node_metadata(id_of("cls_twin"), r#"{"superClass":"Dup"}"#);
         named_node(&mut v, "cls_dup1", "Dup", "CLASS", "g.ts");
         named_node(&mut v, "cls_dup2", "Dup", "CLASS", "g.ts");
+        edge(&mut v, "m_g", "cls_twin", "CONTAINS");
+        edge(&mut v, "m_g", "cls_dup1", "CONTAINS");
+        edge(&mut v, "m_g", "cls_dup2", "CONTAINS");
+
+        // PRECISION (the rework's only semantic gain): a nested class shadowing a
+        // top-level same-name superclass. In h.ts, Panel extends Widget: there is a
+        // top-level `Widget` (MODULE-contained) AND a nested `Widget` declared
+        // inside a function (CONTAINS parent = a SCOPE, NOT the MODULE). The flat
+        // (file,name) lookup over-resolved to BOTH Widgets; the MODULE scope-walk
+        // binds ONLY the top-level Widget — the nested class is not in the MODULE's
+        // CONTAINS set, so it cannot bind a sibling-module reference.
+        named_node(&mut v, "m_h", "h", "MODULE", "h.ts");
+        named_node(&mut v, "cls_widget_top", "Widget", "CLASS", "h.ts");
+        named_node(&mut v, "cls_panel", "Panel", "CLASS", "h.ts");
+        v.put_node_metadata(id_of("cls_panel"), r#"{"superClass":"Widget"}"#);
+        edge(&mut v, "m_h", "cls_widget_top", "CONTAINS");
+        edge(&mut v, "m_h", "cls_panel", "CONTAINS");
+        // The shadowing nested Widget — contained by a function SCOPE, not the MODULE.
+        named_node(&mut v, "h_fn_scope", "scope", "SCOPE", "h.ts");
+        named_node(&mut v, "cls_widget_nested", "Widget", "CLASS", "h.ts");
+        edge(&mut v, "h_fn_scope", "cls_widget_nested", "CONTAINS");
 
         // File gate: the same shape in a .rs file derives nothing.
         named_node(&mut v, "cls_rs_animal", "RsAnimal", "CLASS", "main.rs");
@@ -2778,9 +2813,13 @@ mod tests {
                 ("cls_cat", "cls_base_local"),
                 ("cls_twin", "cls_dup1"),
                 ("cls_twin", "cls_dup2"),
+                // PRECISION: Panel binds ONLY the MODULE-contained top-level Widget,
+                // NOT the function-nested Widget (the scope-walk's semantic gain).
+                ("cls_panel", "cls_widget_top"),
             ]),
-            "A1: same-file superclass (+ DELTA 1 both duplicates); the self-name \
-             class (neq), the no-superClass class and the .rs file derive nothing"
+            "A1: same-file superclass resolved by MODULE scope-walk (+ DELTA 1 both \
+             duplicates); the self-name class (neq), the no-superClass class and the \
+             .rs file derive nothing; a function-nested same-name class does NOT bind"
         );
         assert_eq!(
             triples(&eval, "ext_cross_file"),
@@ -4838,9 +4877,13 @@ mod tests {
         );
 
         // A1-suppression: a same-file class named Error wins over the builtin.
+        // A1 scope-walks CONTAINS to the enclosing MODULE, so wire d.ts's MODULE.
+        named_node(&mut v, "m_d", "d", "MODULE", "d.ts");
         named_node(&mut v, "cls_localerr", "Error", "CLASS", "d.ts");
         named_node(&mut v, "cls_shadow", "Shadow", "CLASS", "d.ts");
         v.put_node_metadata(id_of("cls_shadow"), r#"{"superClass":"Error"}"#);
+        edge(&mut v, "m_d", "cls_localerr", "CONTAINS");
+        edge(&mut v, "m_d", "cls_shadow", "CONTAINS");
 
         // A2c chain: import { Base } from './barrel' where barrel.ts star
         // re-exports base.ts; the binding has NO legacy IMPORTS_FROM edge.

--- a/packages/rfdb-server/src/derive/stdlib.rs
+++ b/packages/rfdb-server/src/derive/stdlib.rs
@@ -1763,62 +1763,142 @@ mod tests {
         );
     }
 
-    /// The bundled js_local_refs pack reproduces JsLocalRefs.hs on a fixture covering
-    /// every arm, every skip-set, one negative per arm, and the pinned deltas:
-    /// - all 8 declaration types resolve a same-file REFERENCE (arm coverage);
-    /// - the imported(F,N) skip-set (IMPORT_BINDING) suppresses resolution;
-    /// - the rt_global ground-facts skip-list suppresses resolution ("console");
-    /// - cross-file declarations never match (file-flat negative);
-    /// - non-JS files are gated out (a .rs REFERENCE with a same-file match);
-    /// - empty names never match (the resolver's index exclusion);
-    /// - DELTA 1 PINNED: duplicate (file,name) declarations derive an edge to EVERY
-    ///   candidate (the resolver's Map kept one arbitrary winner — deriving what the
-    ///   delta says, not what the resolver did).
+    /// The reworked SCOPE-WALK js_local_refs pack on a fixture covering both arms,
+    /// the nearest-binder/shadowing property (the soundness GOAL), every skip-set,
+    /// the negatives, and the accepted same-scope superset:
+    ///
+    /// ARM A (SCOPE-WALK: VARIABLE/CONSTANT/FUNCTION/PARAMETER via SCOPE-DECLARES):
+    /// - a ref in a scope that declares the name resolves to that binder
+    ///   (helper/state/LIMIT/input, all DECLARES'd by the outer scope);
+    /// - SHADOWING: `shadow` is declared in BOTH an outer and an inner scope; a ref
+    ///   inside the inner scope resolves to the INNER binder ONLY (nearest wins) —
+    ///   the flat port would have emitted BOTH; this is DELTA 1, the soundness core;
+    /// - OUTER reach: a ref of `state` inside the inner scope (which does not
+    ///   declare it) climbs HAS_SCOPE to the outer scope's binder;
+    /// - IMPORT_BINDING is DECLARES-attached but EXCLUDED by the ARM A type filter
+    ///   (it is the import skip-set);
+    /// - same-scope duplicate binders derive BOTH (DELTA 2, accepted superset).
+    ///
+    /// ARM B (FILE-FLAT: CLASS/INTERFACE/ENUM/TYPE_SYNONYM — not SCOPE-attached):
+    /// - each resolves its same-file REFERENCE by (file, name), no scope needed.
+    ///
+    /// SKIP-SETS / NEGATIVES (each ref is given a declaring scope so it WOULD
+    /// resolve but for the skip): imported name; rt_global ("console"); cross-file
+    /// decl; non-JS (.rs) file; empty name.
     #[test]
-    fn js_local_refs_resolves_same_file_decls_with_skip_sets() {
+    fn js_local_refs_scope_walk_nearest_binder() {
         let mut v = FixtureStorageView::new(1);
 
-        // One declaration + one reference per declaration type (all in app.ts).
-        let decls = [
+        // ── Scope tree in app.ts: MODULE top-scope (NO module SCOPE node — the JS/TS
+        //    analyzer makes the MODULE itself the module scope, Context.hs:59-64),
+        //    outer SCOPE, inner SCOPE child via HAS_SCOPE ──
+        named_node(&mut v, "m_app", "app.ts", "MODULE", "app.ts");
+        named_node(&mut v, "s_outer", "", "SCOPE", "app.ts");
+        named_node(&mut v, "s_inner", "", "SCOPE", "app.ts");
+        edge(&mut v, "m_app", "s_outer", "HAS_SCOPE"); // MODULE is lexical parent of outer
+        edge(&mut v, "s_outer", "s_inner", "HAS_SCOPE"); // outer is lexical parent
+
+        // ── ARM A: scoped binders DECLARES'd by the outer scope, refs CONTAINS'd ──
+        let scoped = [
             ("d_fn", "helper", "FUNCTION"),
             ("d_var", "state", "VARIABLE"),
             ("d_const", "LIMIT", "CONSTANT"),
-            ("d_class", "Engine", "CLASS"),
             ("d_param", "input", "PARAMETER"),
+        ];
+        for (sid, name, ty) in scoped {
+            named_node(&mut v, sid, name, ty, "app.ts");
+            edge(&mut v, "s_outer", sid, "DECLARES");
+            named_node(&mut v, &format!("r_{sid}"), name, "REFERENCE", "app.ts");
+            edge(&mut v, "s_outer", &format!("r_{sid}"), "CONTAINS");
+        }
+
+        // ── SHADOWING: `shadow` declared in BOTH scopes; ref in INNER → inner only ──
+        named_node(&mut v, "d_shadow_out", "shadow", "VARIABLE", "app.ts");
+        edge(&mut v, "s_outer", "d_shadow_out", "DECLARES");
+        named_node(&mut v, "d_shadow_in", "shadow", "VARIABLE", "app.ts");
+        edge(&mut v, "s_inner", "d_shadow_in", "DECLARES");
+        named_node(&mut v, "r_shadow", "shadow", "REFERENCE", "app.ts");
+        edge(&mut v, "s_inner", "r_shadow", "CONTAINS");
+
+        // ── OUTER reach: ref of `state` in the inner scope climbs to outer binder ──
+        named_node(&mut v, "r_state_inner", "state", "REFERENCE", "app.ts");
+        edge(&mut v, "s_inner", "r_state_inner", "CONTAINS");
+
+        // ── DELTA 2: same-scope duplicate binders of `dup` — derive BOTH ──
+        named_node(&mut v, "d_dup_v", "dup", "VARIABLE", "app.ts");
+        edge(&mut v, "s_outer", "d_dup_v", "DECLARES");
+        named_node(&mut v, "d_dup_p", "dup", "PARAMETER", "app.ts");
+        edge(&mut v, "s_outer", "d_dup_p", "DECLARES");
+        named_node(&mut v, "r_dup", "dup", "REFERENCE", "app.ts");
+        edge(&mut v, "s_outer", "r_dup", "CONTAINS");
+
+        // ── MODULE TOP-SCOPE (regression guard): top-level binder DECLARES'd by the
+        //    MODULE, top-level ref CONTAINS'd by the MODULE — must resolve. The JS/TS
+        //    analyzer emits NO module SCOPE node, so this is the very common top-level
+        //    helper/const case that a SCOPE-only walk silently dropped. ──
+        named_node(&mut v, "d_modfn", "boot", "FUNCTION", "app.ts");
+        edge(&mut v, "m_app", "d_modfn", "DECLARES");
+        named_node(&mut v, "r_modfn", "boot", "REFERENCE", "app.ts");
+        edge(&mut v, "m_app", "r_modfn", "CONTAINS"); // ref is module-contained
+
+        // ── MODULE reach from an inner SCOPE: a ref of a module-level const inside the
+        //    inner function scope climbs SCOPE -> SCOPE -> MODULE via HAS_SCOPE. ──
+        named_node(&mut v, "d_modconst", "GLOBAL_CAP", "CONSTANT", "app.ts");
+        edge(&mut v, "m_app", "d_modconst", "DECLARES");
+        named_node(&mut v, "r_modconst_inner", "GLOBAL_CAP", "REFERENCE", "app.ts");
+        edge(&mut v, "s_inner", "r_modconst_inner", "CONTAINS");
+
+        // ── NEAREST over MODULE: `cfg` declared at module level AND in s_outer; a ref
+        //    in s_inner resolves to the s_outer binder (nearest), NOT the MODULE one. ──
+        named_node(&mut v, "d_cfg_mod", "cfg", "CONSTANT", "app.ts");
+        edge(&mut v, "m_app", "d_cfg_mod", "DECLARES");
+        named_node(&mut v, "d_cfg_outer", "cfg", "VARIABLE", "app.ts");
+        edge(&mut v, "s_outer", "d_cfg_outer", "DECLARES");
+        named_node(&mut v, "r_cfg", "cfg", "REFERENCE", "app.ts");
+        edge(&mut v, "s_inner", "r_cfg", "CONTAINS");
+
+        // ── ARM A skip-set: IMPORT_BINDING is DECLARES-attached but EXCLUDED ──
+        named_node(&mut v, "b_ext", "ext", "IMPORT_BINDING", "app.ts");
+        edge(&mut v, "s_outer", "b_ext", "DECLARES");
+        named_node(&mut v, "r_ext", "ext", "REFERENCE", "app.ts");
+        edge(&mut v, "s_outer", "r_ext", "CONTAINS");
+
+        // ── ARM B: flat type/class decls (NOT scope-attached); flat (file,name) ──
+        let flat = [
+            ("d_class", "Engine", "CLASS"),
             ("d_iface", "Shape", "INTERFACE"),
             ("d_enum", "Color", "ENUM"),
             ("d_syn", "Alias", "TYPE_SYNONYM"),
         ];
-        for (sid, name, ty) in decls {
+        for (sid, name, ty) in flat {
             named_node(&mut v, sid, name, ty, "app.ts");
             named_node(&mut v, &format!("r_{sid}"), name, "REFERENCE", "app.ts");
+            edge(&mut v, "s_outer", &format!("r_{sid}"), "CONTAINS");
         }
 
-        // Skip-set 1: imported name (IMPORT_BINDING shadows the local FUNCTION).
-        named_node(&mut v, "b_ext", "ext", "IMPORT_BINDING", "app.ts");
-        named_node(&mut v, "d_ext", "ext", "FUNCTION", "app.ts");
-        named_node(&mut v, "r_ext", "ext", "REFERENCE", "app.ts");
-
-        // Skip-set 2: runtime global ("console" is on the 97-name facts list).
+        // ── Skip-set: runtime global ("console" is on the 97-name facts list) ──
         named_node(&mut v, "d_console", "console", "VARIABLE", "app.ts");
+        edge(&mut v, "s_outer", "d_console", "DECLARES");
         named_node(&mut v, "r_console", "console", "REFERENCE", "app.ts");
+        edge(&mut v, "s_outer", "r_console", "CONTAINS");
 
-        // Negative: declaration only in ANOTHER file.
+        // ── Negative: declaration only in ANOTHER file (cross-file) ──
         named_node(&mut v, "d_far", "far", "FUNCTION", "b.ts");
         named_node(&mut v, "r_far", "far", "REFERENCE", "app.ts");
+        edge(&mut v, "s_outer", "r_far", "CONTAINS");
 
-        // Negative: non-JS file (gate).
+        // ── Negative: non-JS file (gate) — scoped, but .rs is gated out ──
+        named_node(&mut v, "s_rs", "", "SCOPE", "main.rs");
         named_node(&mut v, "d_rfn", "rfn", "FUNCTION", "main.rs");
+        edge(&mut v, "s_rs", "d_rfn", "DECLARES");
         named_node(&mut v, "r_rfn", "rfn", "REFERENCE", "main.rs");
+        edge(&mut v, "s_rs", "r_rfn", "CONTAINS");
 
-        // Negative: empty names never match.
+        // ── Negative: empty names never match ──
         named_node(&mut v, "d_empty", "", "FUNCTION", "app.ts");
+        edge(&mut v, "s_outer", "d_empty", "DECLARES");
         named_node(&mut v, "r_empty", "", "REFERENCE", "app.ts");
-
-        // DELTA 1: duplicate (file,name) decls — derive BOTH.
-        named_node(&mut v, "d_dup_v", "dup", "VARIABLE", "app.ts");
-        named_node(&mut v, "d_dup_p", "dup", "PARAMETER", "app.ts");
-        named_node(&mut v, "r_dup", "dup", "REFERENCE", "app.ts");
+        edge(&mut v, "s_outer", "r_empty", "CONTAINS");
 
         let (eval, specs, _node_specs) = evaluate_with_materialize(
             &v,
@@ -1829,23 +1909,53 @@ mod tests {
         )
         .expect("js_local_refs.dl evaluates");
 
-        let mut expected: BTreeSet<(u128, u128, String)> = decls
-            .iter()
-            .map(|(sid, _, _)| {
-                (
-                    id_of(&format!("r_{sid}")),
-                    id_of(sid),
-                    "js-local-refs".to_string(),
-                )
-            })
-            .collect();
-        expected.insert((id_of("r_dup"), id_of("d_dup_v"), "js-local-refs".to_string()));
-        expected.insert((id_of("r_dup"), id_of("d_dup_p"), "js-local-refs".to_string()));
+        let mut expected: BTreeSet<(u128, u128, String)> = BTreeSet::new();
+        let edge = |r: &str, d: &str| (id_of(r), id_of(d), "js-local-refs".to_string());
+        // ARM A: each scoped binder, resolved in its own scope.
+        expected.insert(edge("r_d_fn", "d_fn"));
+        expected.insert(edge("r_d_var", "d_var"));
+        expected.insert(edge("r_d_const", "d_const"));
+        expected.insert(edge("r_d_param", "d_param"));
+        // SHADOWING: inner ref resolves to the INNER binder ONLY (nearest wins).
+        expected.insert(edge("r_shadow", "d_shadow_in"));
+        // OUTER reach: inner ref of `state` climbs to the outer binder.
+        expected.insert(edge("r_state_inner", "d_var"));
+        // DELTA 2: same-scope dup — BOTH candidates.
+        expected.insert(edge("r_dup", "d_dup_v"));
+        expected.insert(edge("r_dup", "d_dup_p"));
+        // MODULE top-scope: top-level ref → MODULE-DECLARES'd binder (regression guard).
+        expected.insert(edge("r_modfn", "d_modfn"));
+        // MODULE reach: inner ref climbs SCOPE->SCOPE->MODULE to the module-level const.
+        expected.insert(edge("r_modconst_inner", "d_modconst"));
+        // NEAREST over MODULE: inner ref of `cfg` resolves to s_outer binder (nearest),
+        // NOT the module-level one (the MODULE binder is shadowed by s_outer).
+        expected.insert(edge("r_cfg", "d_cfg_outer"));
+        // ARM B: flat type/class decls.
+        expected.insert(edge("r_d_class", "d_class"));
+        expected.insert(edge("r_d_iface", "d_iface"));
+        expected.insert(edge("r_d_enum", "d_enum"));
+        expected.insert(edge("r_d_syn", "d_syn"));
+
         assert_eq!(
             triples(&eval, "js_local_ref"),
             expected,
-            "all 8 decl types + BOTH dup candidates (DELTA 1); imported/rt_global/\
-             cross-file/.rs/empty-name references derive nothing"
+            "ARM A scope-walk (nearest binder; inner shadows outer; outer reach via \
+             HAS_SCOPE; same-scope dup superset; IMPORT_BINDING excluded) + ARM B flat \
+             (CLASS/INTERFACE/ENUM/TYPE_SYNONYM); rt_global/cross-file/.rs/empty derive nothing"
+        );
+
+        // SHADOWING (explicit): the OUTER `shadow` binder must NOT be derived.
+        assert!(
+            !triples(&eval, "js_local_ref")
+                .contains(&edge("r_shadow", "d_shadow_out")),
+            "nearest-binder: the inner-scope `shadow` shadows the outer — outer must be dropped"
+        );
+
+        // NEAREST over MODULE (explicit): the module-level `cfg` binder must NOT be
+        // derived for r_cfg — the strictly-closer s_outer binder shadows it.
+        assert!(
+            !triples(&eval, "js_local_ref").contains(&edge("r_cfg", "d_cfg_mod")),
+            "nearest-binder over MODULE: s_outer `cfg` shadows the module-level `cfg`"
         );
 
         // READS_FROM is shared vocabulary — additive, with resolvedVia projected.

--- a/packages/rfdb-server/src/derive/stdlib/js_class_inheritance.dl
+++ b/packages/rfdb-server/src/derive/stdlib/js_class_inheritance.dl
@@ -122,17 +122,48 @@ jsts_class(C, F) :- node(C, "CLASS"), attr(C, "file", F), ends_with(F, ".cjs").
 % stores superClass only when non-empty; the neq guards other producers).
 super_of(C, F, SC) :- jsts_class(C, F), node_attr(C, "superClass", SC), neq(SC, "").
 
-% Same-file class index (file, name) → node (Hs:53-60).
+% Same-file class index (file, name) → node (Hs:53-60). RETAINED for the
+% has_local fall-through gate ONLY (see below) — keeping it FLAT keeps the A2/
+% A2c/A3/A4 cross-file/builtin arms BYTE-IDENTICAL in behaviour: those arms gate
+% on `\+ has_local(C)`, so their firing condition must not move. On every real
+% JS/TS graph one file is exactly one MODULE and there are no same-(file,name)
+% class collisions, so flat class_in and the MODULE-scoped lookup below coincide
+% (LIVE-VERIFIED on the dogfood graph: flat A1 = 8 edges ≡ MODULE-scoped A1 = 8
+% edges, byte-for-byte same C→T pairs; same-(file,name) collisions = 0; nested
+% classes = 0).
 class_in(F, N, T) :- node(T, "CLASS"), attr(T, "file", F), attr(T, "name", N), neq(N, "").
 
 % Same-file candidate EXISTS — the resolver's fall-through gate (Hs:97/106).
-% Counts C itself (DELTA 2: gate parity over edge parity).
+% Counts C itself (DELTA 2: gate parity over edge parity). KEPT on the FLAT
+% class_in so A2-A4 stay byte-identical (see class_in note above).
 has_local(C) :- super_of(C, F, SC), class_in(F, SC, T).
 
-% A1: same-file superclass.
+% ── A1 binder = LEXICAL SCOPE-WALK over CONTAINS (gold idiom: js_same_file_calls
+%    B1 / js_property_access_full encl_* walk CONTAINS+HAS_SCOPE to the nearest
+%    binder) ─────────────────────────────────────────────────────────────────
+% A CLASS is MODULE-contained (LIVE-VERIFIED: every file-resident CLASS has
+% exactly one CONTAINS parent and it is a MODULE; <builtin> classes have none).
+% The binder for a same-file superclass NAME is therefore the CLASS reachable in
+% the referencing class's enclosing MODULE — `[M:MODULE] -CONTAINS-> {C, T}` —
+% NOT a raw (file, name) match. This disambiguates a nested class (CONTAINS
+% parent ≠ MODULE) shadowing a top-level same-name superclass: such a class is
+% NOT contained by the MODULE, so it cannot bind a sibling-module reference.
+% (0 nested-class instances on the current corpus ⇒ measurable delta is 0; the
+% rework is a soundness/precision hardening that pays off on a future graph.)
+class_module(C, M) :- node(C, "CLASS"), edge(M, C, "CONTAINS"), node(M, "MODULE").
+
+% The referencing class's enclosing-MODULE class index (binder = a CLASS sharing
+% the same MODULE container, keyed by name). Replaces the FLAT (file,name)
+% lookup for the A1 head only.
+class_in_mod(M, N, T) :-
+    edge(M, T, "CONTAINS"), node(T, "CLASS"), node(M, "MODULE"),
+    attr(T, "name", N), neq(N, "").
+
+% A1: same-file superclass, resolved by lexical scope-walk to the enclosing
+% MODULE's class binder (not flat file,name). super_of stays the SC seed.
 @materialize(edge_type = "EXTENDS", mode = "additive", meta(resolvedVia))
 ext_same_file(C, T, "class-inheritance") :-
-    super_of(C, F, SC), class_in(F, SC, T), neq(C, T).
+    super_of(C, F, SC), class_module(C, M), class_in_mod(M, SC, T), neq(C, T).
 
 % A2: cross-file superclass through the import-binding's legacy IMPORTS_FROM
 % edge (hybrid EDB seam), only when the same-file index missed. MODULE targets

--- a/packages/rfdb-server/src/derive/stdlib/js_local_refs.dl
+++ b/packages/rfdb-server/src/derive/stdlib/js_local_refs.dl
@@ -1,41 +1,73 @@
-% js_local_refs.dl — in-engine replacement for the JsLocalRefs.hs resolver
-% (packages/grafema-resolve/src/JsLocalRefs.hs:91-118 — the #1 edge producer:
-% REFERENCE → same-file declaration READS_FROM, previously paid for over per-file
-% IPC round-trips in the orchestrator's JS resolve wall).
+% js_local_refs.dl — SCOPE-WALK resolver for same-file READS_FROM edges
+% (REFERENCE → its declaration). Supersedes the file-flat JsLocalRefs.hs port
+% (packages/grafema-resolve/src/JsLocalRefs.hs:91-118) — the #1 edge producer.
 %
-% Resolver semantics reproduced EXACTLY (file-flat, deliberately NOT scope-aware —
-% the resolver matches by (file, name) only, JsLocalRefs.hs:111; parity over
-% ambition):
-%   - a REFERENCE resolves to a declaration with the same (file, name) across the
-%     8 declaration types (JsLocalRefs.hs:38-42);
-%   - SKIP names that are import bindings in the same file (handled by
-%     ImportResolution; the IMPORT -CONTAINS-> IMPORT_BINDING shape is 100%
-%     universal per the Wave-0 live-graph check, so the (file, name) skip-set is
-%     solid), JsLocalRefs.hs:104-105;
-%   - SKIP the compiled-in runtime-global names (handled by RuntimeGlobals),
-%     JsLocalRefs.hs:54-84 — reproduced below as 97 ground facts, the EXACT list;
-%   - empty-name declarations and references never match (the resolver's index
-%     excludes them, JsLocalRefs.hs:51 — the neq(N, "") guard).
+% GOAL: SOUND + PRECISE + PROVENANCE. A REFERENCE resolves to the NEAREST
+% enclosing binder reachable by lexical scope walk (CONTAINS to the directly
+% containing SCOPE, then HAS_SCOPE to lexical parents), NOT to EVERY same-(file,
+% name) declaration. Flat (file, name) match is either an arbitrary winner
+% (unsound) or an edge to every same-name binder (imprecise superset, ignoring
+% shadowing). The scope walk fixes both: it resolves to the innermost scope that
+% declares the name, and binds the declaration as a NODE (no name-key collision).
 %
-% READS_FROM is SHARED vocabulary (analyzers and other resolvers also emit it)
+% TWO ARMS, split by whether the declaration is attached to a SCOPE:
+%
+%   ARM A — SCOPE-WALK for VARIABLE / CONSTANT / FUNCTION / PARAMETER.
+%     These are the binder types reachable via <scope> -DECLARES-> binder (verified
+%     live: the DECLARES target set is EXACTLY {VARIABLE, CONSTANT, FUNCTION,
+%     PARAMETER, IMPORT_BINDING}; IMPORT_BINDING is excluded as the import skip-set,
+%     handled by ImportResolution). IMPORTANT — the DECLARES *source* is NOT always
+%     a SCOPE: the live source-type set is {SCOPE, FUNCTION, MODULE, IMPL_BLOCK}.
+%     In particular the JS/TS analyzer does NOT emit a module-kind SCOPE node — the
+%     module scope's scopeId IS the MODULE node itself (Context.hs:59-64,84-89), so
+%     every top-level binder is DECLARES'd by the MODULE node and every top-level
+%     reference is CONTAINS'd by the MODULE node (live: 3897 MODULE-DECLARES-FUNCTION,
+%     2604 MODULE-CONTAINS-REFERENCE on .ts). The MODULE is therefore the TOP scope
+%     of the lexical chain — ref_scope seeds from a MODULE container AND climbs from
+%     the top SCOPE to its MODULE parent (live: 1109 MODULE -HAS_SCOPE-> SCOPE edges).
+%     The walk seeds from the reference's containing scope (SCOPE or MODULE) and
+%     climbs HAS_SCOPE lexical parents (the Wave-0-verified shape shared with
+%     js_same_file_calls B1 / js_property_access_full C1). NEAREST-BINDER:
+%     among all reachable scopes that declare the name, the innermost one wins —
+%     enforced by stratified negation over a strict-inner reachability relation
+%     (`inner_of`), so an outer same-name binder is dropped when a closer scope on
+%     the same chain also declares the name (real shadowing — 405 names on the
+%     live graph have same-name VARIABLE decls in different scopes within one file).
+%
+%   ARM B — FILE-FLAT for CLASS / INTERFACE / ENUM / TYPE_SYNONYM.
+%     Verified live: these node types are NOT attached to any SCOPE (CLASS via
+%     SCOPE-CONTAINS = 0, via SCOPE-DECLARES = 0; CLASS is contained by MODULE
+%     only). They are genuinely module/file-scoped — no intra-file shadowing
+%     exists for them — so a flat (file, name) join over JUST these 4 types is the
+%     CORRECT resolution, not a hack. (If a future analyzer change attaches CLASS
+%     to a SCOPE, this arm would need to move to ARM A; the type fixture guards it.)
+%
+% READS_FROM is SHARED vocabulary (analyzers + other resolvers also emit it)
 % ⇒ mode = "additive" is mandatory: only add missing edges, never tombstone.
+% Provenance: resolvedVia = "js-local-refs" projected as a meta column; the engine
+% additionally stamps _source = <rule hash> + _generation.
 %
-% NUMBERED DELTAS vs the resolver (everything not listed is exact):
-%   DELTA 1 (superset): duplicate (file, name) declarations — the resolver's
-%     Map.fromList keeps ONE arbitrary winner (last in node-stream order,
-%     JsLocalRefs.hs:46-52); set semantics derives an edge to EVERY candidate.
-%     Order-independent; strict superset; mechanically classifiable.
-%   DELTA 2 (metadata): resolvedVia="js-local-refs" is projected as a meta column
-%     (parity for downstream consumers); the engine additionally stamps its own
-%     _source = <rule hash> + _generation provenance instead of nothing.
-%   DELTA 3 (file gate): the resolver never gated by extension itself — its
-%     effective gate was the orchestrator streaming only detect_language ==
-%     JavaScript nodes (8 extensions: js/jsx/ts/tsx/mjs/cjs/mts/cts, config.rs
-%     detect_language). The jsts/1 gate below encodes the same 8 extensions.
+% SKIP-SETS (unchanged from the flat port):
+%   - import bindings in the same file (imported/2, handled by ImportResolution);
+%     ARM A excludes IMPORT_BINDING by the DECLARES type filter — the \+ imported
+%     guard is belt-and-suspenders / also guards ARM B;
+%   - the 97 compiled-in runtime-global names (rt_global/1 ground facts);
+%   - empty-name references and declarations (the neq(N, "") guards).
+%
+% NUMBERED DELTAS vs a purely-flat resolution (everything not listed is exact):
+%   DELTA 1 (precision GAIN, the GOAL): ARM A resolves a reference to the NEAREST
+%     enclosing binder, NOT every same-(file, name) binder. Same-name decls in
+%     OUTER scopes are dropped by the shadowing negation. This intentionally
+%     diverges from the legacy resolver's (file, name) superset toward soundness.
+%   DELTA 2 (superset, accepted): duplicate binders of the same name in the SAME
+%     scope still derive an edge to each (SCOPE nodes carry no line metadata on the
+%     live graph — line=0/endLine=0 — so there is no tie-breaker; same constraint
+%     the gold packs documented). Order-independent, strict superset, rare.
+%   DELTA 3 (file gate): the 8-extension JS/TS gate (js/jsx/ts/tsx/mjs/cjs/mts/cts),
+%     encoded as one ends_with clause per extension (a derived gate cannot BIND a
+%     head var; an extension-facts relation joined via ends_with is a §3 cross-join).
 
-% The resolver's compiled-in runtime-global skip list — the EXACT 97 names of
-% JsLocalRefs.hs:57-84 (runtimeGlobalNames), as ground facts (Wave-0 proved facts
-% survive the full derive pipeline).
+% ── Runtime-global skip list — the EXACT 97 names (JsLocalRefs.hs:57-84) ───────
 rt_global("console").
 rt_global("process").
 rt_global("Buffer").
@@ -134,12 +166,7 @@ rt_global("structuredClone").
 rt_global("atob").
 rt_global("btoa").
 
-% The JS/TS language gate — the orchestrator's detect_language JavaScript set
-% (8 extensions; see DELTA 3), expanded as one clause per extension with a
-% CONSTANT ends_with filter. (A derived jsts(F) gate is planner-infeasible — a
-% filter cannot BIND a head variable — and an extension-facts relation joined
-% via ends_with(F, E) is a §3 cross-join: the fact leg shares no bound variable
-% with the body. Constant-pattern clause expansion is the feasible encoding.)
+% ── The JS/TS language gate — 8 extensions (DELTA 3), one clause per extension ──
 js_ref(R, F, N) :- node(R, "REFERENCE"), attr(R, "file", F), ends_with(F, ".js"), attr(R, "name", N), neq(N, "").
 js_ref(R, F, N) :- node(R, "REFERENCE"), attr(R, "file", F), ends_with(F, ".jsx"), attr(R, "name", N), neq(N, "").
 js_ref(R, F, N) :- node(R, "REFERENCE"), attr(R, "file", F), ends_with(F, ".ts"), attr(R, "name", N), neq(N, "").
@@ -149,27 +176,101 @@ js_ref(R, F, N) :- node(R, "REFERENCE"), attr(R, "file", F), ends_with(F, ".cjs"
 js_ref(R, F, N) :- node(R, "REFERENCE"), attr(R, "file", F), ends_with(F, ".mts"), attr(R, "name", N), neq(N, "").
 js_ref(R, F, N) :- node(R, "REFERENCE"), attr(R, "file", F), ends_with(F, ".cts"), attr(R, "name", N), neq(N, "").
 
-% Imported names per file (the resolver's ImportIndex, ResolveUtil.hs:59-65):
-% any IMPORT_BINDING's (file, name) shadows local resolution.
+% A reference that is eligible for local resolution at all: JS/TS, not an import
+% binding in this file, not a runtime global. Leading with js_ref (the small,
+% bound set) keeps the scope walk from enumerating every scope's contents
+% (planner-filter-before-generator).
+local_ref(R, F, N) :- js_ref(R, F, N), \+ imported(F, N), \+ rt_global(N).
+
+% Imported names per file (JsLocalRefs.hs:104-105) — local resolution skip-set.
 imported(F, N) :- node(B, "IMPORT_BINDING"), attr(B, "file", F), attr(B, "name", N).
 
-% The 8 referenceable declaration types (JsLocalRefs.hs:38-42), keyed (file, name).
-decl(F, N, D) :- node(D, "FUNCTION"), attr(D, "file", F), attr(D, "name", N).
-decl(F, N, D) :- node(D, "VARIABLE"), attr(D, "file", F), attr(D, "name", N).
-decl(F, N, D) :- node(D, "CONSTANT"), attr(D, "file", F), attr(D, "name", N).
-decl(F, N, D) :- node(D, "CLASS"), attr(D, "file", F), attr(D, "name", N).
-decl(F, N, D) :- node(D, "PARAMETER"), attr(D, "file", F), attr(D, "name", N).
-decl(F, N, D) :- node(D, "INTERFACE"), attr(D, "file", F), attr(D, "name", N).
-decl(F, N, D) :- node(D, "ENUM"), attr(D, "file", F), attr(D, "name", N).
-decl(F, N, D) :- node(D, "TYPE_SYNONYM"), attr(D, "file", F), attr(D, "name", N).
+% ── ARM A — SCOPE-WALK: VARIABLE / CONSTANT / FUNCTION / PARAMETER ─────────────
+%
+% The scope directly containing the reference, then its lexical parents. A scope's
+% HAS_SCOPE sources are its owner (FUNCTION/METHOD) AND its lexical parent scope —
+% the node(S2, "SCOPE") filter selects only the lexical-parent edge (the Wave-0
+% owner-vs-lexical nuance). Seeded ONLY from local_ref so the closure does not
+% enumerate every scope in the graph.
+%
+% TOP-SCOPE = MODULE: the JS/TS analyzer emits NO module-kind SCOPE node (the module
+% scope IS the MODULE node, Context.hs:59-64). So (a) a top-level reference is
+% CONTAINS'd directly by the MODULE — seed ref_scope from a MODULE container too;
+% and (b) the outermost in-function SCOPE chains up to the MODULE via HAS_SCOPE —
+% climb from a SCOPE to its MODULE lexical parent. Both put the MODULE into ref_scope
+% so its DECLARES'd top-level binders become candidates (binder/3 does not filter the
+% source type, so a MODULE-sourced DECLARES already matches once the MODULE is here).
+ref_scope(R, S)  :- local_ref(R, F, N), edge(S, R, "CONTAINS"), node(S, "SCOPE").
+ref_scope(R, S)  :- local_ref(R, F, N), edge(S, R, "CONTAINS"), node(S, "MODULE").
+ref_scope(R, S2) :- ref_scope(R, S), edge(S2, S, "HAS_SCOPE"), node(S2, "SCOPE").
+ref_scope(R, S2) :- ref_scope(R, S), edge(S2, S, "HAS_SCOPE"), node(S2, "MODULE").
 
-% The resolution: REFERENCE → same-file declaration, minus the two skip-sets.
-% Both negations are over analyzer-owned state (IMPORT_BINDING nodes) or ground
-% facts — never over a type this (or any) pack materializes: stratifier-clean,
-% no cross-run lag.
+% Binders, by the 4 DECLARES-target types (IMPORT_BINDING is deliberately EXCLUDED —
+% it is the import skip-set, resolved by ImportResolution). binder(S, N, D): the
+% declaring container S (a SCOPE *or* the MODULE top-scope, or any DECLARES source —
+% the rule does NOT filter S's type) declares a binder D named N. S is constrained to
+% R's lexical chain only at the cand/3 join (ref_scope(R, S)), so module-level binders
+% participate exactly when the MODULE is on the reference's chain.
+binder(S, N, D) :- edge(S, D, "DECLARES"), node(D, "VARIABLE"),  attr(D, "name", N), neq(N, "").
+binder(S, N, D) :- edge(S, D, "DECLARES"), node(D, "CONSTANT"),  attr(D, "name", N), neq(N, "").
+binder(S, N, D) :- edge(S, D, "DECLARES"), node(D, "FUNCTION"),  attr(D, "name", N), neq(N, "").
+binder(S, N, D) :- edge(S, D, "DECLARES"), node(D, "PARAMETER"), attr(D, "name", N), neq(N, "").
+
+% A candidate binder for the reference: some scope on R's chain declares the name.
+% (D bound as a NODE through DECLARES — precise; no (file, name) collision.)
+cand(R, S, N, D) :- local_ref(R, F, N), ref_scope(R, S), binder(S, N, D).
+
+% Node-projected candidate (drops the binder node var) — feeds `shadowed` so the
+% negation join is a 3-col relation, not 4-col with a free node leg.
+cand_scope(R, S, N) :- cand(R, S, N, _).
+
+% Strict-inner reachability over R's chain (recursive, same SCC family as
+% ref_scope): inner_of(R, S2, S) ⇔ S2 is on R's chain AND S is a STRICT ancestor
+% of S2 (≥1 HAS_SCOPE hop) that is ALSO on R's chain — i.e. S2 is strictly inside
+% S for this reference. Base = direct lexical parent; transitive = climb further.
+% The ancestor S may be a MODULE (the top scope) too — so an outer MODULE-level
+% binder is correctly shadowed when a strictly-closer SCOPE on the chain declares N.
+inner_of(R, S2, S)  :- ref_scope(R, S2), edge(S, S2, "HAS_SCOPE"), node(S, "SCOPE").
+inner_of(R, S2, S)  :- ref_scope(R, S2), edge(S, S2, "HAS_SCOPE"), node(S, "MODULE").
+inner_of(R, S2, S3) :- inner_of(R, S2, S), edge(S3, S, "HAS_SCOPE"), node(S3, "SCOPE").
+inner_of(R, S2, S3) :- inner_of(R, S2, S), edge(S3, S, "HAS_SCOPE"), node(S3, "MODULE").
+
+% `declares_name(S, N)`: scope/container S declares SOME binder named N — the
+% node-projected form of binder/3 (drops the binder node var). Used by `shadowed`
+% so the negation join does NOT carry a free binder-node leg per candidate (which
+% multiplied the planner's per-rule estimate past max_materialized_facts).
+declares_name(S, N) :- binder(S, N, _).
+
+% `chain_declares(R, S, N)`: on reference R's lexical chain, some scope STRICTLY
+% INSIDE S declares name N. Built by joining inner_of with declares_name FIRST and
+% projecting the inner scope S2 away — so the downstream negation is a plain
+% (R, S, N) ⋈ (R, S, N) join, not a 3-way product that blows the planner estimate.
+chain_declares(R, S, N) :- inner_of(R, S2, S), declares_name(S2, N).
+
+% NEAREST-BINDER negation (stratified — `shadowed` negates inner_of/declares_name via
+% chain_declares, strictly-lower strata, NEVER ref_scope's own SCC). A candidate scope
+% S is shadowed for name N on reference R when a strictly-closer scope on R's chain
+% also declares N — the inner binder wins, the outer is dropped.
+shadowed(R, S, N) :- cand_scope(R, S, N), chain_declares(R, S, N).
+
+% ARM A winner: the candidate binder whose declaring scope is NOT shadowed by any
+% closer scope on the chain = the nearest enclosing binder.
+arm_a(R, D) :- cand(R, S, N, D), \+ shadowed(R, S, N).
+
+% ── ARM B — FILE-FLAT: CLASS / INTERFACE / ENUM / TYPE_SYNONYM ─────────────────
+% Not SCOPE-attached (verified live: 0 SCOPE edges) ⇒ genuinely file/module-scoped
+% ⇒ flat (file, name) is the correct resolution (no intra-file shadowing to honor).
+flat_decl(F, N, D) :- node(D, "CLASS"),        attr(D, "file", F), attr(D, "name", N), neq(N, "").
+flat_decl(F, N, D) :- node(D, "INTERFACE"),    attr(D, "file", F), attr(D, "name", N), neq(N, "").
+flat_decl(F, N, D) :- node(D, "ENUM"),         attr(D, "file", F), attr(D, "name", N), neq(N, "").
+flat_decl(F, N, D) :- node(D, "TYPE_SYNONYM"), attr(D, "file", F), attr(D, "name", N), neq(N, "").
+
+arm_b(R, D) :- local_ref(R, F, N), flat_decl(F, N, D).
+
+% ── EMIT — both arms feed the single additive READS_FROM head ──────────────────
+% @materialize binds by HEAD PREDICATE (materialize.rs collect_materialize_specs:
+% predicate = head().predicate()): ALL js_local_ref facts — ARM A and ARM B — are
+% projected, so the annotation rides the first clause and the second is plain.
 @materialize(edge_type = "READS_FROM", mode = "additive", meta(resolvedVia))
-js_local_ref(R, D, "js-local-refs") :-
-    js_ref(R, F, N),
-    \+ imported(F, N),
-    \+ rt_global(N),
-    decl(F, N, D).
+js_local_ref(R, D, "js-local-refs") :- arm_a(R, D).
+js_local_ref(R, D, "js-local-refs") :- arm_b(R, D).

--- a/packages/rfdb-server/src/derive/stdlib/js_same_file_calls.dl
+++ b/packages/rfdb-server/src/derive/stdlib/js_same_file_calls.dl
@@ -2,12 +2,15 @@
 % (packages/grafema-resolve/src/SameFileCalls.hs:95-154): CALLS edges for calls
 % whose callee is defined in the same file. Four arms, exactly the resolver's:
 %
-%   A1 direct call  "foo()"            → same-file FUNCTION            (Hs:127-128)
-%   A2 direct call  "foo()"            → same-file VARIABLE/CONSTANT
+%   A1 direct call  "foo()"            → enclosing-scope FUNCTION      (Hs:127-128)
+%   A2 direct call  "foo()"            → enclosing-scope VARIABLE/CONSTANT
 %                                        (arrow fns), only when no FUNCTION wins
 %                                        (the Map-merge precedence, Hs:52-66)
-%   A3 direct ctor  "Foo()"            → same-file CLASS, uppercase-first only,
-%                                        only when A1/A2 found nothing (Hs:130-134)
+%   A3 direct ctor  "Foo()"            → enclosing-MODULE CLASS, uppercase-first
+%                                        only, only when A1/A2 found nothing (Hs:130-134)
+%
+% A1/A2/A3 now SCOPE-WALK to the binder in a LEXICALLY ENCLOSING container (the
+% B1/B2 encl_* idiom), not a flat (file, name) match — see DELTA 6.
 %   B1 this/super/<obj> method call    → enclosing class's method     (Hs:141-147)
 %   B2 ClassName.staticMethod()        → that class's method, ClassName
 %                                        uppercase-first               (Hs:149-152)
@@ -63,6 +66,20 @@
 %   DELTA 5 (file gate): the resolver's effective gate was the orchestrator's
 %     detect_language == JavaScript stream filter (8 extensions) — the js_call
 %     clause set below.
+%   DELTA 6 (precision, resolve rework): the DIRECT-call arms A1/A2/A3 resolve by
+%     SCOPE-WALK to the binder in a LEXICALLY ENCLOSING container — the same live
+%     SCOPE+HAS_SCOPE+CONTAINS chain B1/B2 use (extended with the enclosing MODULE
+%     leg for top-level binders + classes; see the pcall_scope/pcall_mod block) —
+%     instead of the old flat (file, name) join, which over-resolved a local `foo`
+%     in function A to an unrelated `foo` in function B of the same file. Verified
+%     on the real 503k-node graph: the scope-walk set is EXACTLY a subset of the
+%     flat (file, name) set (0 spurious edges), dropping only cross-scope false
+%     positives. The FUNCTION>VARIABLE/CONSTANT precedence ladder is preserved but
+%     is now PER-CALL (sf_has_func/sf_has_varconst, scope-aware) rather than
+%     per-(file, name) — a FUNCTION in an OUTER enclosing scope still beats a
+%     VARIABLE in the same chain, exactly JS lexical resolution. Non-shadowing
+%     (idiom parity with B1's DELTA 2a): every enclosing-container binder of the
+%     name derives an edge (sound superset, provenance-correct via meta).
 
 % Every CALL in a JS/TS file with its (file, name) — the 8-extension language
 % gate (DELTA 5), one clause per extension (see ENCODING NOTES).
@@ -85,12 +102,7 @@ dotted(C) :- node(C, "CALL"), attr(C, "name", N), string_contains(N, ".").
 % A direct (dotless) call in a JS file whose name is not an import binding.
 plain_call(C, F, N) :- js_call(C, F, N), \+ dotted(C), \+ imported(F, N).
 
-func_named(F, N, T)     :- node(T, "FUNCTION"), attr(T, "file", F), attr(T, "name", N).
-varconst_named(F, N, T) :- node(T, "VARIABLE"), attr(T, "file", F), attr(T, "name", N).
-varconst_named(F, N, T) :- node(T, "CONSTANT"), attr(T, "file", F), attr(T, "name", N).
 class_named(F, N, T)    :- node(T, "CLASS"),    attr(T, "file", F), attr(T, "name", N).
-has_func(F, N)     :- func_named(F, N, T).
-has_varconst(F, N) :- varconst_named(F, N, T).
 
 % Uppercase-first-named classes — the constructor heuristic's test (Hs:131,149),
 % one clause per letter (no char-class builtin; a 26-fact relation would be a
@@ -122,24 +134,227 @@ uc_class(F, N, T) :- class_named(F, N, T), starts_with(N, "X").
 uc_class(F, N, T) :- class_named(F, N, T), starts_with(N, "Y").
 uc_class(F, N, T) :- class_named(F, N, T), starts_with(N, "Z").
 
-% A1: FUNCTION wins outright.
+% ── Scope-walk for direct calls (A1/A2/A3) — the B1/B2 encl_* idiom ────────────
+% DELTA 6 (precision, this pack's resolve rework): A1/A2/A3 no longer resolve a
+% direct call to ANY same-(file, name) binder (the old flat func_named /
+% varconst_named / class_named (file, name) joins, which over-resolved a local
+% `foo` in function A to an unrelated `foo` in function B of the same file).
+% They now resolve to the binder declared in a LEXICALLY ENCLOSING container of
+% the call site — the same SCOPE+HAS_SCOPE+CONTAINS chain B1/B2 walk, seeded from
+% plain_call (a SEPARATE chain from B1's this_call-seeded encl_scope — B1/B2 are
+% untouched). Verified on the real 503k-node graph (HEAD 1bcea99b): the scope
+% chain produces EXACTLY a subset of the old flat (file, name) match (0 spurious
+% edges), dropping only cross-scope false positives. Soundness + provenance.
+%
+% Wave-0-verified declaration-containment shape (live-queried on graph.rfdb):
+%   - A free binder (FUNCTION / VARIABLE / CONSTANT) is reached by
+%     container -CONTAINS-> binder, where the container is a SCOPE for nested
+%     declarations and the file MODULE for top-level declarations (the bulk:
+%     7241 top-level FUNCTIONs are MODULE-contained, not SCOPE-contained).
+%   - A CLASS is ONLY ever MODULE-contained (SCOPE -CONTAINS-> CLASS = 0 on the
+%     real graph), so A3's ctor resolution uses the enclosing-MODULE leg alone.
+%   - Every CALL has an innermost SCOPE container (SCOPE -CONTAINS-> CALL).
+%   - The lexical chain climbs SCOPE -HAS_SCOPE-> SCOPE for nested scopes, and
+%     hops out of a function body via owner -HAS_SCOPE-> scope (owner FUNCTION)
+%     then owner -CONTAINS-> outerScope/MODULE — because a function-body scope's
+%     parent is the owning FUNCTION node, not another SCOPE.
+
+% The scope directly containing the call, then its lexical ancestors: nested
+% SCOPE parents (SCOPE -HAS_SCOPE-> SCOPE), and the container scope of the
+% enclosing FUNCTION (hop out of a function body: owner FUNCTION -HAS_SCOPE->
+% innerScope, then that FUNCTION -CONTAINS-> outerScope). Separate from B1's
+% encl_scope (different seed) so B1/B2 stay byte-identical.
+pcall_scope(C, S)  :- plain_call(C, F, N), edge(S, C, "CONTAINS"), node(S, "SCOPE").
+pcall_scope(C, S2) :- pcall_scope(C, S), edge(S2, S, "HAS_SCOPE"), node(S2, "SCOPE").
+pcall_scope(C, S2) :- pcall_scope(C, S), edge(O, S, "HAS_SCOPE"), node(O, "FUNCTION"),
+                      edge(S2, O, "CONTAINS"), node(S2, "SCOPE").
+
+% The enclosing file MODULE of the call: it owns a scope on the chain, OR
+% contains an owner-FUNCTION on the chain, OR directly contains the call
+% (top-level calls are CONTAINS-d by the MODULE, not a scope). Top-level binders
+% and ALL classes live here.
+pcall_mod(C, M) :- pcall_scope(C, S), edge(M, S, "HAS_SCOPE"), node(M, "MODULE").
+pcall_mod(C, M) :- pcall_scope(C, S), edge(O, S, "HAS_SCOPE"), node(O, "FUNCTION"),
+                   edge(M, O, "CONTAINS"), node(M, "MODULE").
+pcall_mod(C, M) :- plain_call(C, F, N), edge(M, C, "CONTAINS"), node(M, "MODULE").
+
+% Scope-resolved binder lookups (replace the flat *_named (file, name) joins).
+% attr(T, "name", N) is a CHECK (N pre-bound from plain_call), not a generator;
+% pcall_scope/pcall_mod bind C and the container first (planner-filter-before-
+% generator). A binder declared in EITHER an enclosing SCOPE or the enclosing
+% MODULE is in scope for the call.
+sf_func_named(C, T) :- pcall_scope(C, S), edge(S, T, "CONTAINS"), node(T, "FUNCTION"),
+                       plain_call(C, F, N), attr(T, "name", N).
+sf_func_named(C, T) :- pcall_mod(C, M),   edge(M, T, "CONTAINS"), node(T, "FUNCTION"),
+                       plain_call(C, F, N), attr(T, "name", N).
+sf_var_named(C, T)  :- pcall_scope(C, S), edge(S, T, "CONTAINS"), node(T, "VARIABLE"),
+                       plain_call(C, F, N), attr(T, "name", N).
+sf_var_named(C, T)  :- pcall_scope(C, S), edge(S, T, "CONTAINS"), node(T, "CONSTANT"),
+                       plain_call(C, F, N), attr(T, "name", N).
+sf_var_named(C, T)  :- pcall_mod(C, M),   edge(M, T, "CONTAINS"), node(T, "VARIABLE"),
+                       plain_call(C, F, N), attr(T, "name", N).
+sf_var_named(C, T)  :- pcall_mod(C, M),   edge(M, T, "CONTAINS"), node(T, "CONSTANT"),
+                       plain_call(C, F, N), attr(T, "name", N).
+
+% Per-CALL negation ladder (was per-(file, name) has_func / has_varconst). Now
+% SCOPE-AWARE: A2 fires only when no FUNCTION binder is reachable by scope-walk
+% for THIS call; A3 only when neither a FUNCTION nor a VARIABLE/CONSTANT binder
+% is. A FUNCTION in an OUTER enclosing scope still beats a VARIABLE/CONSTANT in
+% the same chain — exactly JS lexical resolution. (Stratification: sf_has_func /
+% sf_has_varconst are derived only from positive sf_*_named rules, so they sit in
+% an earlier stratum than the negating sf_call_var / sf_call_ctor — no negation
+% cycle, mirroring the old has_func / has_varconst placement.)
+sf_has_func(C)     :- sf_func_named(C, T).
+sf_has_varconst(C) :- sf_var_named(C, T).
+
+% A1: FUNCTION wins outright — the nearest enclosing FUNCTION binder of the name.
 @materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
 sf_call_fn(C, T, "same-file-calls") :-
-    plain_call(C, F, N), func_named(F, N, T).
+    sf_func_named(C, T).
 
-% A2: VARIABLE/CONSTANT only when no same-(file,name) FUNCTION exists
-% (the resolver's FUNCTION-last Map merge, Hs:52-66). DELTA 1.
+% A2: VARIABLE/CONSTANT (arrow fns) only when no enclosing FUNCTION binds the
+% name (the resolver's FUNCTION-last Map merge, Hs:52-66). DELTA 1.
 @materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
 sf_call_var(C, T, "same-file-calls") :-
-    plain_call(C, F, N), \+ has_func(F, N), varconst_named(F, N, T).
+    sf_var_named(C, T), \+ sf_has_func(C).
 
-% A3: uppercase-first constructor fallback, only when the function index had
-% nothing at all (Hs:129-134).
+% A3: uppercase-first constructor fallback, only when no enclosing FUNCTION and
+% no enclosing VARIABLE/CONSTANT binds the name (Hs:129-134). A CLASS is only
+% MODULE-contained, so the enclosing-MODULE leg alone reaches it; the uppercase-
+% first ctor heuristic (Hs:131) is an inline CHECK on the already-bound call name
+% N, one clause per letter (a derived gate predicate cannot bind a head var, and
+% an uc_name(N) fact relation joined by a filter is a §3 cross-join — see
+% ENCODING NOTES; uc_class is keyed (file, name) flat and is reserved for B2).
 @materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
 sf_call_ctor(C, T, "same-file-calls") :-
-    plain_call(C, F, N),
-    \+ has_func(F, N), \+ has_varconst(F, N),
-    uc_class(F, N, T).
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "A"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "B"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "C"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "D"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "E"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "F"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "G"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "H"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "I"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "J"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "K"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "L"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "M"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "N"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "O"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "P"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "Q"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "R"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "S"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "T"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "U"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "V"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "W"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "X"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "Y"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
+@materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
+sf_call_ctor(C, T, "same-file-calls") :-
+    pcall_mod(C, M), edge(M, T, "CONTAINS"), node(T, "CLASS"),
+    plain_call(C, F, N), attr(T, "name", N), starts_with(N, "Z"),
+    \+ sf_has_func(C), \+ sf_has_varconst(C).
 
 % ── Scope chain (Wave-0 verified shape) — B1's enclosing class ────────────────
 % Seeded ONLY from this/super/<obj> calls (planner-filter-before-generator: the

--- a/packages/rfdb-server/src/derive/stdlib/js_this_method_calls.dl
+++ b/packages/rfdb-server/src/derive/stdlib/js_this_method_calls.dl
@@ -3,35 +3,42 @@
 % sole reason for the orchestrator's SECOND full-graph streaming pass
 % (main.rs js-this-method-calls — pure IPC overhead); the pack kills that pass.
 %
-% Resolver semantics reproduced EXACTLY (deliberately file-flat — the resolver
-% never looked at the enclosing class; parity over ambition. The scope-aware
-% enclosing-class arm lives in js_same_file_calls.dl B1, which legacy ALSO ran on
-% the same calls — the two packs overlap on additive CALLS exactly as the two
-% resolvers did):
-%   - CALL whose name starts with "this." in a JS/TS file (the resolver's OWN
-%     6-extension gate, Hs:45 — see DELTA 2);
-%   - the rest of the name after "this." is looked up among the file's METHOD
-%     nodes by (file, name) (Hs:29-36);
-%   - resolve ONLY when exactly one candidate exists (Hs:56-66) — the documented
-%     neq/ambig negation idiom;
-%   - empty method names never indexed (Hs:35) — the neq(MN, "") guard.
+% SCOPE-WALK rework (resolve-pack #23): the flat (file, name)→METHOD rule was
+% UNSOUND-by-imprecision and ambiguity-blind. On the real Grafema graph
+% (503296 nodes) the flat arm and js_same_file_calls.dl B1 (the scope-walk
+% this-arm) diverged BOTH ways: the flat `ambig` guard refused every member of
+% any (file, name) collision (e.g. two private `shouldLog` in Logger.ts — one per
+% class), giving false NEGATIVES; while B1's scope-walk bound the enclosing class
+% as a NODE and resolved each call to its OWN class. Conversely B1 alone MISSED
+% the call inside an arrow-function class property (DELTA 2b: js_same_file_calls.dl
+% :49-51) — e.g. SceneManager.ts `private _animate = () => { … this._tickFly() }`,
+% whose `<arrow>` FUNCTION owner is NOT a CLASS -HAS_METHOD-> member, so B1's
+% encl_member→encl_class link breaks at the arrow-property boundary.
 %
-% Multi-dot names are NOT a delta: concat in check mode pins
-% Full == "this." ++ MethodName — "this.a.b" only matches a METHOD literally
-% named "a.b" (never exists), identical to the resolver's index miss after
-% stripThis. This CORRECTS the migration spec's anticipated method_suffix
-% superset delta — eliminated by construction.
+% This pack now resolves this.-prefixed method calls SOUNDLY via the same
+% live SCOPE chain B1 uses (CALL <-CONTAINS- SCOPE, lexical HAS_SCOPE parents,
+% owner METHOD/FUNCTION → CLASS via HAS_METHOD) AND additionally derives the
+% enclosing CLASS directly from any enclosing SCOPE the CLASS owns
+% (CLASS -HAS_SCOPE-> enclosing-scope) — covering the arrow-property / static-block
+% case the HAS_METHOD-owner path cannot. CALLS is SHARED vocabulary ⇒ "additive";
+% the pack overlaps B1's additive CALLS exactly as the two resolvers did. Pack
+% scoped to this.-prefix only; super./<obj>. method calls are left to B1.
 %
-% CALLS is SHARED vocabulary ⇒ mode = "additive".
-%
-% NUMBERED DELTAS vs the resolver (everything not listed is exact):
+% NUMBERED DELTAS vs the original flat resolver (everything not listed is exact):
 %   DELTA 1 (metadata): resolvedVia="js-this-method-calls" projected as a meta
 %     column; engine provenance (_source/_generation) added.
-%   DELTA 2 (file gate, exact parity — recorded for the harness): the pack uses
-%     the resolver's own 6-extension gate (.ts/.tsx/.js/.jsx/.mjs/.cjs, Hs:45),
-%     which is NARROWER than the orchestrator's 8-extension stream filter —
-%     .mts/.cts this-calls were streamed to the resolver and rejected by it;
-%     the pack rejects them identically.
+%   DELTA 2 (precision, was a flat false-NEGATIVE): two same-named members in one
+%     file (distinct classes) no longer trigger the flat `ambig` skip — each call
+%     site binds its OWN enclosing class as a node and resolves to that class's
+%     member (mirrors js_same_file_calls.dl DELTA 2c).
+%   DELTA 3 (recall, was a flat false-POSITIVE source removed): the call must be
+%     lexically inside an enclosing CLASS via the live scope chain, not merely
+%     share a (file, name) with some METHOD anywhere in the file.
+%   DELTA 4 (file gate, exact parity, recorded for the harness): the pack keeps the
+%     resolver's own 6-extension gate (.ts/.tsx/.js/.jsx/.mjs/.cjs, Hs:45), which
+%     is NARROWER than the orchestrator's 8-extension stream filter — .mts/.cts
+%     this-calls were streamed to the resolver and rejected by it; the pack rejects
+%     them identically.
 
 % The resolver's own JS/TS gate — 6 extensions (Hs:45), NOT the orchestrator's 8 —
 % expanded as one clause per extension with a CONSTANT ends_with filter. (A
@@ -46,15 +53,42 @@ this_call6(C, F, Full) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".js
 this_call6(C, F, Full) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".mjs"), attr(C, "name", Full), starts_with(Full, "this.").
 this_call6(C, F, Full) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".cjs"), attr(C, "name", Full), starts_with(Full, "this.").
 
-% (file, name) → METHOD node (the resolver's MethodIndex, Hs:29-36).
-meth(F, N, M) :- node(M, "METHOD"), attr(M, "file", F), attr(M, "name", N), neq(N, "").
+% ── Scope chain (Wave-0 verified shape) — B1's enclosing-class idiom, reused ────
+% Seeded ONLY from the gated this-calls (planner-filter-before-generator: the
+% closure must not enumerate every scope content in the graph).
+%
+% The scope directly containing the call, then lexical parents: a scope's
+% HAS_SCOPE sources are its owner (FUNCTION/METHOD) AND its lexical parent scope
+% (and, at the top of a class body, the CLASS's own scope) — the node-type filter
+% separates them.
+encl_scope(C, S)  :- this_call6(C, F, Full), edge(S, C, "CONTAINS"), node(S, "SCOPE").
+encl_scope(C, S2) :- encl_scope(C, S), edge(S2, S, "HAS_SCOPE"), node(S2, "SCOPE").
 
-% More than one same-named METHOD in the file — the exactly-one guard (Hs:56-66).
-ambig(F, N) :- meth(F, N, M1), meth(F, N, M2), neq(M1, M2).
+% Scope owners along the chain (METHOD for class methods; FUNCTION kept for parity
+% with the resolver's FUNCTION|METHOD member index, Hs:75).
+encl_member(C, M) :- encl_scope(C, S), edge(M, S, "HAS_SCOPE"), node(M, "METHOD").
+encl_member(C, M) :- encl_scope(C, S), edge(M, S, "HAS_SCOPE"), node(M, "FUNCTION").
+
+% Every enclosing class of the call. Two sound paths into the CLASS node:
+%   (a) the method-owner path — the class owns the enclosing member via HAS_METHOD
+%       (the call sits in a method/function body); identical to B1.
+%   (b) the class-scope path — the class owns an enclosing SCOPE directly via
+%       HAS_SCOPE (the call sits in a class-body position with no METHOD/FUNCTION
+%       owner: an arrow-function class property or a static block). This closes the
+%       DELTA 2b gap that the HAS_METHOD-owner path alone cannot reach.
+encl_class(C, Cls) :- encl_member(C, M), edge(Cls, M, "HAS_METHOD"), node(Cls, "CLASS").
+encl_class(C, Cls) :- encl_scope(C, S), edge(Cls, S, "HAS_SCOPE"), node(Cls, "CLASS").
+
+% this. method call → a member of an enclosing class. concat in
+% check mode pins Full == Prefix ++ MemberName — the resolver's first-dot split,
+% exactly (so "this.a.b" only matches a member literally named "a.b", which never
+% exists — the migration spec's anticipated method_suffix superset delta is
+% eliminated by construction). One clause per prefix constant (a this_prefix fact
+% relation would be a §3 cross-join).
+this_method(C, M) :-
+    this_call6(C, F, Full), encl_class(C, Cls),
+    edge(Cls, M, "HAS_METHOD"), attr(M, "name", MN), neq(MN, ""),
+    concat("this.", MN, Full).
 
 @materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
-js_this_method_call(C, M, "js-this-method-calls") :-
-    this_call6(C, F, Full),
-    meth(F, MN, M),
-    \+ ambig(F, MN),
-    concat("this.", MN, Full).
+js_this_method_call(C, M, "js-this-method-calls") :- this_method(C, M).

--- a/packages/rfdb-server/src/derive/stdlib/rust_calls.dl
+++ b/packages/rfdb-server/src/derive/stdlib/rust_calls.dl
@@ -1,90 +1,164 @@
-% rust_calls.dl — in-engine replacement for the RustCallResolution.hs resolver
-% (packages/rust-resolve/src/RustCallResolution.hs:37-80): same-file CALL →
-% FUNCTION CALLS edges for Rust.
+% rust_calls.dl — in-engine Rust same-file CALL → FUNCTION resolution.
+% (Originally the in-engine replacement for RustCallResolution.hs, Hs:37-80.)
 %
-% Resolver semantics reproduced EXACTLY — two ordered arms (Hs:60-71):
-%   R1 exact:  CALL.name == FUNCTION.name, same file. This arm also covers
-%      method calls (`self.process()` / `w.render()` — the analyzer emits the
-%      bare method name on the CALL node plus a direct CALL -READS_FROM->
-%      receiver REFERENCE, the Wave-0-verified Rust receiver shape) AND fully
-%      qualified assoc-fn paths whose FUNCTION node carries the same qualified
-%      name. The resolver never conditioned on the receiver, so neither does
-%      this pack — receiver-typed dispatch is Wave 1b (rust_cross_methods_ctor),
-%      deliberately NOT implemented here.
-%   R2 '::'-suffix fallback, ONLY when R1 found nothing for that call (the
-%      Hs ordered lookup, encoded as the preference negation \+ has_exact):
-%      the call's path name ends with "::" ++ FUNCTION.name — assoc-fn paths
+% RESOLUTION MODEL — two ordered arms:
+%   R1 SCOPE-WALK exact: a bare-name CALL resolves to the same-name FUNCTION
+%      that is LEXICALLY VISIBLE from the call's nearest enclosing FUNCTION
+%      binder, found by graph-recursion over CONTAINS/HAS_SCOPE — NOT a flat
+%      (file, name) match (see SCOPE-WALK below). This is SOUND + PRECISE:
+%      a call `helper()` inside an `impl A` method resolves to `A::helper`, not
+%      to a same-name `B::helper` in an unrelated impl block of the same file.
+%      Live-verified on the 503k-node graph: the flat (file,name) arm produced
+%      13107 (C,T) pairs; the scope-walk arm produces 8556 — a STRICT SUBSET
+%      (8556 common, 4551 removed, 0 added). 4521/4551 removed pairs are
+%      cross-impl same-method-name collisions (`len`, `iter`, `commit_batch`,
+%      `get_node`, `write_to` …) that flat resolution emitted to EVERY impl;
+%      0 removed pairs are MODULE-level / free-function recall losses.
+%      This arm also covers `self.method()` / `w.method()` (the analyzer emits
+%      the bare method name on the CALL node) — now SCOPE-precise rather than
+%      flat. Receiver-typed cross-impl dispatch stays Wave 1b
+%      (rust_cross_methods_ctor / rust_receiver_typing), deliberately NOT here.
+%   R2 '::'-suffix fallback, ONLY when R1 resolved nothing for that call
+%      (the ordered-lookup preference, encoded as \+ has_scoped): the call's
+%      path name ends with "::" ++ FUNCTION.name — assoc-fn / qualified paths
 %      (`Widget::new()`, `utils::helper()`) resolved by their last segment.
-%      The concat-built "::"-prefixed suffix enforces the segment boundary
-%      (lastSegment, Hs:50-54), and only path calls (names containing "::")
-%      can ever match it — the resolver's seg /= name condition for free.
+%      A qualified path NAMES its type, so it is callable from anywhere and is
+%      NOT lexically scope-restricted — scope-walk does not apply; this arm is
+%      kept FLAT by design. The concat-built "::"-prefixed suffix enforces the
+%      segment boundary (Hs:50-54); only path calls (names containing "::") can
+%      match it. R2 is the EDB seam the downstream Rust packs depend on:
+%      rust_cross_methods_ctor / rust_receiver_typing read the committed CALLS
+%      edge of a `Type::new()` init call to type a variable — R2 produces those
+%      5374 path resolutions and they are preserved unchanged.
+%
+% SCOPE-WALK (Rust scope shape, verified in rust_analyzer.rs):
+%   - A Rust FUNCTION IS its own scope node — NO separate SCOPE node for a fn
+%     body (push_scope, rust_analyzer.rs:178-201). Only Block scopes (if /
+%     match-arm / loop / while / closure bodies) emit a SCOPE node.
+%   - Every non-MODULE node, CALLs included, carries exactly one CONTAINS edge
+%     from its innermost scope (emit_node, rust_analyzer.rs:133-143). So a CALL's
+%     CONTAINS parent is a FUNCTION (call at fn-body top level — the dominant
+%     case), a block SCOPE (call inside if/match/loop/closure), a MODULE
+%     (top-level const-initializer call), or an IMPL_BLOCK (rare).
+%   - HAS_SCOPE chains parent → child-scope (rust_analyzer.rs:204-209): the
+%     test fixtures assert "MODULE HAS_SCOPE FUNCTION" and
+%     "FUNCTION HAS_SCOPE block SCOPE".
+%   The encl/2 closure therefore (a) seeds on the call's DIRECT CONTAINS parent
+%   of ANY type — unlike the JS scope-walk which seeds on SCOPE only, because in
+%   JS the FUNCTION/METHOD is a separate HAS_SCOPE owner of its body SCOPE,
+%   whereas in Rust the FUNCTION IS the body scope and directly CONTAINS its
+%   top-level calls — and (b) walks UP through block SCOPEs via HAS_SCOPE until
+%   it reaches a FUNCTION. Live-verified: every SCOPE-contained Rust call reaches
+%   exactly one enclosing FUNCTION (NEAREST-binder uniqueness: 0 calls with two
+%   distinct enclosing FUNCTIONs — nested fns are not reachable past their own
+%   binder), and the 60 MODULE/IMPL_BLOCK-level calls with no enclosing FUNCTION
+%   resolve free functions via the file-MODULE arm.
+%
+% VISIBILITY MODEL (why the owner join is sound): inline `mod foo { }` blocks
+%   are walked INLINE (walk_mod, rust_analyzer.rs:1197-1203) — no nested MODULE
+%   node, no scope push — so a file is a single flat MODULE whose CONTAINS
+%   children are the free FUNCTIONs and the IMPL_BLOCKs. IMPL_BLOCKs are almost
+%   always MODULE-owned and CONTAINS their methods (MODULE→CONTAINS→MODULE = 0);
+%   the rare function-local impl (e.g. `BuildGuard` in multi_shard.rs) is owned
+%   by its enclosing fn/scope, not a MODULE, and is still handled correctly
+%   because fn_owner reads the enclosing FUNCTION's generic CONTAINS parent.
+%   A FUNCTION named N is visible from a
+%   call iff (i) N shares the call's enclosing-fn owner O (sibling free fn in the
+%   same module, or sibling method in the same impl), OR (ii) N is a free
+%   function owned by the file MODULE (visible from anywhere in the file,
+%   including MODULE-level calls with no enclosing fn). These two arms are the
+%   exact_scoped clauses below.
 %
 % CALLS is SHARED vocabulary (the Rust analyzer's defer_ref also emits CALLS)
 % ⇒ mode = "additive" is mandatory.
 %
-% NUMBERED DELTAS vs the resolver (everything not listed is exact):
-%   DELTA 1 (superset): duplicate (file, name) FUNCTIONs (two `fn new` in two
-%     impl blocks of one file) — the resolver's Map.fromList kept the LAST one
-%     and emitted a single arbitrary edge (Hs:38-44); set semantics derives an
-%     edge per candidate. Order-independent; mechanically classifiable.
-%   DELTA 2 (superset, rare): a FUNCTION whose own name contains "::"
-%     (multi-segment): the resolver compared only the call's LAST segment and
-%     could never match it (lastSegment("a::b::c") = "c" ≠ "b::c"); the pack's
-%     ends_with(N, "::" ++ FName) accepts the multi-segment suffix
-%     ("a::b::c" resolves to a FUNCTION named "b::c").
+% NUMBERED DELTAS vs the original flat resolver (everything not listed is exact):
+%   DELTA 1 (PRECISION — the rework): duplicate-name FUNCTIONs in one file (two
+%     `fn new` in two impl blocks) are NO LONGER all resolved. The original flat
+%     resolver matched ANY same-(file,name) FUNCTION; the scope-walk resolves
+%     only the FUNCTION lexically visible from the call (same impl/module owner,
+%     or a file-level free fn). 4551 cross-scope flat pairs are dropped; 0 are
+%     added. This is a soundness/precision fix, not a superset.
+%   DELTA 2 (superset, rare, R2 only): a FUNCTION whose own name contains "::"
+%     (multi-segment): the original compared only the call's LAST segment; the
+%     pack's ends_with(N, "::" ++ FName) accepts the multi-segment suffix.
 %   DELTA 3 (metadata): resolvedVia="rust-calls" projected as a meta column;
 %     engine provenance (_source/_generation) added.
-%   DELTA 4 (file gate): the resolver's effective gate was the orchestrator
-%     streaming only detect_language == Rust nodes; rs/1 encodes the same.
+%   DELTA 4 (file gate): the rs/1 .rs gate encodes the orchestrator's
+%     detect_language == Rust stream filter.
 %   DELTA 5 (macro filter — Wave M): macro invocations are EXCLUDED from
-%     resolution. The analyzer emits every Rust macro invocation as a CALL
-%     node with metadata macro=true whose name is the macro path WITHOUT '!'
-%     (rust_analyzer.rs:1433-1457, walk_macro), and its contract is explicit:
-%     "foo! is not the function foo" (rust_analyzer.rs:1423-1424). The legacy
-%     resolver on a post-merge graph WOULD have matched a macro name against
-%     a same-file fn of the same name — we deliberately do not. rs_macro is
-%     non-recursive EDB-derived; \+ rs_macro(C) is plain stratified negation
-%     (the established \+ has_exact pattern). The maintain envelope already
-%     excludes this pack (negation), so node_attr adds no NEW envelope loss.
+%     resolution. The analyzer emits every Rust macro invocation as a CALL node
+%     with metadata macro=true whose name is the macro path WITHOUT '!'
+%     (rust_analyzer.rs:1433-1457, walk_macro): "foo! is not the function foo".
+%     rs_macro is non-recursive EDB-derived; \+ rs_macro(C) is plain stratified
+%     negation. The maintain envelope already excludes this pack (negation).
 %
-% NOT implemented (Wave 1b, by design): the resolved-constructor receiver-typing
-% arm (ASSIGNED_FROM → resolved init CALL → impl method) — that is
-% rust_cross_methods_ctor's job, ordered after this pack.
+% NOT implemented (Wave 1b, by design): receiver-typed cross-impl dispatch
+% (ASSIGNED_FROM → resolved init CALL → impl method) — rust_cross_methods_ctor /
+% rust_receiver_typing, ordered after this pack, reading R2's CALLS as EDB.
 
-% Same-file indexes (empty names never indexed, Hs:43). The .rs gate is the
-% inline ends_with filter (DELTA 4) — File is bound by the attr leg.
+% Same-file FUNCTION index (empty names never indexed, Hs:43).
 rs_fn(File, N, T) :- node(T, "FUNCTION"), attr(T, "file", File), attr(T, "name", N), neq(N, "").
 
-% Macro invocations (CALL + metadata macro=true; the name is the macro path
-% without '!') — excluded from name resolution, DELTA 5.
+% Macro invocations (CALL + metadata macro=true) — excluded from name
+% resolution, DELTA 5.
 rs_macro(C) :- node(C, "CALL"), attr(C, "file", F), ends_with(F, ".rs"), node_attr(C, "macro", "true").
 
+% Every resolvable Rust CALL with its (file, name). The .rs gate is DELTA 4.
 rs_call(C, File, N) :-
     node(C, "CALL"), attr(C, "file", File), ends_with(File, ".rs"),
     attr(C, "name", N), neq(N, ""),
     \+ rs_macro(C).
 
-% R1: exact (file, name) match.
-exact_call(C, T) :- rs_call(C, File, N), rs_fn(File, N, T).
-has_exact(C) :- exact_call(C, T).
+% ── SCOPE-WALK: nearest enclosing FUNCTION binder ─────────────────────────────
+% Seed on the call's DIRECT CONTAINS parent of ANY type (Rust FUNCTIONs directly
+% CONTAIN their top-level calls — do NOT filter the seed to SCOPE-only like the
+% JS scope-walk, that would drop every fn-body-top-level call), then walk UP
+% through block SCOPEs via HAS_SCOPE until a FUNCTION is reached. The recursive
+% leg is led by the bound call (planner-filter-before-generator).
+encl(C, P)  :- rs_call(C, File, N), edge(P, C, "CONTAINS").
+encl(C, P2) :- encl(C, S), node(S, "SCOPE"), edge(P2, S, "HAS_SCOPE").
 
-% R2: last-'::'-segment fallback, only when R1 missed (the ordered-lookup
-% preference as negation). The "::"-prefixed concat suffix enforces the
-% segment boundary. The string_contains(N, "::") gate is IMPLIED by
-% ends_with(N, "::" ++ FN) — only a path call can ever carry the suffix — and
-% exists purely so the planner prunes non-path calls BEFORE pairing them with
-% every same-file FUNCTION (W9 fix: the unfiltered calls×fns pairing was 15.4s
-% of rust_calls' 21.7s on the 491k-node graph). Result set: UNCHANGED.
+% The nearest enclosing FUNCTION binder (the CONTAINS-parent is already a
+% FUNCTION, OR a block SCOPE walked up to its owning FUNCTION). NEAREST-binder
+% uniqueness is structural (0 calls reach two distinct FUNCTIONs).
+encl_fn(C, Fn) :- encl(C, Fn), node(Fn, "FUNCTION").
+
+% The item-scope owner (MODULE or IMPL_BLOCK) of the enclosing FUNCTION, and the
+% file's MODULE (free-function visibility, also covers MODULE-level calls).
+fn_owner(C, O)     :- encl_fn(C, Fn), edge(O, Fn, "CONTAINS").
+file_module(C, M)  :- rs_call(C, File, N), node(M, "MODULE"), attr(M, "file", File).
+
+% R1: scope-walk exact. The same-name FUNCTION must be lexically visible —
+% sharing the enclosing fn's owner (sibling method / sibling module fn), a
+% file-level free function (owned by the file MODULE), OR a nested local fn
+% declared directly inside the call's own enclosing FUNCTION (`fn helper` defined
+% in the same fn body — a Rust item-in-fn-body binder, in scope for the rest of
+% that body). The nested-local arm is NEAREST-binder sound: it binds the same
+% enclosing FUNCTION the other arms walk, and excludes the trivial self-edge
+% (neq(Fn, T)). Live-verified: recovers 28 (C,T) pairs the owner/file-MODULE arms
+% miss (nested `fn id_of` / `assert_invertible` test helpers), all ⊆ the flat set.
+exact_scoped(C, T) :- rs_call(C, File, N), rs_fn(File, N, T), fn_owner(C, O), edge(O, T, "CONTAINS").
+exact_scoped(C, T) :- rs_call(C, File, N), rs_fn(File, N, T), file_module(C, M), edge(M, T, "CONTAINS").
+exact_scoped(C, T) :- rs_call(C, File, N), rs_fn(File, N, T), encl_fn(C, Fn), edge(Fn, T, "CONTAINS"), neq(Fn, T).
+has_scoped(C)      :- exact_scoped(C, T).
+
+% R2: last-'::'-segment fallback, ONLY when R1 resolved nothing (the
+% ordered-lookup preference as negation). FLAT by design (a qualified path names
+% its type — not scope-restricted). The "::"-prefixed concat suffix enforces the
+% segment boundary; the string_contains(N, "::") gate is IMPLIED by
+% ends_with(N, "::" ++ FN) and exists so the planner prunes non-path calls
+% BEFORE pairing them with every same-file FUNCTION.
 suffix_call(C, T) :-
     rs_call(C, File, N),
     string_contains(N, "::"),
-    \+ has_exact(C),
+    \+ has_scoped(C),
     rs_fn(File, FN, T),
     concat("::", FN, Suf),
     ends_with(N, Suf).
 
 @materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
-rust_call(C, T, "rust-calls") :- exact_call(C, T).
+rust_call(C, T, "rust-calls") :- exact_scoped(C, T).
 
 @materialize(edge_type = "CALLS", mode = "additive", meta(resolvedVia))
 rust_suffix_call(C, T, "rust-calls") :- suffix_call(C, T).


### PR DESCRIPTION
## #23 scope-walk rework — 5 Datalog packs

Collects the 4 individually-green PR branches (#415/#416/#417/#418) into ONE integration branch and resolves the shared `packages/rfdb-server/src/derive/stdlib.rs` overlap (each branch added a different fixture fn + its own `.dl`; resolved as an **additive union — ALL fixtures from all 4 kept**). The whole set builds and Gate A passes **together** in one build.

**Supersedes the 4 individual PRs #415–#418 — close them in favor of this integrated one.**

### Per-pack differential (from #415–#418)

- **`rust_calls`** (rust_calls_scope_walk_exact_then_suffix_fallback) — exact-then-suffix-fallback scope-walk ladder. Superset shrink; `lost_real` 0.
- **`js_same_file_calls`** (js_same_file_calls_resolves_all_arms_with_preference_ladder) — same-file call resolution across all arms with a preference ladder (A1–A3). Superset shrink; `lost_real` 0.
- **`js_local_refs`** (js_local_refs_scope_walk_nearest_binder) — READS_FROM nearest-binder scope-walk. Superset shrink; `lost_real` 0.
- **`js_this_method_calls`** (js_this_method_calls_scope_walk_with_arrow_property_and_precision) — `this.method()` scope-walk with arrow-property handling and precision. Superset shrink; `lost_real` 0; **+1 coverage edge** (the arrow-property arm now resolved).
- **`js_class_inheritance`** (same_file_and_cross_file_arms + builtin_and_chain_arms) — class-inheritance resolution, same-file and cross-file arms plus builtin/chain arms (A1). Superset shrink; `lost_real` 0.

### ⚠ Graph-output change

These packs **change graph output** (resolution edges differ — superset shrinks, +1 coverage edge in this_method). This is **NOT** for the 0.4.1 cut — target **0.4.2 / 0.5**.

### Gate A

GREEN — `derive::stdlib` **53 passed / 0 failed** (incl. `stdlib_pack_registry_resolves_names_in_canonical_order` and all 5 reworked/new scope-walk packs). Full relevant suites pass together in one build:

- `derive::stdlib` 53/0 (1 ignored)
- `datalog` 267/0
- `cypher` 201/0
- `storage_v2` 437/0 (2 ignored)
- Full lib suite: **1400 passed / 0 failed / 25 ignored** (16.59s)
- Build: `cargo build --profile fast -p rfdb` GREEN (pre-existing dead-code warnings only)

No fixture lost in conflict-resolve: all 5 `.dl` packs under `packages/rfdb-server/src/derive/stdlib/` and all 5 `include_str!` consts (`JS_LOCAL_REFS_DL` / `RUST_CALLS_DL` / `JS_THIS_METHOD_CALLS_DL` / `JS_SAME_FILE_CALLS_DL` / `JS_CLASS_INHERITANCE_DL`) present in `stdlib.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
