### PR TITLE
fix(rfdb/materialize): suppress intra-add auto-flush so @materialize write-back is atomic (W4 #2)

### DIFF
--- a/_ai/gaps.md
+++ b/_ai/gaps.md
@@ -332,6 +332,23 @@ id is identical across generations are not tombstoned by changed-file deletion).
    maybe_auto_flush which publishes WITHOUT the run's pending tombstones — a mid-delta flush
    shows adds before retractions (self-heals at the explicit flush). Suppress auto-flush during
    materialize write-back or weaken the one-flush docstring.
+   - **✅ RESOLVED 2026-06-14 (suppress, not document)**: the design fork resolved by evidence —
+     `materialize_writeback_delta` documents "ONE flush commits node+edge adds + tombstones"
+     (engine_v2.rs) and the MVCC design elsewhere asserts "nothing observes a torn state"
+     (`clear_durable` docs), so weakening the docstring would concede a torn read in a
+     transactional write-back. Fix: a `suppress_auto_flush` engine flag set only for the
+     write-back's apply phase via `with_auto_flush_suppressed` (restores the PRIOR value →
+     re-entrancy safe); `maybe_auto_flush`/`maybe_auto_flush_edges` early-return when set.
+     The closing explicit `flush()` runs outside the suppressed scope → durability + the single
+     atomic publish preserved; every other write path keeps its OOM-safeguard auto-flush.
+     Class check: the only piecewise delete+add+`flush()` write-back is this one —
+     `commit_batch_ext`/`commit_batch_concurrent` use the store-level atomic commit
+     (`store.commit_batch_ext`, single manifest flip), so no sibling tear. Locked by
+     `materialize_writeback_is_atomic_under_buffer_pressure` (engine_v2.rs): forces the
+     node-count auto-flush (`write_buffer_node_limit=1`) during a writeback that adds one ISSUE
+     + retracts one owned-stale ISSUE, asserts the version advances EXACTLY ONCE. Red before the
+     fix: advanced twice (the intra-add flip is the torn intermediate). Full rfdb lib suite
+     1401/0, clippy clean. Items #4/#6 of this W4 list remain open (#7 is STALE per PR #426).
 3. **attr(X,"type",T) bypasses the node-feedback stratifier dependency** (edge axis has no such
    bypass — edge_attr can't read the edge type). Track attr-type-const in node_type_arg or fix docs.
 4. **O(owned²)**: removed_node_ids is a Vec scanned per node of the type; HashSet one-liner.

--- a/packages/rfdb-server/src/graph/engine_v2.rs
+++ b/packages/rfdb-server/src/graph/engine_v2.rs
@@ -175,6 +175,16 @@ pub struct GraphEngineV2 {
     cached_profile: TuningProfile,
     /// Timestamp of last resource re-detection (rate-limits sysinfo calls).
     last_resource_check: Instant,
+    /// W4 #2: when `true`, the buffer-pressure auto-flush hooks at the end of
+    /// `add_nodes`/`add_edges` are inert. Set only for the brief apply phase of an ATOMIC
+    /// multi-step write-back (the `@materialize` delta — see [`Self::materialize_writeback_delta`]),
+    /// where an intra-add `store.flush_all` would publish the adds while the run's
+    /// `pending_tombstone_*` retractions are still engine-side, exposing a torn intermediate
+    /// version. Always restored to its prior value via [`Self::with_auto_flush_suppressed`];
+    /// the explicit `flush()` that closes the delta is never suppressed, so durability and
+    /// the single atomic publish are preserved. Default `false` — every other write path
+    /// keeps its OOM-safeguard auto-flush.
+    suppress_auto_flush: bool,
     /// Embedding engine for semantic search (None when feature disabled or not initialized).
     #[cfg(feature = "embedding")]
     embedding_engine: Option<std::sync::Arc<crate::embedding::EmbeddingEngine>>,
@@ -271,6 +281,7 @@ impl GraphEngineV2 {
             declared_fields: Vec::new(),
             cached_profile: profile,
             last_resource_check: Instant::now(),
+            suppress_auto_flush: false,
             bulk_load_active: false,
             auto_compact_threshold: 8,
             auto_compact_fanout: 4.0,
@@ -299,6 +310,7 @@ impl GraphEngineV2 {
             declared_fields: Vec::new(),
             cached_profile: TuningProfile::default(),
             last_resource_check: Instant::now(),
+            suppress_auto_flush: false,
             bulk_load_active: false,
             auto_compact_threshold: 8,
             auto_compact_fanout: 4.0,
@@ -350,6 +362,7 @@ impl GraphEngineV2 {
             declared_fields: Vec::new(),
             cached_profile: profile,
             last_resource_check: Instant::now(),
+            suppress_auto_flush: false,
             bulk_load_active: false,
             auto_compact_threshold: 8,
             auto_compact_fanout: 4.0,
@@ -1250,20 +1263,26 @@ impl GraphEngineV2 {
             nodes: !added_nodes.is_empty() || !removed_node_ids.is_empty(),
             edges_unbounded: !removed_node_ids.is_empty(),
         };
-        for id in &removed_node_ids {
-            self.delete_node(*id);
-        }
-        for (s, d, t) in &removed {
-            self.delete_edge(*s, *d, t);
-        }
-        if !added.is_empty() {
-            let v1: Vec<EdgeRecord> = added.iter().map(edge_v2_to_v1).collect();
-            self.add_edges(v1, true);
-        }
-        if !added_nodes.is_empty() {
-            let v1: Vec<NodeRecord> = added_nodes.iter().map(node_v2_to_v1).collect();
-            self.add_nodes(v1);
-        }
+        // W4 #2: stage tombstones + adds with intra-add auto-flush suppressed, so the
+        // SINGLE explicit flush() below is the only publish — a buffer-pressure auto-flush
+        // inside add_nodes/add_edges would otherwise expose the adds while these tombstones
+        // are still engine-side (`pending_tombstone_*`), tearing the "ONE flush" invariant.
+        self.with_auto_flush_suppressed(|s| {
+            for id in &removed_node_ids {
+                s.delete_node(*id);
+            }
+            for (src, dst, t) in &removed {
+                s.delete_edge(*src, *dst, t);
+            }
+            if !added.is_empty() {
+                let v1: Vec<EdgeRecord> = added.iter().map(edge_v2_to_v1).collect();
+                s.add_edges(v1, true);
+            }
+            if !added_nodes.is_empty() {
+                let v1: Vec<NodeRecord> = added_nodes.iter().map(node_v2_to_v1).collect();
+                s.add_nodes(v1);
+            }
+        });
         self.flush().map_err(|e| {
             crate::derive::EvalError::Materialize(crate::derive::materialize::MaterializeError {
                 code: "E-MAT-005",
@@ -2367,6 +2386,12 @@ impl GraphEngineV2 {
     fn maybe_auto_flush(&mut self) {
         use std::time::Duration;
 
+        // W4 #2: inert inside an atomic write-back's apply phase — the closing explicit
+        // flush() is the sole publish, so the adds and the run's tombstones land together.
+        if self.suppress_auto_flush {
+            return;
+        }
+
         // Rate-limit resource re-detection to at most once per second.
         // Between checks we use the cached TuningProfile, which is stale
         // by at most 1 s — acceptable for adaptive buffer limits and
@@ -2409,11 +2434,30 @@ impl GraphEngineV2 {
     /// genuine OOM safeguard. Callers that want guaranteed durability should call
     /// flush() or compact() explicitly.
     fn maybe_auto_flush_edges(&mut self) {
+        // W4 #2: same atomic-write-back suppression as the node path (see maybe_auto_flush).
+        if self.suppress_auto_flush {
+            return;
+        }
         if self.store.any_shard_needs_flush(usize::MAX, self.cached_profile.write_buffer_byte_limit) {
             if let Err(e) = self.store.flush_all(self.manifest.get_mut().unwrap()) {
                 tracing::warn!("auto-flush (edges) failed: {}", e);
             }
         }
+    }
+
+    /// W4 #2: run `f` with the buffer-pressure auto-flush hooks suppressed, restoring the
+    /// PRIOR flag afterward (re-entrancy safe). Used by the `@materialize` write-back so its
+    /// `delete_node`/`add_edges`/`add_nodes` sequence cannot publish a torn intermediate
+    /// version mid-delta — only the explicit `flush()` that runs AFTER `f` (outside this
+    /// scope) publishes, committing adds and tombstones together. `f` performs the infallible
+    /// staging operations; the one fallible step (the flush) is intentionally left outside,
+    /// so an early `?`-return can never strand the flag set.
+    fn with_auto_flush_suppressed<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        let prev = self.suppress_auto_flush;
+        self.suppress_auto_flush = true;
+        let out = f(self);
+        self.suppress_auto_flush = prev;
+        out
     }
 
     /// Get incoming neighbors (src nodes of incoming edges).
@@ -4384,6 +4428,81 @@ mod tests {
         assert!(
             engine.store.node_exists_at(&snap3, foreign_id),
             "foreign ISSUE survives the retraction run too"
+        );
+    }
+
+    /// W4 #2 regression: the `@materialize` write-back is ATOMIC even under write-buffer
+    /// pressure. `materialize_writeback_delta` tombstones the owned-stale set then adds the
+    /// derived nodes, relying on a SINGLE final flush to publish both together (its own
+    /// docstring: "ONE flush commits node+edge adds + tombstones"). But `add_nodes` ends in
+    /// `maybe_auto_flush`, which calls `store.flush_all` — and the run's tombstones live in
+    /// the engine's `pending_tombstone_*`, which `flush_all` never touches. So under buffer
+    /// pressure the auto-flush inside `add_nodes` published a manifest version exposing the
+    /// new node while the owned-stale node was NOT yet retracted: a reader pinning that
+    /// intermediate version saw a torn state (the add without the matching retraction).
+    ///
+    /// Observable proxy for the tear: the number of manifest flips. An atomic write-back
+    /// advances the version EXACTLY ONCE; a torn one advances it twice (the intra-add
+    /// auto-flush, then the tombstone-applying final flush) — and that first extra version
+    /// IS the torn intermediate, by construction the only thing committed between the two
+    /// flips is "add without tombstone". So `== version_before + 1` is the atomicity invariant.
+    #[test]
+    fn materialize_writeback_is_atomic_under_buffer_pressure() {
+        let mut engine = GraphEngineV2::create_ephemeral();
+        let hash = node_prog_hash();
+
+        let f = make_v2_node("a.js->FUNCTION->f", "FUNCTION", "f", "a.js");
+        let fid = f.id;
+        // OWNED-STALE ISSUE node (this rule's `_source`, not derived this run) → the
+        // write-back must tombstone it. Pairing an add (for `f`) with this retraction is
+        // exactly the shape that tears under an intra-add auto-flush.
+        let mut stale = make_v2_node("issue::fn::999", "ISSUE", "gone", "c.js");
+        stale.metadata = format!(r#"{{"_source":"{hash}","_generation":1}}"#);
+        let stale_id = stale.id;
+        engine
+            .commit_batch_ext(
+                vec![f, stale],
+                Vec::new(),
+                &["a.js".to_string(), "c.js".to_string()],
+                HashMap::new(),
+                &[],
+            )
+            .expect("base commit");
+
+        // Force the node-count auto-flush to fire as soon as ONE node is staged
+        // (`exceeds_limits` uses `>=`). Pinning `last_resource_check` to now keeps
+        // `maybe_auto_flush`'s 1s-rate-limited re-detection from overwriting the injected
+        // profile mid-call.
+        engine.cached_profile.write_buffer_node_limit = 1;
+        engine.last_resource_check = std::time::Instant::now();
+
+        let version_before = engine.snapshot().version;
+        let (added, removed) = engine
+            .eval_derive_materialize_incremental(NODE_PROG, crate::datalog::EvalLimits::none())
+            .expect("write-back");
+        assert_eq!(
+            (added, removed),
+            (1, 1),
+            "one ISSUE added (for f), one owned-stale ISSUE tombstoned"
+        );
+
+        assert_eq!(
+            engine.snapshot().version,
+            version_before + 1,
+            "write-back must publish EXACTLY ONE manifest version (atomic; no torn \
+             intermediate exposing the add before the retraction)"
+        );
+
+        // Final state is correct regardless (the bug tore only the INTERMEDIATE view).
+        let snap = engine.snapshot();
+        let derived_id = crate::graph::string_id_to_u128(&format!("issue::fn::{fid}"));
+        assert!(
+            engine.store.node_exists_at(&snap, derived_id),
+            "derived ISSUE present in the committed state"
+        );
+        assert!(
+            !engine.store.node_exists_at(&snap, stale_id),
+            "owned-stale ISSUE retracted in the committed state"
         );
     }
 


### PR DESCRIPTION
## Source

`_ai/gaps.md` → "@materialize_node advisory follow-ups (W4 review wf_4abcf48c-1d8, 2026-06-10)" item **#2** — *"Auto-flush can tear run isolation under buffer pressure: add_nodes/add_edges end with maybe_auto_flush which publishes WITHOUT the run's pending tombstones — a mid-delta flush shows adds before retractions (self-heals at the explicit flush). Suppress auto-flush during materialize write-back or weaken the one-flush docstring."* No open GitHub issue / Linear ticket; triaged from the recorded gap (sibling of the shipped #1 → PR #424, #3 → PR #426, #5 → PR #425).

The note hedged "suppress … or weaken docstring". Resolved by evidence to **suppress** (see SPEC) — this is a real torn-read in a transactional write-back, not something to document away.

## SPEC

**Invariant restored:** the `@materialize` write-back is ATOMIC — its tombstones and adds become visible together, in exactly one manifest version. No reader ever observes an intermediate version that exposes a derived add while the run's retractions are still pending.

**Given** a `@materialize`/`@materialize_node` write-back that both adds a derived node and tombstones an owned-stale node, run under write-buffer pressure (a buffered node count that would trip `maybe_auto_flush`)
**When** the write-back applies its delta
**Then** the manifest version advances **exactly once** (the closing explicit `flush()`) — was: twice (an intra-`add_nodes` auto-flush published the add, then `flush()` applied the tombstone), the first of which is a torn intermediate exposing the add without its retraction.

**Preserved:** every non-write-back path keeps its OOM-safeguard auto-flush; the closing explicit `flush()` is never suppressed (durability intact); suppression restores its PRIOR value (re-entrancy safe).

## Root cause (verified at HEAD before fix)

`materialize_writeback_delta` (`packages/rfdb-server/src/graph/engine_v2.rs`) tombstones the owned-stale set, then adds the derived edges/nodes, relying on a single final `flush()` — its own docstring at the apply phase: *"ONE flush commits node+edge adds + tombstones."* But the run's tombstones live in the **engine's** `pending_tombstone_nodes`/`_edges`, and `snapshot()` reads "never the engine's `pending_tombstone_*` (uncommitted deletes)" (engine_v2.rs):

- `delete_node` (`engine_v2.rs`) inserts into `pending_tombstone_*` — engine-side, not published.
- `add_nodes` (`engine_v2.rs`) ends in `maybe_auto_flush` → `store.flush_all`, which flushes the STORE write buffers (the adds) and bumps the manifest version — but does **not** touch the engine's pending tombstones.

So under buffer pressure the auto-flush inside `add_nodes` publishes a manifest version where the new node exists **and the owned-stale node is not yet retracted**. A reader pinning that version sees a torn state; it self-heals at the explicit `flush()`. (Edge path: same shape via `add_edges` → `maybe_auto_flush_edges`.)

## Fix

A `suppress_auto_flush` engine flag, set only for the write-back's apply phase via a small helper:

```rust
fn with_auto_flush_suppressed<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
    let prev = self.suppress_auto_flush;   // restore PRIOR value (re-entrancy safe)
    self.suppress_auto_flush = true;
    let out = f(self);
    self.suppress_auto_flush = prev;
    out
}
```

`maybe_auto_flush` and `maybe_auto_flush_edges` early-return when the flag is set. The apply phase of `materialize_writeback_delta` wraps its `delete_node`/`delete_edge`/`add_edges`/`add_nodes` sequence in `with_auto_flush_suppressed(...)`; the closing `flush()` runs **outside** the suppressed scope. `f` only performs infallible staging — the one fallible step (the flush) is intentionally left outside, so a `?` early-return can never strand the flag set.

## Before / After (live)

```
# New test forces the node-count auto-flush (write_buffer_node_limit = 1) during a
# write-back that adds 1 ISSUE and retracts 1 owned-stale ISSUE.

# BEFORE (red):
materialize_writeback_is_atomic_under_buffer_pressure
  => assertion `left == right` failed: write-back must publish EXACTLY ONE manifest version
     left: 4   right: 3      (version 2 -> 4: the intra-add flip IS the torn intermediate)

# AFTER (green):
cargo test --profile fast --lib materialize
  => 42 passed; 0 failed; 1 ignored
     incl. materialize_writeback_is_atomic_under_buffer_pressure
```

The version-flip count is a sound proxy for the tear: an atomic write-back advances the version once; a torn one advances it twice, and the only thing committed between those two flips is "add without tombstone" — so `== version_before + 1` *is* the atomicity invariant (the same assertion the existing single-flush tests make, now exercised under the pressure that makes the bug bite).

## Adversarial review

- **Round A (correctness):** Empty delta returns before the suppressed block (`n_added == 0 && n_removed == 0` guard). The flag is restored to `prev` (not hardcoded `false`) → nested/re-entrant suppression safe. The only fallible op (`flush()`) is outside the closure → no leak on `?`-return. `delete_node`/`add_*` are infallible (void) → no early return inside. A panic mid-write would leak the flag, but the write path "must not fail" (existing contract) and a panic already aborts the request. Memory: suppression spans only the bounded in-memory derived delta, with `flush()` immediately after → no unbounded buffer growth. **Verdict: sound.**
- **Round B (structural):** one bool field (3 ctor init sites), two 3-line guards, one 6-line helper, one closure wrap. No new coupling. *Pre-existing note:* `engine_v2.rs` is already a >5000-line god-file — not materially worsened; extraction is out of scope.
- **Round C (class-not-instance):** the only two auto-flush call-sites are `add_nodes`/`add_edges`, both now guarded. The only consumer using the piecewise engine `delete_node`+`add_*`+explicit-`flush()` path under an atomicity contract is `materialize_writeback_delta`; `commit_batch_ext`/`commit_batch_concurrent` use the **store-level atomic commit** (`store.commit_batch_ext`, single manifest flip), so they have no sibling tear. **Class fully covered; no follow-ups filed.**

## Blast radius

`suppress_auto_flush` defaults `false` and is only ever `true` within the helper's closure scope (the write-back apply phase), so every other write path — analyzer commits, enricher write storms (RFD-67), bulk load — keeps its auto-flush unchanged. The RFD-67 regression `test_edge_writes_do_not_block_reads` passes unchanged.

## Verification

- `cargo test --profile fast --lib materialize` → 42/0 (1 ignored; 1 new)
- `cargo test --profile fast --lib derive::` → 305/0 (22 ignored)
- `cargo test --profile fast --lib` (full rfdb crate) → **1401 passed, 0 failed**, 25 ignored
- `cargo clippy --profile fast --lib` → exit 0, no new warnings (116 pre-existing crate-wide)

Change is Rust-only in `rfdb-server`; touches no JS/TS — the `pnpm` gate is unaffected.

## Memory write-back

`_ai/gaps.md` W4 item **#2** marked ✅ RESOLVED with the evidence above (and the suppress-vs-document fork resolution). Items #4/#6 of the W4 list remain open; #7 is STALE per PR #426.

**DO NOT auto-merge — Vadim reviews structural graph changes.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYc7dtpX9QotsQPU5NDoqU)_