### PR TITLE
fix(rfdb/materialize): reject all-decimal semantic-ids in @materialize_node (E-MAT-010)

### DIFF
--- a/_ai/gaps.md
+++ b/_ai/gaps.md
@@ -328,6 +328,15 @@ id is identical across generations are not tombstoned by changed-file deletion).
 1. **All-numeric semantic-id drift**: plan_node_writeback blake3-hashes unconditionally;
    the wire writer string_to_id() parses decimal FIRST — a bare-decimal sid mints a divergent
    u128. Unreachable by shipped packs (prefixed sids); extend E-MAT-010 to reject all-decimal sids.
+   **✅ RESOLVED 2026-06-14 (branch `claude/vigilant-lamport-y65ysu`)**: `plan_node_writeback`
+   (`packages/rfdb-server/src/derive/materialize.rs`) now aborts with `E-MAT-010` when the
+   semantic-id column is an all-decimal string — guarded by `s.parse::<u128>().is_ok()`, the
+   EXACT same predicate the wire path (`string_to_id`/`resolve_node_id`, `bin/rfdb_server.rs:1009,1022`)
+   uses, so the rejected set is provably the exact divergence set (and overflowing/negative/prefixed
+   sids that BOTH paths hash stay accepted). Locked by
+   `derive::materialize::tests::plan_node_writeback_rejects_all_decimal_semantic_id` (asserts
+   `blake3("12345") != 12345`, rejects "12345"/"0"/"007", and that prefixed "issue::…::42" still
+   mints one node). Full rfdb lib 1401/0; clippy clean.
 2. **Auto-flush can tear run isolation under buffer pressure**: add_nodes/add_edges end with
    maybe_auto_flush which publishes WITHOUT the run's pending tombstones — a mid-delta flush
    shows adds before retractions (self-heals at the explicit flush). Suppress auto-flush during

--- a/packages/rfdb-server/src/derive/materialize.rs
+++ b/packages/rfdb-server/src/derive/materialize.rs
@@ -287,8 +287,10 @@ pub fn collect_materialize_node_specs(
 ///
 /// Coded aborts BEFORE any commit (I5): a head whose arity is not `3 + len(meta)`
 /// (`E-MAT-009`, the node mirror of `E-MAT-002`), and a semantic-id column that is not a
-/// non-empty string (`E-MAT-010` — column 0 must be the rule-constructed semantic id;
-/// a bare node id there is almost certainly a misordered head).
+/// non-empty string OR is an all-decimal string (`E-MAT-010` — column 0 must be the
+/// rule-constructed semantic id; a bare node id there is almost certainly a misordered
+/// head, and an all-decimal sid would mint a node whose BLAKE3-derived id diverges from
+/// the parse-decimal-first id used by the wire resolver, making it unreachable by sid).
 ///
 /// Facts agreeing on the derived id are ONE node: the batch is deduped by id,
 /// first-encountered fact wins (which name/file/meta surface lands for a duplicated
@@ -319,6 +321,25 @@ pub fn plan_node_writeback(
                 });
             }
             let semantic_id = match &fact[0] {
+                // An all-decimal sid (one that `str::parse::<u128>` accepts) is a silent
+                // id-derivation footgun: this writer mints the u128 via BLAKE3(sid)
+                // (`string_id_to_u128`), but the wire writer/resolver (`string_to_id` /
+                // `resolve_node_id` in the server) parse a decimal string as the u128
+                // FIRST — so `blake3("12345") != 12345` and the minted node would be
+                // unreachable by any sid round-trip. Reject it (the parse-decimal set is
+                // the exact divergence set); shipped packs use prefixed, non-decimal sids.
+                Value::Str(s) if s.parse::<u128>().is_ok() => {
+                    return Err(MaterializeError {
+                        code: "E-MAT-010",
+                        detail: format!(
+                            "@materialize_node predicate '{}' semantic-id column (head column 0) \
+                             must not be an all-decimal string ({:?}); the node writer derives \
+                             the id as BLAKE3(sid) while the wire resolver parses a decimal sid \
+                             as the id directly, so such a node would be unreachable by sid",
+                            spec.predicate, s
+                        ),
+                    })
+                }
                 Value::Str(s) if !s.is_empty() => s.clone(),
                 other => {
                     return Err(MaterializeError {
@@ -833,6 +854,66 @@ mod tests {
                 .expect_err("bad semantic-id column");
             assert_eq!(err.code, "E-MAT-010");
         }
+    }
+
+    #[test]
+    fn plan_node_writeback_rejects_all_decimal_semantic_id() {
+        // An all-decimal semantic-id is a silent id-derivation footgun. The node
+        // writer mints the u128 via BLAKE3(sid) (`string_id_to_u128`), but the wire
+        // writer/resolver (`rfdb_server::string_to_id` / `resolve_node_id`) parse a
+        // decimal string as the u128 FIRST — so `blake3("12345") != 12345` and the
+        // minted node is unreachable by any sid round-trip. The two derivations
+        // provably diverge for the decimal-parseable set:
+        assert_ne!(
+            crate::graph::string_id_to_u128("12345"),
+            "12345".parse::<u128>().unwrap(),
+            "BLAKE3(sid) must differ from the parse-decimal-first wire path"
+        );
+        // So reject it BEFORE any commit (E-MAT-010), the same abort-no-commit
+        // discipline as the other malformed-head cases. `parse::<u128>().is_ok()`
+        // is the exact inverse of the wire path's parse-first branch (covers leading
+        // zeros and "0", which the wire path still parses numerically).
+        let spec = NodeMaterializeSpec {
+            predicate: "issue".to_string(),
+            node_type: "ISSUE".to_string(),
+            rule_ast_hash: "h".to_string(),
+            additive: true,
+            meta: Vec::new(),
+        };
+        for decimal in ["12345", "0", "007"] {
+            let mut eval = Evaluation::default();
+            eval.relations.insert(
+                "issue".to_string(),
+                vec![vec![
+                    Value::Str(decimal.to_string()),
+                    Value::Str("n".into()),
+                    Value::Str("f".into()),
+                ]
+                .into_boxed_slice()],
+            );
+            let err = plan_node_writeback(std::slice::from_ref(&spec), &eval, 1)
+                .expect_err("all-decimal semantic id is rejected, not minted");
+            assert_eq!(
+                err.code, "E-MAT-010",
+                "all-decimal semantic id {decimal:?} must abort with E-MAT-010"
+            );
+        }
+        // Guard the boundary: a prefixed sid that merely CONTAINS digits (the shipped
+        // convention, e.g. "issue::shape-violation::42") is NOT decimal-parseable and
+        // stays accepted — the guard must not regress real packs.
+        let mut eval = Evaluation::default();
+        eval.relations.insert(
+            "issue".to_string(),
+            vec![vec![
+                Value::Str("issue::shape-violation::42".to_string()),
+                Value::Str("n".into()),
+                Value::Str("f".into()),
+            ]
+            .into_boxed_slice()],
+        );
+        let nodes = plan_node_writeback(std::slice::from_ref(&spec), &eval, 1)
+            .expect("a prefixed (non-decimal) sid is still accepted");
+        assert_eq!(nodes.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Source

`_ai/gaps.md` → "@materialize_node advisory follow-ups (W4 review wf_4abcf48c-1d8, 2026-06-10)" item **#1** — *"All-numeric semantic-id drift … extend E-MAT-010 to reject all-decimal sids."* No open GitHub issue / Linear ticket; triaged from the recorded gap.

## SPEC

**Invariant restored:** every semantic-id that `plan_node_writeback` *accepts* must derive the **same** u128 node id regardless of which id-derivation path resolves it later.

The two paths diverge on all-decimal strings:
- **mint** (`derive/materialize.rs:334`): `string_id_to_u128(sid)` → **always BLAKE3**(sid)[0..16].
- **wire resolve** (`bin/rfdb_server.rs:1009` `string_to_id`, `:1022` `resolve_node_id`): `s.parse::<u128>()` **first**, hash only on parse failure.

So a node materialized with sid `"12345"` is minted with id `223388589721311106277013205299978891910` (= blake3) but is looked up as `12345` on every wire round-trip → **silently unreachable by its own sid**.

**Given** a `@materialize_node` predicate whose semantic-id column is an all-decimal string (`"12345"`, `"0"`, `"007"`)
**When** `plan_node_writeback` runs
**Then** it aborts **before any commit** with code `E-MAT-010` (the same abort-no-commit discipline as the other malformed-head cases) — instead of minting an unreachable node.

## Fix

One guard arm in the existing `E-MAT-010` match (`derive/materialize.rs`):

```rust
Value::Str(s) if s.parse::<u128>().is_ok() => { /* E-MAT-010 */ }
```

`parse::<u128>().is_ok()` is the **exact inverse** of the wire path's parse-first branch, so the rejected set is *provably the exact divergence set*. Strings that overflow u128, are negative, contain unicode digits, or are prefixed (the shipped convention) all fail to parse and are hashed by **both** paths → consistent → still accepted.

## Before / After (live)

```
# BEFORE (red) — all-decimal sid is minted, not rejected:
plan_node_writeback(... sid="12345" ...)
  => NodeRecordV2 { semantic_id: "12345", id: 223388589721311106277013205299978891910, ... }
  (blake3("12345"); wire path would resolve 12345 — divergent)

# AFTER (green):
cargo test --profile fast --lib derive::materialize
  => 15 passed; 0 failed
     incl. plan_node_writeback_rejects_all_decimal_semantic_id
```

Test asserts the divergence (`blake3("12345") != 12345`), rejects `"12345"/"0"/"007"` with `E-MAT-010`, and guards the boundary: prefixed `"issue::shape-violation::42"` still mints exactly one node (no regression for real packs).

## Adversarial review

- **Round A (correctness):** guard uses the *same* `parse::<u128>` predicate as the wire path → whatever quirks it has (leading `+`, leading zeros, no whitespace-trim) are identical on both sides; the rejected set is exactly the divergence set. Overflow/negative/unicode-digit/prefixed sids fail to parse → hashed by both → correctly *not* rejected. **Verdict: sound.**
- **Round B (structural):** no new coupling beyond the documented invariant. `string_to_id` lives in the binary crate (`bin/rfdb_server.rs`), not the lib, so a shared helper isn't cleanly reachable — the comment documents the coupling explicitly. *Pre-existing note:* `materialize.rs` is already a >500-line file (mostly tests); extraction is out of scope here.
- **Round C (class-not-instance):** the **edge** path (`plan_writeback`/`value_to_id`, `E-MAT-003`) *intentionally* accepts decimal strings — edge endpoints **reference** existing node ids (the decimal *is* the id), they don't **mint**. So the asymmetry is correct and there's no sibling bug. `plan_node_writeback` is the only place a user-authored `.dl` rule controls a raw minted sid. **No follow-ups filed.**

## Blast radius

Callers: `graph/engine_v2.rs:660`, `:1171` — both propagate via `?` (abort-no-commit). No caller depends on all-decimal sids. Shipped stdlib packs use prefixed sids (`issue::…`, `MODULE#…`), so production output is unchanged.

## Verification

- `cargo test --profile fast --lib derive::materialize` → 15/0
- `cargo test --profile fast --lib` (full rfdb crate) → **1401 passed, 0 failed**, 25 ignored
- `cargo clippy --profile fast --lib` → exit 0, no new warnings (116 pre-existing crate-wide warnings unrelated to this change)

Change is Rust-only in `rfdb-server`, touches no JS/TS — the `pnpm` gate is unaffected.

## Memory write-back

`_ai/gaps.md` item #1 marked ✅ RESOLVED with the evidence above.

**DO NOT auto-merge — Vadim reviews structural graph changes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzwNiYRURcmsH67acQHTxG)_