### PR TITLE
fix(rust-analyzer): emit WRITES_TO for reassignments (REG-1146)

### DIFF
--- a/packages/grafema-orchestrator/src/rust_analyzer.rs
+++ b/packages/grafema-orchestrator/src/rust_analyzer.rs
@@ -1437,6 +1437,50 @@ fn emit_assigned_from(ctx: &mut Ctx, src_id: String, init: &syn::Expr) {
     }
 }
 
+/// Emit a `WRITES_TO` edge from an assignment target (LHS) to the assigned
+/// value (RHS) when both sides reduce to a single node. Models *reassignment*
+/// — `x = expr`, `self.f = expr`, and compound `x += expr` — as a value flow
+/// into an existing place, distinct from `ASSIGNED_FROM` which is reserved for
+/// declarations-with-initializers (`let`/`const`/`static`/enum discriminants).
+///
+/// Mirrors the JS analyzer's `ruleAssignmentExpression`
+/// (`left --WRITES_TO--> right`) so the edge shape is language-uniform and is
+/// picked up by the deep value-trace consumer in `traceDataflow.ts` (it walks
+/// the reference's outgoing `WRITES_TO` to recover the written value). No-op
+/// for compound LHS/RHS that `expr_node_id` cannot reduce to one node —
+/// matching the defensive behaviour of `emit_assigned_from`.
+fn emit_writes_to(ctx: &mut Ctx, lhs: &syn::Expr, rhs: &syn::Expr) {
+    if let (Some(lhs_id), Some(rhs_id)) = (expr_node_id(lhs, ctx), expr_node_id(rhs, ctx)) {
+        ctx.emit_edge(GraphEdge {
+            src: lhs_id,
+            dst: rhs_id,
+            edge_type: "WRITES_TO".to_string(),
+            metadata: HashMap::new(),
+        });
+    }
+}
+
+/// True for compound-assignment operators (`+=`, `-=`, `*=`, `/=`, `%=`, `^=`,
+/// `&=`, `|=`, `<<=`, `>>=`), which write a new value to their LHS place just
+/// like plain `=`. Plain arithmetic/logical/comparison operators return false,
+/// so ordinary `a + b` does not emit a spurious `WRITES_TO`.
+fn is_compound_assign(op: &syn::BinOp) -> bool {
+    use syn::BinOp::*;
+    matches!(
+        op,
+        AddAssign(_)
+            | SubAssign(_)
+            | MulAssign(_)
+            | DivAssign(_)
+            | RemAssign(_)
+            | BitXorAssign(_)
+            | BitAndAssign(_)
+            | BitOrAssign(_)
+            | ShlAssign(_)
+            | ShrAssign(_)
+    )
+}
+
 fn walk_let(local: &syn::Local, ctx: &mut Ctx) {
     // Collect binding IDs before walking init (for ASSIGNED_FROM)
     let binding_ids = collect_pat_binding_ids(&local.pat, "let", ctx);
@@ -2004,13 +2048,28 @@ fn walk_expr(expr: &syn::Expr, ctx: &mut Ctx) {
         }
 
         // ── Transparent: walk children ──────────────────────────────
-        syn::Expr::Binary(e) => { walk_expr(&e.left, ctx); walk_expr(&e.right, ctx); }
+        syn::Expr::Binary(e) => {
+            walk_expr(&e.left, ctx);
+            walk_expr(&e.right, ctx);
+            // Compound assignment (`x += y`, `x |= y`, …) is a reassignment:
+            // emit WRITES_TO like plain `=`. Pure binary ops (`a + b`) do not.
+            if is_compound_assign(&e.op) {
+                emit_writes_to(ctx, &e.left, &e.right);
+            }
+        }
         syn::Expr::Unary(e) => walk_expr(&e.expr, ctx),
         syn::Expr::Block(e) => walk_block(&e.block, ctx),
         syn::Expr::Paren(e) => walk_expr(&e.expr, ctx),
         syn::Expr::Reference(e) => walk_expr(&e.expr, ctx),
         syn::Expr::Await(e) => walk_expr(&e.base, ctx),
-        syn::Expr::Assign(e) => { walk_expr(&e.left, ctx); walk_expr(&e.right, ctx); }
+        syn::Expr::Assign(e) => {
+            walk_expr(&e.left, ctx);
+            walk_expr(&e.right, ctx);
+            // Reassignment `x = expr` / `self.f = expr` writes a new value into
+            // an existing place — emit WRITES_TO so backward Value Trace can
+            // recover it (mirrors the JS analyzer; consumed by traceDataflow).
+            emit_writes_to(ctx, &e.left, &e.right);
+        }
         syn::Expr::Index(e) => { walk_expr(&e.expr, ctx); walk_expr(&e.index, ctx); }
         syn::Expr::Tuple(e) => { for elem in &e.elems { walk_expr(elem, ctx); } }
         syn::Expr::Array(e) => { for elem in &e.elems { walk_expr(elem, ctx); } }
@@ -2864,6 +2923,99 @@ mod tests {
         // The ASSIGNED_FROM dst should be the CALL foo (not the Try node)
         let dst = &assigned[0].dst;
         assert!(dst.contains("CALL"), "ASSIGNED_FROM should point to CALL, got: {}", dst);
+    }
+
+    #[test]
+    fn test_reassignment_writes_to() {
+        // `x = foo()` is a reassignment: a new value flows into the existing
+        // binding `x`. Mirror the JS analyzer's AssignmentExpression rule —
+        // emit WRITES_TO from the LHS reference to the RHS value so backward
+        // Value Trace (traceDataflow.ts) can recover the written value instead
+        // of dead-ending. ASSIGNED_FROM is reserved for declarations-with-
+        // initializers; reassignment uses WRITES_TO (REG-686 / REG-1146).
+        let fa = parse_and_analyze(
+            "fn foo() -> i32 { 1 } fn main() { let mut x = 0; x = foo(); }"
+        );
+        let writes: Vec<_> = fa.edges.iter()
+            .filter(|e| e.edge_type == "WRITES_TO" && e.src.contains("REFERENCE") && e.src.contains("x"))
+            .collect();
+        assert!(!writes.is_empty(), "reassignment x = foo() should emit WRITES_TO, got edges: {:?}",
+            fa.edges.iter().map(|e| e.edge_type.clone()).collect::<Vec<_>>());
+        assert!(writes[0].dst.contains("CALL"),
+            "WRITES_TO should point to the RHS CALL foo, got: {}", writes[0].dst);
+    }
+
+    #[test]
+    fn test_self_field_reassignment_writes_to() {
+        // `self.count = 0` writes to a field place (PROPERTY_ACCESS), not a
+        // declaration — WRITES_TO from the field access to the literal value.
+        let fa = parse_and_analyze(
+            "struct S { count: i32 } impl S { fn reset(&mut self) { self.count = 0; } }"
+        );
+        let writes: Vec<_> = fa.edges.iter()
+            .filter(|e| e.edge_type == "WRITES_TO" && e.src.contains("PROPERTY_ACCESS") && e.src.contains("count"))
+            .collect();
+        assert!(!writes.is_empty(), "self.count = 0 should emit WRITES_TO from PROPERTY_ACCESS");
+        assert!(writes[0].dst.contains("LITERAL"),
+            "WRITES_TO should point to LITERAL 0, got: {}", writes[0].dst);
+    }
+
+    #[test]
+    fn test_compound_assignment_writes_to() {
+        // Compound assignment `total += amount()` is also a reassignment and
+        // must emit WRITES_TO like plain `=`. (syn models `+=` as Expr::Binary
+        // with a compound-assign BinOp, distinct from the Expr::Assign node.)
+        let fa = parse_and_analyze(
+            "fn amount() -> i32 { 1 } fn main() { let mut total = 0; total += amount(); }"
+        );
+        let writes: Vec<_> = fa.edges.iter()
+            .filter(|e| e.edge_type == "WRITES_TO" && e.src.contains("REFERENCE") && e.src.contains("total"))
+            .collect();
+        assert!(!writes.is_empty(), "compound assignment total += amount() should emit WRITES_TO");
+        assert!(writes[0].dst.contains("CALL"),
+            "WRITES_TO should point to RHS CALL amount, got: {}", writes[0].dst);
+    }
+
+    #[test]
+    fn test_assignment_edge_cases_no_panic() {
+        // Compound/irreducible LHS or RHS must degrade gracefully (no panic,
+        // no bogus edge), matching emit_assigned_from's defensive contract:
+        //  * chained `x = y = z` — the outer RHS is itself an assignment that
+        //    expr_node_id cannot reduce, so only the inner `y = z` emits;
+        //  * `arr[i] = v` — Index LHS cannot reduce → no WRITES_TO;
+        //  * `*p = v` — deref reduces through to the inner reference.
+        let fa = parse_and_analyze(
+            "fn main() { \
+                let (mut x, mut y, z) = (0, 0, 0); x = y = z; \
+                let mut arr = [0; 3]; arr[0] = 1; \
+                let mut n = 0; let p = &mut n; *p = 5; \
+            }"
+        );
+        let writes: Vec<_> = fa.edges.iter()
+            .filter(|e| e.edge_type == "WRITES_TO")
+            .collect();
+        // inner `y = z` and `*p = 5` emit; `arr[0] = 1` (Index LHS) and the
+        // outer chained `x = (y = z)` (Assign RHS) cannot reduce, so do not.
+        assert!(writes.iter().any(|e| e.src.contains("REFERENCE") && e.src.contains("y")),
+            "inner chained assignment y = z should emit WRITES_TO");
+        assert!(writes.iter().any(|e| e.src.contains("REFERENCE") && e.src.contains("p")
+            && e.dst.contains("LITERAL")),
+            "deref assignment *p = 5 should emit WRITES_TO from the reference");
+        assert!(!writes.iter().any(|e| e.src.contains("REFERENCE") && e.src.contains("x")
+            && e.dst.contains("REFERENCE") && e.dst.contains("y")),
+            "outer chained x = (y = z) cannot reduce its RHS — no x->y WRITES_TO");
+    }
+
+    #[test]
+    fn test_plain_binary_no_writes_to() {
+        // A pure binary expression `a + b` is NOT an assignment — it must not
+        // emit a spurious WRITES_TO edge. Guards the compound-assign
+        // discriminator against over-emitting on ordinary arithmetic.
+        let fa = parse_and_analyze("fn main() { let a = 1; let b = 2; let _c = a + b; }");
+        let writes: Vec<_> = fa.edges.iter()
+            .filter(|e| e.edge_type == "WRITES_TO")
+            .collect();
+        assert!(writes.is_empty(), "pure binary a + b must not emit WRITES_TO, got: {:?}", writes);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The Rust analyzer walked both sides of an assignment expression but emitted **no edge** linking them. So reassignments dropped their value-flow:

```rust
syn::Expr::Binary(e) => { walk_expr(&e.left, ctx); walk_expr(&e.right, ctx); } // x += y
syn::Expr::Assign(e) => { walk_expr(&e.left, ctx); walk_expr(&e.right, ctx); } // x = y
```

`grep -rn "WRITES_TO" packages/grafema-orchestrator/src/rust_analyzer.rs` → **0 hits** (pre-fix). Meanwhile the JS analyzer emits `WRITES_TO` for every assignment via `ruleAssignmentExpression` (`packages/js-analyzer/src/Rules/Expressions.hs:205-212`, `left --WRITES_TO--> right`), and the deep value-trace consumer walks it (`packages/util/src/queries/traceDataflow.ts:711-719` — refs reading a decl, then their outgoing `WRITES_TO`, to recover the written value).

Net effect: backward Value Trace dead-ended on any reassigned binding in Rust code (`let mut x = 0; x = compute();` → trace from `x` could not reach `compute`). This is a concrete instance of **REG-1146** ("deep value-dataflow is JS-only — `WRITES_TO`/`DERIVED_FROM` emitted only by js+haskell").

## Spec

- **Invariant restored:** a reassignment is a value source for its target place; the written value must be reachable by backward Value Trace, language-uniformly.
- **Given** Rust `x = foo()` / `self.f = 0` / `x += amount()` **When** analyzed **Then** an `ASSIGNED_FROM`-sibling edge `LHS --WRITES_TO--> RHS` is emitted, matching the JS shape that `traceDataflow.ts` consumes. **And** pure binary `a + b` emits nothing.
- **Edge type reuse:** `WRITES_TO` is already registered (`packages/types/src/edges.ts:62`, `typeValidation.ts:42`) and consumed — no new edge type, no pipeline-invariant change; the fix only enriches.

## Fix

`packages/grafema-orchestrator/src/rust_analyzer.rs` (production: +2 helpers, 2 wired arms):

- `emit_writes_to(ctx, lhs, rhs)` — emits `LHS --WRITES_TO--> RHS` via `expr_node_id`, no-op when either side can't reduce to one node (mirrors `emit_assigned_from`'s defensive contract).
- `is_compound_assign(op)` — discriminates compound-assign BinOps (`+= -= *= /= %= ^= &= |= <<= >>=`) so `Expr::Binary` emits `WRITES_TO` for `x += y` but **not** for `a + b`.
- `Expr::Assign` arm emits for plain `=`; `Expr::Binary` arm emits only for compound-assign ops.

`ASSIGNED_FROM` stays reserved for declarations-with-initializers (`let`/`const`/`static`/enum discriminants) — convention preserved.

## Before / After (TDD)

Red (pre-fix), `cargo test -p grafema-orchestrator --lib writes_to`:
```
reassignment x = foo() should emit WRITES_TO, got edges:
["CONTAINS","DECLARES","HAS_SCOPE",...,"ASSIGNED_FROM",...,"READS_FROM","CALLS","READS_FROM"]   // no WRITES_TO
test result: FAILED. 1 passed; 3 failed
```
Green (post-fix):
```
test rust_analyzer::tests::test_reassignment_writes_to ... ok
test rust_analyzer::tests::test_self_field_reassignment_writes_to ... ok
test rust_analyzer::tests::test_compound_assignment_writes_to ... ok
test rust_analyzer::tests::test_plain_binary_no_writes_to ... ok
test rust_analyzer::tests::test_assignment_edge_cases_no_panic ... ok
test result: ok. 461 passed; 0 failed
```

## Adversarial review

- **Round A (correctness):** chained `x = y = z` (outer RHS is `Expr::Assign`, irreducible → only inner `y = z` emits); `arr[i] = v` (Index LHS irreducible → no edge); `*p = v` (deref reduces through to inner ref). All verified by `test_assignment_edge_cases_no_panic` — no panic, no bogus edges. Negative guard `test_plain_binary_no_writes_to` confirms `a + b` emits nothing.
- **Round B (fragility):** helper colocated with `emit_assigned_from`, same shape/contract. Note: `rust_analyzer.rs` is a pre-existing god-file (~3.1k lines, >500 limit) — every REG-686-family fix (#443/#442) has added to it without extraction; splitting it is a separate refactor (cf. RFD-37/38 for rfdb), out of scope here. Flagged, not expanded.
- **Round C (class-not-instance):** both reassignment forms in Rust (`=` and `op=`) are fixed. Index/tuple/destructuring LHS are accepted misses (consistent with `expr_node_id` reduction, same as `ASSIGNED_FROM`). The cross-language siblings (Python/Go/Java analyzers likely missing `WRITES_TO` too) are the body of REG-1146 itself — left as follow-up, not scope-crept.

## Gate

`cargo test -p grafema-orchestrator --lib` → **461 passed, 0 failed** (5 new). Diff is Rust-only (1 file); no TS touched, so the JS gate is unaffected.

## Blast radius / found-but-unrelated

- Pre-existing failure, NOT caused by this PR (reproduced on clean `2a5ea42`): `cargo test --bin grafema-orchestrator pack_failure_summary_names_packs_and_owned_slices` fails (`main.rs:3523`, `@stdlib/haskell_local_calls must have a slice description`). Unrelated to `rust_analyzer.rs`; worth a separate triage.

Source: REG-1146.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YJ49a9ytW5Fr8L7uSR6gik)_