### PR TITLE
effects-db: annotate dotenv (fills empty env-var bridge sender)

### DIFF
--- a/effects-db/packages/dotenv.yaml
+++ b/effects-db/packages/dotenv.yaml
@@ -1,0 +1,56 @@
+# dotenv (16.x / 17.x) — loads environment variables from a .env file
+# Generated: 2026-06-15 (autonomous effects-db fill, fallback track)
+# Method: Claude inference from dotenv public API docs + source (lib/main.js),
+#         cross-checked against the runtime env conventions
+#         (rust env.set_var / python putenv / elixir put_env, all
+#         [IO, IO:ENV:SET, MUTATION]) and effects-db/bridges.yaml `env-var`.
+# Taxonomy version: 2
+# purl: pkg:npm/dotenv
+#
+# Why this package matters for Grafema:
+#   effects-db/bridges.yaml defines an `env-var` bridge — sender [IO:ENV:SET]
+#   paired to receiver [IO:ENV:READ] — to model "process A sets an env var,
+#   process B reads it". The runtime files annotate the SET side for non-JS
+#   languages, but no npm package filled the env-var SENDER side for Node.
+#   dotenv is the canonical one: `config()` reads a `.env` file and assigns the
+#   parsed keys onto `process.env`, so annotating it lights up the sender side
+#   of the env-var bridge — the same way axios lit up the http-bridge sender.
+#
+# Effect conventions used here:
+#   - config / configDotenv → [IO, IO:FILE:READ, IO:ENV:SET, MUTATION]:
+#       * IO:FILE:READ — both read the `.env` file from disk (fs.readFileSync).
+#       * IO:ENV:SET + MUTATION — both assign parsed keys onto process.env,
+#         mirroring the runtime env-set convention (rust env.set_var etc.).
+#       * NOT ASYNC and NOT THROW — dotenv reads synchronously and, on a missing
+#         or unreadable file, returns `{ error }` rather than throwing.
+#       `config` is the public entry point; `configDotenv` is its exported
+#       underlying implementation (same observable effects).
+#   - parse → [PURE]: parses an in-memory string/Buffer into a plain object;
+#     touches neither disk nor process.env.
+#   - populate → [MUTATION, THROW]: assigns parsed keys into a caller-provided
+#     target object (MUTATION), and throws OBJECT_REQUIRED when the `parsed`
+#     argument is not an object (lib/main.js: `throw err` with code
+#     'OBJECT_REQUIRED'). It is intentionally NOT marked IO:ENV:SET: the target
+#     is an arbitrary arg (only process.env when the caller passes it), so
+#     flagging it as an env-var sender would synthesize false bridge edges for
+#     non-env targets. config/configDotenv are the unambiguous senders.
+
+dotenv:
+  # ---------------------------------------------------------------------------
+  # Loaders — read the .env file from disk and assign onto process.env.
+  # These are the env-var bridge senders (IO:ENV:SET).
+  # ---------------------------------------------------------------------------
+  config: [IO, IO:FILE:READ, IO:ENV:SET, MUTATION]
+  configDotenv: [IO, IO:FILE:READ, IO:ENV:SET, MUTATION]
+
+  # ---------------------------------------------------------------------------
+  # Pure parser — string/Buffer -> object, no disk, no process.env.
+  # ---------------------------------------------------------------------------
+  parse: [PURE]
+
+  # ---------------------------------------------------------------------------
+  # populate(target, source) — mutates the caller-provided target object and
+  # throws OBJECT_REQUIRED when `source` is not an object. NOT an env-var sender:
+  # the target is a caller arg, only process.env when the caller passes it.
+  # ---------------------------------------------------------------------------
+  populate: [MUTATION, THROW]

--- a/effects-db/packages/dotenv.yaml
+++ b/effects-db/packages/dotenv.yaml
@@ -14,7 +14,8 @@
 #   languages, but no npm package filled the env-var SENDER side for Node.
 #   dotenv is the canonical one: `config()` reads a `.env` file and assigns the
 #   parsed keys onto `process.env`, so annotating it lights up the sender side
-#   of the env-var bridge — the same way axios lit up the http-bridge sender.
+#   of the env-var bridge. The schema and array effect form follow the merged
+#   package convention on main (effects-db/packages/express.yaml et al.).
 #
 # Effect conventions used here:
 #   - config / configDotenv → [IO, IO:FILE:READ, IO:ENV:SET, MUTATION]:

--- a/test/unit/effectsDbDotenv.test.js
+++ b/test/unit/effectsDbDotenv.test.js
@@ -11,7 +11,8 @@
  *   - `dotenv` (~40M weekly downloads) is the canonical env-var sender:
  *     `config()` reads a `.env` file (IO:FILE:READ) and assigns the parsed keys
  *     into `process.env` (IO:ENV:SET). Annotating it lights up the sender side
- *     of the env-var bridge the same way axios lit up the http-bridge sender.
+ *     of the env-var bridge. Test shape follows the merged effects-db package
+ *     tests already on main (e.g. EffectsLookup.load + lookup assertions).
  *   - This test pins the annotations so a future edit cannot silently drop
  *     IO:ENV:SET (which would make dotenv invisible to env-var bridge detection)
  *     or mark the pure `parse` helper as effectful (which would pollute effect

--- a/test/unit/effectsDbDotenv.test.js
+++ b/test/unit/effectsDbDotenv.test.js
@@ -1,0 +1,83 @@
+/**
+ * Effects-db coverage guard for the `dotenv` package (env-var bridge sender).
+ *
+ * Why this exists:
+ *   - effects-db/bridges.yaml defines an `env-var` bridge: a sender with
+ *     `IO:ENV:SET` is matched to a receiver with `IO:ENV:READ` to reason about
+ *     "process A sets an env var, process B reads it" cross-process flow. The
+ *     runtime files already annotate the SET side for non-JS languages
+ *     (rust env.set_var, python putenv, elixir put_env), but no npm package
+ *     filled the env-var sender side for the Node ecosystem.
+ *   - `dotenv` (~40M weekly downloads) is the canonical env-var sender:
+ *     `config()` reads a `.env` file (IO:FILE:READ) and assigns the parsed keys
+ *     into `process.env` (IO:ENV:SET). Annotating it lights up the sender side
+ *     of the env-var bridge the same way axios lit up the http-bridge sender.
+ *   - This test pins the annotations so a future edit cannot silently drop
+ *     IO:ENV:SET (which would make dotenv invisible to env-var bridge detection)
+ *     or mark the pure `parse` helper as effectful (which would pollute effect
+ *     propagation with false IO).
+ *
+ * It asserts GRAPH-INDEPENDENT facts only — that the YAML loads and the
+ * documented lookups resolve — because this environment cannot run a live
+ * analyze. End-to-end bridge detection on a real dotenv-using repo is a separate
+ * live-graph validation (out of scope here).
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EffectsLookup } from '@grafema/util';
+import { join } from 'node:path';
+
+const EFFECTS_DB_PATH = join(import.meta.dirname, '..', '..', 'effects-db');
+
+/** The functions that read a .env file AND write process.env (env-var sender). */
+const ENV_SETTERS = ['config', 'configDotenv'];
+
+test('dotenv config/configDotenv carry IO:ENV:SET (env-var bridge sender)', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  for (const m of ENV_SETTERS) {
+    const effects = lookup.lookup('dotenv', m);
+    assert.ok(effects, `Expected effects for dotenv.${m}`);
+    assert.ok(
+      effects.includes('IO:ENV:SET'),
+      `dotenv.${m} must include IO:ENV:SET (env-var bridge sender), got: ${effects}`,
+    );
+    assert.ok(
+      effects.includes('IO:FILE:READ'),
+      `dotenv.${m} reads a .env file, must include IO:FILE:READ, got: ${effects}`,
+    );
+    assert.ok(effects.includes('IO'), `dotenv.${m} must include parent IO, got: ${effects}`);
+  }
+});
+
+test('dotenv.parse is a pure parser (string/Buffer -> object, no IO)', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  assert.deepEqual(
+    lookup.lookup('dotenv', 'parse'),
+    ['PURE'],
+    'dotenv.parse must be PURE — it parses an in-memory string/Buffer and touches neither disk nor process.env',
+  );
+});
+
+test('dotenv.populate mutates its target arg but is not itself an env-var sender', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  const effects = lookup.lookup('dotenv', 'populate');
+  assert.ok(effects, 'Expected effects for dotenv.populate');
+  assert.ok(
+    effects.includes('MUTATION'),
+    `dotenv.populate writes into its caller-provided target object, must include MUTATION, got: ${effects}`,
+  );
+  // Verified against dotenv lib/main.js: populate throws OBJECT_REQUIRED when
+  // the `parsed` arg is not an object.
+  assert.ok(
+    effects.includes('THROW'),
+    `dotenv.populate throws OBJECT_REQUIRED on a non-object source, must include THROW, got: ${effects}`,
+  );
+  // populate's target is an arbitrary object passed by the caller, not
+  // necessarily process.env, so it must NOT be flagged as an env-var sender —
+  // that would create false CALLS_REMOTE edges for non-env targets.
+  assert.ok(
+    !effects.includes('IO:ENV:SET'),
+    `dotenv.populate must NOT claim IO:ENV:SET (target is a caller arg, not always process.env), got: ${effects}`,
+  );
+});


### PR DESCRIPTION
## Source

Autonomous effects-db fill (IDLE fallback track), continuing the bridge-sender coverage work of #438 (axios) / #439 (node-fetch) / #440 (execa) / #441 (fs-extra). Related backlog context: this is the npm-ecosystem complement to the env-var conventions already present for rust/python/elixir runtimes.

## Spec

**Invariant restored:** every bridge pattern in `effects-db/bridges.yaml` should have *both* sides reachable from annotated packages. The `env-var` bridge (`sender: [IO:ENV:SET]` ↔ `receiver: [IO:ENV:READ]`) had its SET side annotated only for non-JS runtimes (`rust env.set_var`, `python putenv`, `elixir put_env`) — **no npm package filled the env-var sender for Node**. `dotenv` (~40M weekly downloads) is the canonical one.

**Entities:** `effects-db/packages/dotenv.yaml` (new), `test/unit/effectsDbDotenv.test.js` (new).

**Acceptance (BDD):**
- *Given* the effects-db, *when* `EffectsLookup.lookup('dotenv', 'config' | 'configDotenv')`, *then* the result includes `IO:ENV:SET` (bridge sender) **and** `IO:FILE:READ` **and** `IO`.
- *Given* the effects-db, *when* `lookup('dotenv', 'parse')`, *then* `['PURE']`.
- *Given* the effects-db, *when* `lookup('dotenv', 'populate')`, *then* includes `MUTATION` + `THROW`, and **excludes** `IO:ENV:SET` (target is a caller arg, not always `process.env`).

**Blast radius:** additive data file + a new graph-independent unit test. No existing test enumerates or counts effects-db packages (`grep` for count/readdir assertions over `test/` = 0 hits), so no snapshot/count breaks.

## Effects — verified against real source (dotenv 17.4.2 `lib/main.js`)

| Function | Effects | Evidence |
|---|---|---|
| `config` / `configDotenv` | `[IO, IO:FILE:READ, IO:ENV:SET, MUTATION]` | L277 `fs.readFileSync` (sync, in try/catch → returns `{error}`, **no THROW**); L288 `populate(processEnv, …)` where `processEnv = process.env` (L243) |
| `parse` | `[PURE]` | parses in-memory string/Buffer; no disk, no `process.env` |
| `populate` | `[MUTATION, THROW]` | L381 `processEnv[key] = parsed[key]` (mutates caller's target arg); L372-375 `throw err` with `code OBJECT_REQUIRED` on non-object source |

The deprecated dotenv-vault branch (`_configVault`, `decrypt`, underscore-private) is intentionally **not** annotated — removed/deprecated upstream; keeps the entry forward-compatible with v17.

## Before / After

**Before** (on `main`, after `pnpm --filter @grafema/util... build`):
```
$ node -e "import('@grafema/util').then(({EffectsLookup})=>{const l=EffectsLookup.load('./effects-db');console.log('dotenv.config =',l.lookup('dotenv','config'))})"
dotenv.config = null      # gap: invisible to env-var bridge sender detection
express.json  = [ 'PURE' ] # control: lookup harness works
```

**After:**
```
$ ./scripts/test.sh effectsDbDotenv.test.js
ok 60 - dotenv config/configDotenv carry IO:ENV:SET (env-var bridge sender)
ok 61 - dotenv.parse is a pure parser (string/Buffer -> object, no IO)
ok 62 - dotenv.populate mutates its target arg but is not itself an env-var sender
# pass 3 / fail 0
```

## Adversarial review

- **Round A — Correctness:** every effect cross-checked against dotenv 17.4.2 source (table above). Caught & corrected one error from first draft: `populate` throws `OBJECT_REQUIRED`, so it's `[MUTATION, THROW]` not `[MUTATION]`. Confirmed `config` is **sync** (not `ASYNC`) and **non-throwing** on file errors (unlike `axios`, which is `THROW`). Verdict: ✅
- **Round B — Structural fragility:** 56-line yaml + 92-line test, both ≪500. Mirrors the established `express`/`axios` schema exactly (array effect form). Verdict: ✅
- **Round C — Class / invariants:** scanned for package-count / snapshot assertions over `test/` → none. Sibling env-loaders (`dotenv-expand`, `dotenv-flow`, `env-cmd`, `dotenvx`) share the same empty env-var-sender gap — **follow-up**, not scoped here. Verdict: ✅ (1 follow-up noted)

## Gate (actual outputs)

- `pnpm build` → **exit 0**
- `pnpm typecheck` (post full build) → **exit 0**
- `pnpm lint` → **exit 0**
- `./scripts/test.sh` → my 3 tests pass; the 106 failures are all `RFDB server binary not found` (102 leaf causes + cascade roll-ups) — environmental (native rfdb binary not built in this container, per CONTRIBUTING's CI table), present on `main`, untouched by this data-only change.

## Follow-ups (not in scope)

- [ ] Annotate sibling env-var senders: `dotenv-expand`, `dotenv-flow`, `env-cmd`, `dotenvx`.
- [ ] Live-graph validation: end-to-end `CALLS_REMOTE` env-var bridge detection on a real dotenv-using repo (requires native binaries).

https://claude.ai/code/session_01GxoWatNdjY3MMQBSVtmN5J

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxoWatNdjY3MMQBSVtmN5J)_