### PR TITLE
docs: add Glama score badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Welcome to the party!
 [![CI](https://github.com/Disentinel/grafema/actions/workflows/ci.yml/badge.svg)](https://github.com/Disentinel/grafema/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Disentinel/fb8ae29db701dd788e1beaffb159ffef/raw/grafema-coverage.json)](https://github.com/Disentinel/grafema/actions/workflows/ci.yml)
 [![Benchmark](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Disentinel/fb8ae29db701dd788e1beaffb159ffef/raw/rfdb-benchmark.json)](https://github.com/Disentinel/grafema/actions/workflows/benchmark.yml)
+[![Glama](https://glama.ai/mcp/servers/Disentinel/grafema/badges/score.svg)](https://glama.ai/mcp/servers/Disentinel/grafema)
 
 > **v0.4.1** — Early access. [Changelog](./CHANGELOG.md) | [Known limitations](./KNOWN_LIMITATIONS.md)
 


### PR DESCRIPTION
Adds the Glama MCP listing score badge to the README badge row (CI / Coverage / Benchmark / **Glama**), so the listing quality score is visible on the repo.

Badge: `https://glama.ai/mcp/servers/Disentinel/grafema/badges/score.svg` → links to the Glama listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)