### PR TITLE
fix(rust-analyzer): emit ASSIGNED_FROM for const/static value sources (REG-686)

### DIFF
--- a/packages/grafema-orchestrator/src/rust_analyzer.rs
+++ b/packages/grafema-orchestrator/src/rust_analyzer.rs
@@ -672,11 +672,16 @@ fn walk_const(c: &syn::ItemConst, ctx: &mut Ctx) {
 
     if is_exported {
         ctx.exports.push(ExportInfo {
-            name: ident, node_id, kind: "variable".to_string(), source: None,
+            name: ident, node_id: node_id.clone(), kind: "variable".to_string(), source: None,
         });
     }
 
     walk_expr(&c.expr, ctx);
+
+    // ASSIGNED_FROM edge: the constant ← its initializer expression. Mirrors
+    // `walk_let` so backward Value Trace / Hover can find the value origin of a
+    // top-level `const` instead of dead-ending on the declaration (REG-686).
+    emit_assigned_from(ctx, node_id, &c.expr);
 }
 
 fn walk_static(s: &syn::ItemStatic, ctx: &mut Ctx) {
@@ -704,11 +709,14 @@ fn walk_static(s: &syn::ItemStatic, ctx: &mut Ctx) {
 
     if is_exported {
         ctx.exports.push(ExportInfo {
-            name: ident, node_id, kind: "variable".to_string(), source: None,
+            name: ident, node_id: node_id.clone(), kind: "variable".to_string(), source: None,
         });
     }
 
     walk_expr(&s.expr, ctx);
+
+    // ASSIGNED_FROM edge: `static NAME = INIT` shares const value-source semantics.
+    emit_assigned_from(ctx, node_id, &s.expr);
 }
 
 // ---------------------------------------------------------------------------
@@ -975,10 +983,12 @@ fn walk_impl_item(item: &syn::ImplItem, ctx: &mut Ctx) {
             ctx.enclosing_fn = prev_fn;
         }
         syn::ImplItem::Const(c) => {
-            emit_assoc_const(&c.ident, Some(&c.vis), ctx);
+            let const_id = emit_assoc_const(&c.ident, Some(&c.vis), ctx);
             // Walk the initializer so the constant's value expression (calls,
             // references, literals) participates in the graph like a free const.
             walk_expr(&c.expr, ctx);
+            // ASSIGNED_FROM edge: associated const ← its initializer (REG-686).
+            emit_assigned_from(ctx, const_id, &c.expr);
         }
         syn::ImplItem::Type(t) => {
             emit_assoc_type(&t.ident, Some(&t.vis), ctx);
@@ -1037,10 +1047,12 @@ fn walk_trait(t: &syn::ItemTrait, ctx: &mut Ctx) {
             // Trait items have no visibility (they are part of the trait's public
             // contract), hence `None`.
             syn::TraitItem::Const(c) => {
-                emit_assoc_const(&c.ident, None, ctx);
+                let const_id = emit_assoc_const(&c.ident, None, ctx);
                 // A trait const may carry a default value: `const N: u32 = 0;`.
                 if let Some((_, expr)) = &c.default {
                     walk_expr(expr, ctx);
+                    // ASSIGNED_FROM edge: trait const ← its default value (REG-686).
+                    emit_assigned_from(ctx, const_id, expr);
                 }
             }
             syn::TraitItem::Type(ty) => {
@@ -1059,7 +1071,10 @@ fn walk_trait(t: &syn::ItemTrait, ctx: &mut Ctx) {
 /// edges (emit_declaration) and tagged `associated: true` so queries can tell
 /// `Self::NAME` constants apart from free constants. `vis` is `Some` for impl
 /// items (which carry visibility) and `None` for trait items (which do not).
-fn emit_assoc_const(ident: &syn::Ident, vis: Option<&syn::Visibility>, ctx: &mut Ctx) {
+///
+/// Returns the emitted node id so callers can attach an `ASSIGNED_FROM` edge to
+/// the constant's initializer expression.
+fn emit_assoc_const(ident: &syn::Ident, vis: Option<&syn::Visibility>, ctx: &mut Ctx) -> String {
     let name = ident.to_string();
     let (line, col) = ctx.span_line_col(ident.span());
     let parent = ctx.scope_id().to_string();
@@ -1076,7 +1091,7 @@ fn emit_assoc_const(ident: &syn::Ident, vis: Option<&syn::Visibility>, ctx: &mut
     }
 
     ctx.emit_declaration(GraphNode {
-        id: node_id,
+        id: node_id.clone(),
         node_type: "VARIABLE".to_string(),
         name,
         file: ctx.file.clone(),
@@ -1086,6 +1101,8 @@ fn emit_assoc_const(ident: &syn::Ident, vis: Option<&syn::Visibility>, ctx: &mut
         metadata,
         extra: HashMap::new(),
     });
+
+    node_id
 }
 
 /// Emit a TYPE_ALIAS node for an associated type (`type NAME [= ...];`) declared
@@ -1386,6 +1403,23 @@ fn walk_stmt(stmt: &syn::Stmt, ctx: &mut Ctx) {
     }
 }
 
+/// Emit an `ASSIGNED_FROM` edge from a declaration node (`src_id`) to the node
+/// representing its initializer expression, when that expression maps to a
+/// single value node (literal / call / reference / …). No-op for compound
+/// initializers that `expr_node_id` cannot reduce to one node — matching the
+/// existing `let`-binding behaviour. Shared by `let`, free `const`/`static`,
+/// and associated-const declarations so value-source modelling stays uniform.
+fn emit_assigned_from(ctx: &mut Ctx, src_id: String, init: &syn::Expr) {
+    if let Some(init_node_id) = expr_node_id(init, ctx) {
+        ctx.emit_edge(GraphEdge {
+            src: src_id,
+            dst: init_node_id,
+            edge_type: "ASSIGNED_FROM".to_string(),
+            metadata: HashMap::new(),
+        });
+    }
+}
+
 fn walk_let(local: &syn::Local, ctx: &mut Ctx) {
     // Collect binding IDs before walking init (for ASSIGNED_FROM)
     let binding_ids = collect_pat_binding_ids(&local.pat, "let", ctx);
@@ -1407,16 +1441,8 @@ fn walk_let(local: &syn::Local, ctx: &mut Ctx) {
         }
 
         // ASSIGNED_FROM edges: each binding ← init expression
-        // For simple expressions (path, lit), emit direct edge
-        if let Some(init_node_id) = expr_node_id(&init.expr, ctx) {
-            for var_id in &binding_ids {
-                ctx.emit_edge(GraphEdge {
-                    src: var_id.clone(),
-                    dst: init_node_id.clone(),
-                    edge_type: "ASSIGNED_FROM".to_string(),
-                    metadata: HashMap::new(),
-                });
-            }
+        for var_id in &binding_ids {
+            emit_assigned_from(ctx, var_id.clone(), &init.expr);
         }
     }
 }
@@ -2636,6 +2662,75 @@ mod tests {
             .filter(|e| e.edge_type == "ASSIGNED_FROM")
             .collect();
         assert!(!assigned.is_empty(), "should have ASSIGNED_FROM edges");
+    }
+
+    #[test]
+    fn test_const_item_assigned_from_literal() {
+        // Top-level `const NAME: T = <init>;` must link the declaration to its
+        // initializer via ASSIGNED_FROM, mirroring `let` bindings — otherwise
+        // backward Value Trace / Hover dead-ends on the constant (REG-686).
+        let fa = parse_and_analyze("const MAX: u32 = 42;");
+        let assigned: Vec<_> = fa.edges.iter()
+            .filter(|e| e.edge_type == "ASSIGNED_FROM"
+                && e.src.contains("VARIABLE") && e.src.contains("MAX"))
+            .collect();
+        assert!(!assigned.is_empty(),
+            "const MAX should have ASSIGNED_FROM, got edges: {:?}",
+            fa.edges.iter().map(|e| e.edge_type.clone()).collect::<Vec<_>>());
+        assert!(assigned[0].dst.contains("LITERAL"),
+            "const MAX ASSIGNED_FROM should point to LITERAL, got: {}", assigned[0].dst);
+    }
+
+    #[test]
+    fn test_static_item_assigned_from_literal() {
+        // `static NAME: T = <init>;` shares const value-source semantics.
+        let fa = parse_and_analyze("static GREETING: &str = \"hi\";");
+        let assigned: Vec<_> = fa.edges.iter()
+            .filter(|e| e.edge_type == "ASSIGNED_FROM"
+                && e.src.contains("VARIABLE") && e.src.contains("GREETING"))
+            .collect();
+        assert!(!assigned.is_empty(), "static GREETING should have ASSIGNED_FROM");
+        assert!(assigned[0].dst.contains("LITERAL"),
+            "static GREETING ASSIGNED_FROM should point to LITERAL, got: {}", assigned[0].dst);
+    }
+
+    #[test]
+    fn test_const_assigned_from_call() {
+        // Non-literal initializers (calls) must still link via ASSIGNED_FROM.
+        let fa = parse_and_analyze("const N: usize = compute();");
+        let assigned: Vec<_> = fa.edges.iter()
+            .filter(|e| e.edge_type == "ASSIGNED_FROM"
+                && e.src.contains("VARIABLE") && e.src.contains("N"))
+            .collect();
+        assert!(!assigned.is_empty(), "const N = compute() should have ASSIGNED_FROM");
+        assert!(assigned[0].dst.contains("CALL"),
+            "const N ASSIGNED_FROM should point to CALL, got: {}", assigned[0].dst);
+    }
+
+    #[test]
+    fn test_assoc_const_assigned_from_literal() {
+        // Associated constants inside an `impl` block must link to their value too.
+        let fa = parse_and_analyze("struct Foo; impl Foo { const LIMIT: u32 = 100; }");
+        let assigned: Vec<_> = fa.edges.iter()
+            .filter(|e| e.edge_type == "ASSIGNED_FROM"
+                && e.src.contains("VARIABLE") && e.src.contains("LIMIT"))
+            .collect();
+        assert!(!assigned.is_empty(), "assoc const LIMIT should have ASSIGNED_FROM");
+        assert!(assigned[0].dst.contains("LITERAL"),
+            "assoc const LIMIT ASSIGNED_FROM should point to LITERAL, got: {}", assigned[0].dst);
+    }
+
+    #[test]
+    fn test_trait_const_default_assigned_from_literal() {
+        // A trait const with a default value carries a value source as well.
+        let fa = parse_and_analyze("trait T { const CAP: u32 = 8; }");
+        let assigned: Vec<_> = fa.edges.iter()
+            .filter(|e| e.edge_type == "ASSIGNED_FROM"
+                && e.src.contains("VARIABLE") && e.src.contains("CAP"))
+            .collect();
+        assert!(!assigned.is_empty(), "trait const CAP default should have ASSIGNED_FROM");
+        assert!(assigned[0].dst.contains("LITERAL"),
+            "trait const CAP ASSIGNED_FROM should point to LITERAL, got: {}", assigned[0].dst);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Rust `const`/`static`/associated-const declarations modeled their initializer
in the graph but never linked the declaration to it via `ASSIGNED_FROM`, so
backward Value Trace / Hover dead-ended on Rust constants ("No value origins
found in graph"). This is the Rust slice of **REG-686**.

Links Linear **REG-686** (Rust value-origin acceptance bullet).

## Spec

**Invariant restored:** a value-bearing declaration (`let`, free `const`,
`static`, associated `const`) links to the node representing its initializer
via `ASSIGNED_FROM`, so a backward value trace can step from the declaration to
its value origin.

**Given/When/Then**
- *Given* `const MAX: u32 = 42;` *When* the file is analyzed *Then* the `MAX`
  declaration node has an outgoing `ASSIGNED_FROM` edge to the `42` LITERAL.
- *Given* `const N: usize = compute();` *Then* `N` has `ASSIGNED_FROM` → the
  `compute()` CALL node.
- *Given* `impl Foo { const LIMIT: u32 = 100; }` and `trait T { const CAP: u32 = 8; }`
  *Then* both associated consts link to their value via `ASSIGNED_FROM`.

## Root cause

`packages/grafema-orchestrator/src/rust_analyzer.rs`:
- `walk_let` (the `let`-binding path) emitted `ASSIGNED_FROM` via `expr_node_id`.
- `walk_const`, `walk_static`, `ImplItem::Const`, and `TraitItem::Const` all
  called `walk_expr` on the initializer (so the value node existed) but **never
  emitted the edge**. Rust top-level consts are modeled as `VARIABLE` nodes
  (`kind: "const"`), so they participated in the graph but were value-source
  dead ends.

## Fix (minimal)

- Extracted a shared `emit_assigned_from(ctx, src_id, init)` helper (no-op for
  compound initializers `expr_node_id` can't reduce — same as the existing
  `let` behaviour) and call it from all four declaration sites.
- `emit_assoc_const` now returns its node id so call sites can attach the edge.
- `walk_let` refactored onto the same helper (behaviour-preserving DRY).

+111 / −16, single file.

## Before / After evidence

**Red (before fix)** — new tests fail for the right reason (no edge):
```
test rust_analyzer::tests::test_const_item_assigned_from_literal ... FAILED
test rust_analyzer::tests::test_static_item_assigned_from_literal ... FAILED
test rust_analyzer::tests::test_const_assigned_from_call ... FAILED
test rust_analyzer::tests::test_assoc_const_assigned_from_literal ... FAILED
test rust_analyzer::tests::test_trait_const_default_assigned_from_literal ... FAILED
test rust_analyzer::tests::test_assigned_from ... ok   # let-binding baseline unaffected
```

**Green (after fix)** — full crate lib suite:
```
test result: ok. 453 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```
`cargo clippy --lib` clean for the edited file.

> Verification is at analyzer-output level (`FileAnalysis.nodes/edges`) — exactly
> the node/edge set the orchestrator commits to RFDB. `ASSIGNED_FROM` from a
> `VARIABLE` node is already a production edge type (emitted for `let` bindings
> and consumed by traceValues/Hover), so the new const edges survive to the graph
> identically.

## Adversarial review

- **Round A — correctness.** Top-level `const`/`static` always have an
  initializer (syntactically required) → no None-init path. Trait consts may
  omit a default → guarded by `if let Some(...)`. Compound initializers
  (`[0; 32]`, struct/tuple/binary exprs) yield `expr_node_id == None` → no edge,
  identical to `let` (no spurious edges, no regression). One edge per
  declaration; impl vs trait consts have distinct parented ids → no dup edges.
- **Round B — structural.** `rust_analyzer.rs` is a pre-existing large file;
  this change adds a small helper and mirrors the established `walk_let` pattern
  rather than introducing new shape. Helper removes 4 copies of the emit block.
- **Round C — class / siblings.** Audited every declaration site that walks an
  initializer: `let`/`const`/`static`/assoc-const all now covered. **Sibling gap
  found (not fixed here, follow-up):** `walk_enum` emits `VARIANT` nodes but
  never walks `variant.discriminant`, so `enum E { A = 1 }` drops the
  discriminant value entirely (no node, no edge). Different node type and larger
  semantics → out of scope for this focused PR.

## Blast radius

`ASSIGNED_FROM` consumers (traceValues, Hover, contractEnricher) already handle
this edge type from `let` bindings; the change only adds more edges of an
existing kind from `VARIABLE` (kind=const) sources. JS/TS `CONSTANT` value-source
(the formal `constants-have-value-source` Datalog guarantee) is handled
separately by the JS analyzer + `packages/core-v2/test/constant-value-source.test.mjs`
and is untouched.

## Follow-ups
- [ ] Enum discriminant value sources (`VARIANT` → discriminant expr) — sibling gap above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DZ9o6CCod42SCy9YqsfW2d)_