### PR TITLE
QA-8: suppress INFO log from grafema-orchestrator by default

### DIFF
--- a/packages/cli/src/commands/analyzeAction.ts
+++ b/packages/cli/src/commands/analyzeAction.ts
@@ -396,8 +396,8 @@ export async function analyzeAction(path: string, options: { service?: string; e
         ],
         env: {
           ...process.env,
-          // Pass RUST_LOG for tracing verbosity
-          RUST_LOG: options.debug ? 'debug' : (options.quiet ? 'warn' : 'info'),
+          // Pass RUST_LOG for tracing verbosity; default=warn to avoid INFO noise
+          RUST_LOG: options.debug ? 'debug' : options.verbose ? 'info' : 'warn',
         },
       });
 

--- a/packages/cli/src/commands/resolveAction.ts
+++ b/packages/cli/src/commands/resolveAction.ts
@@ -230,7 +230,7 @@ export async function resolveAction(path: string, options: {
         ],
         env: {
           ...process.env,
-          RUST_LOG: options.debug ? 'debug' : (options.quiet ? 'warn' : 'info'),
+          RUST_LOG: options.debug ? 'debug' : options.verbose ? 'info' : 'warn',
         },
       });
 


### PR DESCRIPTION
## What

`grafema analyze` was printing an INFO-level log on every run:

```
2026-06-15T20:18:32.468957Z INFO grafema_orchestrator: Starting analysis config=… socket=… jobs=4 force=false
```

First-time users read this as an error or debug noise, which hurts onboarding UX during open beta.

## Root cause

`analyzeAction.ts:400` set `RUST_LOG=info` as the default when spawning `grafema-orchestrator`. The INFO log from the Rust tracing subscriber was therefore always shown unless `--quiet` was explicitly passed.

Same pattern existed in `resolveAction.ts:233`.

## Fix

Changed RUST_LOG mapping in both actions:

| flag | before | after |
|---|---|---|
| default | `info` | `warn` |
| `--verbose` | `info` | `info` |
| `--quiet` | `warn` | `warn` |
| `--debug` | `debug` | `debug` |

Default is now `warn` — no INFO noise. Users who want the orchestrator startup line can pass `--verbose`.

## Acceptance criteria

- `grafema analyze .` produces no INFO line on stderr by default ✅
- `grafema analyze . --verbose` shows the INFO line ✅
- `grafema analyze . --quiet` still silent ✅
- `grafema analyze . --debug` shows debug output ✅

## Verification

- Lint passed (eslint) ✅
- 22 unit tests pass, 0 fail ✅
- Files changed: `packages/cli/src/commands/analyzeAction.ts`, `packages/cli/src/commands/resolveAction.ts` — both in `packages/cli` (not engine zone)

Files NOT touched: `packages/grafema-orchestrator`, `packages/rfdb*`, `packages/*-resolve` (engine zone).