### PR TITLE
feat(util): resolution-precision / ambiguity marker — RFD R1 (the explicit-flag primitive)

### DIFF
--- a/packages/util/src/queries/index.ts
+++ b/packages/util/src/queries/index.ts
@@ -48,3 +48,13 @@ export type {
 } from './traceDataflow.js';
 export { traceEffects } from './traceEffects.js';
 export type { TraceEffectsResult, BoundaryCrossing, LeafSource, TraceEffectsOptions } from './traceEffects.js';
+export { classifyResolution, auditResolutionPrecision } from './resolutionPrecision.js';
+export type {
+  ResolutionPrecision,
+  ResolutionMarker,
+  ResolutionBasis,
+  ClassifyContext,
+  MarkedResolution,
+  UnsoundCase,
+  ResolutionPrecisionAudit,
+} from './resolutionPrecision.js';

--- a/packages/util/src/queries/resolutionPrecision.ts
+++ b/packages/util/src/queries/resolutionPrecision.ts
@@ -1,0 +1,345 @@
+/**
+ * Resolution-precision / ambiguity MARKER (RFD R1, spike).
+ *
+ * The load-bearing primitive of the resolution-precision RFD: a util-layer
+ * classification of each *resolution edge* (a CALLS / CALLS_REMOTE edge whose
+ * target is the resolved callee) into one of three soundness classes, derived
+ * from EXISTING local graph signals only — no rust/.dl changes, no SCIP, no
+ * #431 allowlist:
+ *
+ *   precise            — exactly one resolved target AND the resolution carries
+ *                        a basis that names a single concrete callee with no
+ *                        receiver ambiguity (a local same-file/cross-file call,
+ *                        a genuine ecma-global whose receiver is preserved, a
+ *                        builtin external function).
+ *   heuristic-superset — MORE THAN ONE candidate target for the same call (the
+ *                        sound-superset case: the real target is in the set, but
+ *                        the resolver could not pick one), OR a resolvedVia tag
+ *                        known to over-approximate (e.g. rust-cross-method:
+ *                        receiver type unknown → every method of that name).
+ *                        Acceptable-but-noisy.
+ *   suspected-unsound  — a SINGLE target that is provably WRONG: the
+ *                        importedDefault.method() → ecma-GLOBAL::method pattern.
+ *                        The receiver was stripped by suffix-collapse in
+ *                        js_runtime_globals_edges.dl, so `axios.get` resolves to
+ *                        the ecma-global `GLOBAL::get` (PURE) even though `axios`
+ *                        is a real non-relative import. This passes the ≤1-target
+ *                        "is-a-function" guarantee while presenting the WRONG
+ *                        single callee. A defect that must be hard-flagged.
+ *
+ * The classification is a per-edge ATTRIBUTE the graph never carried before
+ * (greenfield — grep over packages/util/src found no existing
+ * precision/confidence/superset marker on edges). Everything else in the RFD
+ * (R2 surfacing, R3 upsell, R4 invariant, R5 detector) consumes this.
+ *
+ * Cheap + local: the classifier itself is pure over signals already on the
+ * edge/target; the suspected-unsound test reuses the exact receiver-resolution
+ * walk that traceEffects.resolveReceiverModule already performs.
+ *
+ * @module queries/resolutionPrecision
+ */
+
+import type { DataflowBackend, DataflowNode, DataflowEdge } from './traceDataflow.js';
+
+// ── Marker schema ─────────────────────────────────────────────
+
+export type ResolutionPrecision = 'precise' | 'heuristic-superset' | 'suspected-unsound';
+
+/**
+ * The marker carried on (conceptually) a resolution edge. In this spike it is
+ * computed on demand by the classifier/audit rather than persisted — the
+ * attribute SHAPE is the contract R2..R5 consume; where it is physically stored
+ * (edge metadata column vs. derived-on-read) is a downstream decision.
+ */
+export interface ResolutionMarker {
+  /** Soundness class. */
+  precision: ResolutionPrecision;
+  /**
+   * Number of resolved targets for this (source CALL, edge-type) — the fan-out.
+   * 1 for precise / suspected-unsound; ≥2 for heuristic-superset.
+   */
+  candidateCount: number;
+  /**
+   * Why this class was assigned. Names the EXISTING signal it was derived from,
+   * so the marker is auditable and the team-server upsell (R3) can quote it.
+   */
+  basis: ResolutionBasis;
+  /** The resolvedVia provenance tag on the edge, if any (verbatim). */
+  resolvedVia?: string;
+}
+
+export type ResolutionBasis =
+  /** Single concrete callee, no receiver ambiguity. */
+  | 'single-concrete-target'
+  /** >1 candidate for the same call: real target present but not disambiguated. */
+  | 'multiple-candidates'
+  /** resolvedVia tag known to over-approximate without a local type clue. */
+  | 'type-unaware-method-superset'
+  /** importedDefault.method() collapsed to an ecma-GLOBAL::method (wrong single target). */
+  | 'imported-default-method-to-ecma-global';
+
+// ── Signals ───────────────────────────────────────────────────
+
+/** Edge types that carry a "resolved callee" relation we classify. */
+const RESOLUTION_EDGE_TYPES = ['CALLS', 'CALLS_REMOTE'];
+
+/**
+ * resolvedVia tags that, per the resolver design, produce a sound SUPERSET when
+ * no local type clue is available — the resolver emits every method of that
+ * name. (rust-cross-method: receiver type unknown ⇒ all same-named methods.)
+ */
+const SUPERSET_RESOLVED_VIA = new Set(['rust-cross-method']);
+
+/** resolvedVia tags whose targets are ecma-globals (suffix-collapse risk). */
+const ECMA_GLOBAL_RESOLVED_VIA = new Set(['runtime-globals']);
+
+// ── Per-edge classifier (pure) ────────────────────────────────
+
+export interface ClassifyContext {
+  /** The originating CALL node. */
+  call: DataflowNode;
+  /** The single resolution edge being classified. */
+  edge: DataflowEdge;
+  /** The resolved target node. */
+  target: DataflowNode | null;
+  /** Total number of resolution-edge targets for this call (fan-out). */
+  candidateCount: number;
+  /**
+   * True iff the call's receiver resolves to a NON-RELATIVE import binding
+   * (the importedDefault.method() precondition). Computed by the caller via
+   * the receiver walk so the classifier stays pure/synchronous.
+   */
+  receiverIsExternalImport: boolean;
+}
+
+/**
+ * Classify one resolution edge. Pure: all async graph reads are done by the
+ * caller and fed in via ClassifyContext.
+ *
+ * Order of tests (most-specific defect first):
+ *  1. suspected-unsound — importedDefault.method() → ecma GLOBAL::method.
+ *  2. heuristic-superset — fan-out > 1, OR a type-unaware-method resolvedVia.
+ *  3. precise — otherwise.
+ */
+export function classifyResolution(ctx: ClassifyContext): ResolutionMarker {
+  const meta = (ctx.edge.metadata ?? {}) as Record<string, unknown>;
+  const resolvedVia = typeof meta.resolvedVia === 'string' ? meta.resolvedVia : undefined;
+
+  // (1) suspected-unsound: the axios.get → GLOBAL::get defect.
+  //
+  // Signature, all derivable locally:
+  //   - target is an ecma GLOBAL_DEFINITION reached via runtime-globals;
+  //   - the CALL name is dotted (receiver.method) but the target name is only
+  //     the method suffix → the receiver was collapsed away;
+  //   - the receiver resolves to a NON-RELATIVE import binding → it is a real
+  //     external package, NOT a genuine ecma-global (JSON / Math / globalThis).
+  if (
+    ctx.target?.type === 'GLOBAL_DEFINITION' &&
+    resolvedVia !== undefined &&
+    ECMA_GLOBAL_RESOLVED_VIA.has(resolvedVia) &&
+    ctx.receiverIsExternalImport &&
+    isReceiverCollapsed(ctx.call, ctx.target)
+  ) {
+    return {
+      precision: 'suspected-unsound',
+      candidateCount: ctx.candidateCount,
+      basis: 'imported-default-method-to-ecma-global',
+      resolvedVia,
+    };
+  }
+
+  // (2) heuristic-superset.
+  if (ctx.candidateCount > 1) {
+    return {
+      precision: 'heuristic-superset',
+      candidateCount: ctx.candidateCount,
+      basis: 'multiple-candidates',
+      resolvedVia,
+    };
+  }
+  if (resolvedVia !== undefined && SUPERSET_RESOLVED_VIA.has(resolvedVia)) {
+    return {
+      precision: 'heuristic-superset',
+      candidateCount: ctx.candidateCount,
+      basis: 'type-unaware-method-superset',
+      resolvedVia,
+    };
+  }
+
+  // (3) precise.
+  return {
+    precision: 'precise',
+    candidateCount: ctx.candidateCount,
+    basis: 'single-concrete-target',
+    resolvedVia,
+  };
+}
+
+/**
+ * True iff the CALL name is dotted (`receiver.method`) but the resolved target
+ * name is ONLY the trailing method segment — i.e. the receiver was stripped by
+ * suffix-collapse. Distinguishes the axios.get→GLOBAL::get defect (call
+ * "axios.get", target "get") from a genuine ecma-global (JSON.parse→
+ * GLOBAL::JSON.parse, where call "JSON.parse" == target "JSON.parse",
+ * receiver preserved).
+ */
+function isReceiverCollapsed(call: DataflowNode, target: DataflowNode): boolean {
+  const callName = typeof call.name === 'string' ? call.name : '';
+  const targetName = typeof target.name === 'string' ? target.name : '';
+  const dot = callName.lastIndexOf('.');
+  if (dot < 0) return false; // call name not dotted → no receiver to collapse
+  const suffix = callName.slice(dot + 1);
+  // Collapsed: target carries only the suffix, not the full dotted callName.
+  return targetName === suffix && targetName !== callName;
+}
+
+// ── Receiver walk (R5 precondition) ───────────────────────────
+//
+// Mirrors traceEffects.resolveReceiverModule: does the CALL's receiver resolve
+// to a NON-RELATIVE import binding? We return the module specifier (truthy) or
+// null. Kept here so the marker is self-contained for the spike; the production
+// merge would share the one copy in traceEffects.
+
+async function receiverExternalImport(
+  backend: DataflowBackend,
+  callId: string,
+): Promise<string | null> {
+  const derivesFrom = await backend.getOutgoingEdges(callId, ['DERIVES_FROM']);
+  for (const df of derivesFrom) {
+    const pa = await backend.getNode(df.dst);
+    if (!pa || pa.type !== 'PROPERTY_ACCESS') continue;
+    const readsFrom = await backend.getOutgoingEdges(pa.id, ['READS_FROM']);
+    for (const rf of readsFrom) {
+      const ref = await backend.getNode(rf.dst);
+      if (!ref) continue;
+      const direct = importBindingSource(ref);
+      if (direct) return direct;
+      if (ref.type === 'REFERENCE') {
+        const rf2s = await backend.getOutgoingEdges(ref.id, ['READS_FROM']);
+        for (const rf2 of rf2s) {
+          const binding = await backend.getNode(rf2.dst);
+          const src = binding ? importBindingSource(binding) : null;
+          if (src) return src;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+function importBindingSource(node: DataflowNode): string | null {
+  if (node.type !== 'IMPORT_BINDING') return null;
+  const source = (node as Record<string, unknown>).source;
+  if (typeof source !== 'string' || source.length === 0) return null;
+  if (source.startsWith('.') || source.startsWith('/')) return null;
+  return source;
+}
+
+// ── POC: graph-wide audit ─────────────────────────────────────
+
+export interface MarkedResolution {
+  callId: string;
+  callName: string;
+  targetId: string;
+  targetName: string;
+  targetType: string;
+  edgeType: string;
+  marker: ResolutionMarker;
+}
+
+export interface UnsoundCase {
+  callId: string;
+  /** e.g. "axios.get" */
+  callName: string;
+  /** The (wrong) resolved ecma-global, e.g. "GLOBAL::get". */
+  resolvedTo: string;
+  /** The collapsed-away receiver's module specifier, e.g. "axios". */
+  receiverModule: string;
+  /** Effects the wrong global presents (e.g. ["PURE"]) — what the defect masks. */
+  presentedEffects: string[];
+}
+
+export interface ResolutionPrecisionAudit {
+  /** Every resolution edge with its marker. */
+  resolutions: MarkedResolution[];
+  /** Tally by precision class. */
+  counts: Record<ResolutionPrecision, number>;
+  /** The suspected-unsound importedDefault.method()→ecma-global cases. */
+  suspectedUnsound: UnsoundCase[];
+}
+
+/**
+ * Walk the graph: classify every CALLS / CALLS_REMOTE resolution edge and
+ * collect the suspected-unsound importedDefault.method()→ecma-global cases.
+ *
+ * Works against any DataflowBackend (RFDBServerBackend on a live socket, or an
+ * in-memory fixture backend for unit tests).
+ */
+export async function auditResolutionPrecision(
+  backend: DataflowBackend,
+): Promise<ResolutionPrecisionAudit> {
+  const calls: DataflowNode[] = [];
+  for await (const n of backend.queryNodes({ type: 'CALL' })) calls.push(n);
+
+  const resolutions: MarkedResolution[] = [];
+  const counts: Record<ResolutionPrecision, number> = {
+    precise: 0,
+    'heuristic-superset': 0,
+    'suspected-unsound': 0,
+  };
+  const suspectedUnsound: UnsoundCase[] = [];
+
+  for (const call of calls) {
+    const edges = await backend.getOutgoingEdges(call.id, RESOLUTION_EDGE_TYPES);
+    if (edges.length === 0) continue;
+    const candidateCount = edges.length;
+
+    // Receiver walk done once per call (independent of the per-edge target).
+    const receiverModule = await receiverExternalImport(backend, call.id);
+    const receiverIsExternalImport = receiverModule !== null;
+
+    for (const edge of edges) {
+      const target = await backend.getNode(edge.dst);
+      const marker = classifyResolution({
+        call,
+        edge,
+        target,
+        candidateCount,
+        receiverIsExternalImport,
+      });
+      counts[marker.precision] += 1;
+      resolutions.push({
+        callId: call.id,
+        callName: typeof call.name === 'string' ? call.name : '',
+        targetId: edge.dst,
+        targetName: typeof target?.name === 'string' ? target.name : '',
+        targetType: target?.type ?? '<missing>',
+        edgeType: edge.type,
+        marker,
+      });
+
+      if (marker.precision === 'suspected-unsound') {
+        suspectedUnsound.push({
+          callId: call.id,
+          callName: typeof call.name === 'string' ? call.name : '',
+          resolvedTo: edge.dst,
+          receiverModule: receiverModule as string,
+          presentedEffects: readEffects(target),
+        });
+      }
+    }
+  }
+
+  return { resolutions, counts, suspectedUnsound };
+}
+
+/** Read a target's effects in either array or comma-string shape. */
+function readEffects(node: DataflowNode | null): string[] {
+  if (!node) return [];
+  const raw = (node as Record<string, unknown>).effects;
+  if (Array.isArray(raw)) return raw.map(String);
+  if (typeof raw === 'string' && raw.length > 0) {
+    return raw.split(',').map(s => s.trim()).filter(s => s.length > 0);
+  }
+  return [];
+}

--- a/test/unit/ResolutionPrecisionMarker.test.js
+++ b/test/unit/ResolutionPrecisionMarker.test.js
@@ -1,0 +1,161 @@
+/**
+ * Resolution-precision / ambiguity MARKER (RFD R1, spike).
+ *
+ * Unit-level proof of the marker classifier + audit against an in-memory
+ * fixture backend whose node/edge shape mirrors the LIVE /tmp/sep-test graph
+ * (probed verbatim 2026-06-17 with fresh #449 binaries):
+ *
+ *   axios.get  CALL → GLOBAL::get (GLOBAL_DEFINITION, name "get", PURE,
+ *              resolvedVia "runtime-globals"); receiver axios is a NON-RELATIVE
+ *              default import  ⇒ suspected-unsound (the defect).
+ *   JSON.parse CALL → GLOBAL::JSON.parse (receiver "JSON" preserved in target
+ *              name; no import binding) ⇒ precise (a genuine ecma-global).
+ *   readFile   CALL → 3 targets (GLOBAL + EXTERNAL_FUNCTION + IMPORT_BINDING)
+ *              ⇒ heuristic-superset (fan-out > 1).
+ *
+ * Per the small-fixtures discipline: a FixtureStorageView-style in-memory
+ * DataflowBackend keeps the test at ~0.0s and free of any rfdb-server process.
+ */
+
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import {
+  classifyResolution,
+  auditResolutionPrecision,
+} from '../../packages/util/dist/queries/index.js';
+
+// ── In-memory DataflowBackend fixture (mirrors /tmp/sep-test) ──
+
+function makeFixtureBackend(nodes, edges) {
+  const byId = new Map(nodes.map(n => [n.id, n]));
+  return {
+    async getNode(id) {
+      return byId.get(id) ?? null;
+    },
+    async *queryNodes(filter) {
+      for (const n of nodes) {
+        if (filter.type && n.type !== filter.type) continue;
+        yield n;
+      }
+    },
+    async getOutgoingEdges(id, types) {
+      return edges.filter(
+        e => e.src === id && (!types || types.includes(e.type)),
+      );
+    },
+    async getIncomingEdges(id, types) {
+      return edges.filter(
+        e => e.dst === id && (!types || types.includes(e.type)),
+      );
+    },
+  };
+}
+
+// Node/edge fixture transcribed from the live sep-test probe.
+const NODES = [
+  // CALLs
+  { id: 'CALL:axios.get', type: 'CALL', name: 'axios.get' },
+  { id: 'CALL:JSON.parse', type: 'CALL', name: 'JSON.parse' },
+  { id: 'CALL:readFile', type: 'CALL', name: 'readFile' },
+  // resolved targets
+  { id: 'GLOBAL::get', type: 'GLOBAL_DEFINITION', name: 'get', effects: 'PURE' },
+  { id: 'GLOBAL::JSON.parse', type: 'GLOBAL_DEFINITION', name: 'JSON.parse', effects: 'THROW' },
+  { id: 'GLOBAL::readFile', type: 'GLOBAL_DEFINITION', name: 'readFile', effects: 'IO' },
+  { id: 'EXT:fs.readFile', type: 'EXTERNAL_FUNCTION', name: 'readFile' },
+  { id: 'IB:readFile', type: 'IMPORT_BINDING', name: 'readFile', source: 'fs/promises', importedName: 'readFile' },
+  // axios.get receiver chain
+  { id: 'PA:axios.get', type: 'PROPERTY_ACCESS', name: 'get' },
+  { id: 'REF:axios', type: 'REFERENCE', name: 'axios' },
+  { id: 'IB:axios', type: 'IMPORT_BINDING', name: 'axios', source: 'axios', importedName: 'default' },
+];
+
+const RV_GLOBAL = { resolvedVia: 'runtime-globals', globalCategory: 'ecmascript' };
+
+const EDGES = [
+  // axios.get → GLOBAL::get (the defect)  + receiver chain
+  { src: 'CALL:axios.get', dst: 'GLOBAL::get', type: 'CALLS', metadata: RV_GLOBAL },
+  { src: 'CALL:axios.get', dst: 'PA:axios.get', type: 'DERIVES_FROM', metadata: { kind: 'callee' } },
+  { src: 'PA:axios.get', dst: 'REF:axios', type: 'READS_FROM', metadata: { kind: 'receiver' } },
+  { src: 'REF:axios', dst: 'IB:axios', type: 'READS_FROM', metadata: {} },
+  // JSON.parse → GLOBAL::JSON.parse (genuine ecma-global, receiver preserved, NO import binding)
+  { src: 'CALL:JSON.parse', dst: 'GLOBAL::JSON.parse', type: 'CALLS', metadata: RV_GLOBAL },
+  // readFile → 3 targets (fan-out superset)
+  { src: 'CALL:readFile', dst: 'GLOBAL::readFile', type: 'CALLS', metadata: RV_GLOBAL },
+  { src: 'CALL:readFile', dst: 'EXT:fs.readFile', type: 'CALLS', metadata: { resolvedVia: 'builtins' } },
+  { src: 'CALL:readFile', dst: 'IB:readFile', type: 'CALLS', metadata: { _source: 'analyzer' } },
+];
+
+describe('resolution-precision marker (R1)', () => {
+  it('classifyResolution: importedDefault.method() → ecma GLOBAL::method = suspected-unsound', () => {
+    const m = classifyResolution({
+      call: { id: 'CALL:axios.get', type: 'CALL', name: 'axios.get' },
+      edge: { src: 'CALL:axios.get', dst: 'GLOBAL::get', type: 'CALLS', metadata: RV_GLOBAL },
+      target: { id: 'GLOBAL::get', type: 'GLOBAL_DEFINITION', name: 'get', effects: 'PURE' },
+      candidateCount: 1,
+      receiverIsExternalImport: true,
+    });
+    assert.equal(m.precision, 'suspected-unsound');
+    assert.equal(m.basis, 'imported-default-method-to-ecma-global');
+    assert.equal(m.candidateCount, 1);
+    assert.equal(m.resolvedVia, 'runtime-globals');
+  });
+
+  it('classifyResolution: genuine ecma-global (receiver preserved, no import) = precise', () => {
+    const m = classifyResolution({
+      call: { id: 'CALL:JSON.parse', type: 'CALL', name: 'JSON.parse' },
+      edge: { src: 'CALL:JSON.parse', dst: 'GLOBAL::JSON.parse', type: 'CALLS', metadata: RV_GLOBAL },
+      target: { id: 'GLOBAL::JSON.parse', type: 'GLOBAL_DEFINITION', name: 'JSON.parse', effects: 'THROW' },
+      candidateCount: 1,
+      receiverIsExternalImport: false,
+    });
+    assert.equal(m.precision, 'precise');
+    assert.equal(m.basis, 'single-concrete-target');
+  });
+
+  it('classifyResolution: fan-out > 1 = heuristic-superset', () => {
+    const m = classifyResolution({
+      call: { id: 'CALL:readFile', type: 'CALL', name: 'readFile' },
+      edge: { src: 'CALL:readFile', dst: 'EXT:fs.readFile', type: 'CALLS', metadata: { resolvedVia: 'builtins' } },
+      target: { id: 'EXT:fs.readFile', type: 'EXTERNAL_FUNCTION', name: 'readFile' },
+      candidateCount: 3,
+      receiverIsExternalImport: false,
+    });
+    assert.equal(m.precision, 'heuristic-superset');
+    assert.equal(m.basis, 'multiple-candidates');
+  });
+
+  it('classifyResolution: type-unaware rust-cross-method = heuristic-superset', () => {
+    const m = classifyResolution({
+      call: { id: 'CALL:foo', type: 'CALL', name: 'x.foo' },
+      edge: { src: 'CALL:foo', dst: 'M:foo', type: 'CALLS', metadata: { resolvedVia: 'rust-cross-method' } },
+      target: { id: 'M:foo', type: 'METHOD', name: 'foo' },
+      candidateCount: 1,
+      receiverIsExternalImport: false,
+    });
+    assert.equal(m.precision, 'heuristic-superset');
+    assert.equal(m.basis, 'type-unaware-method-superset');
+  });
+
+  it('auditResolutionPrecision: flags axios.get on the sep-test fixture shape', async () => {
+    const backend = makeFixtureBackend(NODES, EDGES);
+    const audit = await auditResolutionPrecision(backend);
+
+    // Exactly one suspected-unsound case: axios.get.
+    assert.equal(audit.suspectedUnsound.length, 1, 'one suspected-unsound case');
+    const u = audit.suspectedUnsound[0];
+    assert.equal(u.callName, 'axios.get');
+    assert.equal(u.resolvedTo, 'GLOBAL::get');
+    assert.equal(u.receiverModule, 'axios');
+    assert.deepEqual(u.presentedEffects, ['PURE']);
+
+    // Counts: 1 suspected-unsound (axios.get→GLOBAL), 3 superset (readFile fan-out),
+    // 1 precise (JSON.parse).
+    assert.equal(audit.counts['suspected-unsound'], 1);
+    assert.equal(audit.counts['heuristic-superset'], 3);
+    assert.equal(audit.counts['precise'], 1);
+
+    // JSON.parse is precise, NOT mis-flagged as unsound.
+    const jsonRes = audit.resolutions.find(r => r.callName === 'JSON.parse');
+    assert.equal(jsonRes.marker.precision, 'precise');
+  });
+});


### PR DESCRIPTION
First buildable piece of the resolution-precision RFD (#461) — the **load-bearing primitive**: the place the graph records HOW a use-site resolved, not just WHAT.

## What
`packages/util/src/queries/resolutionPrecision.ts`:
- `classifyResolution(ctx)` — pure per-edge classifier → `{ precision: 'precise' | 'heuristic-superset' | 'suspected-unsound', candidateCount, basis, resolvedVia }`.
- `auditResolutionPrecision(backend)` — walks any backend (live `RFDBServerBackend` or an in-memory fixture) → per-edge markers + the list of suspected-unsound `importedDefault.method() → ecma-global` cases.

Derived **on-read** from existing local signals only (resolvedVia tag, fan-out count, the `GLOBAL::method`-misresolution pattern). **No** rust/.dl changes, **no** SCIP, **no** #431 changes. The attribute SHAPE is the contract that R2 (surface in consumers), R3 (upsell), R4 (soundness guarantee), R5 (unsound detector) build on; physical storage (edge-metadata vs derive-on-read) is a later call.

## Verify (live audit on a real fixture)
```
counts: { precise: 1, heuristic-superset: 3, suspected-unsound: 1 }
  [precise]            JSON.parse → GLOBAL::JSON.parse
  [suspected-unsound]  axios.get  → GLOBAL::get      ← flags the gaps.md unsound case
  [heuristic-superset] readFile   → GLOBAL::readFile + EXTERNAL_FUNCTION:fs/promises.readFile
```
5/5 unit tests. The principle, proven end-to-end: the graph can now say "this single target is **unsound**" / "this is a **superset**" instead of silently presenting one target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)