### PR TITLE
feat(orchestrator): pipeline profiling as a queryable subgraph

### DIFF
--- a/.claude/skills/analyze-perf-profiling/SKILL.md
+++ b/.claude/skills/analyze-perf-profiling/SKILL.md
@@ -49,11 +49,28 @@ grep "Rule pack materialized" analyze.log   # per-pack: pack="@stdlib/..." ms=N 
 grep -E "Analysis complete|enricher|timed out" analyze.log
 ```
 
-Future fix (worth doing): emit the pipeline as a **profile subgraph** — `PHASE`/`STAGE` nodes +
-`METRIC` nodes (`wall_ms`, `edges_produced`, `intermediate_count`, `cap_hit`) + `PRECEDES` edges, in a
-separate profile namespace. Then critical path = a Datalog query (longest `PRECEDES` chain by `wall_ms`),
-dead stages = `wall_ms` high AND `edges_produced=0`, and limit-hits become standing graph facts +
-a CI regression gate. The `METRIC`/`OBSERVES` node+edge types already exist (per-file `parse_ms` today).
+**DONE — the profile subgraph:** `grafema analyze` now emits the pipeline as a **profile subgraph** in
+the `profile:` namespace (under synthetic file `__grafema_profile/<run_ts>`): `profile:run` /
+`profile:phase` / `profile:stage` nodes + `METRIC` nodes (`wall_ms`, `edges_produced`, `nodes_produced`)
++ `PART_OF` / `PRECEDES` / `OBSERVES` edges. The **derive packs are now stages too** — the blind spot is
+closed (no more `Rule pack materialized` log-grep). On by default (`GRAFEMA_PROFILE_SUBGRAPH=0` to
+disable). Read the route + jams + dead stages straight from the GRAPH:
+
+```bash
+node scripts/profile-graph.mjs --project .            # critical path + jams + dead stages
+node scripts/profile-graph.mjs --json
+```
+
+Critical path = longest `PRECEDES` chain by summed `wall_ms` (the helper walks it). Dead stages =
+`wall_ms` high AND `edges_produced=0` — a pure Datalog query (the CI-gate candidate):
+
+```
+dead(S, Name, Ms) :- node(S, "profile:stage"), attr(S, "edges_produced", "0"),
+                     attr(S, "wall_ms", Ms), gt(Ms, "1000"), attr(S, "name", Name).
+```
+
+Full schema + queries: `_ai/profile-subgraph.md`. The `METRIC`/`OBSERVES` node+edge types are reused
+(same as per-file `parse_ms` today).
 
 ## 4. KNOWN artificial limits — check these BEFORE assuming a real bottleneck
 

--- a/.claude/skills/analyze-perf-profiling/SKILL.md
+++ b/.claude/skills/analyze-perf-profiling/SKILL.md
@@ -61,16 +61,16 @@ node scripts/profile-graph.mjs --project .            # critical path + jams + d
 node scripts/profile-graph.mjs --json
 ```
 
-Critical path = longest `PRECEDES` chain by summed `wall_ms` (the helper walks it). Dead stages =
-`wall_ms` high AND `edges_produced=0` — a pure Datalog query (the CI-gate candidate):
+Critical path = longest `PRECEDES` chain by summed `wall_ms` (the helper walks it; the engine can't
+enumerate a metadata value into a var, so the helper reads `wall_ms` via `getNode`). Dead stages =
+produced 0 edges — a pure Datalog query (constant-value match; the CI-gate candidate):
 
 ```
-dead(S, Name, Ms) :- node(S, "profile:stage"), attr(S, "edges_produced", "0"),
-                     attr(S, "wall_ms", Ms), gt(Ms, "1000"), attr(S, "name", Name).
+dead(S, Name) :- node(S, "profile:stage"), attr(S, "edges_produced", "0"), attr(S, "name", Name).
 ```
 
-Full schema + queries: `_ai/profile-subgraph.md`. The `METRIC`/`OBSERVES` node+edge types are reused
-(same as per-file `parse_ms` today).
+Full schema + queries + the engine binding semantics: `_ai/profile-subgraph.md`. The `METRIC`/`OBSERVES`
+node+edge types are reused (same as per-file `parse_ms` today).
 
 ## 4. KNOWN artificial limits — check these BEFORE assuming a real bottleneck
 

--- a/_ai/profile-subgraph.md
+++ b/_ai/profile-subgraph.md
@@ -46,24 +46,35 @@ node scripts/profile-graph.mjs --dead-threshold-ms 5000
 It walks the `PRECEDES` chains, sums `wall_ms`, and prints the critical path
 (longest chain by summed wall_ms), the top jams, and the dead stages.
 
-### Raw Datalog (`grafema query --raw`)
+### Raw Datalog (`grafema query --raw` / `executeDatalog`)
 
-All stages ranked by wall time (the jams):
+> **Engine binding semantics (verified on grafema-dev).** `node(X, "TYPE")` and
+> `edge(A, B, "TYPE")` enumerate freely, and `attr(X, "name", N)` binds `N`
+> (top-level node field). But for a **metadata** key (`wall_ms`,
+> `edges_produced`, `phase`, `kind`, `total_ms`), the derive-query engine only
+> matches by **constant** value — `attr(S, "edges_produced", "0")` works;
+> `attr(S, "wall_ms", Ms)` with `Ms` unbound returns nothing. To read numeric
+> measures, fetch the node (`getNode(id)` spreads metadata as top-level fields)
+> — that is exactly what `profile-graph.mjs` does. The constant-value queries
+> below are the pure-Datalog ones.
+
+**Dead stages** — produced 0 edges (the REG-1128 type-inference / shape-verifier
+class). Pure Datalog, constant-value match on `edges_produced`:
 
 ```
-stage(S, Name, Ms, E) :- node(S, "profile:stage"), attr(S, "name", Name),
-                         attr(S, "wall_ms", Ms), attr(S, "edges_produced", E).
+dead(S, Name) :- node(S, "profile:stage"),
+                 attr(S, "edges_produced", "0"),
+                 attr(S, "name", Name).
 ```
 
-**Dead stages** — high wall time AND zero edges produced (the REG-1128
-type-inference / shape-verifier class):
+(`profile-graph.mjs` additionally filters by a `wall_ms` threshold, read off the
+node, so a fast 0-edge pack isn't flagged. The `wall_ms >= N` clause is *not*
+expressible in this engine's Datalog, hence the helper.)
+
+All stage ids + names (then read measures via `getNode`):
 
 ```
-dead(S, Name, Ms) :- node(S, "profile:stage"),
-                     attr(S, "edges_produced", "0"),
-                     attr(S, "wall_ms", Ms),
-                     gt(Ms, "1000"),
-                     attr(S, "name", Name).
+stage(S, Name) :- node(S, "profile:stage"), attr(S, "name", Name).
 ```
 
 The PRECEDES route (stage order within phases):
@@ -72,15 +83,9 @@ The PRECEDES route (stage order within phases):
 route(A, B) :- edge(A, B, "PRECEDES").
 ```
 
-Per-phase totals:
-
-```
-phase_wall(P, Ms) :- node(P, "profile:phase"), node(M, "METRIC"),
-                     edge(M, P, "OBSERVES"), attr(M, "value", Ms).
-```
-
 > Note: the *critical path = longest PRECEDES chain by summed wall_ms* needs a
 > weighted longest-path walk, which pure Datalog does not express; the
-> `profile-graph.mjs` helper computes it from the `profile:stage` + `PRECEDES`
-> facts. The dead-stage query above is fully expressible in Datalog and is the
-> standing-fact CI-gate candidate.
+> `profile-graph.mjs` helper computes it from the `profile:stage` nodes (measures
+> via `getNode`) + the `PRECEDES` edges (via Datalog). The dead-stage edges=0
+> query above is fully expressible in Datalog and is the standing-fact CI-gate
+> candidate.

--- a/_ai/profile-subgraph.md
+++ b/_ai/profile-subgraph.md
@@ -1,0 +1,86 @@
+# Pipeline profiling as a queryable subgraph
+
+`grafema analyze` emits a **profile subgraph** so the pipeline's critical path
+and bottlenecks are a GRAPH QUERY, not a log-grep. The derive packs in
+particular — previously visible only as a `Rule pack materialized pack=X ms=N
+edges=M` log line (the blind spot) — are now graph facts.
+
+## Schema (everything namespaced `profile:` so it never pollutes code queries)
+
+| Node type       | One per                                   | Attrs (metadata)                                          |
+|-----------------|-------------------------------------------|-----------------------------------------------------------|
+| `profile:run`   | `grafema analyze`                         | `ts`, `total_ms`                                          |
+| `profile:phase` | phase (`resolve`, `derive`, …)            | `phase`                                                   |
+| `profile:stage` | resolver-cmd / derive-pack / enricher     | `phase`, `kind`, `wall_ms`, `edges_produced`, `nodes_produced`, `order` |
+| `METRIC`        | one measure                               | `value`, `unit` — REUSES the existing METRIC node type    |
+
+Edges:
+- `profile:phase --PART_OF--> profile:run`
+- `profile:stage --PART_OF--> profile:phase`
+- `profile:stage --PRECEDES--> profile:stage` (execution order within a phase — the *route*)
+- `METRIC --OBSERVES--> profile:stage` (and per-phase `wall_ms` METRIC OBSERVES the phase) — same shape as today's per-file `parse_ms`
+
+Stages are extracted from the profiler's in-memory event stream
+(`rule_pack_complete`, `resolve_cmd_complete`, `js_resolve_complete`,
+`ruby_resolve_complete`). All ids live under the synthetic file
+`__grafema_profile/<run_ts>` so they tombstone on the next analyze and never
+collide with code nodes.
+
+`kind` ∈ `resolver` | `derive_pack` | `enricher`.
+
+## On by default
+
+Emission is on by default (cheap — a few hundred nodes). Disable with
+`GRAFEMA_PROFILE_SUBGRAPH=0`.
+
+## Reading it
+
+### The helper (route + jams + dead stages from the graph)
+
+```bash
+node scripts/profile-graph.mjs --project .            # human-readable
+node scripts/profile-graph.mjs --json                 # machine-readable
+node scripts/profile-graph.mjs --dead-threshold-ms 5000
+```
+
+It walks the `PRECEDES` chains, sums `wall_ms`, and prints the critical path
+(longest chain by summed wall_ms), the top jams, and the dead stages.
+
+### Raw Datalog (`grafema query --raw`)
+
+All stages ranked by wall time (the jams):
+
+```
+stage(S, Name, Ms, E) :- node(S, "profile:stage"), attr(S, "name", Name),
+                         attr(S, "wall_ms", Ms), attr(S, "edges_produced", E).
+```
+
+**Dead stages** — high wall time AND zero edges produced (the REG-1128
+type-inference / shape-verifier class):
+
+```
+dead(S, Name, Ms) :- node(S, "profile:stage"),
+                     attr(S, "edges_produced", "0"),
+                     attr(S, "wall_ms", Ms),
+                     gt(Ms, "1000"),
+                     attr(S, "name", Name).
+```
+
+The PRECEDES route (stage order within phases):
+
+```
+route(A, B) :- edge(A, B, "PRECEDES").
+```
+
+Per-phase totals:
+
+```
+phase_wall(P, Ms) :- node(P, "profile:phase"), node(M, "METRIC"),
+                     edge(M, P, "OBSERVES"), attr(M, "value", Ms).
+```
+
+> Note: the *critical path = longest PRECEDES chain by summed wall_ms* needs a
+> weighted longest-path walk, which pure Datalog does not express; the
+> `profile-graph.mjs` helper computes it from the `profile:stage` + `PRECEDES`
+> facts. The dead-stage query above is fully expressible in Datalog and is the
+> standing-fact CI-gate candidate.

--- a/packages/grafema-orchestrator/src/analyzer.rs
+++ b/packages/grafema-orchestrator/src/analyzer.rs
@@ -796,6 +796,225 @@ pub fn phase_metrics_to_wire(
 }
 
 // ---------------------------------------------------------------------------
+// Profile subgraph → wire nodes  (pipeline profiling as a queryable subgraph)
+// ---------------------------------------------------------------------------
+
+/// A single pipeline stage extracted from the profiler event stream: an
+/// analyzer / resolver-cmd / derive-pack / enricher with its measured wall time
+/// and edge/node production. Stages are ordered by `elapsed_ms` (execution
+/// order) within their phase; consecutive stages get a `PRECEDES` edge so the
+/// "route" can be walked, and the critical path = the longest `PRECEDES` chain
+/// summed by `wall_ms`.
+#[derive(Debug, Clone)]
+pub struct ProfileStage {
+    /// Phase this stage belongs to: "analysis" | "resolve" | "derive" | "enrich".
+    pub phase: &'static str,
+    /// Stage kind, recorded as `kind` metadata: "resolver" | "derive_pack" | "enricher".
+    pub kind: &'static str,
+    /// Stage name (e.g. "@stdlib/depends", "js-resolution").
+    pub name: String,
+    /// Wall time in ms.
+    pub wall_ms: u64,
+    /// Edges this stage produced (the dead-stage signal: high wall + 0 edges).
+    pub edges_produced: u64,
+    /// Nodes this stage produced (may be 0 / unknown for some stages).
+    pub nodes_produced: u64,
+    /// Order key — profiler `elapsed_ms` at completion (execution order).
+    pub order: u128,
+}
+
+/// Pipeline-level summary used to fill the profile:run node.
+#[derive(Debug, Clone)]
+pub struct ProfileRunSummary {
+    /// Wall-clock total for the whole analyze, ms.
+    pub total_ms: u64,
+    /// ISO timestamp of the run.
+    pub ts: String,
+}
+
+/// Build the **profile subgraph** from collected pipeline stages:
+///
+/// - one `profile:run` node (attrs `ts`, `total_ms`)
+/// - one `profile:phase` node per distinct phase, `PART_OF` → run
+/// - one `profile:stage` node per stage, `PART_OF` → its phase, with a
+///   `PRECEDES` edge to the next stage in the same phase (execution order)
+/// - `METRIC` nodes (REUSING the existing METRIC node type + `OBSERVES` edge):
+///   one per measure (`wall_ms`, `edges_produced`, `nodes_produced`) `OBSERVES`
+///   → its stage. Per-phase `wall_ms` METRIC `OBSERVES` → the phase.
+///
+/// All graph ids live under the synthetic `__grafema_profile/{run_ts}` file so
+/// they tombstone cleanly and never collide with code nodes. Node types are
+/// `profile:*` so code queries that filter by `FUNCTION`/`MODULE`/… ignore them.
+pub fn profile_subgraph_to_wire(
+    run: &ProfileRunSummary,
+    stages: &[ProfileStage],
+    authority: &str,
+) -> (Vec<WireNode>, Vec<WireEdge>) {
+    let mut nodes = Vec::new();
+    let mut edges = Vec::new();
+
+    // Stable-but-unique-per-run namespace. Using the timestamp keeps the run id
+    // deterministic within a run and tombstonable on the next analyze.
+    let run_key = run.ts.replace([':', '-'], "");
+    let synthetic_file = format!("__grafema_profile/{run_key}");
+
+    let run_id = compact_to_uri(&format!("{synthetic_file}->profile:run->{run_key}"), authority);
+
+    // --- profile:run ---
+    {
+        let mut meta = HashMap::new();
+        meta.insert("ts".to_string(), serde_json::json!(run.ts));
+        meta.insert("total_ms".to_string(), serde_json::json!(run.total_ms));
+        meta.insert("source".to_string(), serde_json::json!("profiler"));
+        nodes.push(WireNode {
+            id: run_id.clone(),
+            semantic_id: Some(run_id.clone()),
+            node_type: Some("profile:run".to_string()),
+            name: Some(format!("analyze@{}", run.ts)),
+            file: Some(synthetic_file.clone()),
+            exported: false,
+            metadata: Some(serde_json::to_string(&meta).unwrap()),
+        });
+    }
+
+    // Helper: build a METRIC node + OBSERVES edge to `observed`.
+    let push_metric =
+        |nodes: &mut Vec<WireNode>, edges: &mut Vec<WireEdge>, observed: &str, slug: &str,
+         measure: &str, value: u64, unit: &str| {
+            let metric_id = compact_to_uri(
+                &format!("{synthetic_file}->METRIC->{slug}::{measure}"),
+                authority,
+            );
+            let mut meta = HashMap::new();
+            meta.insert("value".to_string(), serde_json::json!(value));
+            meta.insert("unit".to_string(), serde_json::json!(unit));
+            meta.insert("source".to_string(), serde_json::json!("profiler"));
+            nodes.push(WireNode {
+                id: metric_id.clone(),
+                semantic_id: Some(metric_id.clone()),
+                node_type: Some("METRIC".to_string()),
+                name: Some(measure.to_string()),
+                file: Some(synthetic_file.clone()),
+                exported: false,
+                metadata: Some(serde_json::to_string(&meta).unwrap()),
+            });
+            edges.push(WireEdge {
+                src: metric_id,
+                dst: observed.to_string(),
+                edge_type: "OBSERVES".to_string(),
+                metadata: None,
+            });
+        };
+
+    // Distinct phases in first-seen order.
+    let mut phase_order: Vec<&'static str> = Vec::new();
+    for s in stages {
+        if !phase_order.contains(&s.phase) {
+            phase_order.push(s.phase);
+        }
+    }
+
+    // --- profile:phase nodes + PART_OF run ---
+    let mut phase_ids: HashMap<&'static str, String> = HashMap::new();
+    for phase in &phase_order {
+        let phase_id =
+            compact_to_uri(&format!("{synthetic_file}->profile:phase->{phase}"), authority);
+        let phase_wall: u64 = stages.iter().filter(|s| s.phase == *phase).map(|s| s.wall_ms).sum();
+        let mut meta = HashMap::new();
+        meta.insert("phase".to_string(), serde_json::json!(phase));
+        meta.insert("source".to_string(), serde_json::json!("profiler"));
+        nodes.push(WireNode {
+            id: phase_id.clone(),
+            semantic_id: Some(phase_id.clone()),
+            node_type: Some("profile:phase".to_string()),
+            name: Some(phase.to_string()),
+            file: Some(synthetic_file.clone()),
+            exported: false,
+            metadata: Some(serde_json::to_string(&meta).unwrap()),
+        });
+        edges.push(WireEdge {
+            src: phase_id.clone(),
+            dst: run_id.clone(),
+            edge_type: "PART_OF".to_string(),
+            metadata: None,
+        });
+        push_metric(&mut nodes, &mut edges, &phase_id, &format!("phase::{phase}"), "wall_ms", phase_wall, "ms");
+        phase_ids.insert(phase, phase_id);
+    }
+
+    // --- profile:stage nodes per phase, in execution order, with PRECEDES ---
+    for phase in &phase_order {
+        let mut phase_stages: Vec<&ProfileStage> =
+            stages.iter().filter(|s| s.phase == *phase).collect();
+        phase_stages.sort_by_key(|s| s.order);
+
+        let phase_id = phase_ids.get(phase).cloned().unwrap_or_default();
+        let mut prev_stage_id: Option<String> = None;
+
+        for (i, st) in phase_stages.iter().enumerate() {
+            // Slug must be unique within the run; include phase + index since a
+            // pack/cmd name could repeat across phases.
+            let slug = format!("{phase}.{i}.{}", sanitize_stage(&st.name));
+            let stage_id =
+                compact_to_uri(&format!("{synthetic_file}->profile:stage->{slug}"), authority);
+
+            let mut meta = HashMap::new();
+            meta.insert("phase".to_string(), serde_json::json!(st.phase));
+            meta.insert("kind".to_string(), serde_json::json!(st.kind));
+            meta.insert("wall_ms".to_string(), serde_json::json!(st.wall_ms));
+            meta.insert("edges_produced".to_string(), serde_json::json!(st.edges_produced));
+            meta.insert("nodes_produced".to_string(), serde_json::json!(st.nodes_produced));
+            meta.insert("order".to_string(), serde_json::json!(i));
+            meta.insert("source".to_string(), serde_json::json!("profiler"));
+
+            nodes.push(WireNode {
+                id: stage_id.clone(),
+                semantic_id: Some(stage_id.clone()),
+                node_type: Some("profile:stage".to_string()),
+                name: Some(st.name.clone()),
+                file: Some(synthetic_file.clone()),
+                exported: false,
+                metadata: Some(serde_json::to_string(&meta).unwrap()),
+            });
+
+            // PART_OF → phase
+            edges.push(WireEdge {
+                src: stage_id.clone(),
+                dst: phase_id.clone(),
+                edge_type: "PART_OF".to_string(),
+                metadata: None,
+            });
+
+            // METRIC nodes OBSERVES → stage
+            push_metric(&mut nodes, &mut edges, &stage_id, &slug, "wall_ms", st.wall_ms, "ms");
+            push_metric(&mut nodes, &mut edges, &stage_id, &slug, "edges_produced", st.edges_produced, "count");
+            push_metric(&mut nodes, &mut edges, &stage_id, &slug, "nodes_produced", st.nodes_produced, "count");
+
+            // PRECEDES from previous stage in this phase (the route).
+            if let Some(prev) = prev_stage_id.take() {
+                edges.push(WireEdge {
+                    src: prev,
+                    dst: stage_id.clone(),
+                    edge_type: "PRECEDES".to_string(),
+                    metadata: None,
+                });
+            }
+            prev_stage_id = Some(stage_id);
+        }
+    }
+
+    (nodes, edges)
+}
+
+/// Make a stage name safe for use inside a compact semantic id (no `->`, `/`,
+/// `:` that would confuse `compact_to_uri`'s file/type split).
+fn sanitize_stage(name: &str) -> String {
+    name.chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '_' { c } else { '_' })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
 // Workspace packages → wire nodes (Wave 3c)
 // ---------------------------------------------------------------------------
 
@@ -7266,6 +7485,61 @@ mod tests {
         assert_eq!(meta["phase"], "analysis");
         assert_eq!(meta["value"], 5000);
         assert_eq!(meta["unit"], "ms");
+    }
+
+    // profile_subgraph_to_wire tests
+
+    fn sample_stages() -> Vec<ProfileStage> {
+        vec![
+            ProfileStage { phase: "resolve", kind: "resolver", name: "js_resolve".into(), wall_ms: 11000, edges_produced: 5000, nodes_produced: 100, order: 10 },
+            ProfileStage { phase: "resolve", kind: "resolver", name: "rust-cross-method-calls".into(), wall_ms: 52000, edges_produced: 3000, nodes_produced: 0, order: 20 },
+            ProfileStage { phase: "derive", kind: "derive_pack", name: "@stdlib/depends".into(), wall_ms: 8000, edges_produced: 4000, nodes_produced: 0, order: 30 },
+            // a DEAD stage: high wall, zero edges
+            ProfileStage { phase: "derive", kind: "derive_pack", name: "@stdlib/type_inference".into(), wall_ms: 72000, edges_produced: 0, nodes_produced: 0, order: 40 },
+        ]
+    }
+
+    #[test]
+    fn profile_subgraph_emits_run_phase_stage_metric() {
+        let run = ProfileRunSummary { total_ms: 143000, ts: "2026-06-19T12:00:00Z".into() };
+        let (nodes, edges) = profile_subgraph_to_wire(&run, &sample_stages(), "example.com/repo");
+
+        let count_type = |t: &str| nodes.iter().filter(|n| n.node_type.as_deref() == Some(t)).count();
+        assert_eq!(count_type("profile:run"), 1);
+        assert_eq!(count_type("profile:phase"), 2, "resolve + derive phases");
+        assert_eq!(count_type("profile:stage"), 4);
+        // 3 stage METRICs each (wall_ms/edges_produced/nodes_produced) + 1 per-phase wall_ms.
+        assert_eq!(count_type("METRIC"), 4 * 3 + 2);
+
+        let edge_count = |t: &str| edges.iter().filter(|e| e.edge_type == t).count();
+        // PART_OF: 2 phases->run + 4 stages->phase
+        assert_eq!(edge_count("PART_OF"), 6);
+        // OBSERVES: one per METRIC
+        assert_eq!(edge_count("OBSERVES"), 4 * 3 + 2);
+        // PRECEDES: 1 within resolve (2 stages) + 1 within derive (2 stages)
+        assert_eq!(edge_count("PRECEDES"), 2);
+    }
+
+    #[test]
+    fn profile_subgraph_stage_metadata_has_dead_signal() {
+        let run = ProfileRunSummary { total_ms: 1000, ts: "2026-06-19T12:00:00Z".into() };
+        let (nodes, _) = profile_subgraph_to_wire(&run, &sample_stages(), "example.com/repo");
+        let dead = nodes.iter().find(|n| n.name.as_deref() == Some("@stdlib/type_inference")).unwrap();
+        let meta: HashMap<String, serde_json::Value> =
+            serde_json::from_str(dead.metadata.as_ref().unwrap()).unwrap();
+        assert_eq!(meta["wall_ms"], 72000);
+        assert_eq!(meta["edges_produced"], 0);
+        assert_eq!(meta["kind"], "derive_pack");
+        assert_eq!(meta["phase"], "derive");
+    }
+
+    #[test]
+    fn profile_subgraph_empty_stages_still_emits_run() {
+        let run = ProfileRunSummary { total_ms: 100, ts: "2026-06-19T12:00:00Z".into() };
+        let (nodes, edges) = profile_subgraph_to_wire(&run, &[], "example.com/repo");
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].node_type.as_deref(), Some("profile:run"));
+        assert!(edges.is_empty());
     }
 
     #[test]

--- a/packages/grafema-orchestrator/src/main.rs
+++ b/packages/grafema-orchestrator/src/main.rs
@@ -777,6 +777,69 @@ async fn run_stdlib_rule_packs(
     Ok(())
 }
 
+/// Build the ordered pipeline-stage list (resolve cmds + derive packs) from the
+/// profiler's in-memory event stream. This is the data behind the **profile
+/// subgraph** — derive packs in particular were previously invisible (only a
+/// "Rule pack materialized" log line). See `analyzer::profile_subgraph_to_wire`.
+fn build_profile_stages(events: &[profiler::ProfileEvent]) -> Vec<analyzer::ProfileStage> {
+    let mut stages: Vec<analyzer::ProfileStage> = Vec::new();
+    let num = |e: &profiler::ProfileEvent, k: &str| -> u64 {
+        e.field(k).and_then(|v| v.parse::<u64>().ok()).unwrap_or(0)
+    };
+    for e in events {
+        match e.event.as_str() {
+            // Per-cmd resolver leaves (haskell/rust/java/kotlin/python/go/swift/
+            // apple-cross/jvm-cross/cpp/beam each emit one per resolve command).
+            "resolve_cmd_complete" => {
+                let name = e
+                    .field("cmd")
+                    .map(str::to_string)
+                    .unwrap_or_else(|| "resolve".to_string());
+                stages.push(analyzer::ProfileStage {
+                    phase: "resolve",
+                    kind: "resolver",
+                    name,
+                    wall_ms: num(e, "duration_ms"),
+                    edges_produced: num(e, "edges"),
+                    nodes_produced: num(e, "nodes"),
+                    order: e.elapsed_ms,
+                });
+            }
+            // JS and Ruby have no per-cmd events — their *_resolve_complete IS the leaf.
+            "js_resolve_complete" | "ruby_resolve_complete" => {
+                let name = e.event.trim_end_matches("_complete").to_string();
+                stages.push(analyzer::ProfileStage {
+                    phase: "resolve",
+                    kind: "resolver",
+                    name,
+                    wall_ms: num(e, "duration_ms"),
+                    edges_produced: num(e, "edges"),
+                    nodes_produced: num(e, "nodes"),
+                    order: e.elapsed_ms,
+                });
+            }
+            // Derive-pack stages — THE BLIND SPOT. One per @stdlib/* pack.
+            "rule_pack_complete" => {
+                let name = e
+                    .field("pack")
+                    .map(str::to_string)
+                    .unwrap_or_else(|| "pack".to_string());
+                stages.push(analyzer::ProfileStage {
+                    phase: "derive",
+                    kind: "derive_pack",
+                    name,
+                    wall_ms: num(e, "ms"),
+                    edges_produced: num(e, "edges"),
+                    nodes_produced: 0,
+                    order: e.elapsed_ms,
+                });
+            }
+            _ => {}
+        }
+    }
+    stages
+}
+
 /// Validate, stamp, tag virtual nodes, and commit a resolution output to RFDB.
 async fn commit_resolve_output(
     output: &mut plugin::PluginOutput,
@@ -2411,6 +2474,50 @@ async fn main() -> Result<()> {
                 "compact_ms" => compact_ms,
                 "total_ms" => total_ms
             );
+
+            // 10b. Emit the PROFILE SUBGRAPH (pipeline profiling as a queryable
+            // subgraph). profile:run / profile:phase / profile:stage + METRIC
+            // nodes with PART_OF / PRECEDES / OBSERVES edges, built from the
+            // profiler's in-memory event stream. The derive packs — previously
+            // visible only as a "Rule pack materialized" log line — become graph
+            // facts here, so the critical path and dead stages are GRAPH QUERIES.
+            //
+            // On by default (cheap: a few hundred nodes). Disable with
+            // GRAFEMA_PROFILE_SUBGRAPH=0.
+            let emit_profile_subgraph = std::env::var("GRAFEMA_PROFILE_SUBGRAPH")
+                .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
+                .unwrap_or(true);
+            if emit_profile_subgraph {
+                if let Some(ref p) = prof {
+                    let stages = build_profile_stages(&p.events());
+                    let run = analyzer::ProfileRunSummary {
+                        total_ms,
+                        ts: profiler::iso_now(),
+                    };
+                    let (mut prof_nodes, prof_edges) =
+                        analyzer::profile_subgraph_to_wire(&run, &stages, &authority);
+                    for node in &mut prof_nodes {
+                        gc::stamp_node_metadata(&mut node.metadata, generation, "profile-subgraph");
+                    }
+                    if !prof_nodes.is_empty() {
+                        let prof_files: Vec<String> = prof_nodes
+                            .iter()
+                            .filter_map(|n| n.file.clone())
+                            .collect::<HashSet<_>>()
+                            .into_iter()
+                            .collect();
+                        match rfdb.commit_batch(&prof_files, &prof_nodes, &prof_edges, false).await {
+                            Ok(_) => tracing::info!(
+                                nodes = prof_nodes.len(),
+                                edges = prof_edges.len(),
+                                stages = stages.len(),
+                                "Profile subgraph committed (profile:run/phase/stage + METRIC)"
+                            ),
+                            Err(e) => tracing::warn!(error = %e, "Failed to commit profile subgraph (non-fatal)"),
+                        }
+                    }
+                }
+            }
 
             // 11. Summary
             println!(

--- a/packages/grafema-orchestrator/src/profiler.rs
+++ b/packages/grafema-orchestrator/src/profiler.rs
@@ -130,10 +130,38 @@ fn linux_stats() -> ProcessStats {
     ProcessStats { rss_bytes, cpu_seconds }
 }
 
+/// A captured profiler event, retained in memory so the profile subgraph
+/// (profile:run / profile:phase / profile:stage + METRIC nodes) can be built
+/// at `analysis_complete` from the same stream that is written to the JSONL.
+#[derive(Debug, Clone)]
+pub struct ProfileEvent {
+    /// Event name (e.g. `rule_pack_complete`, `resolve_cmd_complete`).
+    pub event: String,
+    /// Milliseconds since profiler creation when the event was recorded.
+    pub elapsed_ms: u128,
+    /// The key/value fields attached to the event.
+    pub fields: Vec<(String, String)>,
+}
+
+impl ProfileEvent {
+    /// Look up a field value by key.
+    pub fn field(&self, key: &str) -> Option<&str> {
+        self.fields
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+    }
+}
+
 /// JSONL profiler that writes events incrementally to a file.
+///
+/// In addition to the durable JSONL stream, the profiler keeps every event in
+/// memory (`events`) so the orchestrator can build a queryable **profile
+/// subgraph** at the end of the run — see [`Profiler::events`].
 pub struct Profiler {
     file: Mutex<File>,
     start: Instant,
+    events: Mutex<Vec<ProfileEvent>>,
 }
 
 impl Profiler {
@@ -148,7 +176,16 @@ impl Profiler {
         Ok(Self {
             file: Mutex::new(file),
             start: Instant::now(),
+            events: Mutex::new(Vec::new()),
         })
+    }
+
+    /// Snapshot of every event recorded so far, in capture order.
+    ///
+    /// The orchestrator consumes this at `analysis_complete` to build the
+    /// profile subgraph (the route + jams as graph facts, not log lines).
+    pub fn events(&self) -> Vec<ProfileEvent> {
+        self.events.lock().map(|e| e.clone()).unwrap_or_default()
     }
 
     /// Write a profiling event with arbitrary key-value fields.
@@ -181,6 +218,18 @@ impl Profiler {
             let _ = f.write_all(json.as_bytes());
             let _ = f.flush();
         }
+
+        // Retain the event in memory for profile-subgraph emission.
+        if let Ok(mut ev) = self.events.lock() {
+            ev.push(ProfileEvent {
+                event: event_name.to_string(),
+                elapsed_ms: elapsed.as_millis(),
+                fields: fields
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+            });
+        }
     }
 }
 
@@ -189,6 +238,12 @@ fn escape_json(s: &str) -> String {
     s.replace('\\', "\\\\")
         .replace('"', "\\\"")
         .replace('\n', "\\n")
+}
+
+/// Current UTC timestamp in ISO 8601 format (public wrapper, used by the
+/// orchestrator to stamp the profile:run node).
+pub fn iso_now() -> String {
+    chrono_now()
 }
 
 /// Current UTC timestamp in ISO 8601 format without external crate.

--- a/scripts/profile-graph.mjs
+++ b/scripts/profile-graph.mjs
@@ -35,9 +35,16 @@ function parseArgs(argv) {
   return opts;
 }
 
-/** Run a Datalog query, returning rows as plain {var: value} objects. */
+/** Run a Datalog query (rule form `head :- body.`), returning rows as plain
+ *  {var: value} objects. Uses executeDatalog, which accepts the rule form.
+ *
+ *  NOTE: the derive-query engine binds top-level node fields (name/type) and
+ *  matches metadata attrs by CONSTANT value, but does NOT enumerate a metadata
+ *  value into an unbound variable. So we Datalog-query for node IDS + edges and
+ *  read the numeric measures (wall_ms / edges_produced / …) off the node via
+ *  getNode(), where metadata keys are spread as top-level fields. */
 async function dl(backend, query) {
-  const rows = await backend.datalogQuery(query);
+  const rows = await backend.executeDatalog(query);
   return rows.map((r) => {
     const o = {};
     for (const b of r.bindings) o[b.name] = b.value;
@@ -58,24 +65,20 @@ async function main() {
   await backend.connect();
 
   try {
-    // The run (most recent total_ms / ts).
-    const runs = await dl(
-      backend,
-      'r(R, Ts, Total) :- node(R, "profile:run"), attr(R, "ts", Ts), attr(R, "total_ms", Total).'
-    );
+    // The run node id (metadata read via getNode below).
+    const runRows = await dl(backend, 'r(R) :- node(R, "profile:run").');
+    const runNode = runRows.length ? await backend.getNode(runRows[0].R) : null;
+    const runs = runNode
+      ? [{ Ts: runNode.ts, Total: runNode.total_ms }]
+      : [];
 
-    // Every stage with its measures + phase/kind, straight from node metadata.
-    const stages = await dl(
-      backend,
-      's(S, Name, Ms, Edges, Phase, Kind) :- node(S, "profile:stage"), ' +
-        'attr(S, "name", Name), attr(S, "wall_ms", Ms), attr(S, "edges_produced", Edges), ' +
-        'attr(S, "phase", Phase), attr(S, "kind", Kind).'
-    );
+    // Stage node ids (measures read off the node via getNode).
+    const stageRows = await dl(backend, 's(S) :- node(S, "profile:stage").');
 
     // The PRECEDES route (stage execution order edges).
     const precedes = await dl(backend, 'p(A, B) :- edge(A, B, "PRECEDES").');
 
-    if (stages.length === 0) {
+    if (stageRows.length === 0) {
       console.error(
         'No profile:stage nodes found. Either analyze has not run with the ' +
           'profile subgraph enabled, or GRAFEMA_PROFILE_SUBGRAPH=0 was set.'
@@ -84,14 +87,16 @@ async function main() {
     }
 
     const byId = new Map();
-    for (const s of stages) {
-      byId.set(s.S, {
-        id: s.S,
-        name: s.Name,
-        phase: s.Phase,
-        kind: s.Kind,
-        wall_ms: Number(s.Ms) || 0,
-        edges_produced: Number(s.Edges) || 0,
+    for (const row of stageRows) {
+      const n = await backend.getNode(row.S);
+      if (!n) continue;
+      byId.set(row.S, {
+        id: row.S,
+        name: n.name,
+        phase: n.phase,
+        kind: n.kind,
+        wall_ms: Number(n.wall_ms) || 0,
+        edges_produced: Number(n.edges_produced) || 0,
       });
     }
 

--- a/scripts/profile-graph.mjs
+++ b/scripts/profile-graph.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * profile-graph.mjs — read the PROFILE SUBGRAPH from the graph and print the
+ * pipeline's critical path + dead stages. This is the "pipeline profiling as a
+ * queryable subgraph" deliverable: the route + jams come from the GRAPH (incl.
+ * the derive packs, which were previously invisible — only a "Rule pack
+ * materialized" log line), NOT from log-grepping.
+ *
+ * The profile subgraph is emitted by `grafema analyze` (on by default; disable
+ * with GRAFEMA_PROFILE_SUBGRAPH=0). Schema:
+ *   profile:run   — one per analyze (attrs: ts, total_ms)
+ *   profile:phase — analysis | resolve | derive          PART_OF -> run
+ *   profile:stage — one per resolver-cmd / derive-pack    PART_OF -> phase
+ *                   PRECEDES -> next stage in execution order (the route)
+ *   METRIC        — wall_ms / edges_produced / nodes_produced  OBSERVES -> stage
+ *
+ * Usage:
+ *   node scripts/profile-graph.mjs [--project DIR] [--json] [--dead-threshold-ms N]
+ *
+ * The same facts are queryable directly with `grafema query --raw` — see the
+ * documented queries in the skill and in _ai/profile-subgraph.md.
+ */
+import { resolve, join } from 'node:path';
+import { existsSync } from 'node:fs';
+import { RFDBServerBackend } from '@grafema/util';
+
+function parseArgs(argv) {
+  const opts = { project: '.', json: false, deadThresholdMs: 1000 };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--project' || a === '-p') opts.project = argv[++i];
+    else if (a === '--json') opts.json = true;
+    else if (a === '--dead-threshold-ms') opts.deadThresholdMs = parseInt(argv[++i], 10);
+  }
+  return opts;
+}
+
+/** Run a Datalog query, returning rows as plain {var: value} objects. */
+async function dl(backend, query) {
+  const rows = await backend.datalogQuery(query);
+  return rows.map((r) => {
+    const o = {};
+    for (const b of r.bindings) o[b.name] = b.value;
+    return o;
+  });
+}
+
+async function main() {
+  const opts = parseArgs(process.argv);
+  const projectPath = resolve(opts.project);
+  const dbPath = join(projectPath, '.grafema', 'graph.rfdb');
+  if (!existsSync(dbPath)) {
+    console.error(`No graph database at ${dbPath} — run: grafema analyze`);
+    process.exit(1);
+  }
+
+  const backend = new RFDBServerBackend({ dbPath, clientName: 'profile-graph' });
+  await backend.connect();
+
+  try {
+    // The run (most recent total_ms / ts).
+    const runs = await dl(
+      backend,
+      'r(R, Ts, Total) :- node(R, "profile:run"), attr(R, "ts", Ts), attr(R, "total_ms", Total).'
+    );
+
+    // Every stage with its measures + phase/kind, straight from node metadata.
+    const stages = await dl(
+      backend,
+      's(S, Name, Ms, Edges, Phase, Kind) :- node(S, "profile:stage"), ' +
+        'attr(S, "name", Name), attr(S, "wall_ms", Ms), attr(S, "edges_produced", Edges), ' +
+        'attr(S, "phase", Phase), attr(S, "kind", Kind).'
+    );
+
+    // The PRECEDES route (stage execution order edges).
+    const precedes = await dl(backend, 'p(A, B) :- edge(A, B, "PRECEDES").');
+
+    if (stages.length === 0) {
+      console.error(
+        'No profile:stage nodes found. Either analyze has not run with the ' +
+          'profile subgraph enabled, or GRAFEMA_PROFILE_SUBGRAPH=0 was set.'
+      );
+      process.exit(2);
+    }
+
+    const byId = new Map();
+    for (const s of stages) {
+      byId.set(s.S, {
+        id: s.S,
+        name: s.Name,
+        phase: s.Phase,
+        kind: s.Kind,
+        wall_ms: Number(s.Ms) || 0,
+        edges_produced: Number(s.Edges) || 0,
+      });
+    }
+
+    // Build the PRECEDES adjacency among known stages.
+    const next = new Map(); // id -> id
+    const hasIncoming = new Set();
+    for (const e of precedes) {
+      if (byId.has(e.A) && byId.has(e.B)) {
+        next.set(e.A, e.B);
+        hasIncoming.add(e.B);
+      }
+    }
+
+    // Walk each chain from its head (a stage with no incoming PRECEDES) and sum
+    // wall_ms. The critical path = the chain with the largest summed wall_ms.
+    const chains = [];
+    for (const s of byId.values()) {
+      if (hasIncoming.has(s.id)) continue;
+      const chain = [];
+      let cur = s.id;
+      const seen = new Set();
+      while (cur != null && !seen.has(cur)) {
+        seen.add(cur);
+        chain.push(byId.get(cur));
+        cur = next.get(cur) ?? null;
+      }
+      const sum = chain.reduce((a, st) => a + st.wall_ms, 0);
+      chains.push({ phase: chain[0]?.phase, sum_ms: sum, stages: chain });
+    }
+    chains.sort((a, b) => b.sum_ms - a.sum_ms);
+    const critical = chains[0];
+
+    // Top jams overall by wall_ms.
+    const jams = [...byId.values()].sort((a, b) => b.wall_ms - a.wall_ms).slice(0, 12);
+
+    // Dead stages: wall_ms >= threshold AND produced 0 edges (the REG-1128 class).
+    const dead = [...byId.values()]
+      .filter((s) => s.wall_ms >= opts.deadThresholdMs && s.edges_produced === 0)
+      .sort((a, b) => b.wall_ms - a.wall_ms);
+
+    if (opts.json) {
+      console.log(
+        JSON.stringify({ run: runs[0] ?? null, critical, chains, jams, dead }, null, 2)
+      );
+      return;
+    }
+
+    const run = runs[0];
+    console.log('=== PROFILE SUBGRAPH (from the graph) ===');
+    if (run) console.log(`run: ${run.Ts}   total_ms=${run.Total}`);
+    console.log(`stages: ${byId.size}   chains: ${chains.length}\n`);
+
+    console.log('--- critical path (longest PRECEDES chain by summed wall_ms) ---');
+    if (critical) {
+      console.log(`phase=${critical.phase}  sum=${(critical.sum_ms / 1000).toFixed(1)}s`);
+      for (const s of critical.stages) {
+        console.log(
+          `  ${String((s.wall_ms / 1000).toFixed(1) + 's').padStart(8)}  ` +
+            `${s.name.padEnd(34)} edges=${s.edges_produced}`
+        );
+      }
+    }
+
+    console.log('\n--- top jams (all stages by wall_ms) ---');
+    for (const s of jams) {
+      console.log(
+        `  ${String((s.wall_ms / 1000).toFixed(1) + 's').padStart(8)}  ` +
+          `[${s.phase}/${s.kind}] ${s.name.padEnd(34)} edges=${s.edges_produced}`
+      );
+    }
+
+    console.log(`\n--- dead stages (wall_ms >= ${opts.deadThresholdMs} AND edges_produced=0) ---`);
+    if (dead.length === 0) {
+      console.log('  (none)');
+    } else {
+      for (const s of dead) {
+        console.log(
+          `  ${String((s.wall_ms / 1000).toFixed(1) + 's').padStart(8)}  ` +
+            `[${s.phase}/${s.kind}] ${s.name}`
+        );
+      }
+    }
+  } finally {
+    await backend.close?.();
+  }
+}
+
+main().catch((e) => {
+  console.error(e?.stack || String(e));
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Emit the `grafema analyze` pipeline as a **profile subgraph** so the critical path + bottlenecks are a GRAPH QUERY, not log-grepping. Closes the **derive-pack blind spot** — derive packs were previously visible only as a `Rule pack materialized pack=X ms=N edges=M` log line; now each is a graph node.

## Schema (`profile:` namespace, synthetic file `__grafema_profile/<run_ts>`)

| Node type | one per | attrs |
|---|---|---|
| `profile:run` | analyze | `ts`, `total_ms` |
| `profile:phase` | phase (resolve/derive/…) | `phase` |
| `profile:stage` | resolver-cmd / derive-pack | `wall_ms`, `edges_produced`, `nodes_produced`, `kind`, `phase`, `order` |
| `METRIC` | one measure | `value`, `unit` — **reuses the existing METRIC node + OBSERVES edge** (same as per-file `parse_ms`) |

Edges: `profile:phase --PART_OF--> profile:run`; `profile:stage --PART_OF--> profile:phase`; `profile:stage --PRECEDES--> profile:stage` (the route); `METRIC --OBSERVES--> stage/phase`.

On by default (cheap — a few hundred nodes). Disable with `GRAFEMA_PROFILE_SUBGRAPH=0`. Profile nodes are `profile:`-namespaced and committed **after** the analyze summary counts, so code queries and existing count assertions are unaffected.

## Implementation
- `profiler.rs` — retain events in memory (`ProfileEvent`) + `iso_now()`.
- `analyzer.rs` — `profile_subgraph_to_wire()` builds the WireNodes/edges (+ unit tests).
- `main.rs` — `build_profile_stages()` from the event stream; commit the subgraph at end of analyze via `commit_batch`.
- `scripts/profile-graph.mjs` — critical path (longest `PRECEDES` chain by summed `wall_ms`) + jams + dead stages, read from the graph.
- `_ai/profile-subgraph.md` + `SKILL.md` — schema + documented Datalog queries + the engine binding semantics.

## Query (real output from a self-analyze on grafema-dev)

`716928 nodes / 1532179 edges`, **0 SIGSEGV**, 46 stages.

```
--- critical path (longest PRECEDES chain by summed wall_ms) --- phase=derive sum=242.7s
   36.8s @stdlib/js_local_refs   edges=230
   22.8s @stdlib/rust_calls      edges=2404
   18.3s @stdlib/haskell_local_refs edges=89628
   12.8s @stdlib/js_runtime_globals_edges edges=15243
   ...
--- top jams ---
   36.8s [derive] @stdlib/js_local_refs   25.4s [resolve] js_resolve   22.8s [derive] @stdlib/rust_calls
--- dead stages (wall_ms>=1s AND edges=0) — the REG-1128 class ---
   5.8s @stdlib/shape_verifier   3.5s @stdlib/rust_imports   3.3s @stdlib/js_property_access_ns
   3.0s @stdlib/java_imports   2.7s @stdlib/go_imports   1.3s @stdlib/go_context
```

Pure-Datalog dead-stages (CI-gate candidate, verified on the real graph → 14 zero-edge packs):
```
dead(S, Name) :- node(S, "profile:stage"), attr(S, "edges_produced", "0"), attr(S, "name", Name).
```

> Note: the derive-query engine matches metadata attrs by constant value only — it does not enumerate a metadata value into an unbound var. So numeric measures (`wall_ms`) are read via `getNode` in the helper; the `edges_produced=0` dead-stage query is pure Datalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)