### PR TITLE
fix(mcp): honor advertised description/limit/offset in check_invariant (REG-1144)

### DIFF
--- a/packages/mcp/src/handlers/dataflow-handlers.ts
+++ b/packages/mcp/src/handlers/dataflow-handlers.ts
@@ -12,6 +12,7 @@ import {
   serializeBigInt,
   textResult,
   errorResult,
+  normalizeLimit,
 } from '../utils.js';
 import { isGrafemaUri, toCompactSemanticId } from '@grafema/util';
 import type {
@@ -324,11 +325,19 @@ Do NOT repeat the raw graph data — synthesize it into a human-readable explana
   return textResult(sections.join('\n\n'));
 }
 
-// === CHECK INVARIANT (unchanged) ===
+// === CHECK INVARIANT ===
 
+/**
+ * Run a one-off Datalog invariant and report violating nodes. Honors every
+ * advertised `check_invariant` param (REG-1144 class): `description` (label in
+ * result text — was read under the unadvertised `args.name`), `limit` (max
+ * violations, default DEFAULT_LIMIT — was hardcoded 20) and `offset` (pagination).
+ */
 export async function handleCheckInvariant(args: CheckInvariantArgs): Promise<ToolResult> {
   const db = await ensureAnalyzed();
-  const { rule, name: description } = args;
+  const { rule, description } = args;
+  const limit = normalizeLimit(args.limit);
+  const offset = Math.max(0, Math.floor(args.offset ?? 0));
 
   if (!('checkGuarantee' in db)) {
     return errorResult('Backend does not support Datalog queries');
@@ -343,8 +352,9 @@ export async function handleCheckInvariant(args: CheckInvariantArgs): Promise<To
       return textResult(`Invariant holds: ${description || 'No violations found'}`);
     }
 
+    const page = violations.slice(offset, offset + limit);
     const enrichedViolations: unknown[] = [];
-    for (const v of violations.slice(0, 20)) {
+    for (const v of page) {
       const xBinding = v.bindings?.find((b: { name: string; value: string }) => b.name === 'X');
       if (xBinding) {
         const node = await db.getNode(xBinding.value);
@@ -366,12 +376,18 @@ export async function handleCheckInvariant(args: CheckInvariantArgs): Promise<To
       }
     }
 
+    const shownEnd = offset + page.length;
+    const hasMore = shownEnd < total;
+    const label = description ? `${description} — ` : '';
+    const offsetNote = offset > 0 ? ` (from offset ${offset})` : '';
+    const moreNote = hasMore ? `\n\n... and ${total - shownEnd} more (use offset=${shownEnd})` : '';
+
     return textResult(
-      `${total} violation(s) found:\n\n${JSON.stringify(
+      `${label}${total} violation(s) found${offsetNote}:\n\n${JSON.stringify(
         serializeBigInt(enrichedViolations),
         null,
         2
-      )}${total > 20 ? `\n\n... and ${total - 20} more` : ''}`
+      )}${moreNote}`
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -123,7 +123,9 @@ export interface GetShapeArgs {
 
 export interface CheckInvariantArgs {
   rule: string;
-  name?: string;
+  description?: string;
+  limit?: number;
+  offset?: number;
 }
 
 export interface GetSchemaArgs {

--- a/packages/mcp/test/check-invariant-params.test.ts
+++ b/packages/mcp/test/check-invariant-params.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Behavioral tests for `check_invariant` advertised-parameter honoring.
+ *
+ * REG-1144 advertised-but-ignored MCP param class. The check_invariant tool
+ * schema advertises `description`, `limit` and `offset`, but the handler:
+ *   - read `args.name` (a key the schema never advertised) instead of
+ *     `args.description`, so a caller's description was silently dropped;
+ *   - hardcoded `.slice(0, 20)`, ignoring `limit` (advertised default:
+ *     DEFAULT_LIMIT) and `offset` (advertised default: 0) entirely.
+ *
+ * These tests drive the real handler through the mock-backend seam used by
+ * query-graph-count.test.ts (mock.module on ensureAnalyzed) — no RFDB needed.
+ *
+ * TDD: written to FAIL against the pre-fix handler.
+ */
+
+import { describe, it, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { DEFAULT_LIMIT } from '../dist/utils.js';
+
+// --- Mock backend with checkGuarantee + getNode support ---
+
+interface MockBinding {
+  bindings: Array<{ name: string; value: string }>;
+}
+
+function createMockBackend(queryResults: MockBinding[] = []) {
+  const nodes = new Map<string, Record<string, unknown>>();
+  return {
+    async nodeCount() { return nodes.size; },
+    async edgeCount() { return 0; },
+    async countNodesByType() { return {}; },
+    async countEdgesByType() { return {}; },
+    async getNode(id: string) { return nodes.get(id) ?? null; },
+    async getOutgoingEdges() { return []; },
+    async getIncomingEdges() { return []; },
+    async *queryNodes() { /* no-op */ },
+    async getAllNodes() { return []; },
+    async checkGuarantee(_query: string) { return queryResults; },
+    addNode(node: Record<string, unknown>) { nodes.set(node.id as string, node); },
+  };
+}
+
+let mockBackend: ReturnType<typeof createMockBackend>;
+
+mock.module('../dist/analysis.js', {
+  namedExports: {
+    ensureAnalyzed: async () => mockBackend,
+  },
+});
+
+mock.module('../dist/state.js', {
+  namedExports: {
+    getProjectPath: () => '/mock/project',
+  },
+});
+
+const { handleCheckInvariant } = await import('../dist/handlers/dataflow-handlers.js');
+
+/** Build N raw-binding violations whose X value is `v0`, `v1`, ... */
+function rawViolations(n: number): MockBinding[] {
+  return Array.from({ length: n }, (_, i) => ({
+    bindings: [{ name: 'X', value: `v${i}` }],
+  }));
+}
+
+/** Extract and parse the JSON violation array from result text. */
+function parseViolations(text: string): Array<Record<string, string>> {
+  const open = text.indexOf('[');
+  const close = text.lastIndexOf(']');
+  assert.ok(open >= 0 && close > open, `result text has no JSON array: ${text}`);
+  return JSON.parse(text.slice(open, close + 1));
+}
+
+describe('check_invariant honors advertised params (REG-1144 class)', () => {
+  beforeEach(() => {
+    mockBackend = createMockBackend([]);
+  });
+
+  it('description: surfaced in the "invariant holds" message', async () => {
+    mockBackend = createMockBackend([]); // no violations → holds branch
+    const result = await handleCheckInvariant({
+      rule: 'violation(X) :- node(X, "EVAL").',
+      description: 'no eval calls allowed',
+    });
+    assert.ok(!result.isError);
+    assert.ok(
+      result.content[0].text.includes('no eval calls allowed'),
+      `holds message must include the advertised description, got: ${result.content[0].text}`,
+    );
+  });
+
+  it('description: surfaced in the violations report', async () => {
+    mockBackend = createMockBackend(rawViolations(3));
+    const result = await handleCheckInvariant({
+      rule: 'violation(X) :- node(X, "EVAL").',
+      description: 'eval audit',
+    });
+    assert.ok(!result.isError);
+    assert.ok(
+      result.content[0].text.includes('eval audit'),
+      `violations report must include the advertised description, got: ${result.content[0].text}`,
+    );
+  });
+
+  it('limit: caps the number of enriched violations shown', async () => {
+    mockBackend = createMockBackend(rawViolations(25));
+    const result = await handleCheckInvariant({
+      rule: 'violation(X) :- node(X, "EVAL").',
+      limit: 5,
+    });
+    assert.ok(!result.isError);
+    const text = result.content[0].text;
+    assert.ok(text.includes('25 violation(s)'), `should report 25 total, got: ${text}`);
+    const shown = parseViolations(text);
+    assert.strictEqual(shown.length, 5, `limit=5 should show 5 violations, got ${shown.length}`);
+    assert.ok(text.includes('and 20 more'), `should report 20 remaining, got: ${text}`);
+  });
+
+  it('limit: default is DEFAULT_LIMIT, not the old hardcoded 20', async () => {
+    mockBackend = createMockBackend(rawViolations(15));
+    const result = await handleCheckInvariant({
+      rule: 'violation(X) :- node(X, "EVAL").',
+    });
+    assert.ok(!result.isError);
+    const text = result.content[0].text;
+    const shown = parseViolations(text);
+    assert.strictEqual(
+      shown.length,
+      DEFAULT_LIMIT,
+      `default should be DEFAULT_LIMIT (${DEFAULT_LIMIT}), got ${shown.length}`,
+    );
+    assert.ok(
+      text.includes(`and ${15 - DEFAULT_LIMIT} more`),
+      `should report ${15 - DEFAULT_LIMIT} remaining, got: ${text}`,
+    );
+  });
+
+  it('offset: skips the first N violations', async () => {
+    mockBackend = createMockBackend(rawViolations(4));
+    const result = await handleCheckInvariant({
+      rule: 'violation(X) :- node(X, "EVAL").',
+      offset: 2,
+    });
+    assert.ok(!result.isError);
+    const shown = parseViolations(result.content[0].text);
+    assert.strictEqual(shown.length, 2, `offset=2 over 4 should show 2, got ${shown.length}`);
+    assert.deepStrictEqual(
+      shown.map((v) => v.X),
+      ['v2', 'v3'],
+      `offset=2 should start at v2, got: ${JSON.stringify(shown)}`,
+    );
+  });
+
+  it('limit + offset: paginate a window in the middle', async () => {
+    mockBackend = createMockBackend(rawViolations(10));
+    const result = await handleCheckInvariant({
+      rule: 'violation(X) :- node(X, "EVAL").',
+      limit: 3,
+      offset: 4,
+    });
+    assert.ok(!result.isError);
+    const text = result.content[0].text;
+    const shown = parseViolations(text);
+    assert.deepStrictEqual(
+      shown.map((v) => v.X),
+      ['v4', 'v5', 'v6'],
+      `limit=3 offset=4 should be v4..v6, got: ${JSON.stringify(shown)}`,
+    );
+    // 4 skipped + 3 shown = 7; 3 remaining, next offset = 7
+    assert.ok(text.includes('and 3 more'), `should report 3 remaining, got: ${text}`);
+    assert.ok(text.includes('offset=7'), `should suggest next offset=7, got: ${text}`);
+  });
+});

--- a/packages/mcp/test/query-graph-count.test.ts
+++ b/packages/mcp/test/query-graph-count.test.ts
@@ -392,7 +392,7 @@ describe('query_graph count parameter (REG-507)', () => {
 
         const result = await handleCheckInvariant({
           rule: 'violation(S) :- node(X, "IMPORT"), attr(X, "source", S).',
-          name: 'test invariant',
+          description: 'test invariant',
         });
 
         assert.ok(!result.isError);
@@ -417,7 +417,7 @@ describe('query_graph count parameter (REG-507)', () => {
 
         const result = await handleCheckInvariant({
           rule: 'violation(X) :- node(X, "FUNCTION").',
-          name: 'mixed test',
+          description: 'mixed test',
         });
 
         assert.ok(!result.isError);

--- a/packages/mcp/test/regressions.test.ts
+++ b/packages/mcp/test/regressions.test.ts
@@ -750,3 +750,53 @@ describe('remember honors advertised parameters', () => {
     );
   });
 });
+
+// ============================================================================
+// check_invariant must honor every advertised parameter
+//
+// check_invariant advertised `description`, `limit` and `offset`, but
+// handleCheckInvariant read `args.name` (a key the schema never advertised) and
+// hardcoded `.slice(0, 20)` — `description` was dropped, `limit`/`offset` ignored.
+// Same advertised-but-ignored trust hole as REG-1192 (save_document.doc_type) and
+// get_coverage.depth, all under the REG-1144 class.
+//
+// The capability is cheap and the params are now honored (not delisted): like the
+// get_coverage guard, handleCheckInvariant destructures its params, so a param
+// counts as honored if referenced as `args.<param>` OR as a destructured
+// word-boundary identifier in the handler body.
+// ============================================================================
+
+describe('check_invariant honors advertised parameters', () => {
+  it('every advertised check_invariant param is read by handleCheckInvariant', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+
+    const tool = TOOLS.find((t) => t.name === 'check_invariant');
+    assert.ok(tool, 'check_invariant tool must be advertised in TOOLS');
+
+    const schema = tool.inputSchema as { properties?: Record<string, unknown> };
+    const advertised = Object.keys(schema.properties ?? {});
+    assert.ok(advertised.length > 0, 'check_invariant must advertise parameters');
+
+    // Isolate the handleCheckInvariant function body so unrelated handlers in the
+    // same file can't satisfy the invariant by accident.
+    const src = readFileSync(
+      join(here, '..', 'src', 'handlers', 'dataflow-handlers.ts'),
+      'utf8',
+    );
+    const start = src.indexOf('export async function handleCheckInvariant');
+    assert.ok(start >= 0, 'handleCheckInvariant must exist');
+    const after = src.indexOf('\nexport ', start + 1);
+    const body = after >= 0 ? src.slice(start, after) : src.slice(start);
+
+    const ignored = advertised.filter((param) => {
+      if (body.includes(`args.${param}`)) return false;
+      // Allow destructured reads like `const { rule, description } = args`.
+      return !new RegExp(`\\b${param}\\b`).test(body);
+    });
+    assert.deepStrictEqual(
+      ignored,
+      [],
+      `check_invariant advertises params its handler never reads: ${ignored.join(', ')}`,
+    );
+  });
+});


### PR DESCRIPTION
## Source

REG-1144 — MCP "advertised-but-ignored param" class. This closes the **last known sibling** of that class per the #451 sweep, following `save_document.doc_type` (#447), `get_coverage.depth` (#451), and `remember.confidence` (#452).

## Spec

**Invariant restored:** every parameter advertised in a tool's `inputSchema` must be read by its handler — otherwise an agent's argument is silently dropped (a trust hole). `check_invariant` violated this on three params.

**Given** an agent calls `check_invariant` with the advertised params,
**When** the handler runs,
**Then** `description` labels the result, `limit` caps the violations shown (default `DEFAULT_LIMIT`), and `offset` paginates.

## Before (evidence — pre-fix handler, verified via `git stash`)

`packages/mcp/src/handlers/dataflow-handlers.ts` read `args.name` (a key the schema never advertised — `CheckInvariantArgs` declared `name?`) and hardcoded `.slice(0, 20)`:

```
$ node --test test/check-invariant-params.test.ts   # against original source
# tests 6
# pass 0
# fail 6        ← limit=3/offset=4 returned v0..v9 (whole set); description dropped
```
```
$ node --test test/regressions.test.ts
not ok - every advertised check_invariant param is read by handleCheckInvariant
    check_invariant advertises params its handler never reads: limit, offset
```

Schema vs handler at HEAD before fix:
- `query-tools.ts:503` advertises `description`, `:507` `limit` (`default: ${DEFAULT_LIMIT}`=10), `:511` `offset`.
- `types.ts:124` `CheckInvariantArgs { rule; name? }` — no `description`/`limit`/`offset`.
- `dataflow-handlers.ts:331` `const { rule, name: description } = args;` + `.slice(0, 20)`.

## After

- Rename `CheckInvariantArgs.name` → `description`; read `args.description`.
- Thread `limit`/`offset` through the existing `normalizeLimit` helper + a windowed slice (`violations.slice(offset, offset + limit)`), matching the `query-handlers` pagination pattern.
- Result text now carries the description label, an offset note, and a `use offset=N` continuation hint.

HONOR (not delist) because the capability is cheap and intended — unlike `get_coverage.depth` (#451), which was wired to nothing.

```
$ pnpm --filter @grafema/mcp test
# tests 117
# pass 116
# fail 0
# skipped 1
```

## Adversarial review

- **Round A — correctness:** `normalizeLimit` clamps (undefined→`DEFAULT_LIMIT`, 0→1, >MAX→MAX); `offset` is `Math.max(0, Math.floor(…))`; `total===0` short-circuits to the honored-`description` holds message; offset-beyond-total yields a safe empty array; `moreNote` advertises the next offset. Tested: limit cap, default, offset skip, limit+offset window. ✅
- **Round B — structure:** reused `normalizeLimit` (no duplication); kept the file at **499 lines** (<500) by condensing the doc comment rather than scope-creeping an extraction. The file is near the limit — a `dataflow-handlers.ts` split is a reasonable follow-up but out of scope here. ✅
- **Round C — class-not-instance:** this is the last known sibling of REG-1144. Added a static class-guard (mirroring #447/#451/#452) so future schema↔handler drift is caught. No remaining known siblings. ✅

## Gate

`mcp` 116 pass / 1 skip / 0 fail (was 109) · root unit 741 / 0 fail · `pnpm typecheck` clean · `pnpm lint` clean.

## Blast radius

`handleCheckInvariant` callers: `server.ts:308` (dispatch) only. Default `limit` changes 20→10 to match the advertised contract; truncation now surfaces a `use offset=N` hint, so no information is hidden.

## Files

- `packages/mcp/src/handlers/dataflow-handlers.ts` — honor params
- `packages/mcp/src/types.ts` — `CheckInvariantArgs` (`name`→`description`, add `limit`/`offset`)
- `packages/mcp/test/check-invariant-params.test.ts` — 6 behavioral cases (new)
- `packages/mcp/test/regressions.test.ts` — static class-guard
- `packages/mcp/test/query-graph-count.test.ts` — existing calls `name`→`description`

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoQw2UVAgeadApbwHLberU)_