### PR TITLE
feat(effects-db): annotate axios HTTP client (http-bridge sender)

### DIFF
--- a/effects-db/packages/axios.yaml
+++ b/effects-db/packages/axios.yaml
@@ -8,9 +8,17 @@
 # Why this package matters for Grafema:
 #   The effects-db already annotates the HTTP *server* side (express →
 #   IO:HTTP:LISTEN). The `http` bridge pattern (effects-db/bridges.yaml) pairs a
-#   sender with `IO:HTTP:REQUEST` to a receiver with `IO:HTTP:LISTEN` to emit
-#   CALLS_REMOTE edges. axios is the most-used HTTP *client* on npm, so annotating
-#   its request surface lights up the sender side of that bridge.
+#   sender with `IO:HTTP:REQUEST` to a receiver with `IO:HTTP:LISTEN`. axios is the
+#   most-used HTTP *client* on npm, so annotating its request surface supplies the
+#   sender-side effect — `IO:HTTP:REQUEST` previously lived only in the node.yaml
+#   runtime (http.request / fetch), in zero packages.
+#
+# How these annotations are consumed (verified):
+#   `traceEffects` (packages/util/src/queries/traceEffects.ts) — the engine behind
+#   the MCP `trace-effects` handler and behaviorEnricher — resolves an unresolved
+#   `axios.get`-style call through `EffectsLookup.lookup('axios', 'get')` and
+#   propagates the returned effects transitively. test/unit/effectsDbAxios.test.js
+#   exercises exactly this path on a fixture graph.
 #
 # Effect conventions used here:
 #   - Request methods emit [IO, IO:HTTP:REQUEST, ASYNC, THROW]:
@@ -18,24 +26,25 @@
 #         http.request / fetch, which list parent IO alongside the subtype).
 #       * ASYNC — returns a Promise.
 #       * THROW — unlike fetch, axios's default `validateStatus` REJECTS on a
-#         non-2xx response, so awaiting a 4xx/5xx throws. This is the key
-#         behavioural difference from fetch and is load-bearing for callers that
-#         must be marked as possibly-throwing.
-#   - `create` is a PURE factory; its return is annotated `AxiosInstance` so calls
-#     on the configured instance (`const c = axios.create(); c.get(...)`) resolve
-#     back to axios via the receiver-tracing logic in libraryCallbackEnricher —
-#     the same mechanism express uses for `express()` → Application.
+#         non-2xx response, so awaiting a 4xx/5xx throws.
 #   - Data/helper utilities that touch neither the network nor shared state are
-#     PURE. No arg roles are declared: the `http` bridge extracts the URL from
-#     arg[0] directly (see bridges.yaml), and effects-db arg roles are only read
-#     for callback/route/command/tool-schema fan-out, none of which apply here.
+#     PURE (so callers aren't conservatively marked UNKNOWN).
+#   - No arg roles or `returns.type` are declared: the only consumer of structured
+#     entries (args[N].role / returns.type / channel) is the GENERATED registry
+#     effects_callable_facts.dl, whose generator (scripts/generate-effects-
+#     callable-facts.mjs) INCLUDES an entry only if it carries a role-annotated
+#     arg or a channel map — returns-only entries are excluded ("no pack consumes
+#     bare returns yet"). Declaring `axios.create → AxiosInstance` would therefore
+#     be inert: there is no receiver-type tracing that maps a `const c =
+#     axios.create(); c.get()` instance call back to axios today. That gap
+#     (instance-method effect resolution for factory-returned objects) is real but
+#     out of scope for a data-only effects-db entry — see PR follow-ups.
 
 axios:
-  # ---------------------------------------------------------------------------
-  # Default-export request methods. The bare callable form `axios(config)` and
-  # `axios(url, config)` share these effects but is not keyed here because the
-  # call-target parser needs a `module.method` shape.
-  # ---------------------------------------------------------------------------
+  # Default-export request methods. The bare callable form `axios(config)` /
+  # `axios(url, config)` shares these effects but is not keyed here because the
+  # call-target parser (EffectsLookup.parseCallTarget) needs a `module.method`
+  # shape.
   request: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
   get: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
   delete: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
@@ -48,17 +57,7 @@ axios:
   putForm: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
   patchForm: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
 
-  # ---------------------------------------------------------------------------
-  # Factory — returns a configured AxiosInstance (no IO of its own).
-  # ---------------------------------------------------------------------------
-  create:
-    effects: [PURE]
-    returns:
-      type: AxiosInstance
-
-  # ---------------------------------------------------------------------------
   # Aggregator / helpers — pure or async-only, never network IO themselves.
-  # ---------------------------------------------------------------------------
   all: [ASYNC]            # Promise.all wrapper (deprecated); no direct IO
   spread: [PURE]          # returns a function that spreads an array of results
   isAxiosError: [PURE]    # type guard
@@ -66,22 +65,3 @@ axios:
   getUri: [PURE]          # builds a request URI string from config; no network
   toFormData: [PURE]      # serialize object → FormData
   formToJSON: [PURE]      # deserialize FormData/HTMLForm → object
-
-  # ---------------------------------------------------------------------------
-  # AxiosInstance — the object returned by axios.create(). Same request surface
-  # as the default export, keyed as `AxiosInstance.<method>` so receiver tracing
-  # resolves `const c = axios.create(); c.get(...)` back to axios (mirrors
-  # express's Application.* / Router.* convention).
-  # ---------------------------------------------------------------------------
-  AxiosInstance.request: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
-  AxiosInstance.get: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
-  AxiosInstance.delete: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
-  AxiosInstance.head: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
-  AxiosInstance.options: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
-  AxiosInstance.post: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
-  AxiosInstance.put: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
-  AxiosInstance.patch: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
-  AxiosInstance.postForm: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
-  AxiosInstance.putForm: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
-  AxiosInstance.patchForm: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
-  AxiosInstance.getUri: [PURE]

--- a/effects-db/packages/axios.yaml
+++ b/effects-db/packages/axios.yaml
@@ -1,0 +1,87 @@
+# axios (1.x) — Promise-based HTTP client
+# Generated: 2026-06-15 (autonomous effects-db fill, fallback track)
+# Method: Claude inference from axios v1.x public API docs, cross-checked against
+#         the node.yaml HTTP convention and effects-db/bridges.yaml `http` pattern.
+# Taxonomy version: 2
+# purl: pkg:npm/axios
+#
+# Why this package matters for Grafema:
+#   The effects-db already annotates the HTTP *server* side (express →
+#   IO:HTTP:LISTEN). The `http` bridge pattern (effects-db/bridges.yaml) pairs a
+#   sender with `IO:HTTP:REQUEST` to a receiver with `IO:HTTP:LISTEN` to emit
+#   CALLS_REMOTE edges. axios is the most-used HTTP *client* on npm, so annotating
+#   its request surface lights up the sender side of that bridge.
+#
+# Effect conventions used here:
+#   - Request methods emit [IO, IO:HTTP:REQUEST, ASYNC, THROW]:
+#       * IO + IO:HTTP:REQUEST — outgoing HTTP request (mirrors node.yaml's
+#         http.request / fetch, which list parent IO alongside the subtype).
+#       * ASYNC — returns a Promise.
+#       * THROW — unlike fetch, axios's default `validateStatus` REJECTS on a
+#         non-2xx response, so awaiting a 4xx/5xx throws. This is the key
+#         behavioural difference from fetch and is load-bearing for callers that
+#         must be marked as possibly-throwing.
+#   - `create` is a PURE factory; its return is annotated `AxiosInstance` so calls
+#     on the configured instance (`const c = axios.create(); c.get(...)`) resolve
+#     back to axios via the receiver-tracing logic in libraryCallbackEnricher —
+#     the same mechanism express uses for `express()` → Application.
+#   - Data/helper utilities that touch neither the network nor shared state are
+#     PURE. No arg roles are declared: the `http` bridge extracts the URL from
+#     arg[0] directly (see bridges.yaml), and effects-db arg roles are only read
+#     for callback/route/command/tool-schema fan-out, none of which apply here.
+
+axios:
+  # ---------------------------------------------------------------------------
+  # Default-export request methods. The bare callable form `axios(config)` and
+  # `axios(url, config)` share these effects but is not keyed here because the
+  # call-target parser needs a `module.method` shape.
+  # ---------------------------------------------------------------------------
+  request: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+  get: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+  delete: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+  head: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+  options: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+  post: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+  put: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+  patch: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+  postForm: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+  putForm: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+  patchForm: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+
+  # ---------------------------------------------------------------------------
+  # Factory — returns a configured AxiosInstance (no IO of its own).
+  # ---------------------------------------------------------------------------
+  create:
+    effects: [PURE]
+    returns:
+      type: AxiosInstance
+
+  # ---------------------------------------------------------------------------
+  # Aggregator / helpers — pure or async-only, never network IO themselves.
+  # ---------------------------------------------------------------------------
+  all: [ASYNC]            # Promise.all wrapper (deprecated); no direct IO
+  spread: [PURE]          # returns a function that spreads an array of results
+  isAxiosError: [PURE]    # type guard
+  isCancel: [PURE]        # type guard
+  getUri: [PURE]          # builds a request URI string from config; no network
+  toFormData: [PURE]      # serialize object → FormData
+  formToJSON: [PURE]      # deserialize FormData/HTMLForm → object
+
+  # ---------------------------------------------------------------------------
+  # AxiosInstance — the object returned by axios.create(). Same request surface
+  # as the default export, keyed as `AxiosInstance.<method>` so receiver tracing
+  # resolves `const c = axios.create(); c.get(...)` back to axios (mirrors
+  # express's Application.* / Router.* convention).
+  # ---------------------------------------------------------------------------
+  AxiosInstance.request: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+  AxiosInstance.get: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+  AxiosInstance.delete: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+  AxiosInstance.head: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+  AxiosInstance.options: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+  AxiosInstance.post: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+  AxiosInstance.put: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+  AxiosInstance.patch: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+  AxiosInstance.postForm: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+  AxiosInstance.putForm: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+  AxiosInstance.patchForm: [IO, IO:HTTP:REQUEST, ASYNC, THROW]
+  AxiosInstance.getUri: [PURE]

--- a/effects-db/packages/axios.yaml
+++ b/effects-db/packages/axios.yaml
@@ -6,12 +6,16 @@
 # purl: pkg:npm/axios
 #
 # Why this package matters for Grafema:
-#   The effects-db already annotates the HTTP *server* side (express →
-#   IO:HTTP:LISTEN). The `http` bridge pattern (effects-db/bridges.yaml) pairs a
-#   sender with `IO:HTTP:REQUEST` to a receiver with `IO:HTTP:LISTEN`. axios is the
-#   most-used HTTP *client* on npm, so annotating its request surface supplies the
-#   sender-side effect — `IO:HTTP:REQUEST` previously lived only in the node.yaml
-#   runtime (http.request / fetch), in zero packages.
+#   The effects-db already annotates the HTTP *server* (receiver) side —
+#   `IO:HTTP:LISTEN` lives on the node.yaml runtime (http.createServer /
+#   Server.listen / https.createServer). (Note: express.yaml's own
+#   `Application.listen` is only `[IO, ASYNC]`, not refined to IO:HTTP:LISTEN —
+#   an express-side subtype gap, tracked separately.) The `http` bridge pattern
+#   (effects-db/bridges.yaml) pairs a sender carrying `IO:HTTP:REQUEST` with a
+#   receiver carrying `IO:HTTP:LISTEN`. axios is the most-used HTTP *client* on
+#   npm, so annotating its request surface supplies the sender-side effect —
+#   `IO:HTTP:REQUEST` previously lived only in the node.yaml runtime
+#   (http.request / fetch), in zero packages.
 #
 # How these annotations are consumed (verified):
 #   `traceEffects` (packages/util/src/queries/traceEffects.ts) — the engine behind

--- a/test/unit/effectsDbAxios.test.js
+++ b/test/unit/effectsDbAxios.test.js
@@ -4,23 +4,28 @@
  * Why this exists:
  *   - The effects-db had an HTTP *server* (express → IO:HTTP:LISTEN) but no
  *     popular HTTP *client*. The `http` bridge pattern (effects-db/bridges.yaml)
- *     matches a sender with `IO:HTTP:REQUEST` to a receiver with `IO:HTTP:LISTEN`
- *     to synthesize CALLS_REMOTE edges. Without an annotated client package, the
- *     sender side of that bridge is invisible for the ~50M-weekly-download axios.
- *   - This test pins the effect annotations so a future edit can't silently drop
- *     IO:HTTP:REQUEST (which would break http-bridge sender detection) or
- *     mis-annotate the pure helpers as effectful (which would pollute effect
- *     propagation with false IO/THROW).
+ *     pairs a sender carrying `IO:HTTP:REQUEST` with a receiver carrying
+ *     `IO:HTTP:LISTEN`. Without an annotated client, the sender-side effect was
+ *     absent from every package for the ~50M-weekly-download axios.
  *
- * It asserts GRAPH-INDEPENDENT facts only — that the YAML loads and the
- * documented lookups resolve — because this environment cannot run a live
- * analyze. End-to-end bridge detection on a real axios-using repo is a separate
- * live-graph validation (out of scope here).
+ * What this guards:
+ *   1. STRUCTURE — the request methods carry IO:HTTP:REQUEST and the pure helpers
+ *      stay pure, so a future edit can't silently drop the bridge-sender effect or
+ *      mark a pure helper effectful.
+ *   2. FUNCTION — the annotations actually flow through the real propagation
+ *      engine. `traceEffects` (the code behind the MCP `trace-effects` handler and
+ *      behaviorEnricher) is run over a fixture graph: a FUNCTION that calls
+ *      `axios.get`, and the transitive effects must include IO:HTTP:REQUEST. This
+ *      is the same mock-backend pattern as trace-effects.test.js — no live server.
+ *
+ * Not covered here (honest scope): a full `grafema analyze` run and the actual
+ * materialization of CALLS_REMOTE edges by the http bridge require a live graph
+ * (GHC + rfdb-server) and are validated separately.
  */
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { EffectsLookup } from '@grafema/util';
+import { EffectsLookup, traceEffects } from '@grafema/util';
 import { join } from 'node:path';
 
 const EFFECTS_DB_PATH = join(import.meta.dirname, '..', '..', 'effects-db');
@@ -31,49 +36,78 @@ const REQUEST_METHODS = [
   'post', 'put', 'patch', 'postForm', 'putForm', 'patchForm',
 ];
 
+/** Minimal in-memory DataflowBackend (mirrors trace-effects.test.js). */
+function createMockBackend(nodes, edges) {
+  const nodeMap = new Map(nodes.map(n => [n.id, n]));
+  return {
+    async getNode(id) { return nodeMap.get(id) || null; },
+    async *queryNodes(filter) {
+      for (const n of nodes) {
+        if (filter.type && n.type !== filter.type) continue;
+        if (filter.name && n.name !== filter.name) continue;
+        yield n;
+      }
+    },
+    async getOutgoingEdges(id, types) {
+      return edges.filter(e => e.src === id && (!types || types.includes(e.type)));
+    },
+    async getIncomingEdges(id, types) {
+      return edges.filter(e => e.dst === id && (!types || types.includes(e.type)));
+    },
+  };
+}
+
+// ── STRUCTURE ───────────────────────────────────────────────────────────────
+
 test('axios request methods carry IO:HTTP:REQUEST (http-bridge sender)', () => {
   const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
   for (const m of REQUEST_METHODS) {
     const effects = lookup.lookup('axios', m);
     assert.ok(effects, `Expected effects for axios.${m}`);
-    assert.ok(
-      effects.includes('IO:HTTP:REQUEST'),
-      `axios.${m} must include IO:HTTP:REQUEST, got: ${effects}`,
-    );
+    assert.ok(effects.includes('IO:HTTP:REQUEST'), `axios.${m} must include IO:HTTP:REQUEST, got: ${effects}`);
     assert.ok(effects.includes('IO'), `axios.${m} must include parent IO, got: ${effects}`);
     assert.ok(effects.includes('ASYNC'), `axios.${m} must include ASYNC, got: ${effects}`);
-  }
-});
-
-test('axios.create is a pure factory returning an AxiosInstance', () => {
-  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
-  assert.deepEqual(lookup.lookup('axios', 'create'), ['PURE']);
-  const entry = lookup.getEntry('axios', 'create');
-  assert.ok(entry, 'Expected an entry for axios.create');
-  assert.equal(entry.returns?.type, 'AxiosInstance', 'axios.create must declare returns.type AxiosInstance');
-});
-
-test('AxiosInstance request methods mirror the default export (post-create() usage)', () => {
-  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
-  // Instance methods are keyed as `<ReturnType>.<method>` under the package,
-  // mirroring express's `Application.get` / `Router.get` convention.
-  for (const m of REQUEST_METHODS) {
-    const effects = lookup.lookup('axios', `AxiosInstance.${m}`);
-    assert.ok(effects, `Expected effects for axios AxiosInstance.${m}`);
-    assert.ok(
-      effects.includes('IO:HTTP:REQUEST'),
-      `AxiosInstance.${m} must include IO:HTTP:REQUEST, got: ${effects}`,
-    );
   }
 });
 
 test('axios pure helpers are not effectful', () => {
   const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
   for (const helper of ['isAxiosError', 'isCancel', 'getUri', 'toFormData', 'formToJSON', 'spread']) {
-    assert.deepEqual(
-      lookup.lookup('axios', helper),
-      ['PURE'],
-      `axios.${helper} must be PURE`,
-    );
+    assert.deepEqual(lookup.lookup('axios', helper), ['PURE'], `axios.${helper} must be PURE`);
   }
+});
+
+// ── FUNCTION (real engine, fixture graph, no server) ─────────────────────────
+
+test('traceEffects propagates IO:HTTP:REQUEST from an axios.get call', async () => {
+  const effectsLookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  const nodes = [
+    { id: 'fn1', type: 'FUNCTION', name: 'fetchUser', file: 'src/api.ts', line: 1 },
+    { id: 'ext1', type: 'EXTERNAL_MODULE', name: 'axios.get', file: undefined },
+  ];
+  const edges = [{ src: 'fn1', dst: 'ext1', type: 'CALLS' }];
+  const backend = createMockBackend(nodes, edges);
+
+  const result = await traceEffects(backend, 'fn1', effectsLookup);
+  assert.ok(result, 'Expected non-null result');
+  assert.ok(
+    result.transitive.includes('IO:HTTP:REQUEST'),
+    `Expected IO:HTTP:REQUEST in transitive effects, got: ${result.transitive}`,
+  );
+  assert.ok(result.transitive.includes('IO'), `Expected parent IO, got: ${result.transitive}`);
+  assert.equal(result.leaf_sources[0].node, 'axios.get');
+});
+
+test('traceEffects leaves an axios.getUri call pure (no false IO)', async () => {
+  const effectsLookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  const nodes = [
+    { id: 'fn1', type: 'FUNCTION', name: 'buildUrl', file: 'src/api.ts', line: 1 },
+    { id: 'ext1', type: 'EXTERNAL_MODULE', name: 'axios.getUri', file: undefined },
+  ];
+  const edges = [{ src: 'fn1', dst: 'ext1', type: 'CALLS' }];
+  const backend = createMockBackend(nodes, edges);
+
+  const result = await traceEffects(backend, 'fn1', effectsLookup);
+  assert.ok(result, 'Expected non-null result');
+  assert.deepEqual(result.transitive, ['PURE'], `axios.getUri must trace as PURE, got: ${result.transitive}`);
 });

--- a/test/unit/effectsDbAxios.test.js
+++ b/test/unit/effectsDbAxios.test.js
@@ -1,0 +1,79 @@
+/**
+ * Effects-db coverage guard for the `axios` HTTP client.
+ *
+ * Why this exists:
+ *   - The effects-db had an HTTP *server* (express → IO:HTTP:LISTEN) but no
+ *     popular HTTP *client*. The `http` bridge pattern (effects-db/bridges.yaml)
+ *     matches a sender with `IO:HTTP:REQUEST` to a receiver with `IO:HTTP:LISTEN`
+ *     to synthesize CALLS_REMOTE edges. Without an annotated client package, the
+ *     sender side of that bridge is invisible for the ~50M-weekly-download axios.
+ *   - This test pins the effect annotations so a future edit can't silently drop
+ *     IO:HTTP:REQUEST (which would break http-bridge sender detection) or
+ *     mis-annotate the pure helpers as effectful (which would pollute effect
+ *     propagation with false IO/THROW).
+ *
+ * It asserts GRAPH-INDEPENDENT facts only — that the YAML loads and the
+ * documented lookups resolve — because this environment cannot run a live
+ * analyze. End-to-end bridge detection on a real axios-using repo is a separate
+ * live-graph validation (out of scope here).
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EffectsLookup } from '@grafema/util';
+import { join } from 'node:path';
+
+const EFFECTS_DB_PATH = join(import.meta.dirname, '..', '..', 'effects-db');
+
+/** The request methods that perform an outgoing HTTP request. */
+const REQUEST_METHODS = [
+  'request', 'get', 'delete', 'head', 'options',
+  'post', 'put', 'patch', 'postForm', 'putForm', 'patchForm',
+];
+
+test('axios request methods carry IO:HTTP:REQUEST (http-bridge sender)', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  for (const m of REQUEST_METHODS) {
+    const effects = lookup.lookup('axios', m);
+    assert.ok(effects, `Expected effects for axios.${m}`);
+    assert.ok(
+      effects.includes('IO:HTTP:REQUEST'),
+      `axios.${m} must include IO:HTTP:REQUEST, got: ${effects}`,
+    );
+    assert.ok(effects.includes('IO'), `axios.${m} must include parent IO, got: ${effects}`);
+    assert.ok(effects.includes('ASYNC'), `axios.${m} must include ASYNC, got: ${effects}`);
+  }
+});
+
+test('axios.create is a pure factory returning an AxiosInstance', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  assert.deepEqual(lookup.lookup('axios', 'create'), ['PURE']);
+  const entry = lookup.getEntry('axios', 'create');
+  assert.ok(entry, 'Expected an entry for axios.create');
+  assert.equal(entry.returns?.type, 'AxiosInstance', 'axios.create must declare returns.type AxiosInstance');
+});
+
+test('AxiosInstance request methods mirror the default export (post-create() usage)', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  // Instance methods are keyed as `<ReturnType>.<method>` under the package,
+  // mirroring express's `Application.get` / `Router.get` convention.
+  for (const m of REQUEST_METHODS) {
+    const effects = lookup.lookup('axios', `AxiosInstance.${m}`);
+    assert.ok(effects, `Expected effects for axios AxiosInstance.${m}`);
+    assert.ok(
+      effects.includes('IO:HTTP:REQUEST'),
+      `AxiosInstance.${m} must include IO:HTTP:REQUEST, got: ${effects}`,
+    );
+  }
+});
+
+test('axios pure helpers are not effectful', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  for (const helper of ['isAxiosError', 'isCancel', 'getUri', 'toFormData', 'formToJSON', 'spread']) {
+    assert.deepEqual(
+      lookup.lookup('axios', helper),
+      ['PURE'],
+      `axios.${helper} must be PURE`,
+    );
+  }
+});

--- a/test/unit/effectsDbAxios.test.js
+++ b/test/unit/effectsDbAxios.test.js
@@ -2,11 +2,13 @@
  * Effects-db coverage guard for the `axios` HTTP client.
  *
  * Why this exists:
- *   - The effects-db had an HTTP *server* (express → IO:HTTP:LISTEN) but no
- *     popular HTTP *client*. The `http` bridge pattern (effects-db/bridges.yaml)
- *     pairs a sender carrying `IO:HTTP:REQUEST` with a receiver carrying
- *     `IO:HTTP:LISTEN`. Without an annotated client, the sender-side effect was
- *     absent from every package for the ~50M-weekly-download axios.
+ *   - The effects-db annotated the HTTP *server* (receiver) side —
+ *     `IO:HTTP:LISTEN` on the node.yaml runtime (http.createServer /
+ *     Server.listen) — but no popular HTTP *client*. The `http` bridge pattern
+ *     (effects-db/bridges.yaml) pairs a sender carrying `IO:HTTP:REQUEST` with a
+ *     receiver carrying `IO:HTTP:LISTEN`. Without an annotated client, the
+ *     sender-side effect was absent from every package for the
+ *     ~50M-weekly-download axios.
  *
  * What this guards:
  *   1. STRUCTURE — the request methods carry IO:HTTP:REQUEST and the pure helpers


### PR DESCRIPTION
## Why

The effects-db annotated the HTTP **server** side (`express` → `IO:HTTP:LISTEN`) but no popular HTTP **client**. The `http` bridge pattern (`effects-db/bridges.yaml`) pairs a sender carrying `IO:HTTP:REQUEST` with a receiver carrying `IO:HTTP:LISTEN`. With no annotated client, the sender-side effect was absent from every package for **axios** (~50M weekly downloads) — `IO:HTTP:REQUEST` previously lived only in the `node.yaml` runtime (`http.request`/`fetch`).

This is the sanctioned effects-db fallback work (0 open GitHub issues; the open analyzer bugs require a live `grafema analyze` graph that this sandbox can't run).

## How it's consumed (verified, not assumed)

`traceEffects` (`packages/util/src/queries/traceEffects.ts`) — the engine behind the MCP `trace-effects` handler and `behaviorEnricher` — resolves an unresolved `axios.get`-style call via `EffectsLookup.lookup('axios','get')` and propagates the effects transitively. The test exercises exactly this path on a fixture graph (same mock-backend pattern as `trace-effects.test.js`, **no live server**).

## What changed (2 files, additive)

- **`effects-db/packages/axios.yaml`** — default-export request methods → `[IO, IO:HTTP:REQUEST, ASYNC, THROW]` (THROW because axios's default `validateStatus` rejects non-2xx, unlike fetch); pure helpers (`isAxiosError`, `isCancel`, `getUri`, `toFormData`, `formToJSON`, `spread`, `all`) → `[PURE]`/`[ASYNC]`.
- **`test/unit/effectsDbAxios.test.js`** — STRUCTURE guards (request methods carry `IO:HTTP:REQUEST`; helpers stay pure) **plus** a FUNCTIONAL test: `traceEffects` over a `FUNCTION → EXTERNAL_MODULE "axios.get"` fixture asserts the transitive set includes `IO:HTTP:REQUEST`, and `axios.getUri` traces as `PURE`.

## Changed after QA review (see reply below)

The first revision incorrectly also added `create: {returns.type: AxiosInstance}` + `AxiosInstance.*` entries and cited `libraryCallbackEnricher` as the receiver-tracing mechanism. That was wrong and is removed:
- `libraryCallbackEnricher` is a documented **NO-OP** (`libraryCallbackEnricher.ts:55-63`).
- The only consumer of structured entries (`args[N].role` / `returns.type` / `channel`) is the **generated** `effects_callable_facts.dl`, whose generator (`scripts/generate-effects-callable-facts.mjs`) **excludes returns-only entries** ("no pack consumes bare returns yet"). Regenerating produces **zero** axios rows — confirming those entries reached no consumer.
- So instance-method effect resolution for `axios.create()`-returned objects is genuinely **unsupported** by today's architecture; it's documented as a gap in the YAML header + follow-ups, not claimed as working.

## Verification (actual)

- `effectsDbAxios.test.js`: `4/4` (incl. the functional `traceEffects` assertion).
- Regression cluster (effects-lookup, trace-effects, effectSurfaceDiff, libraryCallbackEnricher, httpRouteExtractor): `86/86`.
- `pnpm typecheck` → 0 · `pnpm lint` → 0.
- `node scripts/generate-effects-callable-facts.mjs | grep -c axios` → `0` (no stale generated artifact).
- **Not covered (honest scope):** a full `grafema analyze` and the actual materialization of `CALLS_REMOTE` edges by the http bridge need a live graph (GHC + rfdb-server) — validated separately, not in this PR.

## Blast radius

Additive only — a new data file + a new test. No existing effects-db entry or code path modified.

## Follow-ups (not filed — flagging)

- Annotate sibling HTTP clients (`got`, `undici`, `node-fetch`, `superagent`, `ky`).
- Instance-method effect resolution for factory-returned objects (`const c = axios.create(); c.get()`) — needs receiver-type tracing + a derive pack that consumes `returns.type` (the current `effects_callable_facts.dl` generator excludes returns-only entries).
- End-to-end http-bridge validation on a real axios repo with a live graph.

🚫 Not enabling auto-merge — per repo "Vadim reviews" norm.

https://claude.ai/code/session_01WB4v3mqSxDT1oqd9gyRdvJ