### PR TITLE
fix(rfdb/stratify): track attr(X,"type",T) as a node-materialize dependency (W4 #3)

### DIFF
--- a/_ai/gaps.md
+++ b/_ai/gaps.md
@@ -334,6 +334,22 @@ id is identical across generations are not tombstoned by changed-file deletion).
    materialize write-back or weaken the one-flush docstring.
 3. **attr(X,"type",T) bypasses the node-feedback stratifier dependency** (edge axis has no such
    bypass — edge_attr can't read the edge type). Track attr-type-const in node_type_arg or fix docs.
+   - **✅ RESOLVED 2026-06-14** (verified at HEAD): tracked the read (not just docs) — it was a real
+     soundness hole, not a deliberate boundary. The base `attr(X,"type",T)` relation resolves to the
+     node's structural type `node_type` at exec (`derive/exec.rs:1710,2903` `lookup_name == "type" => node`),
+     so it reads EXACTLY what `@materialize_node` produces — unlike `edge_attr`, which can only reach edge
+     *metadata* (the edge type is the tracked relation arg `edge(_,_,"T")`). The asymmetry the note flagged
+     is why the old "deliberate boundary" docstring was wrong. Fix: new `attr_node_type_arg` helper
+     (`derive/stratify.rs`) recognizes base `attr(_,"type",const|var)` as a node-type read and routes it to
+     the SAME node-materialize producer maps as `node(X,"T")` (const → exact producer; var → conservative
+     all-node + W-STRAT-001). Scoped to the base `attr` predicate ONLY — `node_attr` (metadata-blob builtin,
+     e.g. a value's declared type `"string"`) stays untracked by construction (`predicate() != "attr"`).
+     Variable attr KEY (`attr(X,K,V)`) remains out of scope (would over-couple every variable-key read) —
+     residual. Blast radius zero on shipped packs (no `.dl` reads base `attr(_,"type",_)`; the only hits are
+     `node_attr` in go_types/java_types). Locked by `attr_type_const_read_creates_node_materialize_dependency`,
+     `attr_type_variable_read_depends_on_all_node_materializers_and_warns`, and the class-guard
+     `node_attr_metadata_type_read_takes_no_node_materialize_dependency` (`derive/stratify.rs`). Full rfdb
+     lib 1403/0, clippy exit 0 (no new warnings).
 4. **O(owned²)**: removed_node_ids is a Vec scanned per node of the type; HashSet one-liner.
 5. **Never-rewrite staleness for OWNED nodes**: a re-derived owned node with a CHANGED surface
    (e.g. ISSUE message after method rename on the same CALL) keeps the stale payload forever —
@@ -342,6 +358,15 @@ id is identical across generations are not tombstoned by changed-file deletion).
    the plugin retires (pack can't rewrite or retract it). Document or co-own _source='shape-verifier'.
 7. **Cache pinning for always-scratch programs**: node-materializing entries still pin prior
    snapshots in datalog2_materialize_cache for zero benefit; skip the insert.
+   - **⚠️ STALE / DO-NOT-IMPLEMENT (triaged 2026-06-14)**: the "zero benefit" premise no longer holds.
+     The W9 unchanged-graph short-circuit (`derive_for_materialize`, `graph/engine_v2.rs:1085-1108`)
+     returns the cached evaluation VERBATIM when the snapshot version + tombstone `Arc` are unchanged,
+     and its own comment states this *explicitly covers node specs*: "Programs outside the maintain
+     envelope (negation, **node specs**) are equally covered — the equality argument needs no envelope."
+     So a node-materializing program DOES benefit from the cached entry on idle re-runs (skips full
+     scratch — the 80.7s→188.9s regression the W9 comment warns about). "Skip the insert" would
+     re-introduce that regression. The pin is also already bounded (each insert drops the prior, line 953).
+     No action.
 
 ## Two JS-analyzer producer bugs found by Wave-0 live probing (2026-06-10, wf_07c95bfd-e52)
 

--- a/packages/rfdb-server/src/derive/stratify.rs
+++ b/packages/rfdb-server/src/derive/stratify.rs
@@ -37,9 +37,15 @@
 //! predicate; a **variable** node type conservatively depends on all node-materialized
 //! predicates (the same `W-STRAT-001`). The axes never cross: a variable edge type
 //! depends only on edge materializers, a variable node type only on node materializers.
-//! (Reads of a materialized node's *fields* via `attr(X, …)`/`node_attr(X, …)` are not
-//! tracked — the same deliberate boundary as edge metadata reads via `edge_attr` on the
-//! edge axis.)
+//!
+//! A node's structural type is ALSO readable via the base `attr(X, "type", T)` relation
+//! (it resolves to `node_type` at execution), so that read carries the identical
+//! node-materialize feedback as `node(X, "T")` and is tracked the same way. This is NOT
+//! symmetric with the edge axis: there the type is a relation argument (`edge(_,_,"T")`,
+//! already tracked) and `edge_attr` can only reach edge *metadata*, never the edge type.
+//! Reads of a materialized node's genuine *metadata* fields via `node_attr(X, …)` (and
+//! `attr` keys other than `"type"`) remain untracked — those are field reads, not the
+//! structural type the materializer produces.
 //!
 //! # Algorithm
 //!
@@ -300,6 +306,47 @@ fn node_type_arg(lit: &Literal) -> Option<Option<String>> {
     }
 }
 
+/// The node-type read carried by a base `attr(Id, "type", T)` literal, if any — the
+/// surface-field twin of [`node_type_arg`]. The base `attr` relation's `"type"` key
+/// resolves to a node's structural type (`node_type`) at execution
+/// (`exec.rs` `lookup_name == "type" => node`), so `attr(X, "type", "ISSUE")` reads the
+/// SAME thing `node(X, "ISSUE")` does and the SAME thing `@materialize_node` produces —
+/// it must contribute the identical node-materialize dependency.
+///
+/// Returns:
+/// - `Some(Some(t))` — a constant node type `"t"` (third arg `Const`/`Lit`);
+/// - `Some(None)` — a *variable* node type (third arg `Var`/`Wildcard`); the reader
+///   conservatively depends on all node-materialized predicates (W-STRAT-001);
+/// - `None` — not a base `attr` literal, or its key is not the constant `"type"`.
+///
+/// Only the base `attr` relation is matched — never the `node_attr` builtin, which reads
+/// the METADATA blob (a value's declared/inferred type like `"string"`, not the
+/// structural `node_type`) and is correctly left untracked. A *variable* attr KEY
+/// (`attr(X, K, V)`) is out of scope here: it could read any field including `"type"`,
+/// but coupling every variable-key read to all node materializers over-approximates far
+/// beyond this surface; tracked as a residual (gaps.md W4-#3).
+fn attr_node_type_arg(lit: &Literal) -> Option<Option<String>> {
+    let atom = lit.atom();
+    if atom.predicate() != "attr" {
+        return None;
+    }
+    // The key (2nd arg) must be the constant "type"; anything else is not a type read.
+    let key_is_type = match atom.args().get(1) {
+        Some(Term::Const(k)) => k == "type",
+        Some(Term::Lit(v)) => v.as_str() == "type",
+        _ => false,
+    };
+    if !key_is_type {
+        return None;
+    }
+    match atom.args().get(2) {
+        Some(Term::Const(t)) => Some(Some(t.clone())),
+        Some(Term::Lit(v)) => Some(Some(v.as_str())),
+        Some(Term::Var(_)) | Some(Term::Wildcard) => Some(None),
+        None => None,
+    }
+}
+
 /// A directed dependency edge `from -> to` with a sign.
 struct DepEdge {
     from: String,
@@ -420,7 +467,11 @@ fn add_body_deps(
         //    producers, `node`/`type` readers vs `@materialize_node` producers.
         let type_read = edge_type_arg(lit)
             .map(|arg| (arg, maps.edge, maps.all_edge))
-            .or_else(|| node_type_arg(lit).map(|arg| (arg, maps.node, maps.all_node)));
+            .or_else(|| node_type_arg(lit).map(|arg| (arg, maps.node, maps.all_node)))
+            // The node type is also read via the base `attr(X, "type", T)` relation
+            // (resolves to `node_type` at exec) — same node-materialize feedback as
+            // `node(X, "T")`, routed to the same node producers (never edge).
+            .or_else(|| attr_node_type_arg(lit).map(|arg| (arg, maps.node, maps.all_node)));
         if let Some((type_arg, producer_map, all_producers)) = type_read {
             match type_arg {
                 Some(ty) => {
@@ -829,6 +880,83 @@ mod tests {
         let mk = stratum_of(&strat, "mkissue");
         let rd = stratum_of(&strat, "reader");
         assert!(mk < rd, "reader must sink below the node materializer");
+    }
+
+    #[test]
+    fn attr_type_const_read_creates_node_materialize_dependency() {
+        // The node TYPE is also readable via the base `attr(X, "type", T)` relation — it
+        // resolves to the node's structural type (`node_type`), exactly what
+        // `@materialize_node` produces and the exact join key. So a reader filtering on
+        // `attr(X, "type", "ISSUE")` has the SAME cross-run storage feedback as one reading
+        // `node(X, "ISSUE")` and MUST depend on the ISSUE node materializer. (Regression
+        // guard for the W4-#3 soundness hole: this read previously bypassed the dependency.)
+        let src = r#"
+            @materialize_node(node_type = "ISSUE")
+            mkissue(S, N, F) :- node(C, "CALL"), attr(C, "name", N), attr(C, "file", F),
+                                concat("issue::", C, S).
+            reader(X) :- attr(X, "type", "ISSUE").
+        "#;
+        let prog = parse_ext_program(src).expect("parse");
+        let strat = stratify(&prog).expect("stratify");
+        assert_eq!(strat.strata.len(), 2);
+        let mk = stratum_of(&strat, "mkissue");
+        let rd = stratum_of(&strat, "reader");
+        assert!(
+            mk < rd,
+            "mkissue (node materializer, stratum {mk}) must be below the attr-type reader (stratum {rd})"
+        );
+        // A reader of an UNRELATED type via attr takes no dependency (single stratum).
+        let unrelated = r#"
+            @materialize_node(node_type = "ISSUE")
+            mkissue(S, N, F) :- node(C, "CALL"), attr(C, "name", N), attr(C, "file", F),
+                                concat("issue::", C, S).
+            other(X) :- attr(X, "type", "FUNCTION").
+        "#;
+        let strat2 = stratify(&parse_ext_program(unrelated).expect("parse")).expect("stratify");
+        assert_eq!(strat2.strata.len(), 1, "unrelated attr-type read takes no dependency");
+    }
+
+    #[test]
+    fn attr_type_variable_read_depends_on_all_node_materializers_and_warns() {
+        // `attr(X, "type", Ty)` with a VARIABLE value reads EVERY node's type, so it
+        // conservatively depends on all node materializers (the same W-STRAT-001 treatment
+        // as the variable `node(X, Ty)` form), and never on edge materializers.
+        let src = r#"
+            @materialize_node(node_type = "ISSUE")
+            mkissue(S, N, F) :- node(C, "CALL"), attr(C, "name", N), attr(C, "file", F),
+                                concat("issue::", C, S).
+            reader(X, Ty) :- attr(X, "type", Ty).
+        "#;
+        let prog = parse_ext_program(src).expect("parse");
+        let strat = stratify(&prog).expect("stratify");
+        assert!(
+            strat.warnings.contains(&StratWarning::ConservativeMaterializeDep),
+            "variable attr-type read must warn W-STRAT-001"
+        );
+        let mk = stratum_of(&strat, "mkissue");
+        let rd = stratum_of(&strat, "reader");
+        assert!(mk < rd, "reader must sink below the node materializer");
+    }
+
+    #[test]
+    fn node_attr_metadata_type_read_takes_no_node_materialize_dependency() {
+        // CLASS-NOT-INSTANCE guard: `node_attr(X, "type", T)` is the METADATA-blob builtin
+        // (a value's declared/inferred type like "string"), NOT the structural node type.
+        // It is a genuine field read and must stay UNTRACKED — only the base `attr`
+        // relation reads `node_type`. This pins that the fix does not over-match `node_attr`.
+        let src = r#"
+            @materialize_node(node_type = "ISSUE")
+            mkissue(S, N, F) :- node(C, "CALL"), attr(C, "name", N), attr(C, "file", F),
+                                concat("issue::", C, S).
+            reader(X) :- node(X, "VARIABLE"), node_attr(X, "type", "ISSUE").
+        "#;
+        let strat = stratify(&parse_ext_program(src).expect("parse")).expect("stratify");
+        assert_eq!(
+            strat.strata.len(),
+            1,
+            "node_attr metadata read must not create a node-materialize dependency"
+        );
+        assert!(strat.warnings.is_empty(), "no conservative dep ⇒ no W-STRAT-001");
     }
 
     #[test]


### PR DESCRIPTION
## Source

`_ai/gaps.md` → "@materialize_node advisory follow-ups (W4 review wf_4abcf48c-1d8, 2026-06-10)" item **#3** — *"attr(X,"type",T) bypasses the node-feedback stratifier dependency (edge axis has no such bypass — edge_attr can't read the edge type). Track attr-type-const in node_type_arg or fix docs."* No open GitHub issue / Linear ticket; triaged from the recorded gap (sibling of the just-shipped #1 → PR #424 and #5 → PR #425).

The note hedged "track … or fix docs." Verified at HEAD it is a **real soundness hole**, so it is tracked (not documented away).

## SPEC

**Invariant restored:** the derive stratifier's `@materialize_node` feedback dependency is read-path-complete. Every body literal that reads a node's *structural type* — whichever surface syntax — contributes a dependency on that type's node-materializer, so a consumer is never evaluated before its producer.

**Given** a program where rule `mk` carries `@materialize_node(node_type = "ISSUE")` and another rule `reader` reads the ISSUE nodes via the base relation `attr(X, "type", "ISSUE")`
**When** the program is stratified
**Then** `reader` lands in a strictly higher stratum than `mk` (was: same stratum → `mk` could run after `reader` → `reader` silently sees no/partial ISSUE nodes).

**Variable form preserved:** `attr(X, "type", Ty)` conservatively depends on all node-materializers and raises `W-STRAT-001` (same treatment as the variable `node(X, Ty)` form). The axes never cross. The `node_attr` metadata builtin stays untracked.

## Root cause (verified at HEAD before fix)

`add_body_deps` (`packages/rfdb-server/src/derive/stratify.rs`) detected a node-type read only through `node_type_arg`, which matches `pred == "node" || pred == "type"`. But the **base `attr` relation's `"type"` key resolves to the node's `node_type`** at execution:

```
// derive/exec.rs:1710 / :1911
let lookup_name = if name == "type" { "node" } else { name };
// derive/exec.rs:2903
"type" => n.node_type,
```

So `attr(X, "type", "ISSUE")` reads exactly what `@materialize_node` produces and is the exact join key — yet it produced **no** dependency edge. Result: an unsound stratum ordering, silently yielding incomplete results for any pack consuming materialized nodes via `attr(...,"type",...)`.

### Why the old "deliberate boundary" docstring was wrong

The module doc claimed attr-field reads are untracked "the same deliberate boundary as edge metadata reads via `edge_attr` on the edge axis." That symmetry is **false**: on the edge axis the type is a *relation argument* (`edge(_,_,"T")`, already tracked) and `edge_attr` can only reach edge *metadata*, never the edge type. On the node axis `attr(X,"type",…)` reaches the structural type itself. The note's own observation ("edge axis has no such bypass") is precisely this asymmetry. Docstring corrected.

## Fix

One small documented helper + one `.or_else` arm in the existing type-read chain (`derive/stratify.rs`):

```rust
let type_read = edge_type_arg(lit)
    .map(|arg| (arg, maps.edge, maps.all_edge))
    .or_else(|| node_type_arg(lit).map(|arg| (arg, maps.node, maps.all_node)))
    .or_else(|| attr_node_type_arg(lit).map(|arg| (arg, maps.node, maps.all_node)));
```

`attr_node_type_arg` returns `Some(Some(t))` for a constant type, `Some(None)` for a variable type, `None` otherwise — and matches the **base `attr` predicate only** (the `node_attr` metadata builtin is a different predicate name → never matched). Routed to the **node** producer maps exclusively (never edge).

## Before / After (live)

```
# BEFORE (red):
attr_type_const_read_creates_node_materialize_dependency
  => assertion `left == right` failed  left: 1  right: 2   (no dependency → single stratum)
attr_type_variable_read_depends_on_all_node_materializers_and_warns
  => "variable attr-type read must warn W-STRAT-001"        (no W-STRAT-001)

# AFTER (green):
cargo test --profile fast --lib derive::stratify
  => 18 passed; 0 failed
     incl. the two above + node_attr_metadata_type_read_takes_no_node_materialize_dependency
```

## Adversarial review

- **Round A (correctness):** const key `"type"` + const value → exact producer dep; + variable value → conservative all-node + W-STRAT-001; key ≠ `"type"` (e.g. the `attr(C,"name",N)`/`attr(C,"file",F)` in `mkissue`'s own body) → `None`, so no spurious self-dependency (confirmed: `mkissue` stratifies strictly below `reader`). Program with no node-materializers → `producer_map.get` miss / `all_producers.is_empty()` guard → no dep, no warning. Malformed/short `attr` → arg `get(1)`/`get(2)` `None` → `None`. Negated `\+ attr(X,"type","ISSUE")` inside an SCC correctly yields `E-STRAT-001`, identical to the `node(X,"ISSUE")` case. **Verdict: sound.**
- **Round B (structural):** one ~30-line documented helper mirroring `edge_type_arg`/`node_type_arg` exactly; one chained `.or_else`. No new coupling. *Pre-existing note:* `stratify.rs` is a >500-line file (≈⅓ tests); not introduced here, extraction out of scope.
- **Round C (class-not-instance):** type-read detection is centralized in `add_body_deps`'s `type_read` chain — the single site, so no sibling call-site has the same latent miss. The `type(X,"T")` base relation is already covered by `node_type_arg`. The `node_attr` metadata-blob builtin is correctly left untracked (pinned by the class-guard test). **Residual filed (gaps.md):** a *variable* attr KEY (`attr(X,K,V)`) could read `"type"` too, but coupling every variable-key read to all node-materializers over-approximates far beyond this surface — deliberately out of scope.

## Blast radius

Zero on shipped packs: no `.dl` reads the base `attr(_,"type",_)` relation (grep over `derive/stdlib/*.dl`; the only `attr(…,"type"…)` hits are `node_attr` in `go_types.dl`/`java_types.dl`, a different predicate). Lowering nothing / adding a dependency can only push a consumer to a higher stratum — never removes one — so existing programs keep their ordering. The cross-registry/stdlib stratification tests pass unchanged.

## Verification

- `cargo test --profile fast --lib derive::stratify` → 18/0 (3 new)
- `cargo test --profile fast --lib derive::` → 308/0 (22 ignored)
- `cargo test --profile fast --lib` (full rfdb crate) → **1403 passed, 0 failed**, 25 ignored
- `cargo clippy --profile fast --lib` → exit 0, no new warnings (no clippy diagnostics in `stratify.rs`)

Change is Rust-only in `rfdb-server`; touches no JS/TS — the `pnpm` gate is unaffected.

## Memory write-back

`_ai/gaps.md` W4 item **#3** marked ✅ RESOLVED with the evidence above. Also recorded W4 item **#7** ("skip the insert for always-scratch node programs") as ⚠️ STALE / DO-NOT-IMPLEMENT: the W9 unchanged-graph short-circuit (`engine_v2.rs:1085-1108`) already returns the cached evaluation verbatim for node-spec programs on idle re-runs, so "skip the insert" would re-introduce the 80.7s→188.9s regression that comment warns about. Items #2/#4/#6 of the W4 list remain open.

**DO NOT auto-merge — Vadim reviews structural graph changes.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYxxQV4cQCG9xsvrEUBieJ)_