### PR TITLE
build: Dockerfile for the grafema MCP server (Glama submission)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Grafema MCP server — stdio image
+#
+# This image runs the Grafema MCP server (`grafema-mcp`) over stdio, the
+# transport used by MCP clients (Claude Desktop, Cursor, Glama, etc.) and by
+# Glama's automated introspection check (MCP `initialize` + `tools/list`).
+#
+# The analyzed project is bind-mounted at /workspace at runtime, e.g.:
+#   docker run -i --rm -v "$PWD":/workspace grafema-mcp
+# For Glama's static introspection an empty /workspace is fine — the tool
+# list (~40 tools) is static and does not require an analyzed project.
+#
+# Note: `npm install -g grafema` pulls the native analyzer / rfdb binaries
+# (~100MB+), so the image is intentionally on the larger side.
+
+FROM node:22-bookworm-slim
+
+# ca-certificates is needed for TLS (npm install + any outbound calls the
+# native binaries make). The native binaries are dynamically linked against
+# glibc, already present in the -bookworm-slim (Debian) base.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install the Grafema CLI + MCP server globally. This provides the
+# `grafema-mcp` binary (from the `grafema` package, dist/mcp-server.js).
+RUN npm install -g grafema@latest \
+    && npm cache clean --force
+
+# The analyzed project is bind-mounted here at runtime.
+WORKDIR /workspace
+
+# Start the MCP server over stdio against the mounted project.
+ENTRYPOINT ["grafema-mcp", "--project", "/workspace"]

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Add to `.mcp.json` in your project root:
 }
 ```
 
+There is also a Docker image for running the MCP server (stdio) in a container — see the root [`Dockerfile`](./Dockerfile): `docker run -i --rm -v "$PWD":/workspace grafema-mcp`.
+
 30+ MCP tools available: `find_nodes`, `find_calls`, `trace_dataflow`, `get_file_overview`, `describe`, `query_graph`, and more. The AI agent queries the graph instead of reading files — faster, cheaper, more complete.
 
 `find_nodes` returns rich context in a single call: callers, members, parent, import/call counts. Fuzzy name matching via local embeddings means approximate queries like `find_nodes(name="PtyHostHeartbeatService")` find `HeartbeatService` even without exact match.


### PR DESCRIPTION
## What this is for

Adds a root **`Dockerfile`** that runs the Grafema **MCP server** (`grafema-mcp`) over **stdio**, so [Glama](https://glama.ai/mcp/servers) can build the image, start the server, and pass its automated introspection check (MCP `initialize` + `tools/list`).

This unblocks the Glama listing for Grafema, which in turn unblocks the **punkpeye/awesome-mcp** PR #8027 (it was failing the "missing Glama" check).

## What it does

- Base `node:22-bookworm-slim` + `ca-certificates`.
- `npm install -g grafema@latest` — provides the `grafema-mcp` binary (the `grafema` package, `dist/mcp-server.js`).
- `WORKDIR /workspace`; `ENTRYPOINT ["grafema-mcp", "--project", "/workspace"]`. The analyzed project is bind-mounted at `/workspace` at runtime; for Glama's introspection an empty workspace is fine (the tool list is static).
- One-line note added to the README's "Use with AI (MCP)" section pointing at the image.

## How it was tested

Built and run on a Docker VM (Docker 29.1.3):

- **Build:** `docker build -t grafema-mcp:test .` → **exit 0**.
- **Introspection (the Glama requirement):** piped a JSON-RPC handshake (`initialize` → `notifications/initialized` → `tools/list`) into `docker run -i --rm grafema-mcp:test`. The server responded to both requests (ids 1 and 2) over stdio and returned **52 tools** — sample: `find_nodes`, `find_calls`, `trace_dataflow`, `query_graph`, `describe`, `query_graphql`. Clean stderr; starts fine against an empty `/workspace` with no extra flags/env.

## Image size

**~460 MB** — `npm i -g grafema` pulls the native analyzer / rfdb binaries (~100MB+), so it's intentionally on the larger side. This is expected and fine for an MCP server image.

## Caveats

- Uses `grafema@latest` (currently 0.4.1). If you'd prefer a pinned version for reproducibility, say the word and I'll pin it.
- Existing `.dockerignore` is scoped to `demo/Dockerfile` but doesn't conflict with this build (we only `npm install -g`, no source copy).
- Not merging — leaving for your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)