### PR TITLE
feat: grafema self-analyze at scale — consolidated (derive fixes + RPC + estimator + perf + CI + skill)

### DIFF
--- a/.claude/skills/analyze-perf-profiling/SKILL.md
+++ b/.claude/skills/analyze-perf-profiling/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: analyze-perf-profiling
+description: >-
+  Profile grafema's OWN analysis pipeline (`grafema analyze`) by route + bottlenecks instead of
+  guessing. Use when analyze is slow, hangs, OOMs, or hits a scale limit. Covers the auto-emitted
+  JSONL profiler, the critical-path computation, the derive/enricher blind spot, the KNOWN artificial
+  limits (so you don't rediscover them from a crash), and host/RAM requirements.
+---
+
+# Profiling `grafema analyze` — see the route and its traffic jams
+
+The cardinal rule: **measure the critical path FIRST; never "discover" a bottleneck from a crash or a
+guessed limit.** Most analyze pain is an arbitrary cap that bites at scale or a dead analyzer daemon —
+both are visible up front if you look.
+
+## 1. The profiler is AUTOMATIC — no flag, no special mode
+
+Every `grafema analyze` writes a JSONL profiler stream to **`.grafema/analysis-profile.jsonl`**.
+Read it with the bundled tool:
+
+```bash
+node scripts/profile-analyze.mjs .grafema/analysis-profile.jsonl          # phase breakdown, outliers, mem
+node scripts/profile-analyze.mjs .grafema/analysis-profile.jsonl --predict 14000   # scale to N files
+node scripts/profile-analyze.mjs .grafema/analysis-profile.jsonl --json    # machine-readable
+```
+
+Captured: per-file (`parse_ms`/`analyze_ms`/`total_ms`/`node_count`/`edge_count`, all languages),
+batch commits (`commit_ms` per `batch_index` — growth ⇒ O(N²), RFD-51), phase start/complete events,
+and `rss_mb`/`cpu_s` on every event.
+
+## 2. Critical path (the route + the jams) — one-liner from the JSONL
+
+```bash
+node -e 'const fs=require("fs");const ev=fs.readFileSync(process.argv[1],"utf8").trim().split("\n").map(l=>{try{return JSON.parse(l)}catch{return null}}).filter(Boolean);const s={},r=[];for(const e of ev){const t=e.event||e.type||"";const m=e.elapsed_ms??e.ts_ms;if(t.endsWith("_start"))s[t.replace(/_start$/,"")]=m;if(t.endsWith("_complete")){const k=t.replace(/_complete$/,"");if(s[k]!=null)r.push([k,m-s[k]])}}r.sort((a,b)=>b[1]-a[1]);const tot=r.reduce((x,y)=>x+y[1],0)||1;for(const[k,d]of r)console.log(k.padEnd(22),(d/1000).toFixed(1).padStart(8)+"s",(100*d/tot).toFixed(0)+"%")' .grafema/analysis-profile.jsonl
+```
+
+Real run (grafema self-analyze, June 2026, after the BEAM fix): `rust_resolve 52s/38%`,
+`analysis 37s/27%`, `haskell_resolve 23s/17%`, `beam_resolve 13s`, `js_resolve 11s`, `compact 1.2s`.
+
+## 3. THE BLIND SPOT — derive packs + enrichers are NOT in the JSONL
+
+The profiler covers analysis + the resolve phases. The **derive phase (≈40 `@stdlib/*` rule packs,
+~180s) and the TS enrichers run in rfdb-server / post-resolve and are NOT phase-events in the JSONL** —
+this is exactly where the worst scale bugs live (cap overflows, the parallel-derive SIGSEGV, planner
+q-errors). To see derive bottlenecks today, grep the verbose analyze log:
+
+```bash
+grep "Rule pack materialized" analyze.log   # per-pack: pack="@stdlib/..." ms=N edges=M  → packs with high ms / 0 edges
+grep -E "Analysis complete|enricher|timed out" analyze.log
+```
+
+Future fix (worth doing): emit the pipeline as a **profile subgraph** — `PHASE`/`STAGE` nodes +
+`METRIC` nodes (`wall_ms`, `edges_produced`, `intermediate_count`, `cap_hit`) + `PRECEDES` edges, in a
+separate profile namespace. Then critical path = a Datalog query (longest `PRECEDES` chain by `wall_ms`),
+dead stages = `wall_ms` high AND `edges_produced=0`, and limit-hits become standing graph facts +
+a CI regression gate. The `METRIC`/`OBSERVES` node+edge types already exist (per-file `parse_ms` today).
+
+## 4. KNOWN artificial limits — check these BEFORE assuming a real bottleneck
+
+These conservative caps / timeouts bite at self-scale (~700k nodes). They are env-overridable
+(some only on branch `fix/derive-batch-cap` and the worker branches). **For a full self-analyze run:**
+
+```bash
+RFDB_MATERIALIZE_DEADLINE_SECS=3600 RFDB_MAX_MATERIALIZED_FACTS=200000000 grafema analyze --quickstart
+```
+
+| Limit | Default | Symptom | Override |
+|---|---|---|---|
+| `max_intermediate_results` (derive batch) | 100k | `E-EXEC-001 ... exceeds max_intermediate_results` | `RFDB_MATERIALIZE_MAX_INTERMEDIATE` (lifted by default on fix branch) |
+| `MAX_MATERIALIZED_FACTS` (planner guard) | 10M | `E-PLAN-003 ... per-rule output estimate N exceeds` — often a q-error OVERestimate (cross-product ignoring selective join keys) | `RFDB_MAX_MATERIALIZED_FACTS` |
+| materialize deadline | 30s (query default) | derive aborts mid-pack | `RFDB_MATERIALIZE_DEADLINE_SECS` (default 600) |
+| RFDB RPC client timeout | 60s | `RFDB … timed out after 60000ms` → enrichers SKIPPED | `RFDB_RPC_TIMEOUT_MS` / `RFDB_RPC_BULK_TIMEOUT_MS` |
+| analyzer pool `request_timeout` | 120s/file | a DEAD analyzer daemon burns it per file (BEAM: 25 .ex × 120s = 241s) | fixed by liveness-probe (perf branch); else install the toolchain |
+
+## 5. Host & toolchains
+
+A full self-analyze peaks **~7.5–11 GB RAM / ~14 min**. Run it on **grafema-dev** (Hetzner cx53,
+16 vCPU / 32 GB, `ssh grafema-dev`, `source ~/.cargo/env`), NOT the laptop or a 7 GB VM (OOM kills
+rfdb-server → exit 143, which looks like a crash but is memory pressure). Missing language toolchains
+make those files **skip** (elixir/mix for BEAM, swift, libclang for C/C++) — fast now, but the self-graph
+is then partial for those languages. Running 2 full analyzes on the 32 GB box is the safe max (>2 OOMs).
+
+## 6. Known standing perf debt (don't re-derive)
+
+`REG-1128`: heavy Node.js resolve plugins do N+1 IPC walks — `type-inference 72.7s / 0 edges`,
+`method-call-resolver 55s / 0 edges`, `shape-verifier 53s / 0 edges`. Fix direction = rewrite as Datalog
+rules. Derive-phase plan (parallelize independent packs, hoist `derive_stats`, bound the `js_local_refs`
+scope-walk) is in `_ai/self-analyze-perf-findings.md`.

--- a/.github/workflows/self-analyze.yml
+++ b/.github/workflows/self-analyze.yml
@@ -1,0 +1,177 @@
+# Grafema self-analyze regression guard
+#
+# WHY THIS EXISTS
+# ---------------
+# Grafema's CI runs CodeQL "Analyze" jobs — it does NOT run *Grafema's own*
+# `grafema analyze` against this repo. That gap is exactly what let a whole class
+# of self-scale bugs ship silently: a derive-phase SIGSEGV (compaction vs.
+# parallel-derive heap corruption) plus several conservative planner/eval caps
+# (max_intermediate_results, MAX_MATERIALIZED_FACTS) that only bite when grafema
+# analyzes its OWN ~714k-node / 1.33M-edge monorepo. None of that is reachable by
+# the unit/integration tests, which run on tiny fixture graphs. See
+# fix/derive-batch-cap (Disentinel/grafema#469).
+#
+# WHAT THIS JOB DOES
+# ------------------
+#   1. Builds grafema as it ships: pnpm build (TS) + cargo --release for the two
+#      native binaries the analyze pipeline spawns (rfdb-server + orchestrator).
+#   2. Runs `grafema analyze` against this repo using the checked-in dogfooding
+#      config (.grafema/config.yaml), with the env that makes self-analyze pass.
+#   3. Asserts the run reached exit 0 AND the JS enrichers actually fired — the
+#      graph must contain `mcp:tool` nodes (produced by the behavior enricher on
+#      packages/mcp/src/server.ts). A green exit with an empty graph is a silent
+#      failure we explicitly catch.
+#
+# RUNNER / SCOPE CHOICE
+# ---------------------
+# Runs the FULL monorepo self-analyze (not a scoped subset) so it exercises all
+# ~40 derive packs — including the ones that triggered the SIGSEGV
+# (@stdlib/js_local_refs) and the cap rejects (js_property_access_full). A scoped
+# single-package analyze would NOT reproduce those cross-package derive paths, so
+# scoping was rejected in favor of the full run.
+# Runner: ubuntu-latest (GitHub-hosted: 16 GB RAM / 4 vCPU). A full self-analyze
+# peaks ~7.5 GB RAM and ~14 min wall — it fits in 16 GB with headroom. The job
+# timeout covers the Rust release build (~10-15 min, cached after the first run)
+# plus the analyze. If a future graph outgrows 16 GB, switch `runs-on` to a larger
+# GitHub-hosted runner label, or scope the analyze via `--service mcp --service
+# cli` (note: --service currently takes a single name; would need a small CLI
+# change or a per-service loop).
+#
+# NON-BLOCKING — READ BEFORE MAKING REQUIRED
+# ------------------------------------------
+# This job is intentionally NON-BLOCKING (continue-on-error: true) and is NOT a
+# required status check. As of fix/derive-batch-cap the derive phase completes
+# with 0 SIGSEGV, but the run still fails LATE on an enricher RPC 60s client
+# timeout (being fixed separately on fix/enricher-rpc-timeout). Until a full
+# self-analyze is green end-to-end, this job RUNS and SURFACES the result without
+# blocking PRs.
+#
+# TODO(make-required): once fix/enricher-rpc-timeout lands and a full self-analyze
+# reaches exit 0 with mcp:tool > 0 reliably, remove `continue-on-error: true`
+# below AND add `self-analyze` to the branch-protection required checks for `main`
+# so this class of bug can never regress silently again.
+
+name: Self-Analyze
+
+on:
+  # Run on PRs so regressions surface in review, and on the fix branch itself.
+  # Deliberately NOT wired into every push to main yet (it's non-blocking and
+  # still fails late — see header). Flip this on when made required.
+  pull_request:
+    branches: [main, ai-dev]
+  push:
+    branches: [fix/derive-batch-cap, fix/ci-self-analyze]
+  workflow_dispatch: {}
+
+env:
+  NODE_VERSION: '22'
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: '1'
+  # Self-analyze env from fix/derive-batch-cap — lifts the interactive deadline
+  # and the planner fact-guard so the full 40-pack derive completes at self-scale.
+  RFDB_MATERIALIZE_DEADLINE_SECS: '3600'
+  RFDB_MAX_MATERIALIZED_FACTS: '200000000'
+
+jobs:
+  self-analyze:
+    name: grafema analyze (self, non-blocking)
+    runs-on: ubuntu-latest
+    # Non-blocking: surface the result, never block a PR — see header TODO.
+    continue-on-error: true
+    # Generous: Rust release build (~10-15 min cold) + ~14 min analyze.
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            packages/rfdb-server -> target
+            packages/grafema-orchestrator -> target
+          key: self-analyze
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Build TS packages
+        run: pnpm build
+
+      # The analyze pipeline spawns two native binaries; the CLI auto-detects them
+      # from packages/<pkg>/target/release/ (findRfdbBinary / findOrchestratorBinary).
+      - name: Build rfdb-server (release)
+        working-directory: packages/rfdb-server
+        run: cargo build --release
+
+      - name: Build grafema-orchestrator (release)
+        working-directory: packages/grafema-orchestrator
+        run: cargo build --release
+
+      - name: Show free memory before analyze
+        run: free -h || true
+
+      # The repo ships .grafema/config.yaml (dogfooding config, full monorepo).
+      # --clear rebuilds from scratch; --no-auto-start is NOT used so the CLI
+      # brings up the freshly-built rfdb-server itself.
+      - name: Run grafema self-analyze
+        id: analyze
+        run: |
+          set -o pipefail
+          node packages/cli/dist/cli.js analyze --clear --verbose 2>&1 | tee /tmp/self-analyze.log
+          echo "Analyze exited 0."
+
+      # Assert the JS enrichers fired: the behavior enricher emits mcp:tool nodes
+      # for packages/mcp/src/server.ts. A clean exit with an empty graph is the
+      # silent-failure mode this guard exists to catch.
+      - name: Assert JS enrichers fired (mcp:tool nodes present)
+        run: |
+          set -o pipefail
+          node packages/cli/dist/cli.js query --type "mcp:tool" "" --json -l 100000 2>/dev/null > /tmp/mcp-tool.json
+          COUNT=$(node -e "const a=JSON.parse(require('fs').readFileSync('/tmp/mcp-tool.json','utf8')); console.log(Array.isArray(a)?a.length:0)")
+          echo "mcp:tool node count: $COUNT"
+          echo "mcp:tool nodes: $COUNT" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$COUNT" -lt 1 ]; then
+            echo "::error::self-analyze produced 0 mcp:tool nodes — JS enrichers did not fire (graph is empty/incomplete)."
+            exit 1
+          fi
+          echo "OK: JS enrichers fired ($COUNT mcp:tool nodes)."
+
+      # Best-effort SIGSEGV / derive-reject canary. The derive phase must finish
+      # without a segfault or plan rejects; flag them loudly even though the job
+      # is non-blocking for now.
+      - name: Check derive phase for SIGSEGV / plan rejects
+        if: always()
+        run: |
+          if grep -qiE "SIGSEGV|signal: 11|segmentation fault" /tmp/self-analyze.log 2>/dev/null; then
+            echo "::error::SIGSEGV detected in self-analyze — derive-phase heap corruption regressed."
+            grep -iE "SIGSEGV|signal: 11|segmentation fault" /tmp/self-analyze.log | head >> "$GITHUB_STEP_SUMMARY" || true
+            exit 1
+          fi
+          if grep -qiE "plan reject|rejected by planner|MAX_MATERIALIZED_FACTS guard" /tmp/self-analyze.log 2>/dev/null; then
+            echo "::warning::Derive plan rejects present in self-analyze log (planner cap hit)."
+          fi
+          echo "No SIGSEGV in derive phase."
+
+      - name: Upload self-analyze log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: self-analyze-log
+          path: |
+            /tmp/self-analyze.log
+            /tmp/mcp-tool.json
+          retention-days: 14

--- a/_ai/self-analyze-perf-findings.md
+++ b/_ai/self-analyze-perf-findings.md
@@ -75,21 +75,32 @@ confirming the cost is the daemon-encoding hang, not BEAM parsing.
    analysis fan-out: counter reached 17, 0 circuit-open events, analysis still
    241 s.
 
-### Precise plan for the parallel analysis fan-out (deferred, larger change)
+### LANDED: liveness probe for the BEAM analysis fan-out
 
-Add a **sequential liveness probe** at the top of each
-`analyze_<lang>_files_parallel_pooled` (there are ~3 structurally-identical
-fan-out blocks — BEAM, and the Java/Kotlin/Go/Swift/ObjC parser+analyzer pools):
-analyze `files[0]` synchronously BEFORE fanning out the rest. A healthy daemon
-answers in <1 s and the normal parallel path proceeds (re-using the probe's
-result for file 0). A dead daemon fails the probe in ONE `request_timeout` and
-the remaining files are returned failed-fast — bounding a dead daemon to a
-single 120 s timeout instead of `ceil(N / jobs)` waves of it (25 `.ex` files:
-241 s → ~120 s, and with a shorter probe timeout, → seconds). RISK: the
-fan-out blocks are shared across languages; the probe must be added carefully
-(unique per-call-site context) and must re-use `files[0]`'s result so file 0
-is not double-analyzed. Each call site needs its own before/after timing check.
-Effort: medium; reward: removes the analysis phase's single largest sink.
+`analyze_beam_files_parallel_pooled` now analyzes `files[0]` **synchronously**
+before fanning out the rest. A healthy daemon answers in <1 s and the normal
+parallel path proceeds (file 0 is re-analyzed by the fan-out — one extra
+sub-second analysis, negligible; the fan-out loop is left untouched, the
+lowest-risk shape). A dead daemon fails the probe in ONE `request_timeout` and
+ALL files are returned failed-fast. The BEAM pool's `request_timeout` is also
+lowered from the 120 s default to **30 s** (a real `.ex` file analyzes in ~300 ms,
+so 30 s is generous yet ~4× faster to abandon a hung daemon).
+
+**Measured (grafema self-analyze, grafema-dev, dead BEAM daemon):**
+
+| | analysis phase | BEAM file-work | BEAM timeouts |
+|--|---|---|---|
+| before | **241.7 s** | 3001 s (120 s × 25 files) | 25 |
+| after  | **37.3 s**  | 0 s (24 files skipped after 1 probe) | 1 |
+
+→ **analysis phase 241.7 s → 37.3 s, a 6.5× speedup (−204 s)** off the total
+self-analyze. The remaining 37 s is the legitimate TS/Rust/Haskell analysis plus
+the single 30 s BEAM probe. (On a host where BEAM works, the probe passes in <1 s
+and nothing changes.)
+
+The same probe pattern would extend the win to the other ~3 structurally
+identical analyzer fan-outs (Java/Kotlin/Go/Swift/ObjC) — deferred, not needed
+for grafema's own monorepo (no such files there).
 
 ## Derive phase (180 s / 40 packs) — DOCUMENTED PLAN, not landed here
 

--- a/_ai/self-analyze-perf-findings.md
+++ b/_ai/self-analyze-perf-findings.md
@@ -1,0 +1,105 @@
+# Self-analyze performance: measured sinks + plan (perf/self-analyze)
+
+Profiled `grafema analyze` on grafema's OWN monorepo, on grafema-dev
+(16 vCPU / 30 GB), `RFDB_MATERIALIZE_DEADLINE_SECS=3600
+RFDB_MAX_MATERIALIZED_FACTS=200000000`. Graph: **513,005 nodes / 1,107,496 edges**.
+
+## Measured phase breakdown (baseline, before this branch's fix)
+
+| Phase | Wall time | Notes |
+|-------|-----------|-------|
+| **Analysis** | **241.5 s** | 660 commit batches; dominated by 25 BEAM `.ex` files |
+| JS resolve | 11.3 s | 309 JS/TS files, per-file streaming (1 worker) |
+| Haskell resolve | 23.9 s | |
+| Rust resolve | 53.1 s | streams all ~200k Rust nodes to 1 worker |
+| **Derive** | **180 s** | 40 stdlib rule packs |
+| Compact | <1 s | |
+| TS enrichers/plugins | large tail | `type-inference` + `shape-tracker` (NOT in this lane) |
+
+Per-commit `commit_batch` server time stayed ~350–500 ms with only mild growth
+(451 ms → 1332 ms avg across 33 profiled batches) — **no O(N²) `commit_batch`
+blow-up** observed at this scale (RFD-51's old symptom is not reproducing here).
+
+`clear_durable()` is already **O(1)** — swap to ephemeral placeholders, `rm`
+the manifest authority + data trees, recreate the empty skeleton (W8 Part 2).
+It is **not** O(graph); the "slow clear" hypothesis did not hold.
+`queryNodesByFile` prunes via an **exact** per-segment `file_paths` zone-map
+(`SegmentDescriptor::may_contain`), so per-file resolve is **not** a full scan.
+
+## TOP SINK (analysis phase): BEAM daemon latin1 timeout — FIXED here
+
+Per-extension file-analyze time (sum of per-file `total_ms`):
+
+| ext | files | total | avg/file |
+|-----|-------|-------|----------|
+| **ex** | **25** | **3003 s** | **~120 s** |
+| ts | 309 | 21.2 s | 69 ms |
+| hs | 210 | 18.1 s | 86 ms |
+| rs | 116 | 16.5 s | 142 ms |
+
+`beam-analyzer` is an Erlang **escript**. When the host locale is not UTF-8 the
+Erlang VM falls back to **`latin1` native name encoding**, which mangles the
+length-prefixed binary stdin protocol the orchestrator `ProcessPool` speaks.
+The `--daemon` never replies, so **every** per-file request burns the full
+`DEFAULT_REQUEST_TIMEOUT` (**120 s**) before the pool abandons it — exactly the
+~120 s/file measured, and the "Pool request failed" errors in the log.
+
+The same `.ex` file analyzed in single-shot (non-daemon) mode runs in **309 ms**,
+confirming the cost is the daemon-encoding hang, not BEAM parsing.
+
+**Fix (this branch):** new `PoolConfig.extra_env` pinned on the BEAM analyzer
+and resolve pools, setting `ELIXIR_ERL_OPTIONS=+fnu` (force UTF-8) +
+`LANG`/`LC_ALL=C.UTF-8`. This makes the daemon correct **regardless of host
+locale**, eliminating the 120 s-per-file timeout. The fix is portable (it does
+not depend on the operator's locale being right) and zero-risk for non-BEAM
+analyzers (the env is only applied to the BEAM pools).
+
+## Derive phase (180 s / 40 packs) — DOCUMENTED PLAN, not landed here
+
+Top packs (no single dominant one — the cost is spread):
+
+| ms | edges | pack |
+|----|-------|------|
+| 22.2 s | 2374 | `@stdlib/rust_calls` |
+| 19.3 s | 187 | `@stdlib/js_local_refs` (stratified scope-walk) |
+| 12.5 s | 75759 | `@stdlib/haskell_local_refs` |
+| 10.1 s | 1213 | `@stdlib/js_same_file_calls` |
+| 8.3 s | 7820 | `@stdlib/js_runtime_globals_edges` |
+| 7.0 s | 5764 | `@stdlib/method_calls` |
+
+Why it is expensive: each pack runs a full Datalog `@materialize` over the live
+500k-node snapshot. Index reuse across packs is already implemented
+(`SharedIndexCaches` + `retain_for_commit` for additive commits), and joins are
+already rayon-parallel (`par_join_rows`). The remaining cost is genuine join
+work (scope-walk transitive `inner_of`/`ref_scope` closures, ::-qualified call
+arms). Notably the per-pack flush bumps the manifest version, which **misses**
+`derive_stats_cache` (version-keyed) and forces `count_nodes_by_type_at` to
+re-scan once per pack.
+
+Candidate wins (ranked; all carry derive-engine SIGSEGV-regression risk —
+the 40-pack derive must still complete with 0 SIGSEGV, and auto-compaction must
+stay suppressed during materialize per the 2026-06-19 use-after-unmap fix):
+
+1. **Run independent packs concurrently.** The 40 packs have a partial order
+   (producers before `depends`), but many are independent (e.g. the rust_* and
+   haskell_* and js_* families don't read each other's slices). A topological
+   batching that materializes independent packs in parallel could cut the 180 s
+   substantially. RISK: each `@materialize` commits via `flush()` (a manifest
+   flip under `&mut self`); concurrent materialize needs the `&self`
+   private-buffer commit path + conflict retry, and must not overlap
+   auto-compaction. Medium-high effort, high reward.
+
+2. **Hoist `derive_stats` across the pack run.** Per-type node counts only
+   change when a pack adds NODES (few packs do — most add edges only). For the
+   edge-only majority, the per-version stats recompute is redundant work; a
+   stats delta keyed on "did this commit add nodes" avoids the re-scan. Low
+   risk, modest reward.
+
+3. **`js_local_refs` scope-walk:** bound the `inner_of` transitive closure by
+   chain depth / pre-index DECLARES-by-name so the negation stratum starts from
+   a smaller candidate set. High risk (correctness of shadowing resolution),
+   pack-specific reward (~19 s).
+
+The BEAM fix is landed and measured; the derive plan is deferred because each
+option touches the derive engine's commit/compaction invariants and needs its
+own SIGSEGV-safe verification pass.

--- a/_ai/self-analyze-perf-findings.md
+++ b/_ai/self-analyze-perf-findings.md
@@ -47,12 +47,49 @@ The `--daemon` never replies, so **every** per-file request burns the full
 The same `.ex` file analyzed in single-shot (non-daemon) mode runs in **309 ms**,
 confirming the cost is the daemon-encoding hang, not BEAM parsing.
 
-**Fix (this branch):** new `PoolConfig.extra_env` pinned on the BEAM analyzer
-and resolve pools, setting `ELIXIR_ERL_OPTIONS=+fnu` (force UTF-8) +
-`LANG`/`LC_ALL=C.UTF-8`. This makes the daemon correct **regardless of host
-locale**, eliminating the 120 s-per-file timeout. The fix is portable (it does
-not depend on the operator's locale being right) and zero-risk for non-BEAM
-analyzers (the env is only applied to the BEAM pools).
+### What this branch lands
+
+1. **`PoolConfig.extra_env`** pinned on the BEAM analyzer and resolve pools,
+   setting `ELIXIR_ERL_OPTIONS=+fnu` (force UTF-8) + `LANG`/`LC_ALL=C.UTF-8`.
+   This removes the `latin1` mis-encoding (verified: 0 latin1 warnings after).
+   NOTE — on grafema-dev the daemon STILL fails to reply even with UTF-8 (it
+   raises `{:error, :enxio}`, a deeper escript-daemon problem independent of
+   locale), so on THIS host the encoding fix alone does not recover the time.
+   It is still correct and portable: on a host where the daemon's only problem
+   is the locale, it fully fixes the 120 s/file timeout.
+
+2. **Pool circuit breaker** (`TIMEOUT_CIRCUIT_BREAKER_THRESHOLD`, tested):
+   after N consecutive request timeouts with no success, a pool fails every
+   further `request()` IMMEDIATELY instead of paying `request_timeout` again. A
+   single success resets it. This bounds a dead daemon to `N × request_timeout`
+   on any **serial** daemon request stream — i.e. the resolve daemons (JS
+   per-file `resolve-file`, the single-worker Haskell/Rust/Java/BEAM resolve
+   pools — exactly the REG-1128 N+1 hot path). Zero-risk: a merely-slow daemon
+   never trips it.
+
+   LIMITATION (measured): the breaker does NOT help the **parallel analysis
+   fan-out**. `analyze_*_files_parallel_pooled` dispatches all files
+   concurrently, so every request passes the breaker check at t≈0 (counter
+   still 0) and they all time out together at t=120 s — the counter climbs
+   1→2→…→N but no request arrives AFTER the trip point. Confirmed on the BEAM
+   analysis fan-out: counter reached 17, 0 circuit-open events, analysis still
+   241 s.
+
+### Precise plan for the parallel analysis fan-out (deferred, larger change)
+
+Add a **sequential liveness probe** at the top of each
+`analyze_<lang>_files_parallel_pooled` (there are ~3 structurally-identical
+fan-out blocks — BEAM, and the Java/Kotlin/Go/Swift/ObjC parser+analyzer pools):
+analyze `files[0]` synchronously BEFORE fanning out the rest. A healthy daemon
+answers in <1 s and the normal parallel path proceeds (re-using the probe's
+result for file 0). A dead daemon fails the probe in ONE `request_timeout` and
+the remaining files are returned failed-fast — bounding a dead daemon to a
+single 120 s timeout instead of `ceil(N / jobs)` waves of it (25 `.ex` files:
+241 s → ~120 s, and with a shorter probe timeout, → seconds). RISK: the
+fan-out blocks are shared across languages; the probe must be added carefully
+(unique per-call-site context) and must re-use `files[0]`'s result so file 0
+is not double-analyzed. Each call site needs its own before/after timing check.
+Effort: medium; reward: removes the analysis phase's single largest sink.
 
 ## Derive phase (180 s / 40 packs) — DOCUMENTED PLAN, not landed here
 

--- a/packages/grafema-orchestrator/src/analyzer.rs
+++ b/packages/grafema-orchestrator/src/analyzer.rs
@@ -1861,6 +1861,12 @@ pub async fn analyze_beam_files_parallel_pooled(
         command: analyzers.beam_path(),
         args: vec!["--daemon".to_string()],
         extra_env: crate::config::beam_utf8_env(),
+        // A single `.ex`/`.erl` file analyzes in ~300ms (measured single-shot),
+        // so the 120s default per-request timeout is far too generous for BEAM —
+        // it only ever bites when the daemon is hung. A 30s ceiling keeps a
+        // large/pathological file safe while making both the liveness probe
+        // below and any per-file timeout fail ~4x faster on a dead daemon.
+        request_timeout: std::time::Duration::from_secs(30),
         ..PoolConfig::default()
     };
 
@@ -1874,8 +1880,54 @@ pub async fn analyze_beam_files_parallel_pooled(
         }
     };
 
-    let semaphore = Arc::new(Semaphore::new(jobs.max(1)));
     let total = files.len();
+
+    // ── Liveness gate (perf/self-analyze) ────────────────────────────────────
+    // The parallel fan-out below dispatches every file concurrently, so the
+    // pool's request-level circuit breaker cannot help: all requests pass the
+    // breaker check at t≈0 (counter still 0) and only time out together at
+    // `request_timeout` (120s). A genuinely-non-responsive beam-analyzer daemon
+    // (the escript fails to reply on hosts with a broken Elixir/Erlang runtime)
+    // therefore costs ~120s × ceil(files/jobs) waves — measured at ~241s for
+    // grafema's 25 `.ex` files, the analysis phase's single largest sink.
+    //
+    // Probe ONE file FIRST, sequentially. A healthy daemon answers in <1s and we
+    // fall through to the normal parallel path (file[0] is re-analyzed by the
+    // fan-out — one extra sub-second analysis, negligible). A dead daemon fails
+    // the probe in one `request_timeout` and we short-circuit ALL files as
+    // failed-fast, bounding total damage to a single timeout instead of N. The
+    // fan-out loop below is intentionally left untouched (lowest-risk shape).
+    if let Err(probe_err) = analyze_beam_file_pooled(&pool, &files[0]).await {
+        tracing::error!(
+            file = %files[0].display(),
+            error = %format!("{probe_err:#}"),
+            "beam-analyzer daemon failed its liveness probe — non-responsive; \
+             skipping {} remaining BEAM file(s) instead of paying the per-file \
+             timeout for each (fix the beam-analyzer daemon: ensure a UTF-8 \
+             locale and a working Elixir/Erlang runtime)",
+            total.saturating_sub(1)
+        );
+        let mut out = Vec::with_capacity(total);
+        for file in files {
+            let file_size_bytes = std::fs::metadata(file).map(|m| m.len()).unwrap_or(0);
+            out.push(AnalysisResult {
+                file: file.clone(),
+                analysis: None,
+                errors: vec![format!(
+                    "beam-analyzer daemon non-responsive (liveness probe failed: {probe_err})"
+                )],
+                issues: vec![],
+                metrics: FileMetrics {
+                    file_size_bytes,
+                    ..FileMetrics::default()
+                },
+            });
+        }
+        pool.shutdown().await;
+        return out;
+    }
+
+    let semaphore = Arc::new(Semaphore::new(jobs.max(1)));
 
     let handles: Vec<_> = files
         .iter()

--- a/packages/grafema-orchestrator/src/analyzer.rs
+++ b/packages/grafema-orchestrator/src/analyzer.rs
@@ -1860,6 +1860,7 @@ pub async fn analyze_beam_files_parallel_pooled(
     let pool_config = PoolConfig {
         command: analyzers.beam_path(),
         args: vec!["--daemon".to_string()],
+        extra_env: crate::config::beam_utf8_env(),
         ..PoolConfig::default()
     };
 

--- a/packages/grafema-orchestrator/src/config.rs
+++ b/packages/grafema-orchestrator/src/config.rs
@@ -517,6 +517,29 @@ impl AnalyzerBinaries {
     }
 }
 
+/// Environment pinned on BEAM (Erlang/Elixir) daemon workers so they run with
+/// UTF-8 native name encoding regardless of the host locale.
+///
+/// `beam-analyzer` / `beam-resolve` are escripts; the Erlang VM picks its native
+/// name encoding from the locale at startup and falls back to `latin1` when the
+/// locale is not UTF-8. Under latin1 the Elixir VM mangles the length-prefixed
+/// binary stdin protocol the [`crate::process_pool::ProcessPool`] speaks, the
+/// daemon stops replying, and every per-file request burns the full pool
+/// `request_timeout` (120s) before being abandoned — measured at ~120s × 25 BEAM
+/// files = ~3000s of wasted analysis-phase work on grafema's own monorepo (the
+/// analysis phase's single largest sink there). `+fnu` forces UTF-8 unconditionally;
+/// we also pin the standard env vars so any child shelling out inherits a sane
+/// locale. Set on BOTH the analyzer and resolve BEAM pools. Caller-supplied
+/// `ELIXIR_ERL_OPTIONS` in the host env is intentionally overridden — correctness
+/// of the IPC framing is non-negotiable.
+pub fn beam_utf8_env() -> Vec<(String, String)> {
+    vec![
+        ("ELIXIR_ERL_OPTIONS".to_string(), "+fnu".to_string()),
+        ("LANG".to_string(), "C.UTF-8".to_string()),
+        ("LC_ALL".to_string(), "C.UTF-8".to_string()),
+    ]
+}
+
 /// Plugin configuration.
 #[derive(Debug, Clone, Deserialize)]
 pub struct PluginConfig {

--- a/packages/grafema-orchestrator/src/main.rs
+++ b/packages/grafema-orchestrator/src/main.rs
@@ -1561,6 +1561,7 @@ async fn main() -> Result<()> {
                     request_timeout: std::time::Duration::from_secs(300),
                     effects_db_path: effects_db_path.clone(),
                     skip_resolve_steps: resolve_skips_env.clone(),
+                    extra_env: Vec::new(),
                 };
 
                 match process_pool::ProcessPool::new(resolve_pool_config, 1) {
@@ -2042,6 +2043,7 @@ async fn main() -> Result<()> {
                     command: cfg.analyzers.beam_resolve_path(),
                     args: vec!["--daemon".to_string()],
                     effects_db_path: effects_db_path.clone(),
+                    extra_env: config::beam_utf8_env(),
                     ..process_pool::PoolConfig::default()
                 };
                 match process_pool::ProcessPool::new(pool_cfg, 1) {
@@ -2547,6 +2549,7 @@ async fn main() -> Result<()> {
                     // GRAFEMA_SKIP_RESOLVE_STEPS from the parent env, which gates
                     // the remaining native step (runtime-globals).
                     skip_resolve_steps: None,
+                    extra_env: Vec::new(),
                 };
 
                 match process_pool::ProcessPool::new(resolve_pool_config, 1) {
@@ -2949,6 +2952,7 @@ async fn main() -> Result<()> {
                     command: cfg.analyzers.beam_resolve_path(),
                     args: vec!["--daemon".to_string()],
                     effects_db_path: effects_db_path.clone(),
+                    extra_env: config::beam_utf8_env(),
                     ..process_pool::PoolConfig::default()
                 };
                 match process_pool::ProcessPool::new(pool_cfg, 1) {

--- a/packages/grafema-orchestrator/src/process_pool.rs
+++ b/packages/grafema-orchestrator/src/process_pool.rs
@@ -9,6 +9,7 @@
 
 use anyhow::{bail, Context, Result};
 use std::process::Stdio;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
@@ -16,6 +17,20 @@ use tokio::sync::{mpsc, Mutex};
 
 /// Maximum message size (100 MB), matching RFDB client.
 const DEFAULT_MAX_MESSAGE_SIZE: usize = 100 * 1024 * 1024;
+
+/// Circuit-breaker threshold: once this many requests have timed out on a pool
+/// with NO successful request in between, the daemon is judged non-responsive
+/// and every subsequent `request()` fails IMMEDIATELY instead of paying the
+/// full `request_timeout` again.
+///
+/// Why: a hung analyzer daemon (e.g. the BEAM escript that never replies on
+/// this host) otherwise costs `request_timeout` (120 s) PER FILE — measured at
+/// ~25 × 120 s ≈ the entire 241 s analysis phase of grafema's self-analyze. With
+/// the breaker the damage is bounded to `threshold × request_timeout` total; the
+/// remaining files fail fast and the language is simply skipped (the same
+/// outcome it had after burning 120 s each, but in seconds). A single success
+/// resets the counter, so a merely-slow daemon never trips it.
+const TIMEOUT_CIRCUIT_BREAKER_THRESHOLD: usize = 3;
 
 /// Default per-request timeout (120 seconds).
 /// If a worker takes longer than this, the request is aborted
@@ -86,6 +101,10 @@ pub struct ProcessPool {
     workers: Vec<Mutex<Option<Worker>>>,
     available_rx: Mutex<mpsc::Receiver<usize>>,
     return_tx: mpsc::Sender<usize>,
+    /// Consecutive request timeouts with no intervening success. Drives the
+    /// non-responsive-daemon circuit breaker (see
+    /// [`TIMEOUT_CIRCUIT_BREAKER_THRESHOLD`]). Reset to 0 by any success.
+    consecutive_timeouts: AtomicUsize,
 }
 
 /// Write a length-prefixed frame to the given writer.
@@ -190,6 +209,7 @@ impl ProcessPool {
             workers,
             available_rx: Mutex::new(available_rx),
             return_tx,
+            consecutive_timeouts: AtomicUsize::new(0),
         })
     }
 
@@ -202,6 +222,22 @@ impl ProcessPool {
     /// retry also fails, the error is propagated (the worker slot is still
     /// returned to the pool).
     pub async fn request(&self, payload: &[u8]) -> Result<Vec<u8>> {
+        // Circuit breaker: a daemon that has already timed out
+        // `TIMEOUT_CIRCUIT_BREAKER_THRESHOLD` times in a row (no success between)
+        // is non-responsive. Fail this request IMMEDIATELY rather than paying the
+        // full `request_timeout` again — bounds a dead daemon's total cost to
+        // `threshold × request_timeout` instead of `num_requests × request_timeout`.
+        if self.consecutive_timeouts.load(Ordering::Relaxed)
+            >= TIMEOUT_CIRCUIT_BREAKER_THRESHOLD
+        {
+            bail!(
+                "pool circuit-open: {} consecutive {}s timeouts — daemon judged non-responsive, \
+                 failing fast (no further worker will be probed for this pool)",
+                self.consecutive_timeouts.load(Ordering::Relaxed),
+                self.config.request_timeout.as_secs()
+            );
+        }
+
         let idx = self
             .available_rx
             .lock()
@@ -214,10 +250,13 @@ impl ProcessPool {
         let result = match tokio::time::timeout(timeout, self.do_request(idx, payload)).await {
             Ok(r) => r,
             Err(_) => {
-                // Timeout: kill the stuck worker and respawn
+                // Timeout: kill the stuck worker and respawn. Count it toward the
+                // non-responsive-daemon circuit breaker.
+                let n = self.consecutive_timeouts.fetch_add(1, Ordering::Relaxed) + 1;
                 tracing::error!(
                     worker = idx,
                     timeout_secs = timeout.as_secs(),
+                    consecutive_timeouts = n,
                     "worker timed out — killing and respawning"
                 );
                 let _ = self.respawn_worker(idx).await;
@@ -228,6 +267,8 @@ impl ProcessPool {
 
         match result {
             Ok(response) => {
+                // A success proves the daemon is alive — reset the breaker.
+                self.consecutive_timeouts.store(0, Ordering::Relaxed);
                 let _ = self.return_tx.send(idx).await;
                 Ok(response)
             }
@@ -243,6 +284,7 @@ impl ProcessPool {
                         {
                             Ok(r) => r,
                             Err(_) => {
+                                self.consecutive_timeouts.fetch_add(1, Ordering::Relaxed);
                                 let _ = self.respawn_worker(idx).await;
                                 let _ = self.return_tx.send(idx).await;
                                 bail!(
@@ -253,6 +295,9 @@ impl ProcessPool {
                                 );
                             }
                         };
+                        if retry_result.is_ok() {
+                            self.consecutive_timeouts.store(0, Ordering::Relaxed);
+                        }
                         let _ = self.return_tx.send(idx).await;
                         retry_result.with_context(|| {
                             format!("retry after respawn also failed (original: {})", first_err)
@@ -552,6 +597,67 @@ while True:
         let payload2 = b"second request";
         let response2 = pool.request(payload2).await.unwrap();
         assert_eq!(response2, payload2);
+
+        pool.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_circuit_breaker_fails_fast_on_dead_daemon() {
+        // A daemon that reads the request but NEVER replies (the BEAM-escript
+        // failure mode). Every request hits the per-request timeout. After
+        // TIMEOUT_CIRCUIT_BREAKER_THRESHOLD consecutive timeouts the pool must
+        // fail subsequent requests IMMEDIATELY rather than paying the timeout.
+        let hang_script = r#"
+import sys
+# Drain stdin so the parent's write_frame completes, then hang forever.
+while True:
+    chunk = sys.stdin.buffer.read(65536)
+    if not chunk:
+        break
+"#;
+        let request_timeout = Duration::from_millis(300);
+        let config = PoolConfig {
+            command: "python3".to_string(),
+            args: vec!["-c".to_string(), hang_script.to_string()],
+            max_message_size: DEFAULT_MAX_MESSAGE_SIZE,
+            request_timeout,
+            effects_db_path: None,
+            skip_resolve_steps: None,
+            extra_env: Vec::new(),
+        };
+
+        let pool = match ProcessPool::new(config, 1) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("Skipping test (python3 not available): {}", e);
+                return;
+            }
+        };
+
+        // The first THRESHOLD requests each pay ~request_timeout and increment
+        // the breaker.
+        for _ in 0..TIMEOUT_CIRCUIT_BREAKER_THRESHOLD {
+            let r = pool.request(b"req").await;
+            assert!(r.is_err(), "a hung daemon request must time out");
+        }
+
+        // The next request must trip the breaker and return ALMOST INSTANTLY,
+        // well under a single request_timeout.
+        let start = std::time::Instant::now();
+        let r = pool.request(b"req").await;
+        let elapsed = start.elapsed();
+        assert!(r.is_err(), "circuit-open request must fail");
+        assert!(
+            r.unwrap_err().to_string().contains("circuit-open"),
+            "expected circuit-open error after threshold timeouts"
+        );
+        assert!(
+            elapsed < request_timeout,
+            "circuit-open request should fail fast ({:?}) — much faster than the \
+             {:?} per-request timeout",
+            elapsed,
+            request_timeout
+        );
 
         pool.shutdown().await;
     }

--- a/packages/grafema-orchestrator/src/process_pool.rs
+++ b/packages/grafema-orchestrator/src/process_pool.rs
@@ -42,6 +42,17 @@ pub struct PoolConfig {
     /// effective set (built-in retired steps ∪ user env) and pins it on the child,
     /// overriding plain env inheritance. `None` = inherit the parent env untouched.
     pub skip_resolve_steps: Option<String>,
+    /// Extra environment variables pinned on every worker child, overriding plain
+    /// env inheritance. Used to harden analyzer daemons against host-environment
+    /// quirks that corrupt the length-prefixed binary IPC framing — notably the
+    /// BEAM (Erlang/Elixir) escript, which runs with `latin1` native name encoding
+    /// when the host locale is not UTF-8. Under latin1 the Elixir VM mangles the
+    /// framed stdin protocol, the daemon never replies, and EVERY per-file request
+    /// burns the full `request_timeout` (120s) before the pool gives up — measured
+    /// at ~120s × 25 `.ev`/`.ex` files = ~3000s of wasted analysis-phase work on
+    /// grafema's own monorepo. Pinning `ELIXIR_ERL_OPTIONS=+fnu` (force UTF-8) makes
+    /// the daemon correct regardless of the host locale.
+    pub extra_env: Vec<(String, String)>,
 }
 
 impl Default for PoolConfig {
@@ -53,6 +64,7 @@ impl Default for PoolConfig {
             request_timeout: DEFAULT_REQUEST_TIMEOUT,
             effects_db_path: None,
             skip_resolve_steps: None,
+            extra_env: Vec::new(),
         }
     }
 }
@@ -122,6 +134,13 @@ fn spawn_worker(config: &PoolConfig) -> Result<Worker> {
 
     if let Some(ref steps) = config.skip_resolve_steps {
         cmd.env("GRAFEMA_SKIP_RESOLVE_STEPS", steps);
+    }
+
+    // Pin any caller-supplied env (e.g. ELIXIR_ERL_OPTIONS=+fnu for the BEAM
+    // daemon) AFTER the named vars above so a deliberate override always wins
+    // over inherited host env.
+    for (k, v) in &config.extra_env {
+        cmd.env(k, v);
     }
 
     let mut child = cmd
@@ -471,6 +490,7 @@ mod tests {
             request_timeout: DEFAULT_REQUEST_TIMEOUT,
             effects_db_path: None,
             skip_resolve_steps: None,
+            extra_env: Vec::new(),
         };
         let result = ProcessPool::new(config, 0);
         match result {
@@ -510,6 +530,7 @@ while True:
             request_timeout: DEFAULT_REQUEST_TIMEOUT,
             effects_db_path: None,
             skip_resolve_steps: None,
+            extra_env: Vec::new(),
         };
 
         let pool = match ProcessPool::new(config, 2) {
@@ -559,6 +580,7 @@ while True:
             request_timeout: DEFAULT_REQUEST_TIMEOUT,
             effects_db_path: None,
             skip_resolve_steps: None,
+            extra_env: Vec::new(),
         };
 
         let pool = match ProcessPool::new(config, 3) {
@@ -610,6 +632,7 @@ if len(hdr) == 4:
             request_timeout: DEFAULT_REQUEST_TIMEOUT,
             effects_db_path: None,
             skip_resolve_steps: None,
+            extra_env: Vec::new(),
         };
 
         let pool = match ProcessPool::new(config, 1) {
@@ -657,6 +680,7 @@ while True:
             request_timeout: DEFAULT_REQUEST_TIMEOUT,
             effects_db_path: None,
             skip_resolve_steps: None,
+            extra_env: Vec::new(),
         };
 
         let pool = match ProcessPool::new(config, 1) {

--- a/packages/rfdb-server/src/bin/rfdb_server.rs
+++ b/packages/rfdb-server/src/bin/rfdb_server.rs
@@ -3045,10 +3045,31 @@ fn dispatch_materialize_datalog(
     limits.deadline =
         Some(std::time::Instant::now() + std::time::Duration::from_secs(materialize_deadline_secs));
 
+    // Same E-EXEC-001 reasoning as the deadline above: the 100k `max_intermediate_results` is an
+    // interactive-query bound and is WRONG for a batch full materialize. Intermediate relations of
+    // legitimate stdlib packs (e.g. js_local_refs scope-walk: ref_scope/inner_of/chain_declares)
+    // scale ~linearly with reference count, so a cold materialize over a non-trivial graph routinely
+    // exceeds 100k rows in a single stratum (the ~21k-node mcp graph already produces ~141k). The
+    // batch path is build-step-like; its real guards are the deadline + cancellation + memory, NOT a
+    // fixed row count. Lift it (default: unbounded). Tunable via `RFDB_MATERIALIZE_MAX_INTERMEDIATE`.
+    let materialize_max_intermediate = std::env::var("RFDB_MATERIALIZE_MAX_INTERMEDIATE")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(usize::MAX);
+    limits.max_intermediate_results = materialize_max_intermediate;
+
     // Empty source ⇒ the canonical bundled depends.dl; "@stdlib/<name>" ⇒ a named bundled
     // pack (E-MAT-007 when unknown); anything else ⇒ explicit program text. The single
     // source of truth is `resolve_pack_source` — no drift between dispatchers.
     let program = resolve_pack_source(source)?;
+
+    // Suppress auto-compaction for the duration of this materialize: committing derived edges would
+    // otherwise auto-trigger compaction, which (rayon, memmap2) rewrites/unmaps segments while this
+    // same materialize's `par_join_rows` rayon tasks read them → use-after-unmap heap corruption →
+    // SIGSEGV (confirmed root cause of the parallel-derive crash, 2026-06-19). Deferred compaction
+    // runs at the natural barrier (end_bulk_load / explicit Compact) under the exclusive write lock.
+    let _compaction_guard =
+        rfdb::storage_v2::compaction::coordinator::AutoCompactionSuppressGuard::new();
 
     // Gate D2: the cached entry MAINTAINS the derived relations across calls against this
     // long-lived per-database engine (work-proportional on the 2nd+ run) and commits only the

--- a/packages/rfdb-server/src/derive/plan.rs
+++ b/packages/rfdb-server/src/derive/plan.rs
@@ -40,7 +40,23 @@ use super::stratify::Stratification;
 
 /// Per-rule materialization ceiling (spec §3): a rule whose plan-time output estimate
 /// exceeds this is rejected with `E-PLAN-003`. Ten million facts.
+///
+/// This is the DEFAULT — a conservative guard against cross-join blow-ups whose plan-time
+/// estimate is also q-error-prone (often an OVERestimate). For a large batch self-analyze the
+/// 10M default is too low (a legitimate per-rule output like js property-access READS_FROM on a
+/// ~700k-node graph estimates ~11.7M), so the effective ceiling is env-overridable via
+/// [`max_materialized_facts`] / `RFDB_MAX_MATERIALIZED_FACTS`.
 pub const MAX_MATERIALIZED_FACTS: u64 = 10_000_000;
+
+/// The effective per-rule materialization ceiling: `RFDB_MAX_MATERIALIZED_FACTS` if set and
+/// parseable, else [`MAX_MATERIALIZED_FACTS`]. Read per check (cheap); lets a batch analyze raise
+/// the guard without recompiling.
+pub fn max_materialized_facts() -> u64 {
+    std::env::var("RFDB_MAX_MATERIALIZED_FACTS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(MAX_MATERIALIZED_FACTS)
+}
 
 
 // ── Error taxonomy (invariant I5) ──────────────────────────────────
@@ -361,13 +377,14 @@ fn plan_rule_with(
     }
 
     // §3 per-rule materialization guard.
-    if rule_estimate > MAX_MATERIALIZED_FACTS {
+    let guard = max_materialized_facts();
+    if rule_estimate > guard {
         return Err(PlanError {
             code: PlanCode::GuardRejected,
             head: head.clone(),
             detail: format!(
                 "per-rule output estimate {} exceeds max_materialized_facts {}",
-                rule_estimate, MAX_MATERIALIZED_FACTS
+                rule_estimate, guard
             ),
         });
     }

--- a/packages/rfdb-server/src/derive/plan.rs
+++ b/packages/rfdb-server/src/derive/plan.rs
@@ -363,7 +363,31 @@ fn plan_rule_with(
         // guard (observed: function-has-contains estimated 52,970,680 vs actual 1,747).
         let provided = provided_vars(atom, &bound);
         if lit.is_positive() && !provided.is_empty() {
-            rule_estimate = rule_estimate.saturating_mul(estimate.max(1));
+            // SELECTIVITY-AWARE FAN-OUT (spec §7 / the §3 q-error fix). A generator's raw
+            // magnitude is the fan-out only when its introduced key is UNCONSTRAINED. When a
+            // LATER body leg applies an EQUALITY selection on that key against a value already
+            // bound by a prior leg — a shared-variable equality JOIN KEY — the generator is in
+            // truth a keyed probe, not a full scan: its surviving fan-out is the relation over
+            // its key's distinct population (a 1:1-ish join), NOT the whole relation. The
+            // existing forward loop multiplies the generator's RAW magnitude in BEFORE it ever
+            // sees those downstream equality filters, cross-producting magnitudes the join keys
+            // make nearly 1:1 (observed live 2026-06-12: the stdlib `static_member` rule —
+            // node(Cls,"CLASS") · attr(Cls,"file",F) · attr(Cls,"name",BaseN) ·
+            // edge(Cls,T,"HAS_METHOD") · attr(T,"name",N) — estimated 11 667 968 vs an ACTUAL
+            // 811 materialized edges, a ~14000× over-estimate that spuriously tripped
+            // E-PLAN-003). Reduce the generator's contribution by a key-narrowing factor for
+            // each introduced variable a downstream leg equality-pins. The reduction is
+            // CONSERVATIVE (it never goes below a keyed √-fan-out, and a key with NO downstream
+            // equality is unreduced) so a GENUINE cross-product — whose legs share no pinning
+            // equality — keeps its full magnitude and still trips the guard (I1: ordering /
+            // sizing can only let more rules pass, never change WHICH facts derive).
+            let mut effective = estimate.max(1);
+            for v in &provided {
+                if downstream_equality_pins(v, idx, &ordered, &bound, &provided) {
+                    effective = narrowed_fanout(effective);
+                }
+            }
+            rule_estimate = rule_estimate.saturating_mul(effective);
         }
 
         bound.extend(provided);
@@ -855,6 +879,97 @@ fn leg_estimate(
             derived_estimate(name, *recursive, pattern, stats, estimates, self_base)
         }
     }
+}
+
+/// Whether a variable `v` — freshly introduced by the generator leg at position `idx` — is
+/// EQUALITY-PINNED by some LATER body leg (a shared-variable equality join key), so the
+/// generator is in truth a keyed probe and its fan-out must be key-narrowed, not the full
+/// relation magnitude (the §3 q-error fix; see the call site in `plan_rule_with`).
+///
+/// A later leg pins `v` when it is a positive base-relation EQUALITY selection that references
+/// `v` and whose OTHER variable positions are ALL already-bound at the time it runs — i.e. it
+/// contributes fan-out ≤ 1 and acts purely as `v = <bound value>`:
+///
+///   • `attr(v, "key", BoundOrConstVal)` — a point column read keyed by `v` whose value side is
+///     pinned to an already-bound variable/const (e.g. `attr(Cls,"name",BaseN)` with BaseN bound
+///     from `uc_pa`): an exact equality on the class node `Cls`.
+///   • `attr(BoundId, "key", v)` — the reverse: `v` is the value read off an already-bound id,
+///     an equality that pins `v` to that one node's attribute.
+///   • `edge(v, BoundDst, _)` / `edge(BoundSrc, v, _)` — an adjacency existence check on a bound
+///     endpoint, an equality on `v` against that neighbour.
+///   • `node(v, "T")` is NOT a pin — it only type-restricts, it does not equality-join `v` to a
+///     value a prior leg bound.
+///
+/// `at_run` is the set of variables bound up to and including the generator at `idx` (`bound`
+/// ∪ the generator's freshly-`provided` set), so a later leg's "other positions" are judged
+/// against what is genuinely bound before it. Pure function; never changes which facts derive.
+fn downstream_equality_pins(
+    v: &str,
+    idx: usize,
+    ordered: &[Literal],
+    bound: &HashSet<String>,
+    provided: &HashSet<String>,
+) -> bool {
+    // Variables bound by the time the generator at `idx` finishes. As we walk the LATER legs
+    // (already in bound-first execution order) we fold in each leg's freshly-provided vars, so
+    // an equality filter is judged against everything bound BY THE TIME IT RUNS — including a
+    // binding introduced by an INTERVENING leg between the generator and the filter (e.g. the
+    // class generator runs, a sibling driver then binds the name, and only THEN does the
+    // `attr(Cls,"name",Name)` equality pin the class).
+    let mut run: HashSet<String> = bound.clone();
+    run.extend(provided.iter().cloned());
+
+    for later in ordered.iter().skip(idx + 1) {
+        // Only positive legs can be equality selections.
+        let Literal::Positive(atom) = later else {
+            // A negative leg binds nothing; skip without advancing `run`.
+            continue;
+        };
+        let args = atom.args();
+        // The leg must REFERENCE `v`.
+        let refs_v = args.iter().any(|t| matches!(t, Term::Var(name) if name == v));
+        // A position is "settled" if it is `v` itself, a const/wildcard, or an already-bound
+        // variable. An equality pin requires every position to be settled — the leg then binds
+        // no NEW free variable beyond `v` and is a pure selection on `v`.
+        let other_settled = args.iter().all(|t| match t {
+            Term::Var(name) => name == v || run.contains(name),
+            Term::Const(_) | Term::Lit(_) | Term::Wildcard => true,
+        });
+        // Advance the running bind set with this leg's provided vars BEFORE moving on, so a
+        // downstream filter sees a binding this leg introduced.
+        let provides = positive_can_place_and_provides(atom, &run).1;
+        run.extend(provides);
+        if !refs_v || !other_settled {
+            continue;
+        }
+        match atom.predicate() {
+            // attr(...): an equality selection on `v` only when `v` is the id (point read keyed
+            // by v) or the value (read off a bound id) — NOT when v is merely the key name.
+            "attr" if args.len() >= 3 => {
+                let v_is_id = matches!(&args[0], Term::Var(n) if n == v);
+                let v_is_value = matches!(&args[2], Term::Var(n) if n == v);
+                if v_is_id || v_is_value {
+                    return true;
+                }
+            }
+            // edge(Src, Dst, T): an adjacency equality on `v` when v is an endpoint and the
+            // OTHER endpoint is already bound (the leg is a bound-endpoint existence probe).
+            "edge" | "incoming" if args.len() >= 2 => {
+                let v_is_src = matches!(&args[0], Term::Var(n) if n == v);
+                let v_is_dst = matches!(&args[1], Term::Var(n) if n == v);
+                let other_endpoint = if v_is_src { &args[1] } else { &args[0] };
+                let other_bound = match other_endpoint {
+                    Term::Var(n) => run.contains(n),
+                    _ => true,
+                };
+                if (v_is_src || v_is_dst) && other_bound {
+                    return true;
+                }
+            }
+            _ => {}
+        }
+    }
+    false
 }
 
 /// The cardinality estimate of a base-relation leg under its current bind pattern (spec §7).
@@ -1360,6 +1475,124 @@ mod tests {
             .expect_err("estimate guard fires");
         assert_eq!(err.code, PlanCode::GuardRejected, "{}", err);
         assert!(err.detail.contains("max_materialized_facts"), "{}", err.detail);
+    }
+
+    // ── selectivity-aware shared-variable equality joins (the §3 q-error fix) ──
+
+    /// The stdlib `static_member` shape (js_property_access_full.dl): a derived driver binds
+    /// (F, N, BaseN); a `node(Cls,"CLASS")` generator introduces Cls; two `attr(Cls,...)`
+    /// equality filters PIN Cls to the (file, name) class; `edge(Cls,T,"HAS_METHOD")` fans to
+    /// the method; `attr(T,"name",N)` pins it. The class+method are equality-keyed nearly 1:1,
+    /// so the real output is tiny (~811 on the live graph). The pre-fix estimator cross-
+    /// producted |uc_pa|·|CLASS|·avg_degree ≈ 11.7M and spuriously tripped E-PLAN-003. With the
+    /// selectivity reduction the pinned `node(Cls,"CLASS")` generator is key-narrowed, so the
+    /// rule plans and its estimate is realistic (well under the 10M default guard).
+
+    #[test]
+    fn selective_equality_join_estimate_is_realistic_static_member_shape() {
+        // realistic dogfood magnitudes: ~413k nodes, ~1.2M edges, 12k CLASS nodes.
+        let st = stats_typed(413_000, 1_200_000, &[("CLASS", 12_000)]);
+        let strat = empty_strat();
+        // static_member(PA, T) :- uc_pa(PA,F,N,BaseN), node(Cls,"CLASS"),
+        //   attr(Cls,"file",F), attr(Cls,"name",BaseN), edge(Cls,T,"HAS_METHOD"),
+        //   attr(T,"name",N).
+        // (`uc_pa` is an UNKNOWN predicate to a bare `plan_rule` — it has no stratum, so it is
+        // treated as a derived leg sized at the whole-graph None-fallback magnitude, the same
+        // conservative driver size the live planner saw. The fix must still bring the product
+        // under the guard.)
+        let rule = Rule::new(
+            Atom::new("static_member", vec![v("PA"), v("T")]),
+            vec![
+                pos("uc_pa", vec![v("PA"), v("F"), v("N"), v("BaseN")]),
+                pos("node", vec![v("Cls"), c("CLASS")]),
+                pos("attr", vec![v("Cls"), c("file"), v("F")]),
+                pos("attr", vec![v("Cls"), c("name"), v("BaseN")]),
+                pos("edge", vec![v("Cls"), v("T"), c("HAS_METHOD")]),
+                pos("attr", vec![v("T"), c("name"), v("N")]),
+            ],
+        );
+        let plan = plan_rule(&rule, &strat, &st)
+            .expect("selective equality joins must plan — not a real 11.7M explosion");
+        assert!(
+            plan.estimate <= MAX_MATERIALIZED_FACTS,
+            "static_member estimate {} must drop under the 10M default guard (was ~11.7M)",
+            plan.estimate
+        );
+        // The class generator IS key-narrowed: the estimate is far below the raw
+        // |CLASS|·avg_degree·driver cross-product (≥ tens of millions). A few hundred k is a
+        // safe over-estimate of the true ~811; the point is it no longer trips the guard.
+        assert!(
+            plan.estimate < 1_000_000,
+            "pinned class+method join should collapse to a small keyed estimate, got {}",
+            plan.estimate
+        );
+    }
+
+    /// The selectivity reduction must NOT fire on a GENUINE cross-product: a two-hop generator
+    /// join whose shared variable is NOT equality-pinned by any downstream selection keeps its
+    /// full magnitude and still trips E-PLAN-003. Here `edge(X,Y,"T"), edge(Y,Z,"T")` — Y is the
+    /// join variable but the second leg is itself a GENERATOR over a free Z (it introduces a new
+    /// tuple, it does not equality-pin Y against a bound value), so no key-narrowing applies.
+    #[test]
+    fn genuine_cross_join_without_selective_key_still_trips_guard() {
+        let rule = Rule::new(
+            Atom::new("h", vec![v("X"), v("Y"), v("Z")]),
+            vec![
+                pos("edge", vec![v("X"), v("Y"), c("T")]),
+                pos("edge", vec![v("Y"), v("Z"), c("T")]),
+            ],
+        );
+        let strat = empty_strat();
+        let err = plan_rule(&rule, &strat, &stats(1_000, 100_000_000))
+            .expect_err("a real two-hop explosion must still be rejected");
+        assert_eq!(err.code, PlanCode::GuardRejected, "{}", err);
+        assert!(err.detail.contains("max_materialized_facts"), "{}", err.detail);
+    }
+
+    /// Direct discrimination unit on the pin detector itself. A generator that introduces `Cls`
+    /// is pinned by a downstream `attr(Cls,"name",Name)` equality whose value side is already
+    /// bound (Name bound by an intervening driver) — but NOT by a bare `node(Cls,"CLASS")`
+    /// type-restriction, nor by an `edge(Cls,T,_)` whose other endpoint is itself free (a
+    /// generator hop, not a bound-endpoint probe). This is the discrimination that keeps a
+    /// genuine cross-join from being spuriously reduced.
+    #[test]
+    fn downstream_equality_pin_detection_discriminates() {
+        let bound: HashSet<String> = HashSet::new();
+        let provided: HashSet<String> = ["Cls".to_string()].into_iter().collect();
+
+        // PINNED: drv binds Name (idx1), then attr(Cls,"name",Name) equality-pins Cls (idx2).
+        let pinned = vec![
+            pos("node", vec![v("Cls"), c("CLASS")]),
+            pos("drv", vec![v("Name")]),
+            pos("attr", vec![v("Cls"), c("name"), v("Name")]),
+        ];
+        assert!(
+            downstream_equality_pins("Cls", 0, &pinned, &bound, &provided),
+            "attr(Cls,\"name\",Name) with Name bound downstream must pin Cls"
+        );
+
+        // NOT pinned: only a type-restriction and a HAS_METHOD edge whose dst T is FREE (a
+        // generator hop) — no equality selection on Cls against a bound value.
+        let unpinned = vec![
+            pos("node", vec![v("Cls"), c("CLASS")]),
+            pos("edge", vec![v("Cls"), v("T"), c("HAS_METHOD")]),
+        ];
+        assert!(
+            !downstream_equality_pins("Cls", 0, &unpinned, &bound, &provided),
+            "a free-endpoint HAS_METHOD hop must NOT pin Cls (it is a generator, not an equality)"
+        );
+
+        // NOT pinned: an attr leg keyed on Cls whose VALUE is a fresh free variable (a value
+        // read, not an equality against a bound value) does not pin Cls's identity. (`name` here
+        // is the bound key; the free V is what the leg generates.)
+        let value_read = vec![
+            pos("node", vec![v("Cls"), c("CLASS")]),
+            pos("attr", vec![v("Cls"), c("name"), v("V")]),
+        ];
+        assert!(
+            !downstream_equality_pins("Cls", 0, &value_read, &bound, &provided),
+            "attr(Cls,\"name\",V) with V free is a value read, not an equality pin"
+        );
     }
 
     // ── recursive derived leg → hash-on-delta ───────────────────────

--- a/packages/rfdb-server/src/storage_v2/compaction/coordinator.rs
+++ b/packages/rfdb-server/src/storage_v2/compaction/coordinator.rs
@@ -23,6 +23,38 @@ use crate::storage_v2::shard::{Shard, TombstoneSet};
 use crate::storage_v2::types::{SegmentMeta, SegmentType};
 use crate::storage_v2::writer::{EdgeSegmentWriter, NodeSegmentWriter};
 
+// ── Auto-compaction suppression during derive/materialize ───────────
+//
+// A derive/materialize handler holds a `db.engine.read()` lock but internally commits derived
+// edges across many rule packs; those commits would auto-trigger compaction. Compaction (rayon,
+// memmap2) rewrites/unmaps segments while the SAME materialize's `par_join_rows` rayon tasks read
+// them → use-after-unmap / heap corruption → SIGSEGV (confirmed by isolation test 2026-06-19).
+// While a materialize is in progress we SUPPRESS auto-compaction; the deferred compaction runs at
+// the natural barrier (end_bulk_load / explicit Compact) under the exclusive write lock.
+static AUTO_COMPACTION_SUPPRESSED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Suppress (or re-enable) automatic compaction. Set while a derive/materialize is in progress.
+pub fn set_auto_compaction_suppressed(suppressed: bool) {
+    AUTO_COMPACTION_SUPPRESSED.store(suppressed, std::sync::atomic::Ordering::SeqCst);
+}
+
+/// RAII guard: suppresses auto-compaction for its lifetime, restoring on drop (even on panic).
+pub struct AutoCompactionSuppressGuard;
+
+impl AutoCompactionSuppressGuard {
+    pub fn new() -> Self {
+        set_auto_compaction_suppressed(true);
+        AutoCompactionSuppressGuard
+    }
+}
+
+impl Drop for AutoCompactionSuppressGuard {
+    fn drop(&mut self) {
+        set_auto_compaction_suppressed(false);
+    }
+}
+
 // ── Policy ──────────────────────────────────────────────────────────
 
 /// Check if a shard should be compacted based on L0 segment count.
@@ -32,6 +64,14 @@ use crate::storage_v2::writer::{EdgeSegmentWriter, NodeSegmentWriter};
 ///
 /// Complexity: O(1)
 pub fn should_compact(shard: &Shard, config: &CompactionConfig) -> bool {
+    // Suppressed while a derive/materialize is in progress (see AUTO_COMPACTION_SUPPRESSED) — the
+    // confirmed fix for the parallel-derive SIGSEGV (compaction unmapping segments under parallel
+    // reads). RFDB_DISABLE_COMPACTION=1 is a manual override for diagnostics.
+    if AUTO_COMPACTION_SUPPRESSED.load(std::sync::atomic::Ordering::SeqCst)
+        || std::env::var_os("RFDB_DISABLE_COMPACTION").is_some()
+    {
+        return false;
+    }
     let total_l0 = shard.l0_node_segment_count() + shard.l0_edge_segment_count();
     total_l0 >= config.segment_threshold
 }

--- a/packages/rfdb/ts/base-client.ts
+++ b/packages/rfdb/ts/base-client.ts
@@ -40,11 +40,9 @@ import type {
   CommitBatchResponse,
 } from '@grafema/types';
 
-/**
- * Default timeout for operations (60 seconds).
- * Flush/compact may take time for large graphs, but should not hang indefinitely.
- */
-const DEFAULT_TIMEOUT_MS = 60_000;
+// Per-operation timeout ceilings (interactive vs bulk/streaming/drop) are
+// env-configurable and resolved by the concrete transport's `_send`. See
+// ./timeout-config.ts (RFDB_RPC_TIMEOUT_MS / RFDB_RPC_BULK_TIMEOUT_MS).
 
 export abstract class BaseRFDBClient extends EventEmitter implements IRFDBClient {
   abstract readonly socketPath: string;

--- a/packages/rfdb/ts/client.ts
+++ b/packages/rfdb/ts/client.ts
@@ -9,6 +9,7 @@ import { createConnection, Socket } from 'net';
 import { encode, decode } from '@msgpack/msgpack';
 import { StreamQueue } from './stream-queue.js';
 import { BaseRFDBClient } from './base-client.js';
+import { resolveTimeoutMs, getBulkTimeoutMs } from './timeout-config.js';
 
 import type {
   RFDBCommand,
@@ -269,12 +270,17 @@ export class RFDBClient extends BaseRFDBClient {
     const existing = this._streamTimers.get(id);
     if (existing) clearTimeout(existing);
 
+    // Streaming waits for the FIRST chunk; on a large graph (e.g. the ~714k-node
+    // self graph) the initial scan can exceed the interactive ceiling before any
+    // chunk arrives. Use the longer bulk ceiling here, configurable via
+    // RFDB_RPC_BULK_TIMEOUT_MS (see timeout-config.ts).
+    const streamTimeoutMs = getBulkTimeoutMs();
     const timer = setTimeout(() => {
       this._cleanupStream(id);
       streamQueue.fail(new Error(
-        `RFDB queryNodesStream timed out after ${RFDBClient.DEFAULT_TIMEOUT_MS}ms (no chunk received)`
+        `RFDB queryNodesStream timed out after ${streamTimeoutMs}ms (no chunk received)`
       ));
-    }, RFDBClient.DEFAULT_TIMEOUT_MS);
+    }, streamTimeoutMs);
 
     this._streamTimers.set(id, timer);
   }
@@ -295,19 +301,23 @@ export class RFDBClient extends BaseRFDBClient {
     return Number.isNaN(num) ? null : num;
   }
 
-  private static readonly DEFAULT_TIMEOUT_MS = 60_000;
-
   /**
-   * Send a request and wait for response with timeout
+   * Send a request and wait for response with timeout.
+   *
+   * The timeout ceiling is env-configurable and tiered per operation
+   * (interactive vs bulk/streaming/drop) — see timeout-config.ts. Callers may
+   * still pass an explicit `timeoutMs` to override.
    */
   protected async _send(
     cmd: RFDBCommand,
     payload: Record<string, unknown> = {},
-    timeoutMs: number = RFDBClient.DEFAULT_TIMEOUT_MS,
+    timeoutMs?: number,
   ): Promise<RFDBResponse> {
     if (!this.connected || !this.socket) {
       throw new Error('Not connected to RFDB server');
     }
+
+    const effectiveTimeoutMs = resolveTimeoutMs(cmd, timeoutMs);
 
     return new Promise((resolve, reject) => {
       const id = this.reqId++;
@@ -316,8 +326,8 @@ export class RFDBClient extends BaseRFDBClient {
 
       const timer = setTimeout(() => {
         this.pending.delete(id);
-        reject(new Error(`RFDB ${cmd} timed out after ${timeoutMs}ms. Server may be unresponsive or dbPath may be invalid.`));
-      }, timeoutMs);
+        reject(new Error(`RFDB ${cmd} timed out after ${effectiveTimeoutMs}ms. Server may be unresponsive or dbPath may be invalid.`));
+      }, effectiveTimeoutMs);
 
       const errorHandler = (err: NodeJS.ErrnoException) => {
         this.pending.delete(id);

--- a/packages/rfdb/ts/timeout-config.test.ts
+++ b/packages/rfdb/ts/timeout-config.test.ts
@@ -1,0 +1,80 @@
+/**
+ * RFDB RPC timeout-config unit tests.
+ *
+ * Verifies the env-configurable, per-operation timeout ceilings that unblock
+ * large-graph self-analyze: bulk writes / streaming first-chunk / durable
+ * drops must get a longer ceiling than interactive ops, and both must be
+ * overridable via env (RFDB_RPC_TIMEOUT_MS / RFDB_RPC_BULK_TIMEOUT_MS).
+ *
+ * Imports from ../dist (the built JS), matching the other rfdb tests.
+ */
+
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert';
+import {
+  getDefaultTimeoutMs,
+  getBulkTimeoutMs,
+  resolveTimeoutMs,
+} from '../dist/timeout-config.js';
+
+function clearEnv(): void {
+  delete process.env.RFDB_RPC_TIMEOUT_MS;
+  delete process.env.RFDB_RPC_BULK_TIMEOUT_MS;
+}
+
+describe('rfdb timeout-config', () => {
+  afterEach(clearEnv);
+
+  it('defaults: interactive 300s, bulk 3x = 900s', () => {
+    clearEnv();
+    assert.strictEqual(getDefaultTimeoutMs(), 300_000);
+    assert.strictEqual(getBulkTimeoutMs(), 900_000);
+  });
+
+  it('classifies interactive vs bulk commands', () => {
+    clearEnv();
+    // interactive
+    assert.strictEqual(resolveTimeoutMs('getNode'), 300_000);
+    assert.strictEqual(resolveTimeoutMs('neighbors'), 300_000);
+    assert.strictEqual(resolveTimeoutMs('ping'), 300_000);
+    // bulk / streaming / drop
+    assert.strictEqual(resolveTimeoutMs('addEdges'), 900_000);
+    assert.strictEqual(resolveTimeoutMs('addNodes'), 900_000);
+    assert.strictEqual(resolveTimeoutMs('commitBatch'), 900_000);
+    assert.strictEqual(resolveTimeoutMs('clear'), 900_000);
+    assert.strictEqual(resolveTimeoutMs('dropDatabase'), 900_000);
+  });
+
+  it('honors an explicit per-call override', () => {
+    clearEnv();
+    assert.strictEqual(resolveTimeoutMs('getNode', 1234), 1234);
+    assert.strictEqual(resolveTimeoutMs('addEdges', 1234), 1234);
+  });
+
+  it('RFDB_RPC_TIMEOUT_MS overrides interactive and rescales bulk (3x)', () => {
+    clearEnv();
+    process.env.RFDB_RPC_TIMEOUT_MS = '120000';
+    assert.strictEqual(getDefaultTimeoutMs(), 120_000);
+    assert.strictEqual(getBulkTimeoutMs(), 360_000);
+    assert.strictEqual(resolveTimeoutMs('addEdges'), 360_000);
+  });
+
+  it('RFDB_RPC_BULK_TIMEOUT_MS overrides bulk independently', () => {
+    clearEnv();
+    process.env.RFDB_RPC_BULK_TIMEOUT_MS = '600000';
+    assert.strictEqual(getBulkTimeoutMs(), 600_000);
+    assert.strictEqual(getDefaultTimeoutMs(), 300_000);
+    assert.strictEqual(resolveTimeoutMs('getNode'), 300_000);
+    assert.strictEqual(resolveTimeoutMs('addEdges'), 600_000);
+  });
+
+  it('ignores malformed / non-positive env values (fails safe to defaults)', () => {
+    clearEnv();
+    process.env.RFDB_RPC_TIMEOUT_MS = 'notanumber';
+    assert.strictEqual(getDefaultTimeoutMs(), 300_000);
+    process.env.RFDB_RPC_TIMEOUT_MS = '-5';
+    assert.strictEqual(getDefaultTimeoutMs(), 300_000);
+    process.env.RFDB_RPC_TIMEOUT_MS = '0';
+    assert.strictEqual(getDefaultTimeoutMs(), 300_000);
+  });
+});

--- a/packages/rfdb/ts/timeout-config.ts
+++ b/packages/rfdb/ts/timeout-config.ts
@@ -1,0 +1,95 @@
+/**
+ * RFDB RPC client timeout configuration.
+ *
+ * The RFDB client guards every request with a timeout so a hung/unresponsive
+ * server (or an invalid dbPath) surfaces as a rejected promise instead of an
+ * indefinite hang. The original ceiling was a single hardcoded 60s.
+ *
+ * That 60s is fine for *interactive* round-trips (getNode, neighbors, ping),
+ * but it is too tight for two classes of operation on a large graph:
+ *
+ *   1. Bulk writes — `addEdges` / `addNodes` / `commitBatch` over the
+ *      self-analyze (~714k nodes) make the server do index work that can
+ *      legitimately exceed 60s. The JS enrichers (enrichMcpToolDefinitions,
+ *      contract, behavior, package) all write through `addEdges`, so a 60s
+ *      ceiling makes the enrichers silently fail with
+ *      `RFDB addEdges timed out after 60000ms`.
+ *   2. Streaming reads — `queryNodesStream` waits for the *first* chunk; on a
+ *      714k-node graph the initial scan can take longer than 60s before the
+ *      first chunk arrives (`queryNodesStream timed out after 60000ms`).
+ *   3. Durable drops — `clear` / `dropDatabase` durably truncate a large
+ *      on-disk .rfdb, which can exceed 60s.
+ *
+ * Resolution: timeouts are now env-configurable and tiered per operation. We
+ * keep a *finite* ceiling everywhere (never Infinity) so a genuinely wedged
+ * server still fails loudly — we just give slow-but-progressing bulk/drop work
+ * enough room.
+ *
+ * Env vars (all in milliseconds, all optional):
+ *   RFDB_RPC_TIMEOUT_MS       — default ceiling for interactive ops.
+ *                               Default 300_000 (5 min).
+ *   RFDB_RPC_BULK_TIMEOUT_MS  — ceiling for bulk writes & streaming first-chunk
+ *                               & durable drops. Default = 3× the interactive
+ *                               ceiling, i.e. 900_000 (15 min) by default.
+ *
+ * Why 5 min default (was 60s): a full self-analyze is ~14 min wall and the
+ * slow individual RPCs we observed (bulk addEdges, first stream chunk) sit in
+ * the tens-of-seconds-to-low-minutes range on the 714k graph. 5 min gives a
+ * comfortable margin for interactive ops on a large graph while still failing
+ * a truly hung server in bounded time. Bulk/drop gets 15 min because a durable
+ * drop / large commit is the single longest legitimate operation.
+ */
+
+function readEnvMs(name: string): number | undefined {
+  const raw =
+    typeof process !== 'undefined' && process.env ? process.env[name] : undefined;
+  if (raw === undefined || raw === '') return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return undefined;
+  return Math.floor(n);
+}
+
+/** Default ceiling for interactive ops (env: RFDB_RPC_TIMEOUT_MS). */
+export function getDefaultTimeoutMs(): number {
+  return readEnvMs('RFDB_RPC_TIMEOUT_MS') ?? 300_000;
+}
+
+/**
+ * Ceiling for bulk writes / streaming first-chunk / durable drops
+ * (env: RFDB_RPC_BULK_TIMEOUT_MS). Defaults to 3× the interactive ceiling.
+ */
+export function getBulkTimeoutMs(): number {
+  const explicit = readEnvMs('RFDB_RPC_BULK_TIMEOUT_MS');
+  if (explicit !== undefined) return explicit;
+  return getDefaultTimeoutMs() * 3;
+}
+
+/**
+ * Commands that operate on the whole graph / disk and deserve the longer
+ * bulk ceiling rather than the interactive default.
+ */
+const BULK_COMMANDS: ReadonlySet<string> = new Set([
+  'addEdges',
+  'addNodes',
+  'commitBatch',
+  'clear',
+  'dropDatabase',
+  'compact',
+  'flush',
+  'rebuildIndexes',
+  'getAllNodes',
+  'getAllEdges',
+  'getEdgesByType',
+]);
+
+/**
+ * Resolve the timeout ceiling for a given command, honoring an explicit
+ * per-call override when the caller passed one.
+ */
+export function resolveTimeoutMs(
+  cmd: string,
+  explicitTimeoutMs?: number,
+): number {
+  if (explicitTimeoutMs !== undefined) return explicitTimeoutMs;
+  return BULK_COMMANDS.has(cmd) ? getBulkTimeoutMs() : getDefaultTimeoutMs();
+}

--- a/packages/rfdb/ts/websocket-client.ts
+++ b/packages/rfdb/ts/websocket-client.ts
@@ -12,6 +12,7 @@
 
 import { encode, decode } from '@msgpack/msgpack';
 import { BaseRFDBClient } from './base-client.js';
+import { resolveTimeoutMs } from './timeout-config.js';
 
 import type {
   RFDBCommand,
@@ -23,8 +24,6 @@ interface PendingRequest {
   resolve: (value: RFDBResponse) => void;
   reject: (error: Error) => void;
 }
-
-const DEFAULT_TIMEOUT_MS = 60_000;
 
 export class RFDBWebSocketClient extends BaseRFDBClient {
   readonly socketPath: string;
@@ -121,11 +120,13 @@ export class RFDBWebSocketClient extends BaseRFDBClient {
   protected async _send(
     cmd: RFDBCommand,
     payload: Record<string, unknown> = {},
-    timeoutMs: number = DEFAULT_TIMEOUT_MS,
+    timeoutMs?: number,
   ): Promise<RFDBResponse> {
     if (!this.connected || !this.ws) {
       throw new Error('Not connected to RFDB server');
     }
+
+    const effectiveTimeoutMs = resolveTimeoutMs(cmd, timeoutMs);
 
     return new Promise((resolve, reject) => {
       const id = this.reqId++;
@@ -134,8 +135,8 @@ export class RFDBWebSocketClient extends BaseRFDBClient {
 
       const timer = setTimeout(() => {
         this.pending.delete(id);
-        reject(new Error(`Request timed out: ${cmd} (${timeoutMs}ms)`));
-      }, timeoutMs);
+        reject(new Error(`Request timed out: ${cmd} (${effectiveTimeoutMs}ms)`));
+      }, effectiveTimeoutMs);
 
       this.pending.set(id, {
         resolve: (value) => {


### PR DESCRIPTION
**Consolidates the June-2026 self-analyze hardening campaign into one branch** (supersedes #469-#474; all merged clean, compiles — cargo check rfdb-server + orchestrator exit 0). main could not analyze its own monorepo (~714k nodes); now the full pipeline runs — 40 derive packs, 0 SIGSEGV, enrichers fire.

Rolls up:
- **#469** derive engine: cap-lift (`max_intermediate_results` leaked into batch), **AutoCompactionSuppressGuard** (the parallel-derive heap-corruption SIGSEGV — confirmed via TSan + isolation), plan-guard env override.
- **#471** rfdb TS client: env-configurable tiered RPC timeouts (5/15 min) → enrichers fire (57 mcp:tool nodes), 0 timeouts.
- **#472** planner: selectivity-aware per-rule estimate (E-PLAN-003 q-error 11.7M→7.17M; actual output 811 edges).
- **#473** orchestrator: BEAM daemon liveness probe → analysis phase 241.7s→37.3s (6.5×).
- **#470** CI: non-blocking self-analyze regression guard (the missing guard that hid all of this).
- **#474** `.claude/skills/analyze-perf-profiling` (the method + known limits, distributed to instances).

Verified end-to-end on grafema-dev (32 GB): rc=0, 513k→… nodes, 0 SIGSEGV, 14:01 wall. Since main was already broken on self-analyze, this is forward-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)