### PR TITLE
effects-db: annotate execa (IO:PROCESS:SPAWN bridge sender)

### DIFF
--- a/effects-db/packages/execa.yaml
+++ b/effects-db/packages/execa.yaml
@@ -15,9 +15,8 @@
 #
 # THROW rationale: execa rejects (async) / throws (sync) when the child exits with
 # a non-zero code, unless the caller passes `{ reject: false }`. The default is to
-# throw, so the static annotation records THROW (same reasoning as axios's default
-# validateStatus reject). This mirrors node:child_process.exec/spawn which are also
-# annotated THROW.
+# throw, so the static annotation records THROW. This mirrors node:child_process
+# exec/spawn/execSync in runtimes/node.yaml, which are likewise annotated THROW.
 #
 # ASYNC applies only to the promise-returning forms; the *Sync forms block and
 # therefore carry no ASYNC (mirrors execSync vs exec in node.yaml).

--- a/effects-db/packages/execa.yaml
+++ b/effects-db/packages/execa.yaml
@@ -1,0 +1,59 @@
+# execa (v5.x CJS / v6.x–v9.x ESM) — Process execution
+# Generated: 2026-06-15
+# Method: Claude inference based on execa docs, mirrored against the
+#   node:child_process annotations in runtimes/node.yaml (same effect profile,
+#   same `channel: { binary: arg[0] }` extraction used by the subprocess bridges).
+# Taxonomy version: 2
+# purl: pkg:npm/execa
+#
+# execa is the dominant wrapper around node:child_process (~90M weekly downloads).
+# Every entry point spawns a child process, so each carries IO + IO:PROCESS:SPAWN.
+# This is the SENDER side of the `subprocess-stdio` and `subprocess-cli` bridge
+# patterns (bridges.yaml): sender [IO:PROCESS:SPAWN], channel_match: binary_name.
+# Before this entry, only the node:child_process runtime emitted IO:PROCESS:SPAWN —
+# code that spawns via execa was an invisible bridge sender.
+#
+# THROW rationale: execa rejects (async) / throws (sync) when the child exits with
+# a non-zero code, unless the caller passes `{ reject: false }`. The default is to
+# throw, so the static annotation records THROW (same reasoning as axios's default
+# validateStatus reject). This mirrors node:child_process.exec/spawn which are also
+# annotated THROW.
+#
+# ASYNC applies only to the promise-returning forms; the *Sync forms block and
+# therefore carry no ASYNC (mirrors execSync vs exec in node.yaml).
+#
+# channel.binary = arg[0]: the first argument is the file/command to run, which the
+# subprocess bridge traces to a binary name. For execaCommand* the whole command
+# string is arg[0]; the bridge extracts the binary from its leading token.
+
+execa:
+  # ---------------------------------------------------------------------------
+  # Promise-returning spawners (named exports across v6+; default export in v5)
+  # ---------------------------------------------------------------------------
+  execa:
+    effects: [IO, IO:PROCESS:SPAWN, ASYNC, THROW]
+    channel: { binary: "arg[0]" }
+  execaNode:
+    effects: [IO, IO:PROCESS:SPAWN, ASYNC, THROW]
+    channel: { binary: "arg[0]" }
+  execaCommand:
+    effects: [IO, IO:PROCESS:SPAWN, ASYNC, THROW]
+    channel: { binary: "arg[0]" }
+
+  # ---------------------------------------------------------------------------
+  # Synchronous spawners — block the event loop, no ASYNC
+  # ---------------------------------------------------------------------------
+  execaSync:
+    effects: [IO, IO:PROCESS:SPAWN, THROW]
+    channel: { binary: "arg[0]" }
+  execaCommandSync:
+    effects: [IO, IO:PROCESS:SPAWN, THROW]
+    channel: { binary: "arg[0]" }
+
+  # ---------------------------------------------------------------------------
+  # Script-style template tag (`$`), execa v7+. `$`command`` spawns a child.
+  # No channel: arg[0] is the TemplateStringsArray, not a plain binary string,
+  # so the binary cannot be statically extracted from arg[0] alone.
+  # ---------------------------------------------------------------------------
+  $:
+    effects: [IO, IO:PROCESS:SPAWN, ASYNC, THROW]

--- a/test/unit/effectsDbExeca.test.js
+++ b/test/unit/effectsDbExeca.test.js
@@ -1,0 +1,66 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { EffectsLookup } from '@grafema/util';
+import { join } from 'node:path';
+
+// Loads the REAL effects-db so this test guards effects-db/packages/execa.yaml.
+const EFFECTS_DB_PATH = join(import.meta.dirname, '..', '..', 'effects-db');
+
+describe('effects-db: execa', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+
+  // The async spawners are the SENDER side of the subprocess bridges. Each must
+  // carry IO + IO:PROCESS:SPAWN + ASYNC + THROW and expose channel.binary=arg[0].
+  for (const fn of ['execa', 'execaNode', 'execaCommand']) {
+    it(`${fn} is an async spawning sender with binary channel`, () => {
+      const entry = lookup.getEntry('execa', fn);
+      assert.ok(entry, `Expected effects-db entry for execa.${fn}`);
+      for (const effect of ['IO', 'IO:PROCESS:SPAWN', 'ASYNC', 'THROW']) {
+        assert.ok(
+          entry.effects.includes(effect),
+          `Expected ${effect} in execa.${fn}, got: ${entry.effects}`,
+        );
+      }
+      assert.deepEqual(
+        entry.channel,
+        { binary: 'arg[0]' },
+        `Expected execa.${fn} to declare channel.binary=arg[0] for the subprocess bridge`,
+      );
+    });
+  }
+
+  // Sync spawners block the event loop: spawn + throw, but NOT async.
+  for (const fn of ['execaSync', 'execaCommandSync']) {
+    it(`${fn} spawns and throws synchronously (no ASYNC)`, () => {
+      const effects = lookup.lookup('execa', fn);
+      assert.ok(effects, `Expected effects for execa.${fn}`);
+      assert.ok(
+        effects.includes('IO:PROCESS:SPAWN'),
+        `Expected IO:PROCESS:SPAWN in execa.${fn}, got: ${effects}`,
+      );
+      assert.ok(
+        effects.includes('THROW'),
+        `Expected THROW in execa.${fn}, got: ${effects}`,
+      );
+      assert.ok(
+        !effects.includes('ASYNC'),
+        `Expected NO ASYNC for sync call execa.${fn}, got: ${effects}`,
+      );
+    });
+  }
+
+  it('$ script tag spawns asynchronously and throws', () => {
+    const effects = lookup.lookup('execa', '$');
+    assert.ok(effects, 'Expected effects for execa.$');
+    for (const effect of ['IO', 'IO:PROCESS:SPAWN', 'ASYNC', 'THROW']) {
+      assert.ok(effects.includes(effect), `Expected ${effect} in execa.$, got: ${effects}`);
+    }
+  });
+
+  it('resolves the same way an IMPORT_BINDING does: lookup(source, importedName)', () => {
+    // Mirrors traceEffects.ts IMPORT_BINDING path: lookup('execa', 'execa').
+    const effects = lookup.lookup('execa', 'execa');
+    assert.ok(effects, 'Expected lookup("execa", "execa") to resolve');
+    assert.ok(effects.includes('IO:PROCESS:SPAWN'));
+  });
+});


### PR DESCRIPTION
## Context

Autonomous run, sanctioned IDLE effects-db fallback. Intake re-verified **live** this run:
- **0 open GitHub issues** (`list_issues` totalCount=0); `claude-fix` label absent.
- Linear Bug backlog: **REG-686 / REG-690** (Haskell-analyzer graph-shape) and **RFD-68 / RFD-64** (Rust + large-graph scale) — all require live `grafema analyze` / RFDB graph-shape verification, **unverifiable** in this JS-only env (no `ghc`/`cabal`/built dist; `rfdb-server` child procs reaped). Radio fleet busy with MKT ops, no directed JS/TS-verifiable work.
- Avoided the in-flight HTTP-client PRs (#438 axios, #439 node-fetch).

## Spec

**Invariant restored:** the `subprocess-stdio` / `subprocess-cli` bridge patterns (`bridges.yaml`: sender `[IO:PROCESS:SPAWN]`, `channel_match: binary_name`) had **no annotated npm sender** — `IO:PROCESS:SPAWN` was emitted only by the `node:child_process` runtime. Code that spawns via `execa` (~90M weekly downloads, the dominant child-process wrapper) was an invisible bridge sender.

**Given** a call site `execa('git', ['status'])` / `execaSync(...)` / `$\`cmd\``
**When** the manifest/effects pass resolves the import binding via `lookup('execa', importedName)` (the `IMPORT_BINDING` path in `traceEffects.ts:391-420`)
**Then** the call carries `IO` + `IO:PROCESS:SPAWN` with `channel.binary = arg[0]`, making it matchable by the subprocess bridges.

**Effect rules** (mirror `runtimes/node.yaml` `node:child_process`):
- Async spawners `execa`, `execaNode`, `execaCommand` → `[IO, IO:PROCESS:SPAWN, ASYNC, THROW]` + `channel.binary=arg[0]`
- Sync spawners `execaSync`, `execaCommandSync` → `[IO, IO:PROCESS:SPAWN, THROW]` (no `ASYNC`) + `channel.binary=arg[0]`
- Script tag `$` → `[IO, IO:PROCESS:SPAWN, ASYNC, THROW]` (no channel: `arg[0]` is the `TemplateStringsArray`, binary not statically extractable from `arg[0]` alone)
- `THROW` reflects execa's default `reject: true` (rejects/throws on non-zero exit), same convention as the axios annotation.

## Before / After (actual outputs)

RED (execa.yaml moved aside):
```
not ok 1 - execa is an async spawning sender with binary channel
  error: 'Expected effects-db entry for execa.execa'
... (7 subtests)
# tests 7   # pass 0   # fail 7
```

GREEN (after adding execa.yaml):
```
# execa            tests 7   pass 7   fail 0
# effects-lookup   tests 43  pass 43  fail 0   (no regression)
# trace-effects    tests 14  pass 14  fail 0   (consumer of EffectsLookup)
# effectSurfaceDiff tests 1  pass 1   fail 0
```
Gate: `pnpm install` ✓, `pnpm build` ✓, `pnpm typecheck` ✓ (0 errors), `pnpm lint` ✓ (0). YAML validity proven by `EffectsLookup.load()` parsing it in the passing tests.

## Adversarial rounds
- **A — Correctness:** ASYNC only on promise-returning forms; sync forms drop it (mirrors `exec` vs `execSync`). `THROW` = default reject-on-nonzero-exit (documented). All keys are real execa named exports across v5 (CJS default) → v9 (ESM named). `channel.binary=arg[0]` byte-identical to `node:child_process`.
- **B — Fragility:** 60-line additive data file; channel format mirrors `node.yaml` so bridge-extraction changes move both together. No existing entry touched.
- **C — Class-not-instance:** other unannotated spawn-wrappers with the same invisible-sender gap → follow-ups, not scope creep: `cross-spawn`, `zx`, `tinyexec`. No analysis invariant violated; purely additive (effects-lookup 43/43 unchanged).

## Blast radius
Additive YAML + a new read-only test. No source change; no existing lookup altered. End-to-end bridge detection on a real execa-using repo needs a live graph (out of scope for this JS-only env).

## Follow-ups (not filed)
Annotate `cross-spawn`, `zx`, `tinyexec` (same `IO:PROCESS:SPAWN` sender class); `$.sync`/`$.s` member forms on the script tag.

Note: no automerge — Vadim reviews (repo norm).


---
_Generated by [Claude Code](https://claude.ai/code/session_0121NLJuzB7wnppb82LtrJRE)_