### PR TITLE
fix(rfdb): env-configurable, per-operation RPC client timeouts (unblock enrichers on large self-analyze)

### DIFF
--- a/packages/rfdb-server/src/bin/rfdb_server.rs
+++ b/packages/rfdb-server/src/bin/rfdb_server.rs
@@ -3045,10 +3045,31 @@ fn dispatch_materialize_datalog(
     limits.deadline =
         Some(std::time::Instant::now() + std::time::Duration::from_secs(materialize_deadline_secs));
 
+    // Same E-EXEC-001 reasoning as the deadline above: the 100k `max_intermediate_results` is an
+    // interactive-query bound and is WRONG for a batch full materialize. Intermediate relations of
+    // legitimate stdlib packs (e.g. js_local_refs scope-walk: ref_scope/inner_of/chain_declares)
+    // scale ~linearly with reference count, so a cold materialize over a non-trivial graph routinely
+    // exceeds 100k rows in a single stratum (the ~21k-node mcp graph already produces ~141k). The
+    // batch path is build-step-like; its real guards are the deadline + cancellation + memory, NOT a
+    // fixed row count. Lift it (default: unbounded). Tunable via `RFDB_MATERIALIZE_MAX_INTERMEDIATE`.
+    let materialize_max_intermediate = std::env::var("RFDB_MATERIALIZE_MAX_INTERMEDIATE")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(usize::MAX);
+    limits.max_intermediate_results = materialize_max_intermediate;
+
     // Empty source ⇒ the canonical bundled depends.dl; "@stdlib/<name>" ⇒ a named bundled
     // pack (E-MAT-007 when unknown); anything else ⇒ explicit program text. The single
     // source of truth is `resolve_pack_source` — no drift between dispatchers.
     let program = resolve_pack_source(source)?;
+
+    // Suppress auto-compaction for the duration of this materialize: committing derived edges would
+    // otherwise auto-trigger compaction, which (rayon, memmap2) rewrites/unmaps segments while this
+    // same materialize's `par_join_rows` rayon tasks read them → use-after-unmap heap corruption →
+    // SIGSEGV (confirmed root cause of the parallel-derive crash, 2026-06-19). Deferred compaction
+    // runs at the natural barrier (end_bulk_load / explicit Compact) under the exclusive write lock.
+    let _compaction_guard =
+        rfdb::storage_v2::compaction::coordinator::AutoCompactionSuppressGuard::new();
 
     // Gate D2: the cached entry MAINTAINS the derived relations across calls against this
     // long-lived per-database engine (work-proportional on the 2nd+ run) and commits only the

--- a/packages/rfdb-server/src/derive/plan.rs
+++ b/packages/rfdb-server/src/derive/plan.rs
@@ -40,7 +40,23 @@ use super::stratify::Stratification;
 
 /// Per-rule materialization ceiling (spec §3): a rule whose plan-time output estimate
 /// exceeds this is rejected with `E-PLAN-003`. Ten million facts.
+///
+/// This is the DEFAULT — a conservative guard against cross-join blow-ups whose plan-time
+/// estimate is also q-error-prone (often an OVERestimate). For a large batch self-analyze the
+/// 10M default is too low (a legitimate per-rule output like js property-access READS_FROM on a
+/// ~700k-node graph estimates ~11.7M), so the effective ceiling is env-overridable via
+/// [`max_materialized_facts`] / `RFDB_MAX_MATERIALIZED_FACTS`.
 pub const MAX_MATERIALIZED_FACTS: u64 = 10_000_000;
+
+/// The effective per-rule materialization ceiling: `RFDB_MAX_MATERIALIZED_FACTS` if set and
+/// parseable, else [`MAX_MATERIALIZED_FACTS`]. Read per check (cheap); lets a batch analyze raise
+/// the guard without recompiling.
+pub fn max_materialized_facts() -> u64 {
+    std::env::var("RFDB_MAX_MATERIALIZED_FACTS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(MAX_MATERIALIZED_FACTS)
+}
 
 
 // ── Error taxonomy (invariant I5) ──────────────────────────────────
@@ -361,13 +377,14 @@ fn plan_rule_with(
     }
 
     // §3 per-rule materialization guard.
-    if rule_estimate > MAX_MATERIALIZED_FACTS {
+    let guard = max_materialized_facts();
+    if rule_estimate > guard {
         return Err(PlanError {
             code: PlanCode::GuardRejected,
             head: head.clone(),
             detail: format!(
                 "per-rule output estimate {} exceeds max_materialized_facts {}",
-                rule_estimate, MAX_MATERIALIZED_FACTS
+                rule_estimate, guard
             ),
         });
     }

--- a/packages/rfdb-server/src/storage_v2/compaction/coordinator.rs
+++ b/packages/rfdb-server/src/storage_v2/compaction/coordinator.rs
@@ -23,6 +23,38 @@ use crate::storage_v2::shard::{Shard, TombstoneSet};
 use crate::storage_v2::types::{SegmentMeta, SegmentType};
 use crate::storage_v2::writer::{EdgeSegmentWriter, NodeSegmentWriter};
 
+// ── Auto-compaction suppression during derive/materialize ───────────
+//
+// A derive/materialize handler holds a `db.engine.read()` lock but internally commits derived
+// edges across many rule packs; those commits would auto-trigger compaction. Compaction (rayon,
+// memmap2) rewrites/unmaps segments while the SAME materialize's `par_join_rows` rayon tasks read
+// them → use-after-unmap / heap corruption → SIGSEGV (confirmed by isolation test 2026-06-19).
+// While a materialize is in progress we SUPPRESS auto-compaction; the deferred compaction runs at
+// the natural barrier (end_bulk_load / explicit Compact) under the exclusive write lock.
+static AUTO_COMPACTION_SUPPRESSED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Suppress (or re-enable) automatic compaction. Set while a derive/materialize is in progress.
+pub fn set_auto_compaction_suppressed(suppressed: bool) {
+    AUTO_COMPACTION_SUPPRESSED.store(suppressed, std::sync::atomic::Ordering::SeqCst);
+}
+
+/// RAII guard: suppresses auto-compaction for its lifetime, restoring on drop (even on panic).
+pub struct AutoCompactionSuppressGuard;
+
+impl AutoCompactionSuppressGuard {
+    pub fn new() -> Self {
+        set_auto_compaction_suppressed(true);
+        AutoCompactionSuppressGuard
+    }
+}
+
+impl Drop for AutoCompactionSuppressGuard {
+    fn drop(&mut self) {
+        set_auto_compaction_suppressed(false);
+    }
+}
+
 // ── Policy ──────────────────────────────────────────────────────────
 
 /// Check if a shard should be compacted based on L0 segment count.
@@ -32,6 +64,14 @@ use crate::storage_v2::writer::{EdgeSegmentWriter, NodeSegmentWriter};
 ///
 /// Complexity: O(1)
 pub fn should_compact(shard: &Shard, config: &CompactionConfig) -> bool {
+    // Suppressed while a derive/materialize is in progress (see AUTO_COMPACTION_SUPPRESSED) — the
+    // confirmed fix for the parallel-derive SIGSEGV (compaction unmapping segments under parallel
+    // reads). RFDB_DISABLE_COMPACTION=1 is a manual override for diagnostics.
+    if AUTO_COMPACTION_SUPPRESSED.load(std::sync::atomic::Ordering::SeqCst)
+        || std::env::var_os("RFDB_DISABLE_COMPACTION").is_some()
+    {
+        return false;
+    }
     let total_l0 = shard.l0_node_segment_count() + shard.l0_edge_segment_count();
     total_l0 >= config.segment_threshold
 }

--- a/packages/rfdb/ts/base-client.ts
+++ b/packages/rfdb/ts/base-client.ts
@@ -40,11 +40,9 @@ import type {
   CommitBatchResponse,
 } from '@grafema/types';
 
-/**
- * Default timeout for operations (60 seconds).
- * Flush/compact may take time for large graphs, but should not hang indefinitely.
- */
-const DEFAULT_TIMEOUT_MS = 60_000;
+// Per-operation timeout ceilings (interactive vs bulk/streaming/drop) are
+// env-configurable and resolved by the concrete transport's `_send`. See
+// ./timeout-config.ts (RFDB_RPC_TIMEOUT_MS / RFDB_RPC_BULK_TIMEOUT_MS).
 
 export abstract class BaseRFDBClient extends EventEmitter implements IRFDBClient {
   abstract readonly socketPath: string;

--- a/packages/rfdb/ts/client.ts
+++ b/packages/rfdb/ts/client.ts
@@ -9,6 +9,7 @@ import { createConnection, Socket } from 'net';
 import { encode, decode } from '@msgpack/msgpack';
 import { StreamQueue } from './stream-queue.js';
 import { BaseRFDBClient } from './base-client.js';
+import { resolveTimeoutMs, getBulkTimeoutMs } from './timeout-config.js';
 
 import type {
   RFDBCommand,
@@ -269,12 +270,17 @@ export class RFDBClient extends BaseRFDBClient {
     const existing = this._streamTimers.get(id);
     if (existing) clearTimeout(existing);
 
+    // Streaming waits for the FIRST chunk; on a large graph (e.g. the ~714k-node
+    // self graph) the initial scan can exceed the interactive ceiling before any
+    // chunk arrives. Use the longer bulk ceiling here, configurable via
+    // RFDB_RPC_BULK_TIMEOUT_MS (see timeout-config.ts).
+    const streamTimeoutMs = getBulkTimeoutMs();
     const timer = setTimeout(() => {
       this._cleanupStream(id);
       streamQueue.fail(new Error(
-        `RFDB queryNodesStream timed out after ${RFDBClient.DEFAULT_TIMEOUT_MS}ms (no chunk received)`
+        `RFDB queryNodesStream timed out after ${streamTimeoutMs}ms (no chunk received)`
       ));
-    }, RFDBClient.DEFAULT_TIMEOUT_MS);
+    }, streamTimeoutMs);
 
     this._streamTimers.set(id, timer);
   }
@@ -295,19 +301,23 @@ export class RFDBClient extends BaseRFDBClient {
     return Number.isNaN(num) ? null : num;
   }
 
-  private static readonly DEFAULT_TIMEOUT_MS = 60_000;
-
   /**
-   * Send a request and wait for response with timeout
+   * Send a request and wait for response with timeout.
+   *
+   * The timeout ceiling is env-configurable and tiered per operation
+   * (interactive vs bulk/streaming/drop) — see timeout-config.ts. Callers may
+   * still pass an explicit `timeoutMs` to override.
    */
   protected async _send(
     cmd: RFDBCommand,
     payload: Record<string, unknown> = {},
-    timeoutMs: number = RFDBClient.DEFAULT_TIMEOUT_MS,
+    timeoutMs?: number,
   ): Promise<RFDBResponse> {
     if (!this.connected || !this.socket) {
       throw new Error('Not connected to RFDB server');
     }
+
+    const effectiveTimeoutMs = resolveTimeoutMs(cmd, timeoutMs);
 
     return new Promise((resolve, reject) => {
       const id = this.reqId++;
@@ -316,8 +326,8 @@ export class RFDBClient extends BaseRFDBClient {
 
       const timer = setTimeout(() => {
         this.pending.delete(id);
-        reject(new Error(`RFDB ${cmd} timed out after ${timeoutMs}ms. Server may be unresponsive or dbPath may be invalid.`));
-      }, timeoutMs);
+        reject(new Error(`RFDB ${cmd} timed out after ${effectiveTimeoutMs}ms. Server may be unresponsive or dbPath may be invalid.`));
+      }, effectiveTimeoutMs);
 
       const errorHandler = (err: NodeJS.ErrnoException) => {
         this.pending.delete(id);

--- a/packages/rfdb/ts/timeout-config.test.ts
+++ b/packages/rfdb/ts/timeout-config.test.ts
@@ -1,0 +1,80 @@
+/**
+ * RFDB RPC timeout-config unit tests.
+ *
+ * Verifies the env-configurable, per-operation timeout ceilings that unblock
+ * large-graph self-analyze: bulk writes / streaming first-chunk / durable
+ * drops must get a longer ceiling than interactive ops, and both must be
+ * overridable via env (RFDB_RPC_TIMEOUT_MS / RFDB_RPC_BULK_TIMEOUT_MS).
+ *
+ * Imports from ../dist (the built JS), matching the other rfdb tests.
+ */
+
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert';
+import {
+  getDefaultTimeoutMs,
+  getBulkTimeoutMs,
+  resolveTimeoutMs,
+} from '../dist/timeout-config.js';
+
+function clearEnv(): void {
+  delete process.env.RFDB_RPC_TIMEOUT_MS;
+  delete process.env.RFDB_RPC_BULK_TIMEOUT_MS;
+}
+
+describe('rfdb timeout-config', () => {
+  afterEach(clearEnv);
+
+  it('defaults: interactive 300s, bulk 3x = 900s', () => {
+    clearEnv();
+    assert.strictEqual(getDefaultTimeoutMs(), 300_000);
+    assert.strictEqual(getBulkTimeoutMs(), 900_000);
+  });
+
+  it('classifies interactive vs bulk commands', () => {
+    clearEnv();
+    // interactive
+    assert.strictEqual(resolveTimeoutMs('getNode'), 300_000);
+    assert.strictEqual(resolveTimeoutMs('neighbors'), 300_000);
+    assert.strictEqual(resolveTimeoutMs('ping'), 300_000);
+    // bulk / streaming / drop
+    assert.strictEqual(resolveTimeoutMs('addEdges'), 900_000);
+    assert.strictEqual(resolveTimeoutMs('addNodes'), 900_000);
+    assert.strictEqual(resolveTimeoutMs('commitBatch'), 900_000);
+    assert.strictEqual(resolveTimeoutMs('clear'), 900_000);
+    assert.strictEqual(resolveTimeoutMs('dropDatabase'), 900_000);
+  });
+
+  it('honors an explicit per-call override', () => {
+    clearEnv();
+    assert.strictEqual(resolveTimeoutMs('getNode', 1234), 1234);
+    assert.strictEqual(resolveTimeoutMs('addEdges', 1234), 1234);
+  });
+
+  it('RFDB_RPC_TIMEOUT_MS overrides interactive and rescales bulk (3x)', () => {
+    clearEnv();
+    process.env.RFDB_RPC_TIMEOUT_MS = '120000';
+    assert.strictEqual(getDefaultTimeoutMs(), 120_000);
+    assert.strictEqual(getBulkTimeoutMs(), 360_000);
+    assert.strictEqual(resolveTimeoutMs('addEdges'), 360_000);
+  });
+
+  it('RFDB_RPC_BULK_TIMEOUT_MS overrides bulk independently', () => {
+    clearEnv();
+    process.env.RFDB_RPC_BULK_TIMEOUT_MS = '600000';
+    assert.strictEqual(getBulkTimeoutMs(), 600_000);
+    assert.strictEqual(getDefaultTimeoutMs(), 300_000);
+    assert.strictEqual(resolveTimeoutMs('getNode'), 300_000);
+    assert.strictEqual(resolveTimeoutMs('addEdges'), 600_000);
+  });
+
+  it('ignores malformed / non-positive env values (fails safe to defaults)', () => {
+    clearEnv();
+    process.env.RFDB_RPC_TIMEOUT_MS = 'notanumber';
+    assert.strictEqual(getDefaultTimeoutMs(), 300_000);
+    process.env.RFDB_RPC_TIMEOUT_MS = '-5';
+    assert.strictEqual(getDefaultTimeoutMs(), 300_000);
+    process.env.RFDB_RPC_TIMEOUT_MS = '0';
+    assert.strictEqual(getDefaultTimeoutMs(), 300_000);
+  });
+});

--- a/packages/rfdb/ts/timeout-config.ts
+++ b/packages/rfdb/ts/timeout-config.ts
@@ -1,0 +1,95 @@
+/**
+ * RFDB RPC client timeout configuration.
+ *
+ * The RFDB client guards every request with a timeout so a hung/unresponsive
+ * server (or an invalid dbPath) surfaces as a rejected promise instead of an
+ * indefinite hang. The original ceiling was a single hardcoded 60s.
+ *
+ * That 60s is fine for *interactive* round-trips (getNode, neighbors, ping),
+ * but it is too tight for two classes of operation on a large graph:
+ *
+ *   1. Bulk writes — `addEdges` / `addNodes` / `commitBatch` over the
+ *      self-analyze (~714k nodes) make the server do index work that can
+ *      legitimately exceed 60s. The JS enrichers (enrichMcpToolDefinitions,
+ *      contract, behavior, package) all write through `addEdges`, so a 60s
+ *      ceiling makes the enrichers silently fail with
+ *      `RFDB addEdges timed out after 60000ms`.
+ *   2. Streaming reads — `queryNodesStream` waits for the *first* chunk; on a
+ *      714k-node graph the initial scan can take longer than 60s before the
+ *      first chunk arrives (`queryNodesStream timed out after 60000ms`).
+ *   3. Durable drops — `clear` / `dropDatabase` durably truncate a large
+ *      on-disk .rfdb, which can exceed 60s.
+ *
+ * Resolution: timeouts are now env-configurable and tiered per operation. We
+ * keep a *finite* ceiling everywhere (never Infinity) so a genuinely wedged
+ * server still fails loudly — we just give slow-but-progressing bulk/drop work
+ * enough room.
+ *
+ * Env vars (all in milliseconds, all optional):
+ *   RFDB_RPC_TIMEOUT_MS       — default ceiling for interactive ops.
+ *                               Default 300_000 (5 min).
+ *   RFDB_RPC_BULK_TIMEOUT_MS  — ceiling for bulk writes & streaming first-chunk
+ *                               & durable drops. Default = 3× the interactive
+ *                               ceiling, i.e. 900_000 (15 min) by default.
+ *
+ * Why 5 min default (was 60s): a full self-analyze is ~14 min wall and the
+ * slow individual RPCs we observed (bulk addEdges, first stream chunk) sit in
+ * the tens-of-seconds-to-low-minutes range on the 714k graph. 5 min gives a
+ * comfortable margin for interactive ops on a large graph while still failing
+ * a truly hung server in bounded time. Bulk/drop gets 15 min because a durable
+ * drop / large commit is the single longest legitimate operation.
+ */
+
+function readEnvMs(name: string): number | undefined {
+  const raw =
+    typeof process !== 'undefined' && process.env ? process.env[name] : undefined;
+  if (raw === undefined || raw === '') return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return undefined;
+  return Math.floor(n);
+}
+
+/** Default ceiling for interactive ops (env: RFDB_RPC_TIMEOUT_MS). */
+export function getDefaultTimeoutMs(): number {
+  return readEnvMs('RFDB_RPC_TIMEOUT_MS') ?? 300_000;
+}
+
+/**
+ * Ceiling for bulk writes / streaming first-chunk / durable drops
+ * (env: RFDB_RPC_BULK_TIMEOUT_MS). Defaults to 3× the interactive ceiling.
+ */
+export function getBulkTimeoutMs(): number {
+  const explicit = readEnvMs('RFDB_RPC_BULK_TIMEOUT_MS');
+  if (explicit !== undefined) return explicit;
+  return getDefaultTimeoutMs() * 3;
+}
+
+/**
+ * Commands that operate on the whole graph / disk and deserve the longer
+ * bulk ceiling rather than the interactive default.
+ */
+const BULK_COMMANDS: ReadonlySet<string> = new Set([
+  'addEdges',
+  'addNodes',
+  'commitBatch',
+  'clear',
+  'dropDatabase',
+  'compact',
+  'flush',
+  'rebuildIndexes',
+  'getAllNodes',
+  'getAllEdges',
+  'getEdgesByType',
+]);
+
+/**
+ * Resolve the timeout ceiling for a given command, honoring an explicit
+ * per-call override when the caller passed one.
+ */
+export function resolveTimeoutMs(
+  cmd: string,
+  explicitTimeoutMs?: number,
+): number {
+  if (explicitTimeoutMs !== undefined) return explicitTimeoutMs;
+  return BULK_COMMANDS.has(cmd) ? getBulkTimeoutMs() : getDefaultTimeoutMs();
+}

--- a/packages/rfdb/ts/websocket-client.ts
+++ b/packages/rfdb/ts/websocket-client.ts
@@ -12,6 +12,7 @@
 
 import { encode, decode } from '@msgpack/msgpack';
 import { BaseRFDBClient } from './base-client.js';
+import { resolveTimeoutMs } from './timeout-config.js';
 
 import type {
   RFDBCommand,
@@ -23,8 +24,6 @@ interface PendingRequest {
   resolve: (value: RFDBResponse) => void;
   reject: (error: Error) => void;
 }
-
-const DEFAULT_TIMEOUT_MS = 60_000;
 
 export class RFDBWebSocketClient extends BaseRFDBClient {
   readonly socketPath: string;
@@ -121,11 +120,13 @@ export class RFDBWebSocketClient extends BaseRFDBClient {
   protected async _send(
     cmd: RFDBCommand,
     payload: Record<string, unknown> = {},
-    timeoutMs: number = DEFAULT_TIMEOUT_MS,
+    timeoutMs?: number,
   ): Promise<RFDBResponse> {
     if (!this.connected || !this.ws) {
       throw new Error('Not connected to RFDB server');
     }
+
+    const effectiveTimeoutMs = resolveTimeoutMs(cmd, timeoutMs);
 
     return new Promise((resolve, reject) => {
       const id = this.reqId++;
@@ -134,8 +135,8 @@ export class RFDBWebSocketClient extends BaseRFDBClient {
 
       const timer = setTimeout(() => {
         this.pending.delete(id);
-        reject(new Error(`Request timed out: ${cmd} (${timeoutMs}ms)`));
-      }, timeoutMs);
+        reject(new Error(`Request timed out: ${cmd} (${effectiveTimeoutMs}ms)`));
+      }, effectiveTimeoutMs);
 
       this.pending.set(id, {
         resolve: (value) => {


### PR DESCRIPTION
## Problem

After the derive phase completes on a large self-analyze, the JS enrichers
(`enrichMcpToolDefinitions`, contract, behavior, package) were **silently
skipped** because their RFDB RPC calls hit a single **hardcoded 60s** client
timeout:

```
RFDB addEdges timed out after 60000ms
queryNodesStream timed out after 60000ms (no chunk received)
```

On a large graph (the ~714k-node self graph) the server legitimately needs
longer than 60s for:

1. **Bulk writes** — `addEdges` / `addNodes` / `commitBatch` do server-side
   index work. `mcpToolDefinitionEnricher` calls `client.addEdges(newEdges)`
   directly — that is the exact callsite that timed out.
2. **Streaming reads** — `queryNodesStream` waits for the **first** chunk; the
   initial scan can exceed 60s before any chunk arrives.
3. **Durable drops** — `analyze --clear` truncates a large on-disk `.rfdb`,
   which can exceed 60s.

## Fix

New `packages/rfdb/ts/timeout-config.ts` resolves an **env-configurable,
tiered** timeout ceiling instead of a single 60s constant:

| Env var | Applies to | Default |
|---|---|---|
| `RFDB_RPC_TIMEOUT_MS` | interactive ops (getNode, neighbors, ping, …) | **300000 (5 min)**, was 60s |
| `RFDB_RPC_BULK_TIMEOUT_MS` | bulk writes / streaming first-chunk / durable drops | **3× interactive = 900000 (15 min)** |

Bulk command set: `addEdges`, `addNodes`, `commitBatch`, `clear`,
`dropDatabase`, `compact`, `flush`, `rebuildIndexes`, `getAllNodes`,
`getAllEdges`, `getEdgesByType`. The streaming first-chunk timer
(`_resetStreamTimer`) also uses the bulk ceiling. Callers may still pass an
explicit per-call `timeoutMs` override.

**Why these defaults:** a full self-analyze is ~14 min wall; the slow
individual RPCs (bulk `addEdges`, first stream chunk) sit in the
tens-of-seconds-to-low-minutes range on the 714k graph. 5 min gives comfortable
margin for interactive ops on a large graph while still failing a genuinely
hung server in bounded time; 15 min for bulk/drop covers the single longest
legitimate operation (a durable drop / large commit). **Ceilings stay finite**
(never `Infinity`) so a wedged server still fails loudly.

Wired into all three transports: `client.ts` (unix socket — the one that timed
out), `websocket-client.ts`, and a pointer comment in `base-client.ts`.

## Slow `clear` / durable-drop finding

`GraphEngineV2::clear_durable` (packages/rfdb-server/src/graph/engine_v2.rs)
is **not** O(graph-nodes): it swaps the in-memory store to ephemeral, deletes
the manifest authority, then `std::fs::remove_dir_all(segments/)`. The slow
part is the filesystem deletion of many on-disk **segment files** — O(#segment
files), I/O-bound, which can exceed 60s for a large DB. `reset_derive_caches`
is O(1).

- **Immediate fix (this PR):** `clear` / `dropDatabase` are in the bulk set, so
  they now get the 15-min ceiling instead of 60s — the timeout no longer aborts
  a legitimately-progressing durable drop.
- **Future O(1) win (engine track, not done here to avoid colliding with the
  Rust workers + a full rebuild):** step 2 of `clear_durable` already makes the
  DB *logically empty* the instant the fresh manifest is written (orphaned
  segments are unreferenced and invisible to readers). The expensive
  `remove_dir_all(segments/)` could be **renamed aside** (into the existing
  `gc/` trash convention) and deleted asynchronously, returning to the client
  in O(1). Recorded as a finding for the engine track.

## Verification

- New `packages/rfdb/ts/timeout-config.test.ts` — 6 cases (defaults, command
  classification, explicit override, env overrides, malformed-env fail-safe).
- All **208 existing rfdb client tests pass** — no regression from the `_send`
  signature change (`timeoutMs?: number`).
- End-to-end: built the JS packages + reused the prebuilt v2 rfdb-server on the
  grafema-dev box and ran `analyze --quickstart --clear` on the grafema source —
  see PR comment for result (enrichers fire, mcp:tool nodes created, exit 0).

Base: `main`. Built on top of `fix/derive-batch-cap` (the 3 engine fixes that
let derive complete at scale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
