### PR TITLE
fix(derive): SEP PART B / R6 — receiver-import guard (axios.get→GLOBAL::get unsoundness)

### DIFF
--- a/packages/rfdb-server/src/derive/stdlib.rs
+++ b/packages/rfdb-server/src/derive/stdlib.rs
@@ -4972,6 +4972,62 @@ mod tests {
         assert_eq!(spec.meta, vec!["resolvedVia".to_string(), "globalCategory".to_string()]);
     }
 
+    /// SEP PART B / RFD R6 — the receiver-import guard. A dotted member call on
+    /// a default/namespace-IMPORTED receiver (`axios.get`) must NOT resolve to
+    /// the bare ecma-global `get`: that strips the receiver and is unsound (the
+    /// side-effect-propagation gap). The guard detects the receiver structurally
+    /// via the analyzer-committed chain CALL -DERIVES_FROM-> PROPERTY_ACCESS
+    /// -READS_FROM-> REFERENCE -READS_FROM-> IMPORT_BINDING and blocks the win on
+    /// the STRIPPED suffix. An identical `foo.get` whose receiver is a LOCAL
+    /// variable (not an import) is untouched — proving the discriminator is the
+    /// import receiver, not the dotted shape.
+    #[test]
+    fn js_runtime_globals_edges_receiver_import_guard() {
+        let mut v = FixtureStorageView::new(1);
+
+        // The bare ecma-global endpoint both calls would otherwise win.
+        named_node(&mut v, "GLOBAL::get", "get", "GLOBAL_DEFINITION", "<runtime/js>");
+
+        // DEFECT case: `axios.get`, receiver resolves to an IMPORT_BINDING.
+        named_node(&mut v, "c_axios", "axios.get", "CALL", "app.ts");
+        named_node(&mut v, "pa_axios", "get", "PROPERTY_ACCESS", "app.ts");
+        named_node(&mut v, "ref_axios", "axios", "REFERENCE", "app.ts");
+        named_node(&mut v, "ib_axios", "axios", "IMPORT_BINDING", "app.ts");
+        edge(&mut v, "c_axios", "pa_axios", "DERIVES_FROM");
+        edge(&mut v, "pa_axios", "ref_axios", "READS_FROM");
+        edge(&mut v, "ref_axios", "ib_axios", "READS_FROM");
+
+        // KEEP case: `foo.get`, identical suffix, but receiver is a LOCAL var.
+        named_node(&mut v, "c_foo", "foo.get", "CALL", "app.ts");
+        named_node(&mut v, "pa_foo", "get", "PROPERTY_ACCESS", "app.ts");
+        named_node(&mut v, "ref_foo", "foo", "REFERENCE", "app.ts");
+        named_node(&mut v, "var_foo", "foo", "VARIABLE", "app.ts");
+        edge(&mut v, "c_foo", "pa_foo", "DERIVES_FROM");
+        edge(&mut v, "pa_foo", "ref_foo", "READS_FROM");
+        edge(&mut v, "ref_foo", "var_foo", "READS_FROM");
+
+        let (eval, _specs, _node_specs) = evaluate_with_materialize(
+            &v,
+            JS_RUNTIME_GLOBALS_EDGES_DL,
+            Stats::default(),
+            EvalLimits::none(),
+            EventLog::discard(),
+        )
+        .expect("js_runtime_globals_edges.dl evaluates");
+
+        let edges: BTreeSet<(u128, u128)> = eval
+            .facts("rtg_call_edge")
+            .into_iter()
+            .map(|r| (r[0].as_id().expect("src id"), r[1].as_id().expect("dst id")))
+            .collect();
+        assert_eq!(
+            edges,
+            BTreeSet::from([(id_of("c_foo"), id_of("GLOBAL::get"))]),
+            "the imported-receiver call (axios.get) must be SUPPRESSED; only the \
+             local-receiver call (foo.get) keeps its bare-global edge"
+        );
+    }
+
     /// Realistic small-corpus stats for the Wave-14 fixture tests: the
     /// empty-graph `Stats::default()` (total_nodes = 0) degenerates every
     /// keyed probe into a DERIVED relation to its FULL cardinality

--- a/packages/rfdb-server/src/derive/stdlib/js_runtime_globals_edges.dl
+++ b/packages/rfdb-server/src/derive/stdlib/js_runtime_globals_edges.dl
@@ -63,7 +63,33 @@ sfx(C, S) :- cand(C, N), dpfx(C, D), concat(D, ".", DP), strip_prefix(N, DP, S),
 
 msfx(C, S) :- sfx(C, S), rtg_key(S, _).
 msh(C, S) :- msfx(C, S), msfx(C, S2), concat(".", S, T), ends_with(S2, T).
-win(C, G) :- msfx(C, S), \+ msh(C, S), rtg_key(S, G).
+
+% ── SEP PART B / RFD R6: receiver-import guard (negation ⇒ scratch floor) ─────
+% A dotted member call on a default/namespace-imported module (e.g. `axios.get`)
+% has NO runtime-global meaning: the suffix chain strips the receiver and would
+% match the bare ecma-global `get`, minting an UNSOUND `CALLS C → GLOBAL::get`
+% (the receiver `axios` is lost; downstream effects-db lookup then sees a PURE
+% stand-in — the side-effect-propagation gap, _ai/gaps.md). Detect the receiver
+% structurally via the analyzer-committed receiver chain — CALL -DERIVES_FROM->
+% PROPERTY_ACCESS -READS_FROM-> REFERENCE -READS_FROM-> IMPORT_BINDING (all
+% committed EDB, emitted before any pack ⇒ no ordering dependency) — and block
+% the win on the STRIPPED suffix only. Genuine ecma-globals are untouched:
+% `JSON.parse` wins on the FULL name (not a stripped suffix), and `process.exit`
+% keeps `exit` because `process` is not an IMPORT_BINDING. False negatives (a
+% receiver the analyzer didn't link to its IMPORT_BINDING) degrade to the prior
+% behavior — sound, never a regression.
+recv_import(C) :-
+    edge(C, PA, "DERIVES_FROM"), node(PA, "PROPERTY_ACCESS"),
+    edge(PA, R, "READS_FROM"), node(R, "REFERENCE"),
+    edge(R, IB, "READS_FROM"), node(IB, "IMPORT_BINDING").
+
+% S is a STRIPPED suffix of C when it is a PROPER suffix of the full call name
+% (the dpfx chain removed the receiver), as opposed to the full name itself.
+strip_sfx(C, S) :- msfx(C, S), cand(C, N), neq(S, N).
+
+blocked(C, S) :- strip_sfx(C, S), recv_import(C).
+
+win(C, G) :- msfx(C, S), \+ msh(C, S), \+ blocked(C, S), rtg_key(S, G).
 
 % ── CALLS: matched CALL → its GLOBAL_DEFINITION, pinned by (name, virtual
 %    file). Metadata = the legacy mkEdge payload (:258-267), exact. ─────────


### PR DESCRIPTION
## What

The runtime-globals derive pack (`js_runtime_globals_edges.dl`) resolved a dotted member call on a default/namespace-**imported** module — `axios.get` — onto the bare ecma-global `get`, **stripping the receiver** and minting an unsound `CALLS → GLOBAL::get`. Downstream effects-db lookup then saw a PURE stand-in, so side effects didn't propagate (the SEP gap in `_ai/gaps.md`).

This is **PART B / R6** — the *root* fix. PART A (#460, merged) recovered the effect consumer-side; R5 (#463, merged) flags the unsoundness. This removes the bad edge at the source.

## How

A negative guard suppresses `win(C,S)` on a **stripped** suffix when the receiver chain reaches an `IMPORT_BINDING`:

```
CALL -DERIVES_FROM-> PROPERTY_ACCESS -READS_FROM-> REFERENCE -READS_FROM-> IMPORT_BINDING
```

All three edges are **analyzer-committed EDB** (verified: no `resolvedVia` stamp; `js_local_refs` explicitly excludes IMPORT_BINDING as the import skip-set) — so there is **no pack-ordering dependency**.

Genuine ecma-globals are untouched:
- `JSON.parse` wins on the **full** name (not a stripped suffix) → kept
- `process.exit` keeps `exit` (`process` is not an IMPORT_BINDING) → kept
- False negatives degrade to prior behavior — sound, never a regression.

## Verification

- **e2e on the sep-test fixture** (clean re-analyze with the rebuilt server): `axios.get` no longer mints `GLOBAL::get`; `fetchUser` recovers `IO:HTTP:REQUEST` via the unresolved-path effects-db lookup and is **no longer suspected-unsound**; `loadConfig` unchanged.
- **Unit regression test** `js_runtime_globals_edges_receiver_import_guard` (defect `axios.get` suppressed vs identical-suffix `foo.get` on a local receiver kept); existing `..._first_match_and_endpoint_pin` still green.

## Note

Touches the resolver pack zone (normally vm's). Done with explicit owner sign-off to close SEP. Release note: `rfdb-server` source changed → rfdb prebuilt binaries must be rebuilt at next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)