### PR TITLE
feat(haskell-analyzer): DoScope per do-block — do-bind binders in own scope (REFS single-target residual) — W23

### DIFF
--- a/packages/haskell-analyzer/src/Rules/Expressions.hs
+++ b/packages/haskell-analyzer/src/Rules/Expressions.hs
@@ -637,16 +637,63 @@ walkGRHSResult (L _ (GRHS _ _guards body)) =
 
 -- | Walk do-block statements, returning the result ID from the last
 -- statement. Used for DFG edge emission on DO_BLOCK nodes.
-walkStmtsResult :: [GenLocated l (StmtLR GhcPs GhcPs (LHsExpr GhcPs))] -> Analyzer (Maybe T.Text)
+--
+-- Haskell @do@ desugars right-associatively: @x <- e; rest@ becomes
+-- @e >>= \\x -> rest@, so a do-bind binder is in scope only for the
+-- /remaining/ statements, not for its own RHS. We mirror that here by
+-- minting a fresh 'DoScope' per binding statement (@BindStmt@\/@LetStmt@)
+-- and walking the rest of the block inside it. Consequences:
+--
+--   * sibling do-blocks (e.g. two Hspec @it@ bodies) get
+--     position-stamped, hence distinct, DoScope ids — they never share
+--     a scope;
+--   * two @results <-@ binds inside ONE do-block land in two DISTINCT
+--     nested DoScopes (each opens its own), so a single scope holds at
+--     most one same-name do-bind binder — the @wwspr3tzq@ fanout=2
+--     case is gone.
+--
+-- The bind's RHS ('body') is walked in the CURRENT (outer) scope before
+-- the new scope is pushed, since the binder is not visible in its own
+-- RHS. Non-binding statements ('BodyStmt'\/'LastStmt') introduce no
+-- binder and so do not open a scope.
+walkStmtsResult :: [GenLocated SrcSpanAnnA (StmtLR GhcPs GhcPs (LHsExpr GhcPs))] -> Analyzer (Maybe T.Text)
 walkStmtsResult [] = return Nothing
 walkStmtsResult [s] = walkStmtResult s
-walkStmtsResult (s:ss) = do
-  _ <- walkStmtResult s
-  walkStmtsResult ss
+walkStmtsResult (s@(L _ stmt) : ss) =
+  case stmt of
+    -- x <- expr : binder is visible in `ss`, so open a fresh DoScope
+    -- (anchored on this statement's position) and walk the rest inside.
+    BindStmt _ pat body -> do
+      _ <- walkExpr body              -- RHS: outer scope (binder not in scope yet)
+      anchor <- doStmtAnchor s
+      withScopeNode DoScope anchor $ do
+        walkPat pat                   -- binder lands in the NEW scope
+        walkStmtsResult ss
+    -- let binds : let-bound names are visible in `ss`; same treatment.
+    LetStmt _ binds -> do
+      anchor <- doStmtAnchor s
+      withScopeNode DoScope anchor $ do
+        walkLocalBinds binds
+        walkStmtsResult ss
+    -- non-binding statement: introduces no binder, no new scope.
+    _ -> do
+      _ <- walkStmtResult s
+      walkStmtsResult ss
 
--- | Walk a do-block statement, recursing into contained expressions.
--- Returns the result ID of the statement's expression (if any).
-walkStmtResult :: GenLocated l (StmtLR GhcPs GhcPs (LHsExpr GhcPs)) -> Analyzer (Maybe T.Text)
+-- | The anchor for a do-bind's 'DoScope': @\<enclosingScopeId\>:do@\<line\>:\<col\>@.
+-- Position-stamped on the binding statement so sibling do-blocks /and/
+-- successive binds within one block never collide.
+doStmtAnchor :: GenLocated SrcSpanAnnA (StmtLR GhcPs GhcPs (LHsExpr GhcPs)) -> Analyzer T.Text
+doStmtAnchor lstmt = do
+  parent <- askScopeId
+  let (line, col, _, _) = getLoc lstmt
+  return (parent <> ":do@" <> T.pack (show line) <> ":" <> T.pack (show col))
+
+-- | Walk a single do-block statement, recursing into contained
+-- expressions. Returns the result ID of the statement's expression (if
+-- any). Used for the LAST statement and non-binding statements, where no
+-- new scope is opened (see 'walkStmtsResult' for the binding cases).
+walkStmtResult :: GenLocated SrcSpanAnnA (StmtLR GhcPs GhcPs (LHsExpr GhcPs)) -> Analyzer (Maybe T.Text)
 walkStmtResult (L _ stmt) = case stmt of
   -- x <- expr
   BindStmt _ pat body -> do

--- a/packages/haskell-analyzer/test/Spec.hs
+++ b/packages/haskell-analyzer/test/Spec.hs
@@ -1113,3 +1113,55 @@ main = hspec $ do
       length caseScopes `shouldBe` 2
       let ids = map gnId caseScopes
       length ids `shouldBe` length (dedup ids)
+
+    it "do-bind statement gets its own DoScope" $ do
+      let src = T.unlines
+            [ "module Test where"
+            , "f = do"
+            , "  x <- getLine"
+            , "  putStrLn x"
+            ]
+      let Right fa = analyzeSource "Test.hs" src
+      let scopes = filter (\n -> gnType n == "SCOPE") (faNodes fa)
+      map gnName scopes `shouldContain` ["do"]
+
+    it "two same-name do-binds in ONE do-block land in DISTINCT scopes (wwspr3tzq)" $ do
+      -- THE regression fixture: two `results <-` in one clause must NOT
+      -- collapse into a single scope (was fanout=2). Each bind opens its
+      -- own nested DoScope, so each PARAMETER `results` is CONTAINS'd from
+      -- a DISTINCT scope.
+      let src = T.unlines
+            [ "module Test where"
+            , "f = do"
+            , "  results <- step1"
+            , "  _ <- consume results"
+            , "  results <- step2"
+            , "  consume results"
+            ]
+      let Right fa = analyzeSource "Test.hs" src
+      let paramsR = filter (\n -> gnType n == "PARAMETER" && gnName n == "results") (faNodes fa)
+      length paramsR `shouldBe` 2
+      let paramScopes = concatMap (scopeOf fa . gnId) paramsR
+      length paramScopes `shouldBe` 2
+      -- distinct scopes => at most one same-name do-bind binder per scope
+      length paramScopes `shouldBe` length (dedup paramScopes)
+
+    it "sibling do-blocks binding the same name get DISTINCT scopes" $ do
+      -- two independent do-blocks (e.g. sibling guard branches / Hspec it
+      -- bodies) that each bind `results` must not share a DoScope.
+      let src = T.unlines
+            [ "module Test where"
+            , "f a"
+            , "  | a = do"
+            , "      results <- step1"
+            , "      consume results"
+            , "  | otherwise = do"
+            , "      results <- step2"
+            , "      consume results"
+            ]
+      let Right fa = analyzeSource "Test.hs" src
+      let paramsR = filter (\n -> gnType n == "PARAMETER" && gnName n == "results") (faNodes fa)
+      length paramsR `shouldBe` 2
+      let paramScopes = concatMap (scopeOf fa . gnId) paramsR
+      length paramScopes `shouldBe` 2
+      (head paramScopes /= last paramScopes) `shouldBe` True


### PR DESCRIPTION
## Motivation

PR #427 introduced finer lexical SCOPE nodes per function-clause / lambda / where / let / case, but deliberately left `HsDo` out: do-block `x <- e` `BindStmt`s got no scope of their own and so collapsed into the enclosing **clause** scope. The result was a residual REFS fanout: two `results <-` binds in one do-block (the `wwspr3tzq` case) landed in a single scope, so a scope-walk resolver pack saw fanout=2 and could not pick the nearest single binder.

This PR closes that residual by mirroring #427's `withScopeNode` mechanism for do-blocks. Haskell `do` desugars right-associatively (`x <- e; rest` ≡ `e >>= \x -> rest`), so a do-bind binder is in scope only for the **remaining** statements, not its own RHS. We mint a fresh `DoScope` per binding statement (`BindStmt`/`LetStmt`), walk the bind's RHS in the **outer** scope (binder not yet visible), then push the new scope and walk the rest of the block — the binder lands in the new scope. Non-binding statements (`BodyStmt`/`LastStmt`) introduce no binder and open no scope. The scope is position-stamped (`<enclosingScopeId>:do@<line>:<col>`) so sibling do-blocks and successive binds never collide.

This completes the finer-scope enabler for the intent-faithful REFS resolution pack: with do-binds isolated, a single scope holds at most one same-name do-bind binder, giving the resolver a single nearest target per scope walk.

## Differential

Real-corpus run (982 `.hs` analyzed: ghc-lib-parser 9.8.5 + haskell-analyzer's own sources), BEFORE = `origin/main` (has #427 finer-scope, no DoScope) vs AFTER = this branch:

| metric | BEFORE | AFTER |
|---|---|---|
| `DoScope` (SCOPE name="do") nodes | 0 | 5007 |
| max same-name PARAMETER/VARIABLE binders in one scope | 3 (`mkSpliceDecl` clause, `cs`) | 3 (`pprStgAlt` clause, `pun-right-hand-side`) |
| scopes with >1 same-name binder (fanout) | 118 | **18** |

- **5007 DoScope nodes** appear where there were none — every do-bind now opens its own scope.
- **Fanout scopes 118 → 18 (−100, 85% drop):** the eliminated 100 were exactly the do-bind binders that previously collapsed into the clause scope; they are now isolated into their own DoScopes. The max binder figure stays at 3 because that case is a non-do clause (record/multi-pattern `cs`/`pun-right-hand-side`), correctly out of scope for DoScope — but the do-bind-dominated fanout is gone.
- **Sibling do-blocks distinct:** two independent do-blocks (e.g. sibling guard branches / Hspec `it` bodies) that each bind the same name now get position-stamped, distinct DoScope ids (verified in tests below); two binds within one block likewise open two distinct nested DoScopes.

## Tests

`cabal test`: **114 examples / 0 failures** (3 new specs in "Finer lexical scopes"):

- `do-bind statement gets its own DoScope` — a `x <- e` bind mints a SCOPE named `do`.
- `two same-name do-binds in ONE do-block land in DISTINCT scopes (wwspr3tzq)` — the regression fixture: two `results <-` in one clause → two distinct scopes, each holding one binder.
- `sibling do-blocks binding the same name get DISTINCT scopes` — two do-blocks under sibling guards each binding `results` never share a DoScope.

See `_ai/research/haskell-resolve-intent-spec.md` for the intent-faithful REFS pack that rides on this.

DO NOT MERGE — Vadim reviews structural graph changes.