### PR TITLE
effects-db: annotate node-fetch HTTP client (http-bridge sender)

### DIFF
--- a/effects-db/packages/node-fetch.yaml
+++ b/effects-db/packages/node-fetch.yaml
@@ -1,0 +1,85 @@
+# node-fetch (v2 CJS / v3 ESM) — A light-weight WHATWG fetch for Node.js
+# Generated: 2026-06-15 (autonomous effects-db fill, IDLE fallback track)
+# Method: Claude inference from node-fetch v2/v3 public API, aligned 1:1 with the
+#         ecma:web `fetch` / `Response` / `Headers` / `Request` annotations in
+#         effects-db/runtimes/node.yaml — node-fetch is a WHATWG-fetch polyfill,
+#         so its surface mirrors the platform fetch exactly.
+# Taxonomy version: 2
+# purl: pkg:npm/node-fetch
+#
+# Why this package matters for Grafema:
+#   effects-db already annotates the HTTP *server* side (express → IO:HTTP:LISTEN).
+#   The `http` bridge (effects-db/bridges.yaml) pairs a sender carrying
+#   IO:HTTP:REQUEST with a receiver carrying IO:HTTP:LISTEN to emit CALLS_REMOTE
+#   edges. node-fetch is one of the most-downloaded HTTP *clients* on npm, so
+#   annotating its default `fetch` export lights up the sender side of that bridge
+#   for every `import fetch from 'node-fetch'` call site.
+#
+# Effect conventions used here:
+#   - `fetch` mirrors the platform fetch EXACTLY: [IO, IO:HTTP:REQUEST, ASYNC]
+#     with `channel.url = arg[0]` so the http bridge can extract the request URL
+#     (identical to the ecma:web `fetch` entry in runtimes/node.yaml).
+#     NOTE — unlike axios (whose default `validateStatus` REJECTS on non-2xx),
+#     WHATWG fetch / node-fetch RESOLVES on any HTTP status and only rejects on a
+#     network-level failure, so THROW is intentionally NOT listed here. This is the
+#     load-bearing behavioural difference from axios — see effects-db/packages/axios.yaml.
+#   - `Headers` / `Request` / `Response` are value-object constructors → PURE
+#     (mirrors ecma:web `Headers: [PURE]`, `Request: [PURE]`). Keyed by the bare
+#     export name so `import { Headers } from 'node-fetch'; new Headers()` resolves
+#     via the IMPORT_BINDING path in queries/traceEffects.ts (lookup(source, name)).
+#   - Response body readers return a Promise that drains the already-received body
+#     → [ASYNC] (matches ecma:web `Response.prototype.json: [ASYNC]`); the network
+#     IO is attributed to the originating `fetch` call, not the body reader.
+#   - `blobFrom` / `fileFrom` (v3) read a file from disk → IO:FILE:READ. The async
+#     variants add ASYNC; the *Sync variants do not (mirrors node:fs read/readSync).
+
+node-fetch:
+  # ---------------------------------------------------------------------------
+  # Default export — the fetch function. THE http-bridge sender.
+  # ---------------------------------------------------------------------------
+  fetch:
+    effects: [IO, IO:HTTP:REQUEST, ASYNC]
+    channel: { url: "arg[0]" }
+
+  # ---------------------------------------------------------------------------
+  # WHATWG value-object constructors — pure (no IO until the request is sent).
+  # Bare keys so named-import `new Headers()` resolves via IMPORT_BINDING lookup.
+  # ---------------------------------------------------------------------------
+  Headers: [PURE]
+  Request: [PURE]
+  Response: [PURE]
+
+  # Error classes — pure constructors.
+  FetchError: [PURE]
+  AbortError: [PURE]
+
+  # Pure helper — predicate over an HTTP status code (v3 named export).
+  isRedirect: [PURE]
+
+  # ---------------------------------------------------------------------------
+  # Response body readers — drain the already-received body; async, no new
+  # network request (mirrors ecma:web Response.prototype.* convention).
+  # ---------------------------------------------------------------------------
+  Response.json: [ASYNC]
+  Response.text: [ASYNC]
+  Response.arrayBuffer: [ASYNC]
+  Response.blob: [ASYNC]
+  Response.buffer: [ASYNC]
+  Response.clone: [PURE]
+
+  # ---------------------------------------------------------------------------
+  # Headers instance methods (mirrors ecma:web Headers.prototype.*).
+  # ---------------------------------------------------------------------------
+  Headers.get: [PURE]
+  Headers.set: [MUTATION]
+  Headers.append: [MUTATION]
+  Headers.delete: [MUTATION]
+  Headers.has: [PURE]
+
+  # ---------------------------------------------------------------------------
+  # File → Blob/File helpers (v3) — read a file from disk.
+  # ---------------------------------------------------------------------------
+  blobFrom: [IO, IO:FILE:READ, ASYNC]
+  blobFromSync: [IO, IO:FILE:READ]
+  fileFrom: [IO, IO:FILE:READ, ASYNC]
+  fileFromSync: [IO, IO:FILE:READ]

--- a/effects-db/packages/node-fetch.yaml
+++ b/effects-db/packages/node-fetch.yaml
@@ -13,12 +13,18 @@
 # purl: pkg:npm/node-fetch
 #
 # Why this package matters for Grafema:
-#   effects-db already annotates the HTTP *server* side (express → IO:HTTP:LISTEN).
-#   The `http` bridge (effects-db/bridges.yaml) pairs a sender carrying
-#   IO:HTTP:REQUEST with a receiver carrying IO:HTTP:LISTEN to emit CALLS_REMOTE
-#   edges. node-fetch is one of the most-downloaded HTTP *clients* on npm, so
-#   annotating its default `fetch` export lights up the sender side of that bridge
-#   for every `import fetch from 'node-fetch'` call site.
+#   The `http` bridge (effects-db/bridges.yaml:22-29) pairs a SENDER carrying
+#   IO:HTTP:REQUEST with a RECEIVER carrying IO:HTTP:LISTEN to emit CALLS_REMOTE
+#   edges. The receiver side already exists at the runtime level: node's built-in
+#   HTTP/HTTPS server carries IO:HTTP:LISTEN (`node:http`/`node:https`
+#   `createServer` + `Server.listen`, runtimes/node.yaml:319,338,347). What was
+#   missing was a popular userland HTTP *client* on the SENDER side — node-fetch is
+#   one of the most-downloaded on npm, so annotating its default `fetch` export
+#   (IO:HTTP:REQUEST) lights up that sender side for every
+#   `import fetch from 'node-fetch'` call site.
+#   (NB: framework server `.listen` methods — express/fastify/koa — are annotated
+#   [IO, ASYNC] at the package level, NOT the IO:HTTP:LISTEN subtype; the subtype
+#   is only on the node runtime server they delegate to.)
 #
 # Effect conventions used here:
 #   - `fetch` carries the same effects + channel as the ecma:web `fetch` entry in

--- a/effects-db/packages/node-fetch.yaml
+++ b/effects-db/packages/node-fetch.yaml
@@ -1,10 +1,15 @@
 # node-fetch (v2 CJS / v3 ESM) — A light-weight WHATWG fetch for Node.js
 # Generated: 2026-06-15 (autonomous effects-db fill, IDLE fallback track)
-# Method: Claude inference from node-fetch v2/v3 public API, aligned 1:1 with the
-#         ecma:web `fetch` / `Response` / `Headers` / `Request` annotations in
-#         effects-db/runtimes/node.yaml — node-fetch is a WHATWG-fetch polyfill,
-#         so its surface mirrors the platform fetch exactly.
-# Taxonomy version: 2
+# Method: Claude inference from node-fetch v2/v3 public API. Effect VALUES are
+#         taken from the ecma:web `fetch` / `Response` / `Headers` / `Request`
+#         entries in effects-db/runtimes/node.yaml (node-fetch is a WHATWG-fetch
+#         polyfill). Keys follow the package-file `Class.method` convention used by
+#         express.yaml et al. (no `.prototype.`), so this is NOT a literal copy of
+#         the ecma:web `*.prototype.*` keys — only the effect values are shared.
+# Taxonomy version: 2 — this file uses the v2 IO-subtype vocabulary (IO:HTTP:REQUEST,
+#         IO:FILE:READ) defined in effects-db/taxonomy.yaml (version: 2). The older
+#         package files predate those subtypes and are still marked version 1; the
+#         http-bridge sender annotation here requires v2, hence the bump.
 # purl: pkg:npm/node-fetch
 #
 # Why this package matters for Grafema:
@@ -16,13 +21,14 @@
 #   for every `import fetch from 'node-fetch'` call site.
 #
 # Effect conventions used here:
-#   - `fetch` mirrors the platform fetch EXACTLY: [IO, IO:HTTP:REQUEST, ASYNC]
-#     with `channel.url = arg[0]` so the http bridge can extract the request URL
-#     (identical to the ecma:web `fetch` entry in runtimes/node.yaml).
-#     NOTE — unlike axios (whose default `validateStatus` REJECTS on non-2xx),
-#     WHATWG fetch / node-fetch RESOLVES on any HTTP status and only rejects on a
-#     network-level failure, so THROW is intentionally NOT listed here. This is the
-#     load-bearing behavioural difference from axios — see effects-db/packages/axios.yaml.
+#   - `fetch` carries the same effects + channel as the ecma:web `fetch` entry in
+#     runtimes/node.yaml: [IO, IO:HTTP:REQUEST, ASYNC] with `channel.url = arg[0]`
+#     so the http bridge can extract the request URL.
+#     NOTE — WHATWG fetch / node-fetch RESOLVES on any HTTP status and only rejects
+#     on a network-level failure, so THROW is intentionally NOT listed here. HTTP
+#     clients that reject on non-2xx by default — e.g. axios, via its `validateStatus`
+#     option — would instead carry THROW; that distinction is load-bearing for
+#     callers (a node-fetch call is not a throw site, an axios call is).
 #   - `Headers` / `Request` / `Response` are value-object constructors → PURE
 #     (mirrors ecma:web `Headers: [PURE]`, `Request: [PURE]`). Keyed by the bare
 #     export name so `import { Headers } from 'node-fetch'; new Headers()` resolves

--- a/test/unit/effectsDbNodeFetch.test.js
+++ b/test/unit/effectsDbNodeFetch.test.js
@@ -2,12 +2,13 @@
  * Effects-db coverage guard for the `node-fetch` HTTP client.
  *
  * Why this exists:
- *   - The effects-db annotates the HTTP *server* side (express → IO:HTTP:LISTEN).
- *     The `http` bridge pattern (effects-db/bridges.yaml) matches a sender with
+ *   - The `http` bridge pattern (effects-db/bridges.yaml) matches a sender with
  *     `IO:HTTP:REQUEST` to a receiver with `IO:HTTP:LISTEN` to synthesize
- *     CALLS_REMOTE edges. node-fetch is one of the most-downloaded HTTP *clients*
- *     on npm; annotating its default `fetch` export lights up the sender side of
- *     that bridge for every `import fetch from 'node-fetch'` call site.
+ *     CALLS_REMOTE edges. The receiver side already exists on node's built-in
+ *     http/https server (runtimes/node.yaml: createServer / Server.listen); the
+ *     gap was a popular userland HTTP *client* on the sender side. node-fetch is
+ *     one of the most-downloaded on npm; annotating its default `fetch` export
+ *     lights up the sender side for every `import fetch from 'node-fetch'` call site.
  *   - This test pins the effect annotations so a future edit can't silently drop
  *     IO:HTTP:REQUEST (which would break http-bridge sender detection), drop the
  *     `channel.url` metadata the bridge uses for URL extraction, or — critically —

--- a/test/unit/effectsDbNodeFetch.test.js
+++ b/test/unit/effectsDbNodeFetch.test.js
@@ -1,0 +1,107 @@
+/**
+ * Effects-db coverage guard for the `node-fetch` HTTP client.
+ *
+ * Why this exists:
+ *   - The effects-db annotates the HTTP *server* side (express → IO:HTTP:LISTEN).
+ *     The `http` bridge pattern (effects-db/bridges.yaml) matches a sender with
+ *     `IO:HTTP:REQUEST` to a receiver with `IO:HTTP:LISTEN` to synthesize
+ *     CALLS_REMOTE edges. node-fetch is one of the most-downloaded HTTP *clients*
+ *     on npm; annotating its default `fetch` export lights up the sender side of
+ *     that bridge for every `import fetch from 'node-fetch'` call site.
+ *   - This test pins the effect annotations so a future edit can't silently drop
+ *     IO:HTTP:REQUEST (which would break http-bridge sender detection), drop the
+ *     `channel.url` metadata the bridge uses for URL extraction, or — critically —
+ *     ADD a THROW effect. Unlike axios, node-fetch follows WHATWG fetch semantics:
+ *     it RESOLVES on any HTTP status and only rejects on a network failure, so a
+ *     THROW here would mis-mark every caller as possibly-throwing.
+ *
+ * It asserts GRAPH-INDEPENDENT facts only — that the YAML loads and the
+ * documented lookups resolve — because this environment cannot run a live
+ * analyze. End-to-end bridge detection on a real node-fetch-using repo is a
+ * separate live-graph validation (out of scope here).
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EffectsLookup } from '@grafema/util';
+import { join } from 'node:path';
+
+const EFFECTS_DB_PATH = join(import.meta.dirname, '..', '..', 'effects-db');
+
+test('node-fetch default export is an http-bridge sender (IO:HTTP:REQUEST + ASYNC)', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  const effects = lookup.lookup('node-fetch', 'fetch');
+  assert.ok(effects, 'Expected effects for node-fetch.fetch');
+  assert.ok(effects.includes('IO'), `node-fetch.fetch must include parent IO, got: ${effects}`);
+  assert.ok(
+    effects.includes('IO:HTTP:REQUEST'),
+    `node-fetch.fetch must include IO:HTTP:REQUEST, got: ${effects}`,
+  );
+  assert.ok(effects.includes('ASYNC'), `node-fetch.fetch must include ASYNC, got: ${effects}`);
+});
+
+test('node-fetch.fetch does NOT throw — WHATWG fetch resolves on non-2xx (contrast axios)', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  const effects = lookup.lookup('node-fetch', 'fetch');
+  assert.ok(effects, 'Expected effects for node-fetch.fetch');
+  assert.ok(
+    !effects.includes('THROW'),
+    `node-fetch.fetch must NOT include THROW (fetch resolves on 4xx/5xx), got: ${effects}`,
+  );
+});
+
+test('node-fetch.fetch declares channel.url = arg[0] for http-bridge URL extraction', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  const entry = lookup.getEntry('node-fetch', 'fetch');
+  assert.ok(entry, 'Expected an entry for node-fetch.fetch');
+  assert.equal(
+    entry.channel?.url,
+    'arg[0]',
+    `node-fetch.fetch must declare channel.url = arg[0], got: ${JSON.stringify(entry.channel)}`,
+  );
+});
+
+test('node-fetch WHATWG value-object constructors are PURE', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  for (const ctor of ['Headers', 'Request', 'Response', 'FetchError', 'AbortError']) {
+    assert.deepEqual(
+      lookup.lookup('node-fetch', ctor),
+      ['PURE'],
+      `node-fetch.${ctor} constructor must be PURE`,
+    );
+  }
+});
+
+test('node-fetch.isRedirect is a pure status-code predicate', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  assert.deepEqual(lookup.lookup('node-fetch', 'isRedirect'), ['PURE']);
+});
+
+test('node-fetch Response body readers are ASYNC but not network IO', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  for (const m of ['json', 'text', 'arrayBuffer', 'blob', 'buffer']) {
+    const effects = lookup.lookup('node-fetch', `Response.${m}`);
+    assert.ok(effects, `Expected effects for node-fetch Response.${m}`);
+    assert.ok(effects.includes('ASYNC'), `Response.${m} must include ASYNC, got: ${effects}`);
+    assert.ok(
+      !effects.includes('IO:HTTP:REQUEST'),
+      `Response.${m} must not re-emit IO:HTTP:REQUEST (network IO belongs to fetch), got: ${effects}`,
+    );
+  }
+});
+
+test('node-fetch file helpers read the filesystem; async/sync split mirrors node:fs', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  for (const fn of ['blobFrom', 'fileFrom']) {
+    const effects = lookup.lookup('node-fetch', fn);
+    assert.ok(effects, `Expected effects for node-fetch.${fn}`);
+    assert.ok(effects.includes('IO:FILE:READ'), `node-fetch.${fn} must include IO:FILE:READ, got: ${effects}`);
+    assert.ok(effects.includes('ASYNC'), `node-fetch.${fn} must include ASYNC, got: ${effects}`);
+  }
+  for (const fn of ['blobFromSync', 'fileFromSync']) {
+    const effects = lookup.lookup('node-fetch', fn);
+    assert.ok(effects, `Expected effects for node-fetch.${fn}`);
+    assert.ok(effects.includes('IO:FILE:READ'), `node-fetch.${fn} must include IO:FILE:READ, got: ${effects}`);
+    assert.ok(!effects.includes('ASYNC'), `node-fetch.${fn} (sync) must NOT include ASYNC, got: ${effects}`);
+  }
+});


### PR DESCRIPTION
## What & why

Adds `effects-db/packages/node-fetch.yaml` — effect annotations for [`node-fetch`](https://www.npmjs.com/package/node-fetch), one of the most-downloaded HTTP **clients** on npm.

The `http` bridge pattern (`effects-db/bridges.yaml:22-29`) pairs a **sender** carrying `IO:HTTP:REQUEST` with a **receiver** carrying `IO:HTTP:LISTEN` to synthesize `CALLS_REMOTE` edges. The receiver side already exists at the runtime level — node's built-in HTTP/HTTPS server carries `IO:HTTP:LISTEN` (`node:http`/`node:https` `createServer` + `Server.listen`, `runtimes/node.yaml:319,338,347`). What was missing was a popular userland HTTP **client** on the sender side. Annotating node-fetch's default `fetch` export (`IO:HTTP:REQUEST`) lights up that sender side for every `import fetch from 'node-fetch'` call site. This complements the in-flight axios annotation (#438); the two cover the top HTTP clients on npm.

> Framework server `.listen` methods (`express`/`fastify`/`koa`) are annotated `[IO, ASYNC]` at the package level, **not** the `IO:HTTP:LISTEN` subtype — the subtype is only on the node runtime server they delegate to.

This is the sanctioned IDLE-fallback track: intake found 0 open GitHub issues, and the only Bug-labeled Linear items (REG-686, REG-690) are Haskell-analyzer graph-shape bugs whose acceptance is a live `grafema analyze` graph query — unverifiable in this JS-only environment (no GHC/cabal; `rfdb-server` child processes are reaped). effects-db annotation is fully verifiable here via the `EffectsLookup` unit harness.

## Spec

**Invariant restored:** every popular HTTP client surfaced in the graph as an `IO:HTTP:REQUEST` sender so the `http` bridge can attribute outgoing requests.

**Design — effect VALUES taken from the `ecma:web` entries in `effects-db/runtimes/node.yaml` (node-fetch is a WHATWG-fetch polyfill); keys use the package-file `Class.method` convention (no `.prototype.`, matching `express.yaml` et al.), so this is *not* a literal key-for-key copy of `ecma:web` — only the effect values are shared:**

| entry | effects | rationale |
|-------|---------|-----------|
| `fetch` | `[IO, IO:HTTP:REQUEST, ASYNC]` + `channel.url=arg[0]` | the bridge sender; same effects + channel as `ecma:web.fetch` (node.yaml:940-942) |
| `Headers`/`Request`/`Response`/`FetchError`/`AbortError` | `[PURE]` | value-object / error constructors, no IO until fetched |
| `isRedirect` | `[PURE]` | pure status-code predicate (v3) |
| `Response.json/text/arrayBuffer/blob/buffer` | `[ASYNC]` | drain the already-received body; same value as `Response.prototype.json: [ASYNC]` |
| `Response.clone`, `Headers.get/has` | `[PURE]` | — |
| `Headers.set/append/delete` | `[MUTATION]` | mutate the header bag |
| `blobFrom`/`fileFrom` | `[IO, IO:FILE:READ, ASYNC]` | v3 helpers read a file from disk |
| `blobFromSync`/`fileFromSync` | `[IO, IO:FILE:READ]` | sync variants — no `ASYNC` (mirrors `node:fs` read/readSync) |

**Load-bearing distinction:** WHATWG fetch / node-fetch **resolves** on any HTTP status and only rejects on a network-level failure, so `fetch` intentionally carries **no `THROW`**. (HTTP clients that reject on non-2xx by default — e.g. axios via its `validateStatus` option — would instead carry `THROW`.) A test pins this so a future edit can't silently add `THROW`.

**Resolution (verified by reading `packages/util/src/queries/traceEffects.ts:392-420`):** an imported binding resolves via `lookup(source, importedName)`, so `import fetch from 'node-fetch'; fetch(url)` → `lookup('node-fetch','fetch')` (bare-key convention, like minimatch's bare `minimatch`); named imports (`Headers`, `Request`, …) resolve directly. End-to-end bridge detection on a real repo needs a live graph and is **out of scope** here — this PR proves the lookup layer only, per the Evidence Rule.

## Evidence (actual machine output, at branch HEAD `7897669`)

```
$ node --test test/unit/effects-lookup.test.js test/unit/effectsDbNodeFetch.test.js
# tests 50  # pass 50  # fail 0
$ node --test test/unit/trace-effects.test.js     # path that loads node-fetch.yaml via EffectsLookup
# tests 14  # pass 14  # fail 0
```
TDD red→green for the new test: 7/7 fail without the YAML (lookup returns null) → 7/7 pass with it. Gate: `pnpm build` ✓ · `pnpm typecheck` ✓ (0) · `pnpm lint` ✓ (0).

## Review history

- **QA attempt 1** (`fe07042`) → REJECT: comment cited `effects-db/packages/axios.yaml` (a file only in unmerged #438) + "1:1" overclaim + taxonomy-version nit. **Fixed in `dbc5f97`** (removed dangling citation; corrected wording; justified `version: 2`).
- **QA attempts 2 & 3** → REJECT, but **misattributed**: graded a REG-1166 (`imports-resolve-to-module`, merged separately as #444) DONE-claim that is not part of this PR. No change needed; QA attempt 3 itself confirmed "PASS for node-fetch" and that REG-1166 is on `main`, not this branch.
- **QA attempt 4** (`dbc5f97`) → REJECT (Checks 2–5 PASS): legitimate — the comment/docstring said the bridge receiver is "express → IO:HTTP:LISTEN", but `express.yaml:130` has `Application.listen: [IO, ASYNC]`; the `IO:HTTP:LISTEN` subtype is only on node's runtime server. **Fixed in `7897669`**: receiver now correctly attributed to `node:http`/`node:https` `createServer`/`Server.listen` (node.yaml:319,338,347), with a note that framework `.listen` is `[IO, ASYNC]`.

## Blast radius

Additive only: a new package file + a new test file. No existing entry, runtime, or code path modified.