### PR TITLE
fix(derive): #23 R1 — gate rust_calls free-fn arm off method calls (rust-calls violations → 0)

### DIFF
--- a/packages/rfdb-server/src/derive/stdlib.rs
+++ b/packages/rfdb-server/src/derive/stdlib.rs
@@ -3069,6 +3069,68 @@ mod tests {
         );
     }
 
+    /// R1 method/free-fn name collision (the parser.rs residual). A file with both
+    /// a method `impl Parser { fn parse }` and a free `fn parse`: a `self.parse()`
+    /// method call (CALL with a READS_FROM receiver) must resolve to the METHOD
+    /// ONLY (owner arm), NOT also to the free fn (file-MODULE arm gated by
+    /// \+ has_receiver). A bare free call `parse()` (no receiver) still resolves
+    /// the free fn.
+    #[test]
+    fn rust_calls_r1_method_call_excludes_free_fn_of_same_name() {
+        let mut v = FixtureStorageView::new(1);
+        named_node(&mut v, "m_p", "p", "MODULE", "p.rs");
+
+        // impl Parser { fn parse(&self); fn run(&self) }  +  free fn parse()
+        named_node(&mut v, "ib_parser", "Parser", "IMPL_BLOCK", "p.rs");
+        edge(&mut v, "m_p", "ib_parser", "CONTAINS");
+        named_node(&mut v, "f_method_parse", "parse", "FUNCTION", "p.rs");
+        named_node(&mut v, "f_run", "run", "FUNCTION", "p.rs");
+        named_node(&mut v, "f_free_parse", "parse", "FUNCTION", "p.rs");
+        for (ib, f) in [("ib_parser", "f_method_parse"), ("ib_parser", "f_run")] {
+            edge(&mut v, ib, f, "HAS_METHOD");
+            edge(&mut v, ib, f, "CONTAINS");
+        }
+        edge(&mut v, "m_p", "f_free_parse", "CONTAINS");
+
+        // `self.parse()` inside run: CALL "parse" with a READS_FROM receiver.
+        named_node(&mut v, "c_self", "parse", "CALL", "p.rs");
+        named_node(&mut v, "ref_self", "self", "REFERENCE", "p.rs");
+        edge(&mut v, "f_run", "c_self", "CONTAINS");
+        edge(&mut v, "c_self", "ref_self", "READS_FROM"); // method-call discriminator
+
+        // A bare free call `parse()` at module level (no receiver).
+        named_node(&mut v, "c_free", "parse", "CALL", "p.rs");
+        edge(&mut v, "m_p", "c_free", "CONTAINS");
+
+        let (eval, _specs, _node_specs) = evaluate_with_materialize(
+            &v,
+            RUST_CALLS_DL,
+            Stats::default(),
+            EvalLimits::none(),
+            EventLog::discard(),
+        )
+        .expect("rust_calls.dl evaluates");
+
+        let edges: BTreeSet<(u128, u128, String)> = triples(&eval, "rust_call");
+        let expect: BTreeSet<(u128, u128, String)> = [
+            ("c_self", "f_method_parse"), // method call → impl method ONLY
+            ("c_free", "f_free_parse"),   // free call → free fn
+        ]
+        .iter()
+        .map(|(c, t)| (id_of(c), id_of(t), "rust-calls".to_string()))
+        .collect();
+        assert_eq!(
+            edges, expect,
+            "self.parse() (has receiver) resolves to Parser::parse ONLY; a bare \
+             parse() (no receiver) resolves the free fn"
+        );
+        assert!(
+            !edges.contains(&(id_of("c_self"), id_of("f_free_parse"), "rust-calls".to_string())),
+            "the method call self.parse() must NOT also resolve to the free fn parse \
+             (the parser.rs residual this fix removes)"
+        );
+    }
+
     /// Wave M (rust_calls DELTA 5): macro invocations — CALL nodes the analyzer
     /// stamps with metadata macro=true (rust_analyzer.rs:1433-1457, walk_macro;
     /// the name is the macro path WITHOUT '!') — are EXCLUDED from name

--- a/packages/rfdb-server/src/derive/stdlib/rust_calls.dl
+++ b/packages/rfdb-server/src/derive/stdlib/rust_calls.dl
@@ -133,6 +133,15 @@ encl_fn(C, Fn) :- encl(C, Fn), node(Fn, "FUNCTION").
 fn_owner(C, O)     :- encl_fn(C, Fn), edge(O, Fn, "CONTAINS").
 file_module(C, M)  :- rs_call(C, File, N), node(M, "MODULE"), attr(M, "file", File).
 
+% A method call carries a direct CALL -READS_FROM-> receiver (self / a variable);
+% a plain free-function call never does — the analyzer's method-call discriminator
+% (rust_analyzer.rs:1358-1370, the same signal rust_cross_methods_ctor DELTA 6
+% keys on). `self.foo()` resolves to the impl METHOD (the owner arm), NEVER to a
+% same-named file-level free fn, so the free-fn arm below is gated off method
+% calls. Without this, a file with both `impl T { fn parse }` and a free
+% `fn parse` over-resolves every `self.parse()` to BOTH (the parser.rs residual).
+has_receiver(C) :- rs_call(C, _, _), edge(C, _, "READS_FROM").
+
 % R1: scope-walk exact. The same-name FUNCTION must be lexically visible —
 % sharing the enclosing fn's owner (sibling method / sibling module fn), a
 % file-level free function (owned by the file MODULE), OR a nested local fn
@@ -142,8 +151,11 @@ file_module(C, M)  :- rs_call(C, File, N), node(M, "MODULE"), attr(M, "file", Fi
 % enclosing FUNCTION the other arms walk, and excludes the trivial self-edge
 % (neq(Fn, T)). Live-verified: recovers 28 (C,T) pairs the owner/file-MODULE arms
 % miss (nested `fn id_of` / `assert_invertible` test helpers), all ⊆ the flat set.
+% The file-MODULE free-fn arm is gated by \+ has_receiver: a `self.foo()` method
+% call is resolved by the owner arm to the impl method, not to a same-named free
+% fn (free-fn calls — the legitimate target of this arm — carry no receiver).
 exact_scoped(C, T) :- rs_call(C, File, N), rs_fn(File, N, T), fn_owner(C, O), edge(O, T, "CONTAINS").
-exact_scoped(C, T) :- rs_call(C, File, N), rs_fn(File, N, T), file_module(C, M), edge(M, T, "CONTAINS").
+exact_scoped(C, T) :- rs_call(C, File, N), rs_fn(File, N, T), file_module(C, M), edge(M, T, "CONTAINS"), \+ has_receiver(C).
 exact_scoped(C, T) :- rs_call(C, File, N), rs_fn(File, N, T), encl_fn(C, Fn), edge(Fn, T, "CONTAINS"), neq(Fn, T).
 has_scoped(C)      :- exact_scoped(C, T).
 


### PR DESCRIPTION
## What

Follow-up to #466. The 10 residual `rust-calls` resolution-is-a-function violations were an **R1 (scope-walk)** nuance, not R2: in `parser.rs`, a method `impl Parser { fn parse }` and a free `fn parse` share a name, so `self.parse()` resolved to **both** — the method (owner arm) *and* the free fn (file-MODULE arm).

In Rust, `self.foo()` is always the impl method, never a same-named free fn.

## How

Gate the file-MODULE free-fn arm with `\+ has_receiver(C)`, where a method call is identified by its `CALL -READS_FROM-> receiver` edge (the analyzer's method-call discriminator — the same signal `rust_cross_methods_ctor` DELTA 6 keys on). Free-fn calls (the legitimate target of that arm) carry no receiver and are unaffected.

## Evidence (fresh rust graph, 70,029 CALLs)

| | before (#466) | after |
|---|---|---|
| rust-calls **violations** | 10 | **0** |
| rust_calls total edges | 2381 | 2371 (−10, exactly the spurious free-fn dups) |

No legitimate resolution lost. New test `rust_calls_r1_method_call_excludes_free_fn_of_same_name`; all `rust_*` derive tests green.

## #431 status

With #466 + this, **`rust-calls` contributes ZERO `resolution-is-a-function` violations** — it is now a true function. The only remaining violators are `rust-dyn-dispatch` (324, semantic dispatch — already excluded) and `rust-cross-method` (237, parity-ceiling — carve-out candidate). So `resolution-is-a-function` can ship `severity:error` once those two are carved out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)