### PR TITLE
fix(util): propagate effects-db effects through member calls on default-imported modules (SEP PART A)

### DIFF
--- a/_ai/gaps.md
+++ b/_ai/gaps.md
@@ -482,3 +482,27 @@ at the var-decl level, so a nested-pattern key vs binding distinction is handled
 `extractBindingInfo` (exports the VALUE, not the key) but deeper aliasing is untracked. Also:
 `Declarations.hs` is a pre-existing >500-line god-file — the variable-declaration rules are a
 natural extraction candidate (follow-up, not blocking).
+
+## GAP: effects-db effects don't propagate through member-calls on default-imported external modules (2026-06-17)
+
+**Query that should work but doesn't:** "what side effects does `fetchUser` have?" where
+`fetchUser` calls `axios.get(...)` (`import axios from 'axios'`).
+
+**Expected:** `IO:HTTP:REQUEST` (effects-db `axios.get: [IO, IO:HTTP:REQUEST, ASYNC, THROW]`).
+**Got:** `["ASYNC"]` only — the axios.get effect was NOT propagated.
+
+**Evidence (fixture /tmp/sep-test, fresh #449 binaries, real `traceEffects`):**
+- `loadConfig` → `fs.readFile()` (named import) → `["ASYNC","IO","THROW"]` ✅ propagates.
+- `fetchUser` → `axios.get()` (member call on default import) → `["ASYNC"]` ❌ no IO.
+- `EXTERNAL_MODULE:axios` node IS minted (#449/REG-624 verified) and `effects-db/packages/axios.yaml`
+  HAS `get: [IO, IO:HTTP:REQUEST, ...]` — so node + annotation both present; the missing link is
+  the `pkg.method()` → effects-db `lookup(module="axios", fn="get")` path in side-effect propagation.
+
+**Class:** SEP (side-effect propagation) works for direct named external-function calls but not for
+member-method calls on a default-imported external module. Surfaced by #449 (node) + the effects-db
+package annotations (#438-445) — before #449 npm had no EXTERNAL_MODULE anchor at all. Not a #449
+regression — a pre-existing propagation gap now reachable.
+
+**Locus (to confirm):** `traceEffects`/`findCallsInFunction` (packages/util) member-call resolution
+to (module, method) for the effects-db lookup, OR the JS property-access/method-call resolution that
+should link `axios.get` CALL → module=axios + method=get. Tracked: triage task.

--- a/packages/util/src/queries/traceEffects.ts
+++ b/packages/util/src/queries/traceEffects.ts
@@ -79,6 +79,87 @@ function extractDirectEffects(node: DataflowNode): Set<EffectType> {
   return effects;
 }
 
+/**
+ * Read a node's `effects` metadata in either shape: a JSON array (legacy
+ * enricher / Haskell resolver) or a comma-joined string (derive
+ * js_runtime_globals_nodes pack, whose meta() can only project strings).
+ * Returns null when no effects metadata is present.
+ */
+function readMetaEffects(node: DataflowNode): string[] | null {
+  const raw = (node as Record<string, unknown>).effects;
+  if (Array.isArray(raw)) return raw.map(String);
+  if (typeof raw === 'string' && raw.length > 0) {
+    return raw.split(',').map(s => s.trim()).filter(s => s.length > 0);
+  }
+  return null;
+}
+
+/**
+ * Resolve the receiver of a dotted member call (e.g. `axios.get`) to the
+ * bare/scoped module specifier it was imported from.
+ *
+ * The analyzer emits a dotted CALL node `axios.get` (receiver folded into the
+ * name, object=undefined) whose receiver is reachable via:
+ *
+ *   CALL -[DERIVES_FROM]-> PROPERTY_ACCESS {base:"axios"}
+ *        -[READS_FROM kind:receiver]-> REFERENCE "axios"
+ *        -[READS_FROM]-> IMPORT_BINDING "axios" {source:"axios", importedName:"default"}
+ *
+ * Returns the IMPORT_BINDING.source iff it is a NON-RELATIVE specifier (a bare
+ * or scoped package, not "./..."). Returns null for relative imports, locals,
+ * or genuine ecma-globals (JSON / Math) — whose receiver does not resolve to an
+ * IMPORT_BINDING at all — so callers must NOT override the global's metadata.
+ *
+ * @param callId  ID of the originating CALL node (NOT the resolved target).
+ */
+async function resolveReceiverModule(
+  backend: DataflowBackend,
+  callId: string,
+): Promise<string | null> {
+  // CALL -[DERIVES_FROM]-> PROPERTY_ACCESS (the receiver member access)
+  const derivesFrom = await backend.getOutgoingEdges(callId, ['DERIVES_FROM']);
+  for (const dfEdge of derivesFrom) {
+    const pa = await backend.getNode(dfEdge.dst);
+    if (!pa || pa.type !== 'PROPERTY_ACCESS') continue;
+
+    // PROPERTY_ACCESS -[READS_FROM]-> REFERENCE (the receiver identifier)
+    const readsFrom = await backend.getOutgoingEdges(pa.id, ['READS_FROM']);
+    for (const rfEdge of readsFrom) {
+      const ref = await backend.getNode(rfEdge.dst);
+      if (!ref) continue;
+
+      // Direct hit: the READS_FROM target is itself the IMPORT_BINDING.
+      const fromImport = importBindingSource(ref);
+      if (fromImport) return fromImport;
+
+      // One more hop: REFERENCE -[READS_FROM]-> IMPORT_BINDING.
+      if (ref.type === 'REFERENCE') {
+        const readsFrom2 = await backend.getOutgoingEdges(ref.id, ['READS_FROM']);
+        for (const rf2Edge of readsFrom2) {
+          const binding = await backend.getNode(rf2Edge.dst);
+          const src = binding ? importBindingSource(binding) : null;
+          if (src) return src;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Return the source specifier of a node iff it is an IMPORT_BINDING whose
+ * source is a NON-RELATIVE module (bare `axios` / scoped `@scope/pkg`), else
+ * null. Relative sources ("./util") are rejected — effects-db only annotates
+ * external modules, and overriding for a local import would be wrong.
+ */
+function importBindingSource(node: DataflowNode): string | null {
+  if (node.type !== 'IMPORT_BINDING') return null;
+  const source = (node as Record<string, unknown>).source;
+  if (typeof source !== 'string' || source.length === 0) return null;
+  if (source.startsWith('.') || source.startsWith('/')) return null;
+  return source;
+}
+
 // ── DFS state ─────────────────────────────────────────────────
 
 interface DfsResult {
@@ -182,6 +263,7 @@ async function dfsCollectEffects(
       const result = await processTarget(
         backend, node, targetNode, effectsLookup, visited,
         depth, maxDepth, effects, leafSources, boundaryCrossings,
+        { callId: call.id, callName: call.name },
       );
       if (result.maxDepthReached) maxDepthReached = true;
     } else {
@@ -271,6 +353,13 @@ async function processTarget(
   effects: Set<EffectType>,
   leafSources: LeafSource[],
   boundaryCrossings: BoundaryCrossing[],
+  /**
+   * Context about the originating CALL node, present only when the target was
+   * discovered via findCallsInFunction (Strategy 1). Used to reconcile a
+   * dotted member call (`axios.get`) against effects-db by its imported
+   * receiver module when the resolved target is a PURE ecma-global stand-in.
+   */
+  callContext?: { callId: string; callName: string },
 ): Promise<{ maxDepthReached: boolean }> {
   let maxDepthReached = false;
 
@@ -320,17 +409,56 @@ async function processTarget(
 
   // ── EXTERNAL_MODULE / GLOBAL_DEFINITION → metadata effects first, then effects-db ──
   if (targetNode.type === 'EXTERNAL_MODULE' || targetNode.type === 'GLOBAL_DEFINITION') {
+    // ── Member-call reconciliation (default-imported external module) ──
+    // A dotted CALL like `axios.get` whose receiver is a default/namespace
+    // import gets resolved by the runtime-globals pack onto the ecma-global
+    // `get` (GLOBAL_DEFINITION, effects=PURE) — the receiver is dropped. Before
+    // accepting that PURE stand-in, recover the real module from the receiver
+    // chain and consult effects-db. Guarded to ONLY override a PURE/empty/
+    // UNKNOWN global AND only when the receiver resolves to a non-relative
+    // imported module — so genuine ecma-globals (JSON.parse, Math.max) and the
+    // named-import path are untouched.
+    if (callContext) {
+      const parsedCall = parseCallTarget(callContext.callName);
+      const globalEffects = readMetaEffects(targetNode);
+      const globalIsInert =
+        globalEffects === null ||
+        globalEffects.length === 0 ||
+        globalEffects.every(e => e === 'PURE' || e === 'UNKNOWN');
+      if (parsedCall && globalIsInert) {
+        const [receiverToken, fn] = parsedCall;
+        const source =
+          (await resolveReceiverModule(backend, callContext.callId)) ?? null;
+        if (source) {
+          const known =
+            effectsLookup.lookup(source, fn) ??
+            effectsLookup.lookup(`node:${source}`, fn);
+          if (known) {
+            const leafEffects = collectEffectsFromLookup(known, effects);
+            leafSources.push({
+              node: `${source}.${fn}`,
+              id: targetNode.id,
+              effects: leafEffects,
+              depth,
+              file: targetNode.file,
+            });
+            return { maxDepthReached };
+          }
+        }
+        // Receiver token did not resolve via the chain; do NOT fall back to the
+        // bare token here — without a confirmed non-relative IMPORT_BINDING we
+        // cannot distinguish `axios.get` from a local-object `foo.get`. The
+        // global's own (inert) metadata is used below, preserving prior behavior.
+        void receiverToken;
+      }
+    }
+
     // Try reading effects from node metadata. Two producers, two shapes:
     // - legacy GenericRuntimeGlobals enricher / Haskell resolver: JSON array (MetaList)
     // - derive js_runtime_globals_nodes pack (Wave 4, DELTA 1): @materialize_node
     //   meta() can only project string surfaces, so effects arrive comma-joined
     //   ("IO,THROW"). Fresh graphs have ONLY pack-minted nodes — accept both.
-    const rawMetaEffects = (targetNode as Record<string, unknown>).effects;
-    const metaEffects = Array.isArray(rawMetaEffects)
-      ? rawMetaEffects
-      : typeof rawMetaEffects === 'string' && rawMetaEffects.length > 0
-        ? rawMetaEffects.split(',').map(s => s.trim()).filter(s => s.length > 0)
-        : null;
+    const metaEffects = readMetaEffects(targetNode);
     if (Array.isArray(metaEffects) && metaEffects.length > 0) {
       const leafEffects: EffectType[] = [];
       for (const e of metaEffects) {

--- a/test/unit/effectsDbAxios.test.js
+++ b/test/unit/effectsDbAxios.test.js
@@ -100,6 +100,107 @@ test('traceEffects propagates IO:HTTP:REQUEST from an axios.get call', async () 
   assert.equal(result.leaf_sources[0].node, 'axios.get');
 });
 
+// ── REGRESSION: member call on a default-imported external module ────────────
+//
+// Real-graph shape (verified live on /tmp/sep-test, 2026-06-17). The analyzer
+// emits ONE dotted CALL node `axios.get` (object=undefined) whose only CALLS
+// edge points at the ecma-global stand-in GLOBAL::get (GLOBAL_DEFINITION,
+// effects=PURE) — the receiver was collapsed by the runtime-globals pack. The
+// receiver is still reachable:
+//   CALL -[DERIVES_FROM]-> PROPERTY_ACCESS {base:"axios"}
+//        -[READS_FROM kind:receiver]-> REFERENCE "axios"
+//        -[READS_FROM]-> IMPORT_BINDING "axios" {source:"axios"}
+// traceEffects must walk that chain, recover module="axios", and consult
+// effects-db instead of accepting the PURE global. (PART A of the SEP gap fix.)
+function axiosGetGlobalCollapseGraph() {
+  const nodes = [
+    { id: 'fn1', type: 'FUNCTION', name: 'fetchUser', file: 'src/api.ts', line: 1, async: true },
+    { id: 'call1', type: 'CALL', name: 'axios.get', file: 'src/api.ts', line: 2 },
+    { id: 'GLOBAL::get', type: 'GLOBAL_DEFINITION', name: 'get', source: 'effects-db', effects: 'PURE' },
+    { id: 'pa1', type: 'PROPERTY_ACCESS', name: 'get', base: 'axios', file: 'src/api.ts', line: 2 },
+    { id: 'ref1', type: 'REFERENCE', name: 'axios', file: 'src/api.ts', line: 2 },
+    { id: 'imp1', type: 'IMPORT_BINDING', name: 'axios', source: 'axios', importedName: 'default' },
+  ];
+  const edges = [
+    { src: 'fn1', dst: 'call1', type: 'AWAITS' },
+    { src: 'call1', dst: 'GLOBAL::get', type: 'CALLS' },
+    { src: 'call1', dst: 'pa1', type: 'DERIVES_FROM', metadata: { kind: 'callee' } },
+    { src: 'pa1', dst: 'ref1', type: 'READS_FROM', metadata: { kind: 'receiver' } },
+    { src: 'ref1', dst: 'imp1', type: 'READS_FROM' },
+  ];
+  return { nodes, edges };
+}
+
+test('traceEffects recovers axios.get effects through a collapsed PURE global', async () => {
+  const effectsLookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  const { nodes, edges } = axiosGetGlobalCollapseGraph();
+  const backend = createMockBackend(nodes, edges);
+
+  const result = await traceEffects(backend, 'fn1', effectsLookup);
+  assert.ok(result, 'Expected non-null result');
+  assert.ok(
+    result.transitive.includes('IO:HTTP:REQUEST'),
+    `Expected IO:HTTP:REQUEST in transitive effects, got: ${result.transitive}`,
+  );
+  assert.ok(result.transitive.includes('IO'), `Expected parent IO, got: ${result.transitive}`);
+  const leaf = result.leaf_sources.find(l => l.node === 'axios.get');
+  assert.ok(leaf, `Expected a leaf source for axios.get, got: ${JSON.stringify(result.leaf_sources)}`);
+  assert.ok(leaf.effects.includes('IO:HTTP:REQUEST'), `axios.get leaf must carry IO:HTTP:REQUEST, got: ${leaf.effects}`);
+});
+
+test('traceEffects does NOT clobber a genuine ecma-global (JSON.parse stays inert)', async () => {
+  // JSON.parse resolves onto a PURE/THROW global with NO IMPORT_BINDING behind
+  // the receiver — the override must not fire and invent module="JSON" effects.
+  const effectsLookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  const nodes = [
+    { id: 'fn1', type: 'FUNCTION', name: 'load', file: 'src/api.ts', line: 1 },
+    { id: 'call1', type: 'CALL', name: 'JSON.parse', file: 'src/api.ts', line: 2 },
+    { id: 'GLOBAL::parse', type: 'GLOBAL_DEFINITION', name: 'parse', source: 'effects-db', effects: 'PURE' },
+    // Receiver chain dead-ends at a plain REFERENCE (JSON is a global, not imported).
+    { id: 'pa1', type: 'PROPERTY_ACCESS', name: 'parse', base: 'JSON', file: 'src/api.ts', line: 2 },
+    { id: 'ref1', type: 'REFERENCE', name: 'JSON', file: 'src/api.ts', line: 2 },
+  ];
+  const edges = [
+    { src: 'fn1', dst: 'call1', type: 'RETURNS' },
+    { src: 'call1', dst: 'GLOBAL::parse', type: 'CALLS' },
+    { src: 'call1', dst: 'pa1', type: 'DERIVES_FROM', metadata: { kind: 'callee' } },
+    { src: 'pa1', dst: 'ref1', type: 'READS_FROM', metadata: { kind: 'receiver' } },
+  ];
+  const backend = createMockBackend(nodes, edges);
+
+  const result = await traceEffects(backend, 'fn1', effectsLookup);
+  assert.ok(result, 'Expected non-null result');
+  // No IMPORT_BINDING → no override → the global's own (PURE) metadata stands.
+  assert.deepEqual(result.transitive, ['PURE'], `JSON.parse via PURE global must stay PURE, got: ${result.transitive}`);
+});
+
+test('traceEffects does NOT override for a relative-import receiver', async () => {
+  // A `helpers.get` member call whose receiver is imported from "./helpers"
+  // must NOT be reconciled against effects-db (relative source is rejected).
+  const effectsLookup = EffectsLookup.load(EFFECTS_DB_PATH);
+  const nodes = [
+    { id: 'fn1', type: 'FUNCTION', name: 'use', file: 'src/api.ts', line: 1 },
+    { id: 'call1', type: 'CALL', name: 'axios.get', file: 'src/api.ts', line: 2 },
+    { id: 'GLOBAL::get', type: 'GLOBAL_DEFINITION', name: 'get', source: 'effects-db', effects: 'PURE' },
+    { id: 'pa1', type: 'PROPERTY_ACCESS', name: 'get', base: 'axios', file: 'src/api.ts', line: 2 },
+    { id: 'ref1', type: 'REFERENCE', name: 'axios', file: 'src/api.ts', line: 2 },
+    // Local re-name: the identifier `axios` is actually a relative import.
+    { id: 'imp1', type: 'IMPORT_BINDING', name: 'axios', source: './local-axios', importedName: 'default' },
+  ];
+  const edges = [
+    { src: 'fn1', dst: 'call1', type: 'RETURNS' },
+    { src: 'call1', dst: 'GLOBAL::get', type: 'CALLS' },
+    { src: 'call1', dst: 'pa1', type: 'DERIVES_FROM', metadata: { kind: 'callee' } },
+    { src: 'pa1', dst: 'ref1', type: 'READS_FROM', metadata: { kind: 'receiver' } },
+    { src: 'ref1', dst: 'imp1', type: 'READS_FROM' },
+  ];
+  const backend = createMockBackend(nodes, edges);
+
+  const result = await traceEffects(backend, 'fn1', effectsLookup);
+  assert.ok(result, 'Expected non-null result');
+  assert.deepEqual(result.transitive, ['PURE'], `relative-import receiver must stay PURE, got: ${result.transitive}`);
+});
+
 test('traceEffects leaves an axios.getUri call pure (no false IO)', async () => {
   const effectsLookup = EffectsLookup.load(EFFECTS_DB_PATH);
   const nodes = [


### PR DESCRIPTION
## Gap (verified, `_ai/gaps.md`)
`trace_effects` did not propagate effects-db effects through a **member call on a default-imported external module**. Repro fixture: `import axios from 'axios'` + `fetchUser()` → `axios.get(...)` yielded only `["ASYNC"]`, missing `IO:HTTP:REQUEST` (effects-db `axios.get: [IO, IO:HTTP:REQUEST, ASYNC, THROW]`). Named-import calls (`readFile()`) worked.

## Root cause (two collaborating defects)
- **Defect 1 (decisive, rust resolver pack — NOT in this PR):** `js_runtime_globals_edges.dl` suffix-strips `axios.get` → binds it to the ecma-global `GLOBAL::get` (PURE), discarding the receiver. This is a broader **unsound single-resolution** (any `importedDefault.method()` mis-resolves to an ecma-global of that method name) that passes the `≤1`-target function guarantee. Handed to the resolver owner as **PART B** (needs an engine/pack rebuild).
- **Defect 2 (this PR):** `traceEffects` trusted the bad `GLOBAL::get(PURE)` edge and never recovered the real module.

## This PR — PART A (TypeScript only, no native rebuild)
`traceEffects.ts`: when a dotted call (`recv.fn`) resolves to a PURE/empty/UNKNOWN global, first walk the receiver chain `CALL -[DERIVES_FROM]-> PROPERTY_ACCESS -[READS_FROM]-> REFERENCE -[READS_FROM]-> IMPORT_BINDING` to recover the module `source`, then `effectsLookup.lookup(source, fn)` and use those effects. **Guard:** only overrides when the receiver resolves to a **non-relative imported module** — genuine ecma-globals (`JSON.parse`) and relative imports stay untouched.

## Verify (e2e on the fixture, fresh analyze)
- `fetchUser`: `["ASYNC"]` → **`["ASYNC","IO","IO:HTTP:REQUEST","THROW"]`** ✅
- `loadConfig`: `["ASYNC","IO","THROW"]` (unchanged — named-import path intact)
- 3 new regression tests (recovery + `JSON.parse` guard + relative-import guard); full effects/trace suite **130/130**.

PART B (the resolver-side root fix) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)