### PR TITLE
effects-db: annotate ioredis + fix dropped SPAWN/MESSAGE_PASSING effects

### DIFF
--- a/effects-db/packages/ioredis.yaml
+++ b/effects-db/packages/ioredis.yaml
@@ -1,0 +1,115 @@
+# ioredis (5.x) — robust, performance-focused Redis client for Node.js
+# Generated: 2026-06-16 (autonomous effects-db fill, IDLE fallback track)
+# Method: Claude probe of the REAL installed ioredis@5.11.1 (no Redis server),
+#         cross-checked against effects-db/taxonomy.yaml v2 and the
+#         effects-db/bridges.yaml `unix-socket` pattern.
+# Taxonomy version: 2
+# purl: pkg:npm/ioredis
+#
+# Why this package matters for Grafema:
+#   The `unix-socket` bridge pattern (effects-db/bridges.yaml) pairs a SENDER
+#   carrying `IO:SOCKET:WRITE` / `IO:SOCKET:CONNECT` with a RECEIVER carrying
+#   `IO:SOCKET:LISTEN` / `IO:SOCKET:READ`. The receiver side exists on the
+#   node.yaml runtime (net.createServer / Server.listen); the sender side existed
+#   only on the node.yaml runtime primitives (net.connect / socket.write) — no
+#   userland npm package on `main` supplied it. ioredis is one of the most-used
+#   socket clients on npm (~5M weekly downloads), so annotating its connection +
+#   command surface lights up the socket-bridge SENDER for every
+#   `new Redis(); redis.get(...)` / `redis.publish(...)` call site.
+#
+#   ioredis is also the first npm package here to carry `MESSAGE_PASSING`: Redis
+#   pub/sub (`publish` / `subscribe`) is genuine inter-service message passing
+#   (until now MESSAGE_PASSING lived only on the elixir/erlang runtimes). This is
+#   exactly the channel-shaped sender/receiver signal that cross-service /
+#   cross-repo contract MATCHING consumes (REG-1145). Plain data commands
+#   (get/set/del) are socket writes but NOT message passing — that distinction is
+#   pinned by test/unit/effectsDbIoredis.test.js so a future edit can't blur it.
+#
+# How these annotations are consumed (verified):
+#   `traceEffects` (packages/util/src/queries/traceEffects.ts) — the engine behind
+#   the MCP `trace-effects` handler and behaviorEnricher — resolves an unresolved
+#   `redis.publish`-style call through `EffectsLookup.lookup('ioredis', ...)` and
+#   propagates the returned effects transitively. test/unit/effectsDbIoredis.test.js
+#   exercises exactly this path on a fixture graph (red→green).
+#
+# Effect conventions used here (all from a live probe of ioredis@5.11.1):
+#   - The default export IS the `Redis` class (module.exports === Redis === Redis.Redis).
+#     Instance methods are keyed `Redis.<method>` (the ClassName.method convention
+#     shared with the pg/mysql2 socket-client entries): a call `const r = new Redis();
+#     r.publish(...)` is resolved by the analyzer to leaf `ioredis.Redis.publish`,
+#     and `EffectsLookup.parseCallTarget` splits on the FIRST dot → module `ioredis`,
+#     fn `Redis.publish`. The constructor `new Redis()` keys the bare `Redis`.
+#   - new Redis() / new Redis.Cluster() connect EAGERLY: a probe against a dead port
+#     emitted an async `error` (ECONNREFUSED) WITHOUT a sync throw → constructors are
+#     [IO, IO:SOCKET:CONNECT, ASYNC], NO THROW. (Distinct from pg's lazy `new Client()`
+#     = PURE; ioredis matches mysql2.createConnection's eager-connect shape.)
+#   - Command methods (get/set/publish/subscribe/call/sendCommand/...) are added to
+#     the prototype chain by the Commander mixin (@ioredis/commands), not declared
+#     statically. They QUEUE the command and return a Promise; failures reject
+#     ASYNCHRONOUSLY. So every command is [IO, IO:SOCKET:WRITE, ASYNC] with NO THROW
+#     (an async rejection is not a sync THROW — same stance as node Socket.write / pg).
+#   - Pub/sub (publish / subscribe / psubscribe / unsubscribe / punsubscribe) add
+#     MESSAGE_PASSING on top of the socket write. The literal message RECEIPT happens
+#     via `redis.on('message', cb)` (an event handler, not a method call) and is not
+#     keyed here.
+#   - pipeline() / multi() return a `Pipeline` builder SYNCHRONOUSLY and perform no IO
+#     until `.exec()` → PURE. disconnect() returns void (a synchronous socket close) →
+#     [IO] (no ASYNC). quit() sends the QUIT command and returns a Promise →
+#     [IO, IO:SOCKET:WRITE, ASYNC]. duplicate() builds a new client (eager connect) →
+#     [IO, IO:SOCKET:CONNECT, ASYNC].
+#   - No structured `channel`/`args`/`returns` entries are declared: the only consumer
+#     of those is the GENERATED registry effects_callable_facts.dl, and no current
+#     bridge pattern matches a Redis pub/sub channel (the `unix-socket` bridge matches
+#     on socket_path from the connection args, not the publish arg). A dedicated
+#     redis-pubsub bridge pattern + channel.name extraction is a future follow-up;
+#     declaring it now would be inert. Plain effect arrays are what `traceEffects`
+#     consumes and what this PR's test verifies.
+#
+# Scope (honest): the data-command set below is REPRESENTATIVE of the ~200 Redis
+# commands (all routed through the same Commander/sendCommand mechanism, which is
+# itself annotated), not exhaustive — mirroring the pg/mysql2 precedent of keying
+# the connection lifecycle + the underlying transport + a representative command
+# slice rather than every generated command method. Cluster shares the same command
+# API as Redis; only its constructor is keyed here.
+
+ioredis:
+  # ── Constructors (eager connect) ──────────────────────────────────────────
+  Redis: [IO, IO:SOCKET:CONNECT, ASYNC]    # new Redis() — connects eagerly
+  Cluster: [IO, IO:SOCKET:CONNECT, ASYNC]  # new Redis.Cluster() — connects eagerly
+
+  # ── Connection lifecycle ──────────────────────────────────────────────────
+  Redis.connect: [IO, IO:SOCKET:CONNECT, ASYNC]    # explicit connect (lazyConnect:true); returns Promise
+  Redis.duplicate: [IO, IO:SOCKET:CONNECT, ASYNC]  # builds a new client; connects per its options
+  Redis.quit: [IO, IO:SOCKET:WRITE, ASYNC]         # sends QUIT then closes; returns Promise
+  Redis.disconnect: [IO]                           # synchronous socket close; returns void
+  Redis.sendCommand: [IO, IO:SOCKET:WRITE, ASYNC]  # the underlying transport for every command
+
+  # ── Pub/sub — socket writes that are ALSO message passing (REG-1145) ───────
+  Redis.publish: [IO, IO:SOCKET:WRITE, MESSAGE_PASSING, ASYNC]
+  Redis.subscribe: [IO, IO:SOCKET:WRITE, MESSAGE_PASSING, ASYNC]
+  Redis.psubscribe: [IO, IO:SOCKET:WRITE, MESSAGE_PASSING, ASYNC]
+  Redis.unsubscribe: [IO, IO:SOCKET:WRITE, MESSAGE_PASSING, ASYNC]
+  Redis.punsubscribe: [IO, IO:SOCKET:WRITE, MESSAGE_PASSING, ASYNC]
+
+  # ── Representative data commands — socket writes, NOT message passing ──────
+  Redis.call: [IO, IO:SOCKET:WRITE, ASYNC]    # generic command runner (alias of sendCommand surface)
+  Redis.get: [IO, IO:SOCKET:WRITE, ASYNC]
+  Redis.set: [IO, IO:SOCKET:WRITE, ASYNC]
+  Redis.del: [IO, IO:SOCKET:WRITE, ASYNC]
+  Redis.hget: [IO, IO:SOCKET:WRITE, ASYNC]
+  Redis.hset: [IO, IO:SOCKET:WRITE, ASYNC]
+  Redis.incr: [IO, IO:SOCKET:WRITE, ASYNC]
+  Redis.expire: [IO, IO:SOCKET:WRITE, ASYNC]
+  Redis.exists: [IO, IO:SOCKET:WRITE, ASYNC]
+  Redis.ttl: [IO, IO:SOCKET:WRITE, ASYNC]
+  Redis.keys: [IO, IO:SOCKET:WRITE, ASYNC]
+  Redis.scan: [IO, IO:SOCKET:WRITE, ASYNC]
+  Redis.eval: [IO, IO:SOCKET:WRITE, ASYNC]    # server-side Lua; socket round-trip
+  Redis.evalsha: [IO, IO:SOCKET:WRITE, ASYNC]
+  Redis.scanStream: [IO, IO:SOCKET:WRITE, ASYNC]  # Readable stream issuing SCAN over the socket
+
+  # ── Builders & value/helper exports ───────────────────────────────────────
+  Redis.pipeline: [PURE]   # returns a Pipeline builder; no IO until .exec()
+  Redis.multi: [PURE]      # returns a Pipeline (transaction) builder; no IO until .exec()
+  ReplyError: [PURE]       # Error subclass constructor (value type)
+  print: [IO, IO:CONSOLE:WRITE]  # callback helper that console.logs the reply/err

--- a/packages/mcp/src/definitions/query-tools.ts
+++ b/packages/mcp/src/definitions/query-tools.ts
@@ -266,7 +266,7 @@ Use this when you need to:
 - "What crosses module boundaries?" → boundary_crossings shows file-to-file effect flow
 
 Effect types: PURE, MUTATION, IO (with subtypes like IO:FILE:READ, IO:HTTP:REQUEST),
-THROW, ASYNC, NONDETERMINISTIC, UNKNOWN.
+THROW, ASYNC, NONDETERMINISTIC, SPAWN, MESSAGE_PASSING, UNKNOWN.
 
 UNKNOWN means: unresolved call, external package not in effects-db, or depth limit reached.
 

--- a/packages/mcp/src/handlers/documentation-handlers.ts
+++ b/packages/mcp/src/handlers/documentation-handlers.ts
@@ -242,6 +242,8 @@ Contents:
 - THROW — may throw exceptions
 - ASYNC — returns Promise, accepts callbacks
 - NONDETERMINISTIC — output varies (internal randomness, timestamps)
+- SPAWN — creates a new concurrent context (process, fiber, worker)
+- MESSAGE_PASSING — sends/coordinates messages between contexts (pub/sub, GenServer.call/cast, send)
 - UNKNOWN — analysis could not determine (FFI, eval, dynamic require)
 
 Propagation: A calls B → A inherits all of B's effects. UNKNOWN propagates transitively.

--- a/packages/util/src/manifest/types.ts
+++ b/packages/util/src/manifest/types.ts
@@ -19,11 +19,20 @@ export type EffectType =
   | 'ASYNC'
   | 'NONDETERMINISTIC'
   | 'UNKNOWN'
+  | 'SPAWN'
+  | 'MESSAGE_PASSING'
   | `IO:${string}`;
 
-/** Valid top-level effect names from taxonomy.yaml */
+/**
+ * Valid top-level effect names from taxonomy.yaml (v2 + REG-1097 additions).
+ * SPAWN and MESSAGE_PASSING were added to the taxonomy and the elixir/erlang
+ * runtimes by REG-1097; they MUST be listed here or `isValidEffect` rejects them
+ * and `traceEffects` silently drops them from propagation (e.g. an Elixir `send` /
+ * `GenServer.cast`, or a Redis `publish`, would otherwise trace as PURE).
+ */
 export const VALID_EFFECTS: ReadonlySet<string> = new Set([
   'PURE', 'MUTATION', 'IO', 'THROW', 'ASYNC', 'NONDETERMINISTIC', 'UNKNOWN',
+  'SPAWN', 'MESSAGE_PASSING',
 ]);
 
 /** Check if a string is a valid effect (top-level or IO subtype) */

--- a/test/unit/effectsDbIoredis.test.js
+++ b/test/unit/effectsDbIoredis.test.js
@@ -1,0 +1,193 @@
+/**
+ * Effects-db coverage guard for the `ioredis` Redis client (~5M weekly downloads).
+ *
+ * Why this exists:
+ *   - The `unix-socket` bridge pattern (effects-db/bridges.yaml) pairs a SENDER
+ *     carrying `IO:SOCKET:WRITE` / `IO:SOCKET:CONNECT` with a RECEIVER carrying
+ *     `IO:SOCKET:LISTEN` / `IO:SOCKET:READ`. Until now no npm *package* annotated
+ *     on `main` supplied the socket sender side — `IO:SOCKET:*` lived only in the
+ *     node.yaml runtime (net/tls). ioredis is one of the most-used socket clients
+ *     on npm; annotating it lights up the socket-bridge sender for every
+ *     `new Redis(); redis.get(...)` / `redis.publish(...)` call site.
+ *   - ioredis is also the first JS package here to carry `MESSAGE_PASSING`: Redis
+ *     pub/sub (`publish` / `subscribe`) is genuine inter-service message passing,
+ *     which directly feeds cross-service/cross-repo contract matching (REG-1145).
+ *     Plain data commands (get/set/del) are socket writes but NOT message passing —
+ *     this test pins that distinction so a future edit can't blur it.
+ *
+ * What this guards:
+ *   1. STRUCTURE — pub/sub carries MESSAGE_PASSING + IO:SOCKET:WRITE; the
+ *      constructor carries IO:SOCKET:CONNECT (eager connect); data commands are
+ *      socket writes WITHOUT message passing; builders (pipeline/multi) stay PURE;
+ *      nothing carries THROW (commands queue and reject asynchronously — a sync
+ *      THROW would mis-mark every caller as possibly-throwing).
+ *   2. FUNCTION — the annotations flow through the real propagation engine.
+ *      `traceEffects` (the code behind the MCP `trace-effects` handler and
+ *      behaviorEnricher) is run over a fixture graph and the transitive effects
+ *      must reflect the annotation. Same mock-backend pattern as the axios/mysql2
+ *      guards — no live server.
+ *
+ * Not covered here (honest scope): a full `grafema analyze` run and the live
+ * materialization of CALLS_REMOTE edges by the socket bridge require a live graph
+ * (grafema CLI + rfdb-server) and are validated separately. The exact leaf-naming
+ * the analyzer emits for an `new Redis()` instance method (`ioredis.Redis.<m>`) is
+ * the documented ClassName.method convention shared with the pg/mysql2 entries;
+ * this guard verifies the lookup + propagation mechanism, not analyzer leaf naming.
+ *
+ * All effects below were derived from a REAL probe of ioredis@5.11.1 (no Redis
+ * server): `new Redis()` to a dead port does not sync-throw and emits an async
+ * ECONNREFUSED (eager connect); get/set/publish/subscribe/connect/quit all return
+ * Promises (ASYNC) and reject asynchronously (no sync THROW); pipeline()/multi()
+ * return a Pipeline builder synchronously (no IO until .exec()); disconnect()
+ * returns void (sync socket close).
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EffectsLookup, traceEffects } from '@grafema/util';
+import { join } from 'node:path';
+
+const EFFECTS_DB_PATH = join(import.meta.dirname, '..', '..', 'effects-db');
+
+/** Redis pub/sub methods — socket writes that are ALSO message passing. */
+const PUBSUB_METHODS = ['publish', 'subscribe', 'psubscribe', 'unsubscribe', 'punsubscribe'];
+
+/** Representative data commands — socket writes, NOT message passing. */
+const DATA_COMMANDS = ['get', 'set', 'del', 'hget', 'hset', 'incr', 'expire', 'exists', 'ttl', 'keys', 'scan', 'call', 'sendCommand'];
+
+/** Minimal in-memory DataflowBackend (mirrors trace-effects.test.js / axios guard). */
+function createMockBackend(nodes, edges) {
+  const nodeMap = new Map(nodes.map(n => [n.id, n]));
+  return {
+    async getNode(id) { return nodeMap.get(id) || null; },
+    async *queryNodes(filter) {
+      for (const n of nodes) {
+        if (filter.type && n.type !== filter.type) continue;
+        if (filter.name && n.name !== filter.name) continue;
+        yield n;
+      }
+    },
+    async getOutgoingEdges(id, types) {
+      return edges.filter(e => e.src === id && (!types || types.includes(e.type)));
+    },
+    async getIncomingEdges(id, types) {
+      return edges.filter(e => e.dst === id && (!types || types.includes(e.type)));
+    },
+  };
+}
+
+// ── STRUCTURE ───────────────────────────────────────────────────────────────
+
+test('ioredis constructor (new Redis / Cluster) is a socket-bridge sender (IO:SOCKET:CONNECT, eager, ASYNC, no THROW)', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  for (const ctor of ['Redis', 'Cluster']) {
+    const effects = lookup.lookup('ioredis', ctor);
+    assert.ok(effects, `Expected effects for ioredis.${ctor}`);
+    assert.ok(effects.includes('IO'), `ioredis.${ctor} must include parent IO, got: ${effects}`);
+    assert.ok(effects.includes('IO:SOCKET:CONNECT'), `ioredis.${ctor} must include IO:SOCKET:CONNECT (eager connect), got: ${effects}`);
+    assert.ok(effects.includes('ASYNC'), `ioredis.${ctor} must include ASYNC, got: ${effects}`);
+    assert.ok(!effects.includes('THROW'), `ioredis.${ctor} must NOT include THROW (connect fails async), got: ${effects}`);
+  }
+});
+
+test('ioredis pub/sub methods carry MESSAGE_PASSING + IO:SOCKET:WRITE (cross-service bridge — REG-1145)', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  for (const m of PUBSUB_METHODS) {
+    const effects = lookup.lookup('ioredis', `Redis.${m}`);
+    assert.ok(effects, `Expected effects for ioredis.Redis.${m}`);
+    assert.ok(effects.includes('MESSAGE_PASSING'), `ioredis.Redis.${m} must include MESSAGE_PASSING, got: ${effects}`);
+    assert.ok(effects.includes('IO:SOCKET:WRITE'), `ioredis.Redis.${m} must include IO:SOCKET:WRITE, got: ${effects}`);
+    assert.ok(effects.includes('IO'), `ioredis.Redis.${m} must include parent IO, got: ${effects}`);
+    assert.ok(effects.includes('ASYNC'), `ioredis.Redis.${m} must include ASYNC, got: ${effects}`);
+    assert.ok(!effects.includes('THROW'), `ioredis.Redis.${m} must NOT include THROW (rejects async), got: ${effects}`);
+  }
+});
+
+test('ioredis data commands are socket writes but NOT message passing', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  for (const m of DATA_COMMANDS) {
+    const effects = lookup.lookup('ioredis', `Redis.${m}`);
+    assert.ok(effects, `Expected effects for ioredis.Redis.${m}`);
+    assert.ok(effects.includes('IO:SOCKET:WRITE'), `ioredis.Redis.${m} must include IO:SOCKET:WRITE, got: ${effects}`);
+    assert.ok(effects.includes('ASYNC'), `ioredis.Redis.${m} must include ASYNC, got: ${effects}`);
+    assert.ok(
+      !effects.includes('MESSAGE_PASSING'),
+      `ioredis.Redis.${m} must NOT include MESSAGE_PASSING (data command, not pub/sub), got: ${effects}`,
+    );
+    assert.ok(!effects.includes('THROW'), `ioredis.Redis.${m} must NOT include THROW (rejects async), got: ${effects}`);
+  }
+});
+
+test('ioredis quit closes via socket write (async); disconnect is a sync socket close (no ASYNC)', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  const quit = lookup.lookup('ioredis', 'Redis.quit');
+  assert.ok(quit, 'Expected effects for ioredis.Redis.quit');
+  assert.ok(quit.includes('IO:SOCKET:WRITE'), `Redis.quit must include IO:SOCKET:WRITE, got: ${quit}`);
+  assert.ok(quit.includes('ASYNC'), `Redis.quit must include ASYNC (returns Promise), got: ${quit}`);
+
+  const disconnect = lookup.lookup('ioredis', 'Redis.disconnect');
+  assert.ok(disconnect, 'Expected effects for ioredis.Redis.disconnect');
+  assert.ok(disconnect.includes('IO'), `Redis.disconnect must include IO, got: ${disconnect}`);
+  assert.ok(!disconnect.includes('ASYNC'), `Redis.disconnect must NOT include ASYNC (returns void), got: ${disconnect}`);
+});
+
+test('ioredis duplicate opens a new connection (IO:SOCKET:CONNECT, ASYNC)', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  const effects = lookup.lookup('ioredis', 'Redis.duplicate');
+  assert.ok(effects, 'Expected effects for ioredis.Redis.duplicate');
+  assert.ok(effects.includes('IO:SOCKET:CONNECT'), `Redis.duplicate must include IO:SOCKET:CONNECT, got: ${effects}`);
+  assert.ok(effects.includes('ASYNC'), `Redis.duplicate must include ASYNC, got: ${effects}`);
+});
+
+test('ioredis pipeline/multi return a builder — PURE until .exec()', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  for (const m of ['pipeline', 'multi']) {
+    assert.deepEqual(
+      lookup.lookup('ioredis', `Redis.${m}`),
+      ['PURE'],
+      `ioredis.Redis.${m} must be PURE (returns a Pipeline builder, no IO until exec)`,
+    );
+  }
+});
+
+test('ioredis pure / value helpers are not effectful (ReplyError); print writes the console', () => {
+  const lookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  assert.deepEqual(lookup.lookup('ioredis', 'ReplyError'), ['PURE'], 'ioredis.ReplyError ctor must be PURE');
+
+  const print = lookup.lookup('ioredis', 'print');
+  assert.ok(print, 'Expected effects for ioredis.print');
+  assert.ok(print.includes('IO:CONSOLE:WRITE'), `ioredis.print must include IO:CONSOLE:WRITE, got: ${print}`);
+});
+
+// ── FUNCTION (real engine, fixture graph, no server) ─────────────────────────
+
+test('traceEffects propagates MESSAGE_PASSING + IO:SOCKET:WRITE from a redis.publish call', async () => {
+  const effectsLookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  const nodes = [
+    { id: 'fn1', type: 'FUNCTION', name: 'broadcast', file: 'src/bus.ts', line: 1 },
+    { id: 'ext1', type: 'EXTERNAL_MODULE', name: 'ioredis.Redis.publish', file: undefined },
+  ];
+  const edges = [{ src: 'fn1', dst: 'ext1', type: 'CALLS' }];
+  const backend = createMockBackend(nodes, edges);
+
+  const result = await traceEffects(backend, 'fn1', effectsLookup);
+  assert.ok(result, 'Expected non-null result');
+  assert.ok(result.transitive.includes('MESSAGE_PASSING'), `Expected MESSAGE_PASSING, got: ${result.transitive}`);
+  assert.ok(result.transitive.includes('IO:SOCKET:WRITE'), `Expected IO:SOCKET:WRITE, got: ${result.transitive}`);
+  assert.ok(result.transitive.includes('IO'), `Expected parent IO, got: ${result.transitive}`);
+  assert.equal(result.leaf_sources[0].node, 'ioredis.Redis.publish');
+});
+
+test('traceEffects leaves a redis.pipeline call pure (builder, no false IO)', async () => {
+  const effectsLookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  const nodes = [
+    { id: 'fn1', type: 'FUNCTION', name: 'buildBatch', file: 'src/bus.ts', line: 1 },
+    { id: 'ext1', type: 'EXTERNAL_MODULE', name: 'ioredis.Redis.pipeline', file: undefined },
+  ];
+  const edges = [{ src: 'fn1', dst: 'ext1', type: 'CALLS' }];
+  const backend = createMockBackend(nodes, edges);
+
+  const result = await traceEffects(backend, 'fn1', effectsLookup);
+  assert.ok(result, 'Expected non-null result');
+  assert.deepEqual(result.transitive, ['PURE'], `redis.pipeline must trace as PURE, got: ${result.transitive}`);
+});

--- a/test/unit/traceEffectsTaxonomy.test.js
+++ b/test/unit/traceEffectsTaxonomy.test.js
@@ -1,0 +1,87 @@
+/**
+ * Regression guard: SPAWN and MESSAGE_PASSING survive traceEffects propagation.
+ *
+ * Why this exists:
+ *   effects-db/taxonomy.yaml v2 (+ the REG-1097 additions) defines two
+ *   concurrency effects — SPAWN and MESSAGE_PASSING — used by the elixir/erlang
+ *   runtimes (effects-db/runtimes/elixir.yaml: `send: [MESSAGE_PASSING]`,
+ *   `spawn: [SPAWN]`, `GenServer.cast`, ...) and now by the ioredis package
+ *   (Redis pub/sub). But the TypeScript effect model (packages/util manifest
+ *   types) originally listed only PURE/MUTATION/IO/THROW/ASYNC/NONDETERMINISTIC/
+ *   UNKNOWN in `VALID_EFFECTS`. `traceEffects` calls `isValidEffect(e)` on every
+ *   leaf effect and silently DROPS anything not in that set — so an Elixir `send`
+ *   or a Redis `publish` traced as PURE, hiding genuine message-passing / spawn
+ *   behavior. This guard pins that both effects now propagate, via the two leaf
+ *   shapes traceEffects accepts:
+ *     1. node metadata effects (comma-joined string) — the beam-analyzer / Haskell
+ *        resolver / pack-minted EXTERNAL_MODULE path;
+ *     2. effects-db lookup — the npm-package path.
+ *
+ * It asserts GRAPH-INDEPENDENT facts only (a fixture graph + the real propagation
+ * engine), no live analyze.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { traceEffects, EffectsLookup } from '@grafema/util';
+import { join } from 'node:path';
+
+const EFFECTS_DB_PATH = join(import.meta.dirname, '..', '..', 'effects-db');
+
+/** Minimal in-memory DataflowBackend (mirrors trace-effects.test.js). */
+function createMockBackend(nodes, edges) {
+  const nodeMap = new Map(nodes.map(n => [n.id, n]));
+  return {
+    async getNode(id) { return nodeMap.get(id) || null; },
+    async *queryNodes(filter) {
+      for (const n of nodes) {
+        if (filter.type && n.type !== filter.type) continue;
+        if (filter.name && n.name !== filter.name) continue;
+        yield n;
+      }
+    },
+    async getOutgoingEdges(id, types) {
+      return edges.filter(e => e.src === id && (!types || types.includes(e.type)));
+    },
+    async getIncomingEdges(id, types) {
+      return edges.filter(e => e.dst === id && (!types || types.includes(e.type)));
+    },
+  };
+}
+
+test('traceEffects propagates SPAWN + MESSAGE_PASSING from node metadata effects (beam-analyzer path)', async () => {
+  // Mirrors an Elixir `spawn_link` / `GenServer.cast` leaf minted with comma-joined
+  // effects metadata (the shape derive packs / the Haskell resolver emit).
+  const nodes = [
+    { id: 'fn1', type: 'FUNCTION', name: 'startWorker', file: 'lib/worker.ex', line: 1 },
+    { id: 'ext1', type: 'EXTERNAL_MODULE', name: 'Kernel.spawn_link', file: undefined, effects: 'SPAWN,MESSAGE_PASSING' },
+  ];
+  const edges = [{ src: 'fn1', dst: 'ext1', type: 'CALLS' }];
+  const backend = createMockBackend(nodes, edges);
+
+  const result = await traceEffects(backend, 'fn1', EffectsLookup.empty());
+  assert.ok(result, 'Expected non-null result');
+  assert.ok(result.transitive.includes('SPAWN'), `Expected SPAWN in transitive, got: ${result.transitive}`);
+  assert.ok(
+    result.transitive.includes('MESSAGE_PASSING'),
+    `Expected MESSAGE_PASSING in transitive, got: ${result.transitive}`,
+  );
+  assert.deepEqual(result.leaf_sources[0].effects.sort(), ['MESSAGE_PASSING', 'SPAWN']);
+});
+
+test('traceEffects propagates MESSAGE_PASSING from an effects-db package lookup (ioredis pub/sub)', async () => {
+  const effectsLookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  const nodes = [
+    { id: 'fn1', type: 'FUNCTION', name: 'emit', file: 'src/bus.ts', line: 1 },
+    { id: 'ext1', type: 'EXTERNAL_MODULE', name: 'ioredis.Redis.publish', file: undefined },
+  ];
+  const edges = [{ src: 'fn1', dst: 'ext1', type: 'CALLS' }];
+  const backend = createMockBackend(nodes, edges);
+
+  const result = await traceEffects(backend, 'fn1', effectsLookup);
+  assert.ok(result, 'Expected non-null result');
+  assert.ok(
+    result.transitive.includes('MESSAGE_PASSING'),
+    `Expected MESSAGE_PASSING in transitive, got: ${result.transitive}`,
+  );
+});


### PR DESCRIPTION
## Summary

Two coupled changes, surfaced together:

1. **Annotate `ioredis`** (~5M weekly downloads) in effects-db. It is the **first npm package on `main`** to supply the `unix-socket` bridge **SENDER** side (`IO:SOCKET:CONNECT` / `IO:SOCKET:WRITE`) — until now `IO:SOCKET:*` lived only on the `node.yaml` runtime — and the **first JS package to carry `MESSAGE_PASSING`** (Redis pub/sub), the channel-shaped sender/receiver signal that cross-service/cross-repo contract matching consumes (**REG-1145**).

2. **Fix a latent bug it surfaced:** the TypeScript effect model (`packages/util/src/manifest/types.ts`) never learned about `SPAWN` / `MESSAGE_PASSING`, even though `effects-db/taxonomy.yaml` v2 (+ the REG-1097 additions) defines both and the elixir/erlang runtimes already use them (`send: [MESSAGE_PASSING]`, `spawn: [SPAWN]`, 85 + 30 occurrences). `isValidEffect()` rejected them, so `traceEffects` **silently dropped** them — an Elixir `send`/`GenServer.cast` or a Redis `publish` traced as `PURE`.

This is the IDLE-fallback track (0 open GH issues, 0 `claude-fix` Linear, backlog gated for this env: no ghc/cabal, at-scale/engine-zone RFDB bugs). Not linked to a single issue; advances REG-1145 (cross-service contracts).

## SPEC

**Invariant restored:** every effect defined in `taxonomy.yaml` v2 survives `traceEffects` propagation; a `publish`/`send`/`spawn` call is not silently flattened to `PURE`.

**Given** a function that calls `ioredis` `Redis.publish` (or an Elixir leaf carrying `SPAWN,MESSAGE_PASSING` metadata)
**When** `traceEffects` runs over it
**Then** the transitive effect set includes `MESSAGE_PASSING` (and `IO:SOCKET:WRITE`, `IO` for the Redis case) — not `[PURE]`.

**Blast radius:** `VALID_EFFECTS` is consumed only via `isValidEffect` (`packages/util/src/manifest/index.ts:8`, two call sites in `traceEffects.ts:247,338`). Adding two members is purely additive — no existing effect changes. The two MCP doc-string edits are agent-facing documentation that enumerate the taxonomy.

## Effect model (probed against the REAL installed `ioredis@5.11.1`, no Redis server)

| Symbol | Effects | Evidence from probe |
|---|---|---|
| `Redis` / `Cluster` (ctor) | `[IO, IO:SOCKET:CONNECT, ASYNC]` | `new Redis()` to a dead port emits async `ECONNREFUSED`, **no sync-throw** (eager connect) |
| `Redis.publish/subscribe/psubscribe/unsubscribe/punsubscribe` | `[IO, IO:SOCKET:WRITE, MESSAGE_PASSING, ASYNC]` | return Promise; pub/sub = inter-service message passing |
| `Redis.get/set/del/.../call/sendCommand/scanStream/eval` | `[IO, IO:SOCKET:WRITE, ASYNC]` | commands queue, return Promise, reject **async** (no sync THROW); NOT message passing |
| `Redis.quit` | `[IO, IO:SOCKET:WRITE, ASYNC]` | returns Promise |
| `Redis.disconnect` | `[IO]` | returns `void` (synchronous socket close) |
| `Redis.duplicate` | `[IO, IO:SOCKET:CONNECT, ASYNC]` | builds a new client |
| `Redis.pipeline/multi` | `[PURE]` | return a `Pipeline` builder synchronously; no IO until `.exec()` |
| `print` | `[IO, IO:CONSOLE:WRITE]` | callback helper that `console.log`s the reply |
| `ReplyError` | `[PURE]` | `Error` subclass constructor (value type) |

## BEFORE / AFTER evidence

**BEFORE — ioredis unknown to the tracer (baseline):**
```
ioredis.Redis.publish = null
packages has ioredis key: false
```

**BEFORE — MESSAGE_PASSING dropped by traceEffects (red, against pre-fix VALID_EFFECTS):**
```
traceEffects propagates MESSAGE_PASSING ... → got: ASYNC,IO,IO:SOCKET:WRITE   # MESSAGE_PASSING missing
test/unit/traceEffectsTaxonomy.test.js → 2 fail
test/unit/effectsDbIoredis.test.js → 8 pass / 1 fail
```

**AFTER:**
```
test/unit/effectsDbIoredis.test.js        → 9 pass / 0 fail
test/unit/traceEffectsTaxonomy.test.js    → 2 pass / 0 fail
```

## Adversarial review

- **Round A — Correctness:** verified each effect against live probe, not memory. Eager-vs-lazy connect (async ECONNREFUSED, no sync-throw) → ctor is `ASYNC` not `THROW`. Async command rejection ≠ sync `THROW` (consistent with node `Socket.write` / pg stance). `disconnect` returns `void` → `[IO]` no `ASYNC`. `pipeline/multi` return a builder → `PURE`. `Redis.call` left as a generic socket write (could run any command incl. PUBLISH — conservative, not MESSAGE_PASSING). `scanStream` is `ASYNC` per taxonomy ("produces values over time").
- **Round B — Structural fragility:** `ioredis.yaml` ~135 lines, both test files < 215 lines, `types.ts` +9 lines — all well under the 500-line limit. No god-file, no duplication.
- **Round C — Class, not instance:** the dropped-effect bug was **not** ioredis-specific — it affected every `SPAWN`/`MESSAGE_PASSING` annotation, including the existing elixir/erlang runtimes. Fixed the class (`VALID_EFFECTS` + `EffectType` + both MCP doc strings), and added `traceEffectsTaxonomy.test.js` guarding **both** leaf paths that reach `isValidEffect` (node-metadata string from the beam/Haskell analyzers, and effects-db lookup). Confirmed red against pre-fix code, green after.

## Verification (full gate, actual outputs)

```
pnpm build      → exit 0
pnpm typecheck  → exit 0
pnpm lint       → exit 0
./scripts/test.sh → # tests 784  # pass 784  # fail 0
@grafema/mcp test → # tests 117  # pass 116  # skip 1  # fail 0
```

## Honest scope / follow-ups

- The exact analyzer leaf-naming for `new Redis()` instance methods (`ioredis.Redis.<m>`) is the `ClassName.method` convention shared with the pg/mysql2 entries; this PR verifies the lookup + propagation mechanism, not a live `grafema analyze` (no grafema CLI / rfdb in this env).
- Data-command set is **representative** of the ~200 Redis commands (all route through the annotated `sendCommand`/Commander mechanism), mirroring the pg/mysql2 precedent. `Cluster` instance methods mirror `Redis`; only its constructor is keyed.
- No structured `channel`/`args` declared (no current bridge pattern matches a Redis pub/sub channel). A dedicated **redis-pubsub bridge pattern** + `channel.name` extraction is a reasonable follow-up.
- Sibling brokers/clients sharing the same socket-sender + MESSAGE_PASSING gap (follow-up class, not filed): `kafkajs`, `nats`, `mqtt`, `redis` (node-redis), `mongodb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SFqHpuz5sYR2C464QTgaP

---
_Generated by [Claude Code](https://claude.ai/code/session_019SFqHpuz5sYR2C464QTgaP)_