### PR TITLE
fix(mcp): persist advertised doc_type on save_document (REG-1192)

### DIFF
--- a/packages/mcp/src/handlers/enox-handlers.ts
+++ b/packages/mcp/src/handlers/enox-handlers.ts
@@ -1061,6 +1061,12 @@ export interface SaveDocumentArgs {
   title: string;
   content: string;
   domain?: string;
+  /**
+   * Document classification (e.g. "adr", "postmortem", "spec", "note",
+   * "artifact"). Persisted on the DOCUMENT node metadata so saved documents
+   * are queryable by type. Defaults to "note" when omitted.
+   */
+  doc_type?: string;
   relates_to?: string[];
 }
 
@@ -1068,6 +1074,7 @@ export async function handleSaveDocument(args: SaveDocumentArgs): Promise<ToolRe
   try {
     const client = await getKnowledgeClient();
     const domain = args.domain || 'general';
+    const docType = args.doc_type || 'note';
 
     const docId = `doc:${createHash('sha256')
       .update(`${args.title}|${Date.now()}`)
@@ -1083,6 +1090,7 @@ export async function handleSaveDocument(args: SaveDocumentArgs): Promise<ToolRe
       metadata: JSON.stringify({
         content: args.content,
         domain,
+        doc_type: docType,
         created_at: nowISO(),
       }),
     }]);
@@ -1110,6 +1118,7 @@ export async function handleSaveDocument(args: SaveDocumentArgs): Promise<ToolRe
       `Document saved:`,
       `  ID: ${docId}`,
       `  Title: ${args.title}`,
+      `  Type: ${docType}`,
       `  Domain: ${domain}`,
       `  Content: ${args.content.length} chars`,
     ];

--- a/packages/mcp/test/regressions.test.ts
+++ b/packages/mcp/test/regressions.test.ts
@@ -605,3 +605,48 @@ describe('REG-1144 — advertised tools all have dispatch handlers', () => {
     );
   });
 });
+
+// ============================================================================
+// REG-1192 — save_document must honor every advertised parameter
+//
+// The save_document tool advertises a `doc_type` parameter (enum adr/postmortem/
+// spec/note/artifact). Before the fix, handleSaveDocument never read it, so an
+// agent calling save_document({ doc_type: "adr" }) silently lost the
+// classification — the same advertised-but-ignored trust hole as REG-1191
+// (analyze_project.index_only) and QA-7 (semantic_search.include_edges).
+//
+// This guards the REG-1191-style invariant for save_document: every parameter
+// advertised in its inputSchema must be referenced by handleSaveDocument as
+// `args.<param>`, or it is dead-on-arrival for callers.
+// ============================================================================
+
+describe('REG-1192 — save_document honors advertised parameters', () => {
+  it('every advertised save_document param is read by handleSaveDocument', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+
+    const tool = TOOLS.find((t) => t.name === 'save_document');
+    assert.ok(tool, 'save_document tool must be advertised in TOOLS');
+
+    const schema = tool.inputSchema as { properties?: Record<string, unknown> };
+    const advertised = Object.keys(schema.properties ?? {});
+    assert.ok(advertised.length > 0, 'save_document must advertise parameters');
+
+    // Isolate the handleSaveDocument function body so unrelated handlers in the
+    // same file can't satisfy the invariant by accident.
+    const src = readFileSync(
+      join(here, '..', 'src', 'handlers', 'enox-handlers.ts'),
+      'utf8',
+    );
+    const start = src.indexOf('export async function handleSaveDocument');
+    assert.ok(start >= 0, 'handleSaveDocument must exist');
+    const after = src.indexOf('\nexport ', start + 1);
+    const body = after >= 0 ? src.slice(start, after) : src.slice(start);
+
+    const ignored = advertised.filter((param) => !body.includes(`args.${param}`));
+    assert.deepStrictEqual(
+      ignored,
+      [],
+      `save_document advertises params its handler never reads: ${ignored.join(', ')}`,
+    );
+  });
+});


### PR DESCRIPTION
Fixes REG-1192. Sibling of REG-1191 (`analyze_project.index_only`) and QA-7 (`semantic_search.include_edges`), all under the REG-1144 advertised-but-dead class.

## SPEC

**Invariant restored:** every parameter the `save_document` MCP tool *advertises* must be *honored* by its handler — no advertised-but-dead trust hole for agents.

**Given** the `save_document` tool advertises a `doc_type` parameter (enum `adr/postmortem/spec/note/artifact`, with an example in its description),
**When** an agent calls `save_document({ title, content, doc_type: "adr" })`,
**Then** `doc_type` must be persisted on the resulting `DOCUMENT` node (so saved documents are queryable by classification), defaulting to `"note"` when omitted.

## Before (evidence)

- Advertised: `packages/mcp/src/definitions/enox-tools.ts:440` (schema property) + example at `:428`.
- Dropped: `packages/mcp/src/handlers/enox-handlers.ts:1060` — `SaveDocumentArgs` declared only `title/content/domain/relates_to`; the handler wrote `metadata: { content, domain, created_at }`. `doc_type` never landed in the node, schema, or any edge.

Failing test (red for the right reason):
```
# Subtest: REG-1192 — save_document honors advertised parameters
        save_document advertises params its handler never reads: doc_type
not ok 18 - REG-1192 — save_document honors advertised parameters
# pass 106
# fail 1
```

## Fix (option A — implement, per issue recommendation)

Threaded `doc_type` into `SaveDocumentArgs` and stamped it onto the `DOCUMENT` node metadata (defaulting to `"note"` per the schema description). The write path already builds a `metadata` object, so this is a cheap, queryable classification field. Also surfaced `Type:` in the success output so callers see it was honored. `doc_type` is not an RFDB reserved metadata key (`type/id/name/file/exported`), so no flattening collision.

## After (evidence)

```
ok 18 - REG-1192 — save_document honors advertised parameters
# pass 107
# fail 0
```

Full gate:
- `pnpm build` ✓
- root `./scripts/test.sh` → **741 pass / 0 fail**
- `pnpm --filter @grafema/mcp test` → **107 pass / 0 fail**
- `pnpm typecheck` ✓
- `pnpm lint` ✓

## Test (REG-1144 / REG-1191 static-invariant style)

Server-free regression in `packages/mcp/test/regressions.test.ts`: isolates the `handleSaveDocument` body and asserts every parameter advertised in `save_document`'s `inputSchema` is read as `args.<param>`. (Behavioral testing of the handler would require a live RFDB socket — `getKnowledgeClient()` connects directly — so the static invariant matches the established precedent for this class.)

## Adversarial review

- **A — Correctness:** omit/empty `doc_type` → `"note"`; arbitrary values stored as-is (server doesn't enforce the enum; metadata is a free string — acceptable). Test bounds the function body via the next `\nexport ` so sibling handlers can't satisfy the invariant by accident.
- **B — Structural fragility:** `enox-handlers.ts` is a pre-existing ~1135-line god-file (>500-line limit). This PR adds ~12 lines and does **not** introduce the violation; a split is out of scope. Follow-up below.
- **C — Class-not-instance:** REG-1192 is one instance of the REG-1144 class; siblings QA-7 (fixed) and REG-1191 (in review) already handled. A generic "advertised ⊆ read" invariant across all 49 tools would catch the whole class but risks false positives (destructure renames, intentionally-reserved params), so the test is scoped per-tool per precedent.

## Blast radius

`save_document` is additive: existing callers (no `doc_type`) now get `doc_type: "note"` on their DOCUMENT nodes; no existing field changes. `relates_to` / `domain` paths untouched.

## Follow-ups (out of scope, not filed)

- Generic advertised-⊆-read invariant across all MCP tools (would subsume REG-1144's handler-existence check).
- Split `enox-handlers.ts` (~1135 lines) per the <500-line rule.

https://claude.ai/code/session_013vT2ZTrVnA45S4VDLgzDmP

---
_Generated by [Claude Code](https://claude.ai/code/session_013vT2ZTrVnA45S4VDLgzDmP)_