### PR TITLE
fix(mcp): honor advertised `confidence` param in remember handler (REG-1144)

### DIFF
--- a/packages/mcp/src/handlers/enox-handlers.ts
+++ b/packages/mcp/src/handlers/enox-handlers.ts
@@ -234,12 +234,18 @@ export async function handleRemember(args: RememberArgs): Promise<ToolResult> {
       }),
     }]);
 
+    // Honor the advertised `confidence` parameter (0-1, default 0.9), matching
+    // handleAddAssertion. Without this the caller's confidence was silently
+    // dropped — the stored assertion edge carried no confidence at all. `??`
+    // (not `||`) preserves an explicit confidence of 0.
+    const confidence = args.confidence ?? 0.9;
+
     // Create edge from subject to fact
     await client.addEdges([{
       src: subjectId,
       dst: factNodeId,
       edgeType: relation as EdgeType,
-      metadata: JSON.stringify({ created_at: nowISO() }),
+      metadata: JSON.stringify({ created_at: nowISO(), confidence }),
     }]);
 
     await client.flush();
@@ -249,7 +255,8 @@ export async function handleRemember(args: RememberArgs): Promise<ToolResult> {
       `  Subject: ${subjectId}\n` +
       `  Fact: ${factNodeId}\n` +
       `  Relation: ${relation}\n` +
-      `  Domain: ${domain}`
+      `  Domain: ${domain}\n` +
+      `  Confidence: ${confidence}`
     );
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);

--- a/packages/mcp/test/regressions.test.ts
+++ b/packages/mcp/test/regressions.test.ts
@@ -702,3 +702,51 @@ describe('get_coverage honors advertised parameters', () => {
     );
   });
 });
+
+// ============================================================================
+// remember must honor every advertised parameter
+//
+// The remember tool advertises a `confidence` parameter ("Confidence level 0-1
+// (default: 0.9)"). Before the fix, handleRemember never read it, so an agent
+// calling remember({ confidence: 0.5 }) silently lost the confidence — the
+// stored HAS_FACT assertion edge carried no confidence at all. This is the same
+// advertised-but-ignored trust hole as REG-1192 (save_document.doc_type) and
+// get_coverage.depth.
+//
+// Unlike get_coverage.depth (which was delisted because it was wired to nothing),
+// the capability already exists here: handleAddAssertion stamps `confidence` onto
+// edge metadata. So the fix is to HONOR `confidence` in handleRemember, matching
+// the assertion handler, not to delist it.
+// ============================================================================
+
+describe('remember honors advertised parameters', () => {
+  it('every advertised remember param is read by handleRemember', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+
+    const tool = TOOLS.find((t) => t.name === 'remember');
+    assert.ok(tool, 'remember tool must be advertised in TOOLS');
+
+    const schema = tool.inputSchema as { properties?: Record<string, unknown> };
+    const advertised = Object.keys(schema.properties ?? {});
+    assert.ok(advertised.length > 0, 'remember must advertise parameters');
+
+    // Isolate the handleRemember function body so unrelated handlers in the same
+    // file (e.g. handleAddAssertion, which does read args.confidence) can't
+    // satisfy the invariant by accident.
+    const src = readFileSync(
+      join(here, '..', 'src', 'handlers', 'enox-handlers.ts'),
+      'utf8',
+    );
+    const start = src.indexOf('export async function handleRemember');
+    assert.ok(start >= 0, 'handleRemember must exist');
+    const after = src.indexOf('\nexport ', start + 1);
+    const body = after >= 0 ? src.slice(start, after) : src.slice(start);
+
+    const ignored = advertised.filter((param) => !body.includes(`args.${param}`));
+    assert.deepStrictEqual(
+      ignored,
+      [],
+      `remember advertises params its handler never reads: ${ignored.join(', ')}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The `remember` MCP tool advertises a `confidence` parameter (`"Confidence level 0-1 (default: 0.9)"`, `packages/mcp/src/definitions/enox-tools.ts:84`) and `RememberArgs` even declares `confidence?: number` (`enox-handlers.ts:204`), but **`handleRemember` never read it**. The stored `HAS_FACT` assertion edge carried `{ created_at }` only — so a caller passing `remember({ confidence: 0.5 })` had their confidence **silently dropped**.

This is another instance of the **advertised-but-ignored MCP param** class (REG-1144), following:
- #447 — `save_document.doc_type` (REG-1192, honor)
- #451 — `get_coverage.depth` (honest delist)

The #451 class-sweep explicitly flagged `remember.confidence` as a remaining genuine open sibling that needs **HONOR, not delist** — because the capability already exists.

## Spec

- **Invariant restored:** every parameter advertised in a tool's `inputSchema` is actually read by its handler (no advertised-but-dead trust hole for agents).
- **Given** an agent calls `remember(subject, fact, confidence=0.5)`, **When** the assertion edge is created, **Then** its metadata carries `confidence: 0.5`. **And** when `confidence` is omitted, the advertised default `0.9` is stamped.

## Fix

`handleAddAssertion` already stamps `confidence` onto edge metadata (`enox-handlers.ts:514`) — the capability exists, so the fix mirrors it:

```ts
const confidence = args.confidence ?? 0.9;   // ?? (not ||) preserves an explicit 0
// ...
metadata: JSON.stringify({ created_at: nowISO(), confidence }),
```

`confidence` is also surfaced in the result text, matching `add_assertion`.

## Before / After

**Before** — `handleRemember` body contained no `args.confidence`:
```
$ grep -n "args.confidence" enox-handlers.ts
514:    if (args.confidence !== undefined) edgeMeta.confidence = args.confidence;   # handleAddAssertion
532: ...                                                                            # handleAddAssertion
577: ...                                                                            # handleUpdateAssertion
```
New regression test → **RED for the right reason**:
```
remember advertises params its handler never reads: confidence
+ [ 'confidence' ]
- []
```

**After** — full gate green:
| Check | Result |
|---|---|
| `pnpm --filter @grafema/mcp test` | **109 pass / 1 skip / 0 fail** |
| `pnpm test:coverage` (root unit) | **741 pass / 0 fail** |
| `pnpm typecheck` | exit 0 |
| `pnpm lint` | exit 0 |

## Test

`packages/mcp/test/regressions.test.ts` — static-source regression (no RFDB server needed), mirroring the REG-1192 / get_coverage precedent: isolates the `handleRemember` body (so sibling handlers that *do* read `args.confidence` can't satisfy it by accident) and asserts every advertised `remember` param is read as `args.<param>`.

## Adversarial rounds

- **A — Correctness:** explicit `confidence: 0` preserved via `??` (not `||`); omitted → advertised `0.9` default; parity with `handleAddAssertion` (no range validation — pre-existing across the assertion handlers, not introduced here).
- **B — Structural:** `enox-handlers.ts` is a pre-existing 1141-line god-file; this is a +6-line honor fix that doesn't meaningfully worsen it. Extraction is a separate refactor (out of scope).
- **C — Class-not-instance:** per the #451 sweep, the **only** remaining known open sibling is `check_invariant` (schema advertises `description` but handler reads `args.name`; `limit`/`offset` advertised yet ignored — hardcoded `.slice(0,20)`). That needs handler-logic changes (a larger change) and is filed as a **follow-up**, not bundled here. The sweep already cleared `get_node`/`get_neighbors`/`traverse_graph`/`find_shared_behaviors`/`trace_dataflow` as false positives (params honored via destructure/helpers).

## Blast radius

Only `handleRemember`. Consumers (`recall` / `enox_explore`) already render `eMeta.confidence` when present, so remember-created edges now display consistently with `add_assertion`-created ones.

Refs REG-1144 (advertised-but-dead MCP class), prior art #447 / #451.

https://claude.ai/code/session_01A27rYkhdXMZuuBebzuCwvN

---
_Generated by [Claude Code](https://claude.ai/code/session_01A27rYkhdXMZuuBebzuCwvN)_