### PR TITLE
fix(js-analyzer): emit EXPORTS edge to every destructured export binding

### DIFF
--- a/_ai/gaps.md
+++ b/_ai/gaps.md
@@ -353,3 +353,35 @@ id is identical across generations are not tombstoned by changed-file deletion).
 2. **EXPORT sid collision**: two `export` statements in one file both emit semantic id
    `<file>->EXPORT->named` and merge into ONE node in-graph. Latent producer bug; fix the sid to
    include position/name.
+
+### ✅ RESOLVED at HEAD (2026-06-14) — both bugs + the destructuring-export sibling
+
+Verified at HEAD (branch `claude/vigilant-lamport-ec4898`) via in-process Hspec
+(`packages/js-analyzer/test/Spec.hs`, `cabal test spec`):
+
+1. **Multi-declarator export** — FIXED. `ruleVariableDeclarationBindings`
+   (`Declarations.hs`) is now the single source of truth and returns every binding;
+   `ruleExportNamedDeclaration` iterates it, emitting an EXPORTS edge + export-index entry per
+   binding. Locked by "exports every declarator of a multi-declarator export" (asserts EXPORTS
+   edge to both `a` and `b`).
+2. **EXPORT sid collision** — FIXED. `ruleExportNamedDeclaration` now disambiguates the sid by
+   `spanStart` (`contentHash [("k","named"),("start", …)]`), so each `export` statement owns a
+   distinct EXPORT node. Locked by "emits a distinct EXPORT node per named-export statement"
+   and the star-arm twin.
+3. **Destructuring-export sibling** — FIXED (this run). `export const { a, b } = obj` /
+   `export const [c, d] = arr` previously got export-INDEX entries for every binding (via
+   `handleDestructuringDecl`) but only the FIRST binding got an `EXPORT → CONSTANT` EXPORTS
+   edge: `ruleVariableDeclarationBindings` reported a destructuring declarator as a single
+   empty-name `firstId`. Now `ruleVariableDeclarator`/`handleDestructuringDecl` return one
+   entry per destructured binding (empty name — index ownership stays with
+   `handleDestructuringDecl`, no double-emit — but a real node id), so the export path emits an
+   EXPORTS edge to each. Locked by "emits an EXPORTS edge to every destructured object/array
+   binding" + "handles a mixed simple+destructuring export without double-emitting"
+   (index-count == 1 per name). Scope threading and the `Maybe Text` `ruleVariableDeclaration`
+   contract (Walker.hs consumer) are unchanged.
+
+Remaining (separate, out of scope): destructured bindings have no single importable identifier
+at the var-decl level, so a nested-pattern key vs binding distinction is handled by
+`extractBindingInfo` (exports the VALUE, not the key) but deeper aliasing is untracked. Also:
+`Declarations.hs` is a pre-existing >500-line god-file — the variable-declaration rules are a
+natural extraction candidate (follow-up, not blocking).

--- a/packages/js-analyzer/src/Rules/Declarations.hs
+++ b/packages/js-analyzer/src/Rules/Declarations.hs
@@ -34,15 +34,21 @@ import Data.Maybe (fromMaybe)
 -- ── Variable Declaration ────────────────────────────────────────────────
 
 -- | Walk a VariableDeclaration, returning @(bindingName, nodeId)@ for every
--- top-level simple-identifier declarator, in source order. Each binding is
--- declared in scope for the declarators that follow it (so later initializers
--- resolve earlier bindings). Destructuring declarators are still emitted as
--- nodes but reported with an empty @bindingName@ — they have no single binding id.
+-- binding it introduces, in source order. A simple-identifier declarator
+-- contributes one entry carrying its name; a destructuring declarator
+-- (@const { a, b } = obj@ / @const [c, d] = arr@) contributes one entry per
+-- bound name, each with an empty @bindingName@ (the destructured bindings have
+-- no single importable identifier at this level) but a real node id — so
+-- callers can still reach every binding (e.g. to emit an EXPORTS edge per
+-- binding). Simple bindings are declared in scope for the declarators that
+-- follow them (so later initializers resolve earlier bindings); destructured
+-- bindings self-declare inside 'handleDestructuringDecl'.
 --
 -- This is the single source of truth for "which bindings does this var-decl
 -- introduce". Both 'ruleVariableDeclaration' (plain-walk path) and
 -- 'ruleExportNamedDeclaration' (export path) consume it, so a multi-declarator
--- declaration (@const a = 1, b = 2@) yields every binding exactly once.
+-- declaration (@const a = 1, b = 2@) — or a destructuring export — yields every
+-- binding exactly once.
 ruleVariableDeclarationBindings :: ASTNode -> Analyzer [(Text, Text)]
 ruleVariableDeclarationBindings node = do
   let decls = getChildren "declarations" node
@@ -57,17 +63,22 @@ ruleVariableDeclarationBindings node = do
     goDeclarators :: DeclKind -> [ASTNode] -> Analyzer [(Text, Text)]
     goDeclarators _ [] = return []
     goDeclarators dk (d:ds) = do
-      mNodeId <- withAncestor node (ruleVariableDeclarator d node)
-      case mNodeId of
-        Just nodeId -> do
-          let name = case getChildrenMaybe "id" d of
-                       Just idNode -> getTextFieldOr "name" "" idNode
-                       Nothing     -> ""
-          rest <- if T.null name
-                    then goDeclarators dk ds
-                    else declareInScope (Declaration nodeId dk name) (goDeclarators dk ds)
-          return ((name, nodeId) : rest)
-        Nothing -> goDeclarators dk ds
+      -- A declarator yields one binding (simple identifier) or many (a
+      -- destructuring pattern, each entry with an empty name). Destructured
+      -- bindings were already declared in scope inside 'handleDestructuringDecl';
+      -- simple bindings (non-empty name) are declared here so a later
+      -- declarator's initializer (@const a = 1, b = a@) can resolve them.
+      pairs <- withAncestor node (ruleVariableDeclarator d node)
+      let toDeclare = [ (nm, i) | (nm, i) <- pairs, not (T.null nm) ]
+      rest <- declareAll dk toDeclare (goDeclarators dk ds)
+      return (pairs ++ rest)
+
+    -- Nest 'declareInScope' so each binding is visible to everything evaluated
+    -- in the continuation (the remaining declarators and their initializers).
+    declareAll :: DeclKind -> [(Text, Text)] -> Analyzer a -> Analyzer a
+    declareAll _ [] cont = cont
+    declareAll dk' ((nm, i):xs) cont =
+      declareInScope (Declaration i dk' nm) (declareAll dk' xs cont)
 
 -- | VariableDeclaration: walk every declarator (emitting nodes + scope edges)
 -- and return the first declarator's node id, preserving 'walkNode's
@@ -79,8 +90,14 @@ ruleVariableDeclaration node = do
     ((_, firstId) : _) -> Just firstId
     []                 -> Nothing
 
--- | VariableDeclarator: emit VARIABLE or CONSTANT node + DECLARES edge + ASSIGNED_FROM
-ruleVariableDeclarator :: ASTNode -> ASTNode -> Analyzer (Maybe Text)
+-- | VariableDeclarator: emit VARIABLE or CONSTANT node(s) + DECLARES edge +
+-- ASSIGNED_FROM, returning @(bindingName, nodeId)@ for every binding the
+-- declarator introduces. A simple identifier yields a single named entry; a
+-- destructuring pattern yields one entry per bound name, each with an empty
+-- name (the binding's index entry, if exported, is owned by
+-- 'handleDestructuringDecl') but a real node id so the export path can emit an
+-- EXPORTS edge to each. An unrecognised id yields no bindings.
+ruleVariableDeclarator :: ASTNode -> ASTNode -> Analyzer [(Text, Text)]
 ruleVariableDeclarator node parentDecl = do
   file <- askFile
   curScopeId <- askScopeId
@@ -95,9 +112,16 @@ ruleVariableDeclarator node parentDecl = do
   -- Extract binding name from id field
   case getChildrenMaybe "id" node of
     Just idNode -> case idNode of
-      -- Destructuring patterns: create individual nodes for each binding
-      ObjectPatternNode _ _ -> handleDestructuringDecl idNode node parentDecl nodeType kind dk
-      ArrayPatternNode _ _  -> handleDestructuringDecl idNode node parentDecl nodeType kind dk
+      -- Destructuring patterns: create individual nodes for each binding. The
+      -- bindings are reported with empty names (their export-index entry, when
+      -- exported, is emitted inside 'handleDestructuringDecl') and a real node
+      -- id, so the export path can still emit an EXPORTS edge to every binding.
+      ObjectPatternNode _ _ -> do
+        pairs <- handleDestructuringDecl idNode node parentDecl nodeType kind dk
+        return [ ("", i) | (_, i) <- pairs ]
+      ArrayPatternNode _ _  -> do
+        pairs <- handleDestructuringDecl idNode node parentDecl nodeType kind dk
+        return [ ("", i) | (_, i) <- pairs ]
       -- Normal identifier binding: existing logic
       _ -> do
         let name = getTextFieldOr "name" "<anonymous>" idNode
@@ -149,8 +173,8 @@ ruleVariableDeclarator node parentDecl = do
                 , geMetadata = Map.empty
                 }
           Nothing -> return ()
-        return (Just nodeId)
-    Nothing -> return Nothing
+        return [(name, nodeId)]
+    Nothing -> return []
 
 -- ── Destructuring Helpers ──────────────────────────────────────────────
 
@@ -200,8 +224,11 @@ extractBindingInfo node = case node of
       _ -> []
 
 -- | Handle destructuring declarations (ObjectPattern / ArrayPattern).
--- Creates individual VARIABLE/CONSTANT nodes for each binding with ASSIGNED_FROM edges.
-handleDestructuringDecl :: ASTNode -> ASTNode -> ASTNode -> Text -> Text -> DeclKind -> Analyzer (Maybe Text)
+-- Creates individual VARIABLE/CONSTANT nodes for each binding with ASSIGNED_FROM
+-- edges and returns @(bindingName, nodeId)@ for every binding in source order,
+-- so the caller can reach each binding's node (e.g. to emit an EXPORTS edge per
+-- binding). When exported, each binding's export-index entry is emitted here.
+handleDestructuringDecl :: ASTNode -> ASTNode -> ASTNode -> Text -> Text -> DeclKind -> Analyzer [(Text, Text)]
 handleDestructuringDecl patternNode declaratorNode _parentDecl nodeType kind dk = do
   file <- askFile
   curScopeId <- askScopeId
@@ -217,12 +244,12 @@ handleDestructuringDecl patternNode declaratorNode _parentDecl nodeType kind dk 
   let bindings = extractBindingInfo patternNode
 
   -- Emit nodes and edges for each binding, accumulating scope declarations
-  emitBindings file curScopeId parent isExported nodeType kind dk mInitId declaratorNode bindings Nothing
+  emitBindings file curScopeId parent isExported nodeType kind dk mInitId declaratorNode bindings
   where
     emitBindings :: Text -> Text -> Maybe Text -> Bool -> Text -> Text
-                 -> DeclKind -> Maybe Text -> ASTNode -> [(Text, ASTNode, Maybe ASTNode)] -> Maybe Text -> Analyzer (Maybe Text)
-    emitBindings _ _ _ _ _ _ _ _ _ [] firstId = return firstId
-    emitBindings file' scopeId' parent' exported' nType knd dKind mInitId declNode ((name, spanNode, mDefaultExpr):rest) firstId = do
+                 -> DeclKind -> Maybe Text -> ASTNode -> [(Text, ASTNode, Maybe ASTNode)] -> Analyzer [(Text, Text)]
+    emitBindings _ _ _ _ _ _ _ _ _ [] = return []
+    emitBindings file' scopeId' parent' exported' nType knd dKind mInitId declNode ((name, spanNode, mDefaultExpr):rest) = do
       let sp = astNodeSpan spanNode
           nodeId = semanticId file' nType name parent' Nothing
       emitNode GraphNode
@@ -278,12 +305,11 @@ handleDestructuringDecl patternNode declaratorNode _parentDecl nodeType kind dk 
                { eiName = name, eiNodeId = nodeId
                , eiKind = NamedExport, eiSource = Nothing }
         else return ()
-      let firstId' = case firstId of
-            Nothing -> Just nodeId
-            _       -> firstId
-      -- Declare this binding in scope for subsequent bindings
-      declareInScope (Declaration nodeId dKind name) $
-        emitBindings file' scopeId' parent' exported' nType knd dKind mInitId declNode rest firstId'
+      -- Declare this binding in scope for subsequent bindings, and collect the
+      -- (name, nodeId) pair so the caller sees every destructured binding.
+      rest' <- declareInScope (Declaration nodeId dKind name) $
+        emitBindings file' scopeId' parent' exported' nType knd dKind mInitId declNode rest
+      return ((name, nodeId) : rest')
 
 -- ── Function Declaration ────────────────────────────────────────────────
 

--- a/packages/js-analyzer/test/Spec.hs
+++ b/packages/js-analyzer/test/Spec.hs
@@ -355,6 +355,107 @@ exportTests = do
     -- the object KEY `e` is not a local binding and must NOT be exported
     hasExport "e" NamedExport fa `shouldBe` False
 
+  -- Test 8f: `export const { a, b } = obj` must emit an EXPORTS edge from the
+  -- EXPORT statement node to EVERY destructured binding, not just the first.
+  -- On HEAD the binding NODES exist and both reach the export index (test 8d),
+  -- but ruleVariableDeclarationBindings reports only the FIRST binding's id for a
+  -- destructuring declarator (empty name + single firstId), so
+  -- ruleExportNamedDeclaration emits one EXPORTS edge (to `a`) and `b`'s
+  -- CONSTANT node is left without an EXPORTS edge from its EXPORT statement —
+  -- invisible to EXPORTS-edge traversal of that statement. This is the
+  -- destructuring sibling of the multi-declarator edge fix (test 8b) and is
+  -- recorded in _ai/gaps.md as the destructuring-export gap.
+  it "emits an EXPORTS edge to every destructured object binding" $ do
+    let fa = analyzeAST $ BL.concat
+          [ "{\"type\":\"Program\",\"start\":0,\"end\":40,\"body\":["
+          , "{\"type\":\"ExportNamedDeclaration\",\"start\":0,\"end\":40,"
+          , "\"declaration\":{\"type\":\"VariableDeclaration\",\"start\":7,\"end\":39,\"kind\":\"const\",\"declarations\":["
+          , "{\"type\":\"VariableDeclarator\",\"start\":13,\"end\":38,"
+          , "\"id\":{\"type\":\"ObjectPattern\",\"start\":13,\"end\":19,\"properties\":["
+          , "{\"type\":\"Property\",\"start\":15,\"end\":16,\"shorthand\":true,"
+          , "\"key\":{\"type\":\"Identifier\",\"start\":15,\"end\":16,\"name\":\"a\"},"
+          , "\"value\":{\"type\":\"Identifier\",\"start\":15,\"end\":16,\"name\":\"a\"}},"
+          , "{\"type\":\"Property\",\"start\":18,\"end\":19,\"shorthand\":true,"
+          , "\"key\":{\"type\":\"Identifier\",\"start\":18,\"end\":19,\"name\":\"b\"},"
+          , "\"value\":{\"type\":\"Identifier\",\"start\":18,\"end\":19,\"name\":\"b\"}}"
+          , "]},"
+          , "\"init\":{\"type\":\"Identifier\",\"start\":22,\"end\":25,\"name\":\"obj\"}}"
+          , "]},\"specifiers\":[]}"
+          , "]}"
+          ]
+    exportNode <- requireNode "EXPORT" "named" fa
+    aNode <- requireNode "CONSTANT" "a" fa
+    bNode <- requireNode "CONSTANT" "b" fa
+    hasEdge "EXPORTS" (gnId exportNode) (gnId aNode) fa `shouldBe` True
+    hasEdge "EXPORTS" (gnId exportNode) (gnId bNode) fa `shouldBe` True
+    -- the export index must still hold exactly one entry per binding (no double
+    -- emission once the edge path also iterates every binding)
+    length (filter (\e -> eiName e == "a" && eiKind e == NamedExport) (faExports fa)) `shouldBe` 1
+    length (filter (\e -> eiName e == "b" && eiKind e == NamedExport) (faExports fa)) `shouldBe` 1
+
+  -- Test 8g: the same EXPORTS-edge invariant for array patterns —
+  -- `export const [c, d] = arr` must emit an EXPORTS edge to both c and d.
+  it "emits an EXPORTS edge to every destructured array binding" $ do
+    let fa = analyzeAST $ BL.concat
+          [ "{\"type\":\"Program\",\"start\":0,\"end\":40,\"body\":["
+          , "{\"type\":\"ExportNamedDeclaration\",\"start\":0,\"end\":40,"
+          , "\"declaration\":{\"type\":\"VariableDeclaration\",\"start\":7,\"end\":39,\"kind\":\"const\",\"declarations\":["
+          , "{\"type\":\"VariableDeclarator\",\"start\":13,\"end\":38,"
+          , "\"id\":{\"type\":\"ArrayPattern\",\"start\":13,\"end\":19,\"elements\":["
+          , "{\"type\":\"Identifier\",\"start\":14,\"end\":15,\"name\":\"c\"},"
+          , "{\"type\":\"Identifier\",\"start\":17,\"end\":18,\"name\":\"d\"}"
+          , "]},"
+          , "\"init\":{\"type\":\"Identifier\",\"start\":22,\"end\":25,\"name\":\"arr\"}}"
+          , "]},\"specifiers\":[]}"
+          , "]}"
+          ]
+    exportNode <- requireNode "EXPORT" "named" fa
+    cNode <- requireNode "CONSTANT" "c" fa
+    dNode <- requireNode "CONSTANT" "d" fa
+    hasEdge "EXPORTS" (gnId exportNode) (gnId cNode) fa `shouldBe` True
+    hasEdge "EXPORTS" (gnId exportNode) (gnId dNode) fa `shouldBe` True
+
+  -- Test 8h: a multi-declarator export mixing a simple binding and a
+  -- destructuring pattern — `export const a = 1, { b, c } = obj` — must emit an
+  -- EXPORTS edge to all three bindings and exactly one export-index entry each.
+  -- This guards the no-double-emit invariant: the simple binding's index entry
+  -- is owned by ruleExportNamedDeclaration (non-empty name), the destructured
+  -- ones by handleDestructuringDecl (empty name in the bindings list), so each
+  -- name must appear once and only once in the export index.
+  it "handles a mixed simple+destructuring export without double-emitting" $ do
+    let fa = analyzeAST $ BL.concat
+          [ "{\"type\":\"Program\",\"start\":0,\"end\":60,\"body\":["
+          , "{\"type\":\"ExportNamedDeclaration\",\"start\":0,\"end\":60,"
+          , "\"declaration\":{\"type\":\"VariableDeclaration\",\"start\":7,\"end\":59,\"kind\":\"const\",\"declarations\":["
+          , "{\"type\":\"VariableDeclarator\",\"start\":13,\"end\":18,"
+          , "\"id\":{\"type\":\"Identifier\",\"start\":13,\"end\":14,\"name\":\"a\"},"
+          , "\"init\":{\"type\":\"Literal\",\"start\":17,\"end\":18,\"value\":1,\"raw\":\"1\"}},"
+          , "{\"type\":\"VariableDeclarator\",\"start\":20,\"end\":40,"
+          , "\"id\":{\"type\":\"ObjectPattern\",\"start\":20,\"end\":26,\"properties\":["
+          , "{\"type\":\"Property\",\"start\":22,\"end\":23,\"shorthand\":true,"
+          , "\"key\":{\"type\":\"Identifier\",\"start\":22,\"end\":23,\"name\":\"b\"},"
+          , "\"value\":{\"type\":\"Identifier\",\"start\":22,\"end\":23,\"name\":\"b\"}},"
+          , "{\"type\":\"Property\",\"start\":25,\"end\":26,\"shorthand\":true,"
+          , "\"key\":{\"type\":\"Identifier\",\"start\":25,\"end\":26,\"name\":\"c\"},"
+          , "\"value\":{\"type\":\"Identifier\",\"start\":25,\"end\":26,\"name\":\"c\"}}"
+          , "]},"
+          , "\"init\":{\"type\":\"Identifier\",\"start\":29,\"end\":32,\"name\":\"obj\"}}"
+          , "]},\"specifiers\":[]}"
+          , "]}"
+          ]
+    exportNode <- requireNode "EXPORT" "named" fa
+    aNode <- requireNode "CONSTANT" "a" fa
+    bNode <- requireNode "CONSTANT" "b" fa
+    cNode <- requireNode "CONSTANT" "c" fa
+    hasEdge "EXPORTS" (gnId exportNode) (gnId aNode) fa `shouldBe` True
+    hasEdge "EXPORTS" (gnId exportNode) (gnId bNode) fa `shouldBe` True
+    hasEdge "EXPORTS" (gnId exportNode) (gnId cNode) fa `shouldBe` True
+    -- each binding appears exactly once in the export index (no double emission)
+    let countExport nm = length (filter (\e -> eiName e == nm && eiKind e == NamedExport) (faExports fa))
+    countExport "a" `shouldBe` 1
+    countExport "b" `shouldBe` 1
+    countExport "c" `shouldBe` 1
+
 
 edgeCaseTests :: Spec
 edgeCaseTests = do


### PR DESCRIPTION
## Summary

`export const { a, b } = obj` (and `export const [c, d] = arr`) registered an export-**index** entry for every destructured binding — so `import { b }` resolves — but only the **first** binding got an `EXPORT → CONSTANT` **EXPORTS edge**. Later destructured bindings were invisible to EXPORTS-edge traversal of the statement (impact analysis, "what does this export?" queries).

This is the destructuring sibling of the multi-declarator export fix (closing GH #394) — the same latent "only the first binding" class, on the destructuring arm.

## Root cause (`packages/js-analyzer/src/Rules/Declarations.hs`)

`ruleVariableDeclarationBindings` is the single source of truth for "which bindings does this var-decl introduce", consumed by both the plain-walk path and `ruleExportNamedDeclaration`. For a **destructuring** declarator it reported a single empty-name `firstId` (the pattern node has no `name` field), so the export path's `forM_ binds` emitted exactly one EXPORTS edge. The per-binding export-index entries came separately from `handleDestructuringDecl`, masking the gap.

## Fix

`ruleVariableDeclarator` / `handleDestructuringDecl` now return one `(name, nodeId)` entry **per destructured binding** in source order instead of just the first.

- Destructured entries keep an **empty name** → their export-index entry stays owned by `handleDestructuringDecl` (no double-emit), but they carry a **real node id** → the export path emits an EXPORTS edge to each.
- Scope threading is preserved: simple bindings declare in scope via a nested `declareAll` continuation (identical to the prior single-binding behaviour, so `const a = 1, b = a` still resolves `a`); destructured bindings self-declare inside `handleDestructuringDecl`.
- The `Maybe Text` contract of `ruleVariableDeclaration` (the `Walker.hs:52` consumer) is unchanged.

## Spec (BDD)

- **Given** `export const { a, b } = obj` **When** analyzed **Then** the EXPORT node has an EXPORTS edge to both `a` and `b`, and each name appears exactly once in the export index.
- **Given** `export const [c, d] = arr` **Then** EXPORTS edge to both `c` and `d`.
- **Given** `export const a = 1, { b, c } = obj` (mixed) **Then** EXPORTS edge to all three, export-index count == 1 per name (no double-emit).

## Evidence (`cabal test spec`, in-process `analyzeAST` graph-shape assertions)

**Before (red, on the prior code):**
```
emits an EXPORTS edge to every destructured object binding [x]
emits an EXPORTS edge to every destructured array binding  [x]
  1) ... expected: True  but got: False   (edge to 2nd binding missing)
```

**After (green):**
```
exports every declarator of a multi-declarator export [v]
emits an EXPORTS edge to every destructured object binding [v]
emits an EXPORTS edge to every destructured array binding [v]
handles a mixed simple+destructuring export without double-emitting [v]
33 examples, 1 failure
```

The single remaining failure is **pre-existing and unrelated** — `TypeScript Interfaces / creates METHOD_SIGNATURE with HAS_PROPERTY edge from interface` — it fails identically on clean HEAD before this change (verified: baseline was `30 examples, 1 failure` at the same test). Executable builds clean under `-Wall -Werror -O2`.

## Adversarial review

- **Round A (correctness):** object / array / nested / rest / default / mixed-declarator patterns. `extractBindingInfo` already exports the destructured VALUE not the key (`{ e: f }` → `f`), and drops empties; empty pattern `{}` yields no bindings (no edges, no crash). Mixed simple+destructuring covered by an explicit test.
- **Round B (structural):** change is +~25 lines, contained to `Declarations.hs`. Note: `Declarations.hs` is a **pre-existing >500-line god-file**; extracting the variable-declaration rules into their own module is a natural follow-up (not in scope here).
- **Round C (class + invariant):** both destructuring arms (object + array) fixed; the no-double-emit invariant on the export index is asserted by test; additive EXPORTS edges match the simple-declarator behaviour, no analysis-pipeline invariant violated.

## Blast radius

`ruleVariableDeclarator` (called only at the `goDeclarators` site) and `handleDestructuringDecl` (called only at its two pattern sites) are module-internal. `ruleVariableDeclaration` (the `Walker.hs` consumer) keeps its `Maybe Text` signature.

Recorded in `_ai/gaps.md` (the 2026-06-10 "Two JS-analyzer producer bugs" entry — both bugs + this destructuring sibling now marked resolved at HEAD).

https://claude.ai/code/session_01TMM5HFU7FEhVGZEZRBEkqv

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMM5HFU7FEhVGZEZRBEkqv)_