### PR TITLE
perf(rfdb/materialize): dedup owned-node retraction via HashSet (O(N²)→O(N)) — W4 #4

### DIFF
--- a/_ai/gaps.md
+++ b/_ai/gaps.md
@@ -360,6 +360,21 @@ id is identical across generations are not tombstoned by changed-file deletion).
      `node_attr_metadata_type_read_takes_no_node_materialize_dependency` (`derive/stratify.rs`). Full rfdb
      lib 1403/0, clippy exit 0 (no new warnings).
 4. **O(owned²)**: removed_node_ids is a Vec scanned per node of the type; HashSet one-liner.
+   - **✅ RESOLVED 2026-06-14** (branch `claude/vigilant-lamport-hjnbvg`, verified at HEAD): the
+     owned-node retraction loop in `materialize_writeback_delta`
+     (`packages/rfdb-server/src/graph/engine_v2.rs:1282`) now dedups claimed ids through a
+     `HashSet<u128>` instead of a growing `Vec` probed with `.contains()` per node. The old code
+     iterated `find_nodes_at(type)` = N nodes and probed the up-to-K already-claimed ids linearly
+     → O(N×K) ≈ O(N²) on the hot incremental write-back path; the set makes the probe O(1) → O(N),
+     and `insert` is inherently idempotent. This aligns the node path with the edge-removal path in
+     the SAME function (`prev_keys`/`new_keys`/`additive_types`), which was already `HashSet`-based —
+     the node path (added for item #5) was the sole remaining linear-scan instance. Behavior is
+     identical (the removed set, counts, and tombstones are unchanged; deletion order is irrelevant —
+     `delete_node` records into a tombstone set). Locked by
+     `materialize_node_retraction_tombstones_each_owned_node_exactly_once` (5 owned ISSUEs, a
+     derives-nothing re-run retracts each exactly once → `n_removed == 5`, no double, none dropped).
+     Full rfdb lib **1407/0** (25 ignored); `cargo clippy --profile fast --lib` exit 0, no new
+     warnings. Rust-only in `rfdb-server` — no JS/TS, pnpm gate unaffected.
 5. **Never-rewrite staleness for OWNED nodes**: a re-derived owned node with a CHANGED surface
    (e.g. ISSUE message after method rename on the same CALL) keeps the stale payload forever —
    diverges from the plugin's last-write-wins; rewrite owned-changed nodes or record the delta.

--- a/packages/rfdb-server/src/graph/engine_v2.rs
+++ b/packages/rfdb-server/src/graph/engine_v2.rs
@@ -1269,7 +1269,17 @@ impl GraphEngineV2 {
                 Some(stored) => owned_node_surface_changed(n, &stored),
             })
             .collect();
-        let mut removed_node_ids: Vec<u128> = Vec::new();
+        // Membership SET, not a Vec: the old `removed_node_ids.contains(&n.id)` dedup
+        // guard scanned a growing Vec for EVERY node of the spec's type, so a write-back
+        // over a type with K owned nodes did O(K²) comparisons on the hot incremental
+        // path (`find_nodes_at` yields all N nodes of the type; each probes the up-to-K
+        // already-claimed ids). A `HashSet` makes the probe O(1) → O(N) overall, and its
+        // `insert` is inherently idempotent. This mirrors the edge-removal path above,
+        // which already dedups via `HashSet`s (`prev_keys`/`new_keys`/`additive_types`);
+        // the node path is the only one that had regressed to a linear-scan Vec.
+        // Tombstone order is irrelevant — `delete_node` records into a tombstone SET — so
+        // dropping insertion order costs nothing.
+        let mut removed_node_ids: HashSet<u128> = HashSet::new();
         for spec in node_specs {
             if spec.additive {
                 continue; // additive: never delete (the whole point of the mode)
@@ -1289,7 +1299,7 @@ impl GraphEngineV2 {
                     .and_then(|m| m.get("_source").and_then(|s| s.as_str().map(String::from)))
                     .is_some_and(|s| s == spec.rule_ast_hash);
                 if owned {
-                    removed_node_ids.push(n.id);
+                    removed_node_ids.insert(n.id);
                 }
             }
         }
@@ -4590,6 +4600,70 @@ mod tests {
             .expect("idempotent re-run");
         assert_eq!((a3, r3), (0, 0), "unchanged surface is a true no-op");
         assert_eq!(engine.snapshot().version, v_before, "a no-op run commits nothing");
+    }
+
+    /// W4 review follow-up #4 (`_ai/gaps.md`): the owned-node retraction loop in
+    /// `materialize_writeback_delta` dedups claimed ids through a SET, so a write-back
+    /// over a `node_type` with K owned nodes tombstones each exactly once in O(N) — not
+    /// O(N×K) by re-scanning a growing `Vec`. This characterizes the removal-COUNT
+    /// invariant the set must preserve (behavior is identical to the prior Vec; the swap
+    /// is a perf refactor): with several owned nodes, a run that derives NOTHING retracts
+    /// every one of them exactly once (`n_removed == count`, never doubled, never dropped).
+    #[test]
+    fn materialize_node_retraction_tombstones_each_owned_node_exactly_once() {
+        const PROG: &str = r#"@materialize_node(node_type = "ISSUE", mode = "exclusive")
+            issue(Sid, Name, File) :- node(X, "FUNCTION"), attr(X, "name", Name),
+                                      attr(X, "file", File), concat("issue::", X, Sid)."#;
+
+        let mut engine = GraphEngineV2::create_ephemeral();
+        // Several FUNCTION nodes of the SAME materialized type → several owned ISSUEs.
+        let fns: Vec<NodeRecordV2> = (0..5)
+            .map(|i| {
+                make_v2_node(&format!("a.js->FUNCTION->f{i}"), "FUNCTION", &format!("f{i}"), "a.js")
+            })
+            .collect();
+        let fn_ids: Vec<u128> = fns.iter().map(|n| n.id).collect();
+        engine
+            .commit_batch_ext(fns, Vec::new(), &["a.js".to_string()], HashMap::new(), &[])
+            .expect("base commit");
+
+        // Run 1: derive one owned ISSUE per FUNCTION.
+        let (a1, r1) = engine
+            .eval_derive_materialize_incremental(PROG, crate::datalog::EvalLimits::none())
+            .expect("first derivation");
+        assert_eq!((a1, r1), (5, 0), "one ISSUE per FUNCTION derived, nothing removed");
+
+        // Remove every deriving FUNCTION → the program now derives ZERO ISSUEs, so every
+        // owned ISSUE must retract. This drives the changed retraction loop with K=5 owned
+        // nodes of the type.
+        for id in &fn_ids {
+            engine.delete_node(*id);
+        }
+        engine.flush().expect("flush deletions");
+
+        // Run 2: nothing derived; each of the 5 owned ISSUEs is tombstoned EXACTLY once.
+        let (a2, r2) = engine
+            .eval_derive_materialize_incremental(PROG, crate::datalog::EvalLimits::none())
+            .expect("retraction run");
+        assert_eq!(
+            (a2, r2),
+            (0, 5),
+            "all 5 owned ISSUEs retract, each counted once (no double-tombstone, none dropped)"
+        );
+        let snap = engine.snapshot();
+        for id in &fn_ids {
+            let issue_id = crate::graph::string_id_to_u128(&format!("issue::{id}"));
+            assert!(
+                !engine.store.node_exists_at(&snap, issue_id),
+                "owned ISSUE retracted"
+            );
+        }
+
+        // Run 3: idempotent no-op (nothing left to add or remove).
+        let (a3, r3) = engine
+            .eval_derive_materialize_incremental(PROG, crate::datalog::EvalLimits::none())
+            .expect("idempotent re-run");
+        assert_eq!((a3, r3), (0, 0), "nothing left to retract");
     }
 
     /// A `@materialize_node` head whose arity is not `3 + len(meta)` aborts the run with


### PR DESCRIPTION
## Source

`_ai/gaps.md` → "@materialize_node advisory follow-ups (W4 review wf_4abcf48c-1d8, 2026-06-10)" item **#4** — *"O(owned²): removed_node_ids is a Vec scanned per node of the type; HashSet one-liner."* No open GitHub issue / Linear ticket; triaged from the recorded gap (sibling of the shipped #1 → PR #424, #3 → PR #426, #5 → PR #425; #2 in flight → PR #429).

This is a **perf refactor**, not a bug fix — behavior is identical before/after — so there is no red-first test; the new test is a behavior-lock characterization (see Tests).

## SPEC

**Invariant preserved (not changed):** a `@materialize` write-back over a `node_type` with K owned nodes tombstones each owned-and-no-longer-derived node **exactly once**. The change is the *cost* of computing that set, not the set.

**Given** an EXCLUSIVE `@materialize_node` whose type has K owned nodes in the graph
**When** the incremental write-back computes the owned-node retraction set
**Then** it does O(N) work (N = nodes of that type) — was O(N×K) ≈ O(N²) — and emits the identical tombstone set, identical `(added, removed)` counts, identical resulting graph.

## Root cause (verified at HEAD before fix)

`materialize_writeback_delta` (`packages/rfdb-server/src/graph/engine_v2.rs`) built its owned-node retraction set in a `Vec<u128>` and used `removed_node_ids.contains(&n.id)` as the dedup guard. `find_nodes_at(snapshot, type)` yields **all N** nodes of the type, and each iteration scanned the growing Vec of up-to-K already-claimed ids linearly → **O(N×K) ≈ O(N²)** on the hot incremental re-run path (a node-materializing pack over a big graph re-runs this every commit). The sibling **edge**-removal path in the *same function* (`prev_keys` / `new_keys` / `additive_types`) was already `HashSet`-based; the node path — added later for the owned-node-staleness fix (W4 #5) — was the sole remaining linear-scan instance.

## Fix

```rust
// was: let mut removed_node_ids: Vec<u128> = Vec::new();  ...  .push(n.id);
let mut removed_node_ids: HashSet<u128> = HashSet::new();   // HashSet already in fn scope
...
removed_node_ids.insert(n.id);
```

`.contains` probe → O(1); `insert` is inherently idempotent. Every downstream use is set-compatible: `.len()` (distinct count, identical to the dedup'd Vec), `.is_empty()` (×2, for `CommitTouch`), and `for id in &removed_node_ids { delete_node(*id) }` — deletion order is irrelevant because `delete_node` records into a tombstone **set**.

## Before / After (test evidence)

New RED-not-applicable behavior-lock test (perf refactor) `materialize_node_retraction_tombstones_each_owned_node_exactly_once`: 5 FUNCTION nodes → 5 owned ISSUEs; delete every FUNCTION; a derives-nothing re-run retracts all 5 **exactly once**:

```
assert_eq!((a2, r2), (0, 5), "all 5 owned ISSUEs retract, each counted once (no double-tombstone, none dropped)");
```

Passes on both the prior `Vec` and the new `HashSet` (behavior is identical) — it locks the removal-count invariant the set must preserve and exercises the changed loop at K=5.

## Adversarial review

- **Round A (correctness):** empty `node_specs` → empty set, same as before. `additive` spec → `continue`, never inserts. A node already in `new_node_ids` (a HashSet) is skipped first (unchanged). `n_removed = removed.len() + removed_node_ids.len()` — the old Vec was already dedup'd by its `.contains` guard, so `len()` is identical. HashSet iteration order differs but `delete_node` is order-independent (tombstone set), and counts are order-independent. **Verdict: behavior-identical, sound.**
- **Round B (structural):** one type swap (`Vec`→`HashSet`, `push`→`insert`), `HashSet` already imported in the function scope. No new coupling. *Pre-existing note:* `engine_v2.rs` is a >5000-line god-file (already flagged on #429) — not materially worsened; extraction out of scope.
- **Round C (class-not-instance):** the edge-removal path in the same function is already HashSet-based, so the node path was the only sibling. Grep of `.contains(&` in `engine_v2.rs` / `materialize.rs` shows the only remaining hits are test assertions. **Class complete; no follow-ups filed.**

## Blast radius

Touches only the local `removed_node_ids` accumulator inside `materialize_writeback_delta` (the three entries `eval_derive_materialize` / `_incremental` / maintain all funnel through it). No wire/API/storage type changes. Rust-only in `rfdb-server` — no JS/TS, so the pnpm gate is unaffected.

## Verification (actual)

```
cargo test --profile fast --lib materialize → 47 passed; 0 failed (1 ignored)
cargo test --profile fast --lib derive::    → 310 passed; 0 failed (22 ignored)
cargo test --profile fast --lib (full rfdb) → 1407 passed; 0 failed (25 ignored)
cargo clippy --profile fast --lib           → exit 0, no new warnings
  (the one `unused import: HashSet` is pre-existing in src/sa_layout.rs:14, unrelated)
```

## Memory write-back

`_ai/gaps.md` W4 item **#4** marked ✅ RESOLVED with the evidence above. Items #2 (PR #429), #6, #7 (#7 STALE) tracked separately.

**DO NOT auto-merge — Vadim reviews.**

🤖 Generated with [Claude Code](https://claude.ai/code/session_01Qf2baUjA5uvfhtttLrUh8U)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qf2baUjA5uvfhtttLrUh8U)_