### PR TITLE
feat(profiling): hook the enrich phase into the profiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- feat(profiling): **parallelism headroom on the profile subgraph**. `profile:stage` nodes now carry `REQUIRES` edges (true data dependencies — the subset of `PRECEDES` that is load-bearing); each `profile:phase` gets `critical_path_ms` + `parallelism_headroom_ms` METRICs and `profile:run` a run-level total. "What could run in parallel" = `total_work − critical_path` is now a graph query. Derive model: independent language verticals → shared sinks (`depends`/`method_calls`/`shape_verifier`); resolvers are fully independent (their sequential execution is pure headroom).
 - feat(profiling): the **enrich phase is now profiled**. The Rust enrichment
   plugins (`type-inference`, `shape-tracker`) were silently folded into
   `resolve_ms` (~90s of it on the grafema monorepo, mis-labeled as resolution);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- feat(profiling): the **enrich phase is now profiled**. The Rust enrichment
+  plugins (`type-inference`, `shape-tracker`) were silently folded into
+  `resolve_ms` (~90s of it on the grafema monorepo, mis-labeled as resolution);
+  they are now de-conflated into a dedicated `enrich_ms`, emit one
+  `enrich_plugin_complete` profiler event each, and appear as `phase=enrich`
+  stages in the profile subgraph. The TS enrichers (`mcp-tool`, `contract`,
+  `behavior`, `package-api`, …) run after the orchestrator exits and now append
+  `enrich_step_complete` events to `analysis-profile.jsonl` (timed across
+  success *and* RPC-timeout skips), so the enrich tail is no longer a blind spot
+  in the JSONL profiler and the route view.
+
 ## [0.4.1] - 2026-06-14
 
 ### Highlights

--- a/_ai/profile-subgraph.md
+++ b/_ai/profile-subgraph.md
@@ -10,7 +10,7 @@ edges=M` log line (the blind spot) — are now graph facts.
 | Node type       | One per                                   | Attrs (metadata)                                          |
 |-----------------|-------------------------------------------|-----------------------------------------------------------|
 | `profile:run`   | `grafema analyze`                         | `ts`, `total_ms`                                          |
-| `profile:phase` | phase (`resolve`, `derive`, …)            | `phase`                                                   |
+| `profile:phase` | phase (`resolve`, `derive`, `enrich`, …)  | `phase`                                                   |
 | `profile:stage` | resolver-cmd / derive-pack / enricher     | `phase`, `kind`, `wall_ms`, `edges_produced`, `nodes_produced`, `order` |
 | `METRIC`        | one measure                               | `value`, `unit` — REUSES the existing METRIC node type    |
 
@@ -22,11 +22,30 @@ Edges:
 
 Stages are extracted from the profiler's in-memory event stream
 (`rule_pack_complete`, `resolve_cmd_complete`, `js_resolve_complete`,
-`ruby_resolve_complete`). All ids live under the synthetic file
+`ruby_resolve_complete`, `enrich_plugin_complete`). All ids live under the synthetic file
 `__grafema_profile/<run_ts>` so they tombstone on the next analyze and never
 collide with code nodes.
 
-`kind` ∈ `resolver` | `derive_pack` | `enricher`.
+`kind` ∈ `resolver` | `derive_pack` | `enrich_plugin` | `enrich_step`.
+
+## The enrich phase (closing the second blind spot)
+
+Enrichment runs in two places, both previously invisible:
+
+- **Rust plugins** (`type-inference`, `shape-tracker`) run inside the
+  orchestrator. They used to be folded into `resolve_ms` (mis-attributed as
+  resolution — ~90s of it on the grafema monorepo). They now emit one
+  `enrich_plugin_complete` event each, are subtracted from `resolve_ms` into a
+  dedicated `enrich_ms`, and appear as `phase=enrich` stages in the subgraph.
+- **TS enrichers** (`mcp-tool`, `contract`, `speced-contract`, `behavior`,
+  `package-api`, `library-callback`) run in the CLI **after** the orchestrator
+  process exits, so they append `enrich_step_complete` events to the same
+  `analysis-profile.jsonl` (see `packages/cli/src/utils/profileAppend.ts`).
+  They are in the JSONL profiler and the route view today; they enter the
+  *subgraph* only once it is rebuilt from the full JSONL file after enrich
+  (the orchestrator commits the subgraph from its in-memory stream, which
+  predates the TS phase — the `enrich_step_complete` arm in
+  `build_profile_stages` is ready for that rebuild).
 
 ## On by default
 

--- a/_ai/profile-subgraph.md
+++ b/_ai/profile-subgraph.md
@@ -14,10 +14,13 @@ edges=M` log line (the blind spot) — are now graph facts.
 | `profile:stage` | resolver-cmd / derive-pack / enricher     | `phase`, `kind`, `wall_ms`, `edges_produced`, `nodes_produced`, `order` |
 | `METRIC`        | one measure                               | `value`, `unit` — REUSES the existing METRIC node type    |
 
+Per-phase METRICs now also include `critical_path_ms` (longest REQUIRES-weighted chain) and `parallelism_headroom_ms` (Σ wall_ms − critical_path); the `profile:run` carries a run-level `parallelism_headroom_ms` — the wall-clock the pipeline could shed if every independent-but-sequential stage ran in parallel. **"What could run in parallel" is now `headroom = total_work − critical_path`, a graph query.**
+
 Edges:
 - `profile:phase --PART_OF--> profile:run`
 - `profile:stage --PART_OF--> profile:phase`
 - `profile:stage --PRECEDES--> profile:stage` (execution order within a phase — the *route*)
+- `profile:stage --REQUIRES--> profile:stage` (TRUE data dependency — the subset of PRECEDES that is load-bearing). A PRECEDES edge with **no** REQUIRES backing it = ran sequentially but didn't need to = **parallelism headroom**. Derive model (conservative): language verticals chain internally; the shared sinks (`depends`/`method_calls`/`shape_verifier`) REQUIRE the last pack of every vertical; resolvers & TS-enrich steps have no REQUIRES (fully parallel); `shape-tracker` REQUIRES `type-inference`.
 - `METRIC --OBSERVES--> profile:stage` (and per-phase `wall_ms` METRIC OBSERVES the phase) — same shape as today's per-file `parse_ms`
 
 Stages are extracted from the profiler's in-memory event stream

--- a/packages/cli/src/commands/analyzeAction.ts
+++ b/packages/cli/src/commands/analyzeAction.ts
@@ -34,6 +34,7 @@ import { commanderExtractor } from '@grafema/util/enrichers/extractors/commander
 import { mcpInputSchemaExtractor } from '@grafema/util/enrichers/extractors/mcpInputSchemaExtractor';
 import { vscodeContributesExtractor } from '@grafema/util/enrichers/extractors/vscodeContributesExtractor';
 import { httpRouteExtractor } from '@grafema/util/enrichers/extractors/httpRouteExtractor';
+import { appendProfileEvent } from '../utils/profileAppend.js';
 import type { LogLevel } from '@grafema/util';
 import { scanExtensions, generateSmartConfig, writeConfig, updateGitignore, formatDetected } from '../utils/quickstart.js';
 
@@ -419,6 +420,26 @@ export async function analyzeAction(path: string, options: { service?: string; e
       info(`  Nodes: ${stats.nodeCount}`);
       info(`  Edges: ${stats.edgeCount}`);
 
+      // Profile the TS enrich phase into the same JSONL the orchestrator writes,
+      // so the ~90s enrich tail (which runs after the orchestrator exits) stops
+      // being a blind spot. enrichStep times each enricher — including ones that
+      // SKIP on an RPC timeout — via finally, and records duration_ms as an
+      // `enrich_step_complete` event (→ profile:stage phase=enrich).
+      const profilePath = join(grafemaDir, 'analysis-profile.jsonl');
+      const enrichStep = async (step: string, fn: () => Promise<void>): Promise<void> => {
+        const t0 = Date.now();
+        try {
+          await fn();
+        } catch (err) {
+          debug(`${step} enricher skipped: ${err instanceof Error ? err.message : String(err)}`);
+        } finally {
+          appendProfileEvent(profilePath, startTime, 'enrich_step_complete', {
+            step,
+            duration_ms: Date.now() - t0,
+          });
+        }
+      };
+
       // Run library-callback enricher before manifest generation.
       // Creates domain nodes (cli:command, mcp:tool, ...) and HANDLES edges
       // for callbacks passed to library entry points (Commander, MCP SDK, ...).
@@ -427,7 +448,7 @@ export async function analyzeAction(path: string, options: { service?: string; e
       const effectsLookup = effectsDbPath
         ? EffectsLookup.load(effectsDbPath)
         : EffectsLookup.empty();
-      try {
+      await enrichStep('library-callbacks', async () => {
         // RFDBServerBackend's RFDBClient field is private at compile time but
         // accessible at runtime; the enricher only needs the wire-level client.
         const client = (backend as unknown as { client: Parameters<typeof enrichLibraryCallbacks>[0] }).client;
@@ -435,16 +456,14 @@ export async function analyzeAction(path: string, options: { service?: string; e
           const result = await enrichLibraryCallbacks(client, effectsLookup);
           info(`  Library callbacks: ${result.domainNodesCreated} domain nodes, ${result.handlesEdgesCreated} HANDLES edges (unresolved: ${result.unresolvedCalls})`);
         }
-      } catch (err) {
-        debug(`Library callback enricher skipped: ${err instanceof Error ? err.message : String(err)}`);
-      }
+      });
 
       // MCP tool definition enricher — scans `packages/mcp/src/definitions/*-tools.ts`
       // (or any matching tree under projectPath) and creates `mcp:tool` nodes for
       // each defined tool. Complements libraryCallbackEnricher: that one captures
       // the high-level setRequestHandler calls; this one captures the ~30+ tools
       // dispatched by the switch statement inside the CallTool handler.
-      try {
+      await enrichStep('mcp-tool-defs', async () => {
         const client = (backend as unknown as { client: Parameters<typeof enrichMcpToolDefinitions>[0] }).client;
         if (client) {
           const definitionsDir = join(projectPath, 'packages/mcp/src/definitions');
@@ -453,9 +472,7 @@ export async function analyzeAction(path: string, options: { service?: string; e
             info(`  MCP tool defs: ${result.toolNodesCreated} mcp:tool nodes, ${result.handlesEdgesCreated} HANDLES edges (unresolved: ${result.unresolvedHandlers.length})`);
           }
         }
-      } catch (err) {
-        debug(`MCP tool definition enricher skipped: ${err instanceof Error ? err.message : String(err)}`);
-      }
+      });
 
       // Contract enricher — for every FEATURE-class node (cli:command, mcp:tool,
       // vscode:command) created by the L0 entry-point enrichers above, walk the
@@ -464,22 +481,20 @@ export async function analyzeAction(path: string, options: { service?: string; e
       // creators (enrichLibraryCallbacks, enrichMcpToolDefinitions) so HANDLES
       // edges already exist, and BEFORE generateManifest so contracts can flow
       // into the manifest if needed.
-      try {
+      await enrichStep('contracts', async () => {
         const client = (backend as unknown as { client: Parameters<typeof enrichContracts>[0] }).client;
         if (client) {
           const result = await enrichContracts(client);
           info(`  Contracts: ${result.contractsCreated} contracts (${result.inputsTotal} inputs, ${result.outputsTotal} outputs, ${result.errorsTotal} errors); ${result.featuresWithoutEntry} features lacked HANDLES edge`);
         }
-      } catch (err) {
-        debug(`Contract enricher skipped: ${err instanceof Error ? err.message : String(err)}`);
-      }
+      });
 
       // Speced-contract enricher — for every FEATURE node, run the registered
       // per-category extractors (commander spec strings, MCP inputSchema, …)
       // to produce SPECED_CONTRACT nodes carrying the user-facing interface.
       // Distinct from the existing CONTRACT (handler signature scrape) which
       // is implementation-side. See `_ai/research/feature-taxonomy.md` §1.3.
-      try {
+      await enrichStep('speced-contracts', async () => {
         const client = (backend as unknown as { client: Parameters<typeof enrichSpecedContracts>[0] }).client;
         if (client) {
           const result = await enrichSpecedContracts(client, [
@@ -490,24 +505,20 @@ export async function analyzeAction(path: string, options: { service?: string; e
           ]);
           info(`  Speced contracts: ${result.contractsCreated} (${result.inputsTotal} inputs); byCategory=${JSON.stringify(result.byCategory)}; missingExtractor=${result.featuresWithoutExtractor}, missingSpec=${result.featuresWithoutSpec}`);
         }
-      } catch (err) {
-        debug(`Speced contract enricher skipped: ${err instanceof Error ? err.message : String(err)}`);
-      }
+      });
 
       // Behavior enricher — for every FEATURE-class node, walk the HANDLES
       // edge to the entry function and compute a transitive CALLS closure.
       // Stores BEHAVIOR with hash + effects + summary (no COMPRISES edges —
       // see skill `materialize-only-what-queries-need`). Pass 2 emits
       // SHARES_BEHAVIOR_WITH between behaviors with identical hash.
-      try {
+      await enrichStep('behaviors', async () => {
         const client = (backend as unknown as { client: Parameters<typeof enrichBehaviors>[0] }).client;
         if (client) {
           const result = await enrichBehaviors(client, effectsLookup);
           info(`  Behaviors: ${result.behaviorsCreated} BEHAVIOR nodes, ${result.sharesBehaviorEdges} SHARES_BEHAVIOR_WITH edges (totalCoreNodes=${result.totalCoreNodes}, missingEntry=${result.featuresWithoutEntry})`);
         }
-      } catch (err) {
-        debug(`Behavior enricher skipped: ${err instanceof Error ? err.message : String(err)}`);
-      }
+      });
 
       // Package API enricher — for every monorepo package barrel
       // (`packages/<pkg>/src/index.ts`), emit a `package:export` FEATURE node
@@ -515,7 +526,7 @@ export async function analyzeAction(path: string, options: { service?: string; e
       // Surfaces inter-package public-API surfaces so the contract enricher
       // (run already) can wire contracts onto these on the next pass; the
       // benefit is realised by downstream consumers (manifest, GUI, agents).
-      try {
+      await enrichStep('package-apis', async () => {
         const client = (backend as unknown as { client: Parameters<typeof enrichPackageApis>[0] }).client;
         if (client) {
           const result = await enrichPackageApis(client);
@@ -523,9 +534,7 @@ export async function analyzeAction(path: string, options: { service?: string; e
             info(`  Package APIs: ${result.apiNodesCreated} package:export nodes, ${result.handlesEdgesCreated} HANDLES edges across ${result.packagesScanned} barrels (unresolved: ${result.exportsWithoutHandler})`);
           }
         }
-      } catch (err) {
-        debug(`Package API enricher skipped: ${err instanceof Error ? err.message : String(err)}`);
-      }
+      });
 
       // Generate manifest after successful analysis
       try {

--- a/packages/cli/src/utils/profileAppend.ts
+++ b/packages/cli/src/utils/profileAppend.ts
@@ -1,0 +1,38 @@
+import { appendFileSync } from 'fs';
+
+/**
+ * Append one event to the analysis JSONL profiler (`.grafema/analysis-profile.jsonl`),
+ * matching the schema the Rust orchestrator writes: `ts`, `elapsed_ms`, `event`,
+ * `rss_mb`, `cpu_s`, plus arbitrary custom fields.
+ *
+ * Why this exists: the orchestrator stops profiling at `analysis_complete_final`,
+ * but the CLI runs the TS enrichers (mcp-tool, contract, behavior, package-api…)
+ * AFTER the orchestrator process exits. Without this append, that ~90s enrich tail
+ * is a blind spot in the JSONL profiler and the route view. `startTimeMs` is the
+ * analyze-invocation start (Date.now()), so enrich events sort after every
+ * orchestrator event when the profile is read back as a timeline.
+ *
+ * Best-effort: never throws — profiling must not fail an analyze run.
+ */
+export function appendProfileEvent(
+  profilePath: string,
+  startTimeMs: number,
+  event: string,
+  fields: Record<string, string | number> = {},
+): void {
+  try {
+    const rssMb = process.memoryUsage().rss / (1024 * 1024);
+    const cpuS = process.cpuUsage().user / 1e6;
+    const rec: Record<string, unknown> = {
+      ts: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+      elapsed_ms: Date.now() - startTimeMs,
+      event,
+      rss_mb: Math.round(rssMb * 10) / 10,
+      cpu_s: Math.round(cpuS * 100) / 100,
+      ...fields,
+    };
+    appendFileSync(profilePath, JSON.stringify(rec) + '\n');
+  } catch {
+    // Profiling is best-effort; swallow all errors.
+  }
+}

--- a/packages/grafema-orchestrator/src/analyzer.rs
+++ b/packages/grafema-orchestrator/src/analyzer.rs
@@ -943,6 +943,8 @@ pub fn profile_subgraph_to_wire(
     }
 
     // --- profile:stage nodes per phase, in execution order, with PRECEDES ---
+    // Collected for the REQUIRES/headroom pass below: (phase, kind, name, wall_ms, id).
+    let mut stage_index: Vec<(&'static str, &'static str, String, u64, String)> = Vec::new();
     for phase in &phase_order {
         let mut phase_stages: Vec<&ProfileStage> =
             stages.iter().filter(|s| s.phase == *phase).collect();
@@ -999,8 +1001,138 @@ pub fn profile_subgraph_to_wire(
                     metadata: None,
                 });
             }
+            stage_index.push((st.phase, st.kind, st.name.clone(), st.wall_ms, stage_id.clone()));
             prev_stage_id = Some(stage_id);
         }
+    }
+
+    // ===== REQUIRES edges (true data dependencies) + parallelism headroom =====
+    // PRECEDES (above) is the ACTUAL sequential execution order. REQUIRES is the
+    // SUBSET of it that is a real data dependency. A PRECEDES edge with no REQUIRES
+    // backing it = ran sequentially but DIDN'T NEED TO = parallelism headroom.
+    //
+    // Dependency model (CONSERVATIVE — over-approximates deps, so headroom is a
+    // floor, never an over-promise):
+    //   * resolver / enrich_step stages  → independent (no REQUIRES) — fully parallel
+    //   * derive language verticals       → internal chain (consecutive same-vertical
+    //                                        packs); feature-detect packs (http_routes,
+    //                                        entrypoint_features, axum) chain only their
+    //                                        own nodes->edges
+    //   * derive shared sinks (depends / method_calls / shape_verifier) → require the
+    //     LAST pack of every language vertical; shape_verifier also requires method_calls
+    //   * enrich shape-tracker            → requires type-inference (declared depends_on)
+    // headroom(phase) = Σ wall_ms − critical path (longest REQUIRES-weighted chain).
+    fn derive_group(name: &str) -> &'static str {
+        let n = name.strip_prefix("@stdlib/").unwrap_or(name);
+        if n.starts_with("js_http_routes")
+            || n.starts_with("js_entrypoint_features")
+            || n == "axum_routes"
+        {
+            return "featuredetect";
+        }
+        match n {
+            "depends" | "method_calls" | "shape_verifier" => "sink",
+            _ if n.starts_with("js") => "js",
+            _ if n.starts_with("rust") => "rust",
+            _ if n.starts_with("haskell") => "haskell",
+            _ if n.starts_with("java") => "java",
+            _ if n.starts_with("kotlin") => "kotlin",
+            _ if n.starts_with("go") => "go",
+            _ => "other",
+        }
+    }
+
+    let mut total_headroom: u64 = 0;
+    for phase in &phase_order {
+        let idxs: Vec<usize> = stage_index
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| s.0 == *phase)
+            .map(|(i, _)| i)
+            .collect();
+        if idxs.is_empty() {
+            continue;
+        }
+        // requires[k] = positions (within idxs) that stage k depends on.
+        let mut requires: Vec<Vec<usize>> = vec![Vec::new(); idxs.len()];
+        let mut vertical_last: HashMap<&'static str, usize> = HashMap::new();
+        let mut prev_in_group: HashMap<&'static str, usize> = HashMap::new();
+        let mut method_calls_pos: Option<usize> = None;
+        for (k, &gi) in idxs.iter().enumerate() {
+            let kind = stage_index[gi].1;
+            let name = stage_index[gi].2.clone();
+            match kind {
+                "derive_pack" => {
+                    let g = derive_group(&name);
+                    if g == "sink" {
+                        let mut deps: Vec<usize> = vertical_last.values().copied().collect();
+                        deps.sort_unstable();
+                        requires[k].extend(deps);
+                        let n = name.strip_prefix("@stdlib/").unwrap_or(&name);
+                        if n == "method_calls" {
+                            method_calls_pos = Some(k);
+                        }
+                        if n == "shape_verifier" {
+                            if let Some(mk) = method_calls_pos {
+                                requires[k].push(mk);
+                            }
+                        }
+                    } else {
+                        if let Some(&pk) = prev_in_group.get(g) {
+                            requires[k].push(pk);
+                        }
+                        prev_in_group.insert(g, k);
+                        vertical_last.insert(g, k);
+                    }
+                }
+                "enrich_plugin" => {
+                    if name == "shape-tracker" {
+                        if let Some((tk, _)) = idxs
+                            .iter()
+                            .enumerate()
+                            .find(|(_, &gj)| stage_index[gj].2 == "type-inference")
+                        {
+                            requires[k].push(tk);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        // critical path (idxs in execution order; REQUIRES only points backward).
+        let mut cp: Vec<u64> = vec![0; idxs.len()];
+        let mut total: u64 = 0;
+        for k in 0..idxs.len() {
+            let w = stage_index[idxs[k]].3;
+            total += w;
+            let dep_max = requires[k].iter().map(|&d| cp[d]).max().unwrap_or(0);
+            cp[k] = w + dep_max;
+        }
+        let critical = cp.iter().copied().max().unwrap_or(0);
+        let headroom = total.saturating_sub(critical);
+        total_headroom += headroom;
+        // emit REQUIRES edges (consumer --REQUIRES--> producer).
+        for k in 0..idxs.len() {
+            let consumer = stage_index[idxs[k]].4.clone();
+            for &d in &requires[k] {
+                let producer = stage_index[idxs[d]].4.clone();
+                edges.push(WireEdge {
+                    src: consumer.clone(),
+                    dst: producer,
+                    edge_type: "REQUIRES".to_string(),
+                    metadata: None,
+                });
+            }
+        }
+        if let Some(pid) = phase_ids.get(phase).cloned() {
+            push_metric(&mut nodes, &mut edges, &pid, &format!("phase::{phase}"), "critical_path_ms", critical, "ms");
+            push_metric(&mut nodes, &mut edges, &pid, &format!("phase::{phase}"), "parallelism_headroom_ms", headroom, "ms");
+        }
+    }
+    // run-level total: how much wall-clock the whole pipeline could shed if every
+    // independent stage that ran sequentially ran in parallel instead.
+    if !stages.is_empty() {
+        push_metric(&mut nodes, &mut edges, &run_id, "run", "parallelism_headroom_ms", total_headroom, "ms");
     }
 
     (nodes, edges)
@@ -7493,9 +7625,10 @@ mod tests {
         vec![
             ProfileStage { phase: "resolve", kind: "resolver", name: "js_resolve".into(), wall_ms: 11000, edges_produced: 5000, nodes_produced: 100, order: 10 },
             ProfileStage { phase: "resolve", kind: "resolver", name: "rust-cross-method-calls".into(), wall_ms: 52000, edges_produced: 3000, nodes_produced: 0, order: 20 },
-            ProfileStage { phase: "derive", kind: "derive_pack", name: "@stdlib/depends".into(), wall_ms: 8000, edges_produced: 4000, nodes_produced: 0, order: 30 },
-            // a DEAD stage: high wall, zero edges
-            ProfileStage { phase: "derive", kind: "derive_pack", name: "@stdlib/type_inference".into(), wall_ms: 72000, edges_produced: 0, nodes_produced: 0, order: 40 },
+            // a DEAD stage: high wall, zero edges (a producer vertical)
+            ProfileStage { phase: "derive", kind: "derive_pack", name: "@stdlib/type_inference".into(), wall_ms: 72000, edges_produced: 0, nodes_produced: 0, order: 30 },
+            // depends is a SINK — runs last, consumes the verticals above
+            ProfileStage { phase: "derive", kind: "derive_pack", name: "@stdlib/depends".into(), wall_ms: 8000, edges_produced: 4000, nodes_produced: 0, order: 40 },
         ]
     }
 
@@ -7508,16 +7641,41 @@ mod tests {
         assert_eq!(count_type("profile:run"), 1);
         assert_eq!(count_type("profile:phase"), 2, "resolve + derive phases");
         assert_eq!(count_type("profile:stage"), 4);
-        // 3 stage METRICs each (wall_ms/edges_produced/nodes_produced) + 1 per-phase wall_ms.
-        assert_eq!(count_type("METRIC"), 4 * 3 + 2);
+        // 3 stage METRICs each (wall_ms/edges_produced/nodes_produced) + 1 per-phase
+        // wall_ms + 2 per-phase headroom (critical_path_ms/parallelism_headroom_ms)
+        // + 1 run-level parallelism_headroom_ms.
+        assert_eq!(count_type("METRIC"), 4 * 3 + 2 + 2 * 2 + 1);
 
         let edge_count = |t: &str| edges.iter().filter(|e| e.edge_type == t).count();
         // PART_OF: 2 phases->run + 4 stages->phase
         assert_eq!(edge_count("PART_OF"), 6);
         // OBSERVES: one per METRIC
-        assert_eq!(edge_count("OBSERVES"), 4 * 3 + 2);
+        assert_eq!(edge_count("OBSERVES"), 4 * 3 + 2 + 2 * 2 + 1);
         // PRECEDES: 1 within resolve (2 stages) + 1 within derive (2 stages)
         assert_eq!(edge_count("PRECEDES"), 2);
+        // REQUIRES: depends (sink) requires the last vertical pack (type_inference);
+        // the two resolvers are independent (no REQUIRES) — that IS the headroom.
+        assert_eq!(edge_count("REQUIRES"), 1);
+    }
+
+    #[test]
+    fn profile_subgraph_emits_parallelism_headroom() {
+        let run = ProfileRunSummary { total_ms: 143000, ts: "2026-06-19T12:00:00Z".into() };
+        let (nodes, _) = profile_subgraph_to_wire(&run, &sample_stages(), "example.com/repo");
+        let metric_val = |id_frag: &str| -> u64 {
+            let n = nodes.iter().find(|n|
+                n.node_type.as_deref() == Some("METRIC")
+                && n.id.contains(id_frag)).expect("metric exists");
+            let m: HashMap<String, serde_json::Value> =
+                serde_json::from_str(n.metadata.as_ref().unwrap()).unwrap();
+            m["value"].as_u64().unwrap()
+        };
+        // resolve: js_resolve 11s ∥ rust 52s — independent → headroom = 63−52 = 11s.
+        assert_eq!(metric_val("phase::resolve::parallelism_headroom_ms"), 11000);
+        // derive: depends REQUIRES type_inference (sink) → sequential → headroom 0.
+        assert_eq!(metric_val("phase::derive::parallelism_headroom_ms"), 0);
+        // run-level total = 11000 + 0.
+        assert_eq!(metric_val("run::parallelism_headroom_ms"), 11000);
     }
 
     #[test]

--- a/packages/grafema-orchestrator/src/main.rs
+++ b/packages/grafema-orchestrator/src/main.rs
@@ -834,6 +834,41 @@ fn build_profile_stages(events: &[profiler::ProfileEvent]) -> Vec<analyzer::Prof
                     order: e.elapsed_ms,
                 });
             }
+            // Enrichment plugins (Rust: type-inference, shape-tracker) — run in
+            // the orchestrator after resolve; de-conflated from resolve_ms.
+            "enrich_plugin_complete" => {
+                let name = e
+                    .field("plugin")
+                    .map(str::to_string)
+                    .unwrap_or_else(|| "enrich".to_string());
+                stages.push(analyzer::ProfileStage {
+                    phase: "enrich",
+                    kind: "enrich_plugin",
+                    name,
+                    wall_ms: num(e, "duration_ms"),
+                    edges_produced: num(e, "edges"),
+                    nodes_produced: num(e, "nodes"),
+                    order: e.elapsed_ms,
+                });
+            }
+            // Enrichment steps (TS: mcp-tool, contract, behavior, package-api…) —
+            // appended to the JSONL by the CLI after the orchestrator exits. Picked
+            // up only when the subgraph is (re)built from the full JSONL file.
+            "enrich_step_complete" => {
+                let name = e
+                    .field("step")
+                    .map(str::to_string)
+                    .unwrap_or_else(|| "enrich".to_string());
+                stages.push(analyzer::ProfileStage {
+                    phase: "enrich",
+                    kind: "enrich_step",
+                    name,
+                    wall_ms: num(e, "duration_ms"),
+                    edges_produced: num(e, "edges"),
+                    nodes_produced: num(e, "nodes"),
+                    order: e.elapsed_ms,
+                });
+            }
             _ => {}
         }
     }
@@ -2203,6 +2238,7 @@ async fn main() -> Result<()> {
                 })
                 .cloned()
                 .collect();
+            let mut enrich_ms: u64 = 0;
             if !user_plugins.is_empty() {
                 tracing::info!(count = user_plugins.len(), "Running user-defined plugins");
 
@@ -2236,10 +2272,25 @@ async fn main() -> Result<()> {
                     pool.shutdown().await;
                 }
 
-                dag_result?;
+                let plugin_results = dag_result?;
+                // De-conflate enrichment from resolve: type-inference and
+                // shape-tracker are an ENRICH phase, not resolution. Emit one
+                // profiler event per plugin (→ profile:stage phase=enrich) and
+                // accumulate enrich_ms so the ~90s tail stops hiding in resolve_ms.
+                for r in &plugin_results {
+                    profile!("enrich_plugin_complete",
+                        "plugin" => r.plugin_name,
+                        "duration_ms" => r.duration.as_millis() as u64,
+                        "nodes" => r.nodes_emitted,
+                        "edges" => r.edges_emitted);
+                    enrich_ms += r.duration.as_millis() as u64;
+                }
             }
 
-            let resolve_ms = resolve_timer.elapsed().as_millis() as u64;
+            // resolve_ms EXCLUDES the enrich plugins above (summed into enrich_ms):
+            // they are an enrichment phase, not resolution.
+            let resolve_ms =
+                (resolve_timer.elapsed().as_millis() as u64).saturating_sub(enrich_ms);
 
 
 
@@ -2431,6 +2482,7 @@ async fn main() -> Result<()> {
                     ("rfdb_commit",  "p99_ms",       p99_ms,                     "ms"),
                     ("rfdb_commit",  "batches",      batch_count,                "count"),
                     ("resolve",      "duration_ms",  resolve_ms,                 "ms"),
+                    ("enrich",       "duration_ms",  enrich_ms,                  "ms"),
                     ("diagnostics",  "duration_ms",  diagnostics_ms,             "ms"),
                     ("depends_on",   "duration_ms",  depends_on_ms,              "ms"),
                     ("compact",      "duration_ms",  compact_ms as u64,          "ms"),
@@ -2469,6 +2521,7 @@ async fn main() -> Result<()> {
                 "analysis_ms" => analysis_ms,
                 "rfdb_commit_ms" => rfdb_commit_total_ms,
                 "resolve_ms" => resolve_ms,
+                "enrich_ms" => enrich_ms,
                 "diagnostics_ms" => diagnostics_ms,
                 "depends_on_ms" => depends_on_ms,
                 "compact_ms" => compact_ms,


### PR DESCRIPTION
## What

Hooks the **enrich phase** into the analysis profiler — the second profiler blind spot after the derive packs (closed in the profile-subgraph PR this is stacked on).

Enrichment ran in two invisible places:
- **Rust plugins** (`type-inference` ~64s, `shape-tracker` ~34s) — run inside the orchestrator but were silently **folded into `resolve_ms`** (~98s mislabeled as resolution).
- **TS enrichers** (`mcp-tool`, `contract`, `speced-contract`, `behavior`, `package-api`, `library-callback`) — run in the CLI **after** the orchestrator exits, so they never touched the JSONL.

## Changes

- **Rust** (`grafema-orchestrator`): de-conflate the user-plugins from `resolve_ms` into a dedicated `enrich_ms`; emit one `enrich_plugin_complete` profiler event per plugin; add `enrich` to `phase_summary` + the phase METRIC nodes; map `enrich_plugin_complete` → `phase=enrich` `profile:stage` in `build_profile_stages` (lands in the subgraph in-process, before the commit).
- **TS** (`@grafema/cli`): new `profileAppend.ts` util that appends to `analysis-profile.jsonl` in the orchestrator's schema; an `enrichStep` wrapper times each enricher — including ones that **skip on an RPC timeout** (via `finally`) — and emits `enrich_step_complete`.
- `build_profile_stages` also maps `enrich_step_complete` (ready for when the subgraph is rebuilt from the full JSONL after enrich — the orchestrator currently commits the subgraph from its in-memory stream, which predates the TS phase).
- Docs: `_ai/profile-subgraph.md` + `CHANGELOG.md`.

## Verification (real self-analyze on the grafema monorepo)

```
phase_summary: resolve_ms=102024  enrich_ms=97783  depends_on_ms=157729  total_ms=414788
enrich_plugin_complete  type-inference   63858ms
enrich_plugin_complete  shape-tracker    33925ms
enrich_step_complete    library-callbacks  2ms
Profile subgraph committed … stages=47   (was 45 → +2 enrich plugins)
```

`resolve_ms` dropped from a single conflated ~200s to a true 102s resolve + 98s enrich.

## Note

This run surfaced a pre-existing slow/hanging `mcp-tool-defs` enricher (a queryNodesStream that no longer fails fast) — exactly the kind of bottleneck this instrumentation is meant to make visible. Orthogonal to this PR.

## Base

Stacked on `feat/pipeline-profile-graph` (the profile-subgraph PR). Merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
