### PR TITLE
chore(glama): valid SPDX license id + glama.json maintainer claim

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["Disentinel"]
+}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "graph"
   ],
   "author": "Vadim Reshetnikov",
-  "license": "FSL-1.1-Apache-2.0",
+  "license": "FSL-1.1-ALv2",
   "repository": {
     "type": "git",
     "url": "https://github.com/Disentinel/grafema.git"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -28,7 +28,7 @@
     "api",
     "code-analysis"
   ],
-  "license": "FSL-1.1-Apache-2.0",
+  "license": "FSL-1.1-ALv2",
   "author": "Vadim Reshetnikov",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,7 +33,7 @@
     "code-analysis",
     "static-analysis"
   ],
-  "license": "FSL-1.1-Apache-2.0",
+  "license": "FSL-1.1-ALv2",
   "author": "Vadim Reshetnikov",
   "repository": {
     "type": "git",

--- a/packages/grafema-darwin-arm64/package.json
+++ b/packages/grafema-darwin-arm64/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/Disentinel/grafema.git",
     "directory": "packages/grafema-darwin-arm64"
   },
-  "license": "FSL-1.1-Apache-2.0",
+  "license": "FSL-1.1-ALv2",
   "author": "Vadim Reshetnikov",
   "engines": {
     "node": ">= 18"

--- a/packages/grafema-darwin-x64/package.json
+++ b/packages/grafema-darwin-x64/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/Disentinel/grafema.git",
     "directory": "packages/grafema-darwin-x64"
   },
-  "license": "FSL-1.1-Apache-2.0",
+  "license": "FSL-1.1-ALv2",
   "author": "Vadim Reshetnikov",
   "engines": {
     "node": ">= 18"

--- a/packages/grafema-linux-arm64/package.json
+++ b/packages/grafema-linux-arm64/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/Disentinel/grafema.git",
     "directory": "packages/grafema-linux-arm64"
   },
-  "license": "FSL-1.1-Apache-2.0",
+  "license": "FSL-1.1-ALv2",
   "author": "Vadim Reshetnikov",
   "engines": {
     "node": ">= 18"

--- a/packages/grafema-linux-x64/package.json
+++ b/packages/grafema-linux-x64/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/Disentinel/grafema.git",
     "directory": "packages/grafema-linux-x64"
   },
-  "license": "FSL-1.1-Apache-2.0",
+  "license": "FSL-1.1-ALv2",
   "author": "Vadim Reshetnikov",
   "engines": {
     "node": ">= 18"

--- a/packages/grafema/package.json
+++ b/packages/grafema/package.json
@@ -34,7 +34,7 @@
     "ast",
     "mcp"
   ],
-  "license": "FSL-1.1-Apache-2.0",
+  "license": "FSL-1.1-ALv2",
   "author": "Vadim Reshetnikov",
   "repository": {
     "type": "git",

--- a/packages/lang-defs/package.json
+++ b/packages/lang-defs/package.json
@@ -21,7 +21,7 @@
     "build": "tsc",
     "clean": "rm -rf dist"
   },
-  "license": "FSL-1.1-Apache-2.0",
+  "license": "FSL-1.1-ALv2",
   "author": "Vadim Reshetnikov",
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/packages/lang-spec/package.json
+++ b/packages/lang-spec/package.json
@@ -31,7 +31,7 @@
     "code-analysis",
     "graph-vocabulary"
   ],
-  "license": "FSL-1.1-Apache-2.0",
+  "license": "FSL-1.1-ALv2",
   "author": "Vadim Reshetnikov",
   "repository": {
     "type": "git",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -35,7 +35,7 @@
     "model-context-protocol",
     "code-analysis"
   ],
-  "license": "FSL-1.1-Apache-2.0",
+  "license": "FSL-1.1-ALv2",
   "author": "Vadim Reshetnikov",
   "repository": {
     "type": "git",

--- a/packages/rfdb-server/package.json
+++ b/packages/rfdb-server/package.json
@@ -23,7 +23,7 @@
     "rfdb"
   ],
   "author": "Vadim Reshetnikov",
-  "license": "FSL-1.1-Apache-2.0",
+  "license": "FSL-1.1-ALv2",
   "engines": {
     "node": ">= 16"
   },

--- a/packages/rfdb/package.json
+++ b/packages/rfdb/package.json
@@ -36,7 +36,7 @@
     "rega-flow",
     "rfdb"
   ],
-  "license": "FSL-1.1-Apache-2.0",
+  "license": "FSL-1.1-ALv2",
   "author": "Vadim Reshetnikov",
   "repository": {
     "type": "git",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -26,7 +26,7 @@
     "code-analysis",
     "typescript"
   ],
-  "license": "FSL-1.1-Apache-2.0",
+  "license": "FSL-1.1-ALv2",
   "author": "Vadim Reshetnikov",
   "repository": {
     "type": "git",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -29,7 +29,7 @@
     "code-analysis",
     "utilities"
   ],
-  "license": "FSL-1.1-Apache-2.0",
+  "license": "FSL-1.1-ALv2",
   "author": "Vadim Reshetnikov",
   "repository": {
     "type": "git",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/Disentinel/grafema",
     "directory": "packages/vscode"
   },
-  "license": "FSL-1.1-Apache-2.0",
+  "license": "FSL-1.1-ALv2",
   "engines": {
     "vscode": "^1.74.0"
   },


### PR DESCRIPTION
## What

Two small metadata changes for Glama listing hygiene:

1. **Fix invalid SPDX license id.** Every `package.json` declared `"FSL-1.1-Apache-2.0"`, which is not a valid SPDX identifier. Corrected to `"FSL-1.1-ALv2"` — the canonical SPDX id that matches the repo's actual `LICENSE` file (Functional Source License, Version 1.1, ALv2 Future License). 16 `package.json` files updated.
2. **Add `glama.json`** at the repo root claiming `Disentinel` as the maintainer for the Glama MCP listing.

## Why

- Glama listing hygiene / ownership claim.
- SPDX correctness: the previous string was not a recognized SPDX id.

## Note

This does **NOT** change the actual license — it remains FSL-1.1-ALv2 (as in `LICENSE`). The diff is limited to the license-id string in each `package.json` plus the new `glama.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)